### PR TITLE
fix: suite leaks, flakes, and live binding data-plane

### DIFF
--- a/packages/alchemy/src/AWS/EC2/Instance.ts
+++ b/packages/alchemy/src/AWS/EC2/Instance.ts
@@ -668,6 +668,11 @@ export const InstanceProvider = () =>
             handler: raw.handler,
             build: raw.build,
             port: raw.port,
+            // `isExternal` chooses the bundler entry (raw file vs virtual
+            // `export default` wrapper). Omitting it here re-bundles an
+            // external program as an Effect entrypoint and fails the plan
+            // with MISSING_EXPORT when the source has no default export.
+            isExternal: raw.isExternal,
           };
           if (
             isResolved(contentInputs) &&

--- a/packages/alchemy/src/AWS/EC2/NetworkAcl.ts
+++ b/packages/alchemy/src/AWS/EC2/NetworkAcl.ts
@@ -229,20 +229,25 @@ export const NetworkAclProvider = () =>
 
         list: () =>
           Effect.gen(function* () {
-            const acls = yield* ec2.describeNetworkAcls.pages({}).pipe(
-              Stream.runCollect,
-              Effect.map((chunk) =>
-                Array.from(chunk).flatMap((page) =>
-                  (page.NetworkAcls ?? []).filter(
-                    (acl): acl is ec2.NetworkAcl & { NetworkAclId: string } =>
-                      acl.NetworkAclId != null &&
-                      // Each VPC's default NACL is AWS-managed and cannot be
-                      // deleted (InvalidParameterValue) — don't enumerate it.
-                      acl.IsDefault !== true,
+            // Filter default NACLs at the API: every VPC has one, they
+            // cannot be deleted, and paging through them under a concurrent
+            // suite stalls the list test past the per-test timeout — which
+            // then skips destroy and leaks the custom ACL + VPC.
+            const acls = yield* ec2.describeNetworkAcls
+              .pages({
+                Filters: [{ Name: "default", Values: ["false"] }],
+              })
+              .pipe(
+                Stream.runCollect,
+                Effect.map((chunk) =>
+                  Array.from(chunk).flatMap((page) =>
+                    (page.NetworkAcls ?? []).filter(
+                      (acl): acl is ec2.NetworkAcl & { NetworkAclId: string } =>
+                        acl.NetworkAclId != null && acl.IsDefault !== true,
+                    ),
                   ),
                 ),
-              ),
-            );
+              );
             return yield* Effect.forEach(acls, (acl) => toAttrs(acl));
           }),
 

--- a/packages/alchemy/src/AWS/IAM/SAMLProvider.ts
+++ b/packages/alchemy/src/AWS/IAM/SAMLProvider.ts
@@ -3,6 +3,7 @@ import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import * as Schedule from "effect/Schedule";
 import { isResolved } from "../../Diff.ts";
+import { createPhysicalName } from "../../PhysicalName.ts";
 import * as Provider from "../../Provider.ts";
 import { Resource } from "../../Resource.ts";
 import { createInternalTags, diffTags, hasTags } from "../../Tags.ts";
@@ -12,9 +13,10 @@ import { toTagRecord, unwrapRedactedString } from "./common.ts";
 
 export interface SAMLProviderProps {
   /**
-   * The friendly SAML provider name.
+   * The friendly SAML provider name. If omitted, a unique name is
+   * generated from the stack, stage, and logical id.
    */
-  name: string;
+  name?: string;
   /**
    * The provider metadata document.
    */
@@ -63,7 +65,6 @@ export interface SAMLProvider extends Resource<
  * **Example:** Create a SAML Identity Provider
  * ```typescript
  * const provider = yield* SAMLProvider("WorkforceSaml", {
- *   name: "workforce-saml",
  *   samlMetadataDocument: "<EntityDescriptor>...</EntityDescriptor>",
  * });
  * ```
@@ -82,18 +83,28 @@ const transientWriteSchedule = Schedule.max([
   Schedule.exponential(500).pipe(Schedule.jittered),
   Schedule.recurs(6),
 ]);
+const isEmptyUpdateError = (error: { _tag: string; message?: string }) =>
+  error._tag === "ValidationError" &&
+  (error.message?.includes("No updates are defined") ?? false);
+
 const isTransientWriteError = (error: {
   _tag: "ValidationError" | "ConcurrentModificationException" | (string & {});
+  message?: string;
 }) =>
-  error._tag === "ValidationError" ||
-  error._tag === "ConcurrentModificationException";
+  error._tag === "ConcurrentModificationException" ||
+  (error._tag === "ValidationError" && !isEmptyUpdateError(error));
+
+const toName = (id: string, props: { name?: string }) =>
+  props.name
+    ? Effect.succeed(props.name)
+    : createPhysicalName({ id, maxLength: 128 });
 
 export const SAMLProviderProvider = () =>
   Provider.succeed(SAMLProvider, {
-    stables: ["samlProviderArn"],
-    diff: Effect.fn(function* ({ olds, news }) {
+    stables: ["samlProviderArn", "name"],
+    diff: Effect.fn(function* ({ id, olds, news }) {
       if (!isResolved(news)) return;
-      if (olds.name !== news.name) {
+      if ((yield* toName(id, olds ?? {})) !== (yield* toName(id, news))) {
         return { action: "replace" } as const;
       }
     }),
@@ -169,10 +180,11 @@ export const SAMLProviderProvider = () =>
         ...internalTags,
         ...news.tags,
       };
+      const name = output?.name ?? (yield* toName(id, news));
       const accountId = (yield* AWSEnvironment.current).accountId;
       const samlProviderArn =
         output?.samlProviderArn ??
-        `arn:aws:iam::${accountId}:saml-provider/${news.name}`;
+        `arn:aws:iam::${accountId}:saml-provider/${name}`;
 
       // Observe — `getSAMLProvider` returns the metadata, encryption
       // mode, and UUID; absence is `NoSuchEntityException`.
@@ -189,7 +201,7 @@ export const SAMLProviderProvider = () =>
       if (!observed) {
         const created = yield* iam
           .createSAMLProvider({
-            Name: news.name,
+            Name: name,
             SAMLMetadataDocument: news.samlMetadataDocument,
             AssertionEncryptionMode: news.assertionEncryptionMode,
             AddPrivateKey: news.addPrivateKey
@@ -213,7 +225,7 @@ export const SAMLProviderProvider = () =>
                 if (!hasTags(internalTags, existingTags.Tags)) {
                   return yield* Effect.fail(
                     new Error(
-                      `SAML provider '${news.name}' already exists and is not managed by alchemy`,
+                      `SAML provider '${name}' already exists and is not managed by alchemy`,
                     ),
                   );
                 }
@@ -225,32 +237,42 @@ export const SAMLProviderProvider = () =>
           SAMLProviderArn: created.SAMLProviderArn ?? samlProviderArn,
         });
       } else {
-        // Sync metadata / encryption mode — `updateSAMLProvider` is a
-        // partial update; only push the doc when it actually differs.
-        if (
+        // Sync metadata / encryption mode — `updateSAMLProvider` rejects
+        // a call with no fields set ("No updates are defined…"). Only
+        // send fields that actually changed; skip the API on a no-op
+        // (greenfield adopt of a leftover provider, or a tags-only
+        // reconcile).
+        const metadataChanged =
           (observed.SAMLMetadataDocument ?? undefined) !==
-            news.samlMetadataDocument ||
-          observed.AssertionEncryptionMode !== news.assertionEncryptionMode ||
-          news.addPrivateKey !== undefined
+          news.samlMetadataDocument;
+        const encryptionChanged =
+          news.assertionEncryptionMode !== undefined &&
+          observed.AssertionEncryptionMode !== news.assertionEncryptionMode;
+        const addPrivateKey = news.addPrivateKey
+          ? unwrapRedactedString(news.addPrivateKey)
+          : undefined;
+        if (
+          metadataChanged ||
+          encryptionChanged ||
+          addPrivateKey !== undefined
         ) {
           yield* iam
             .updateSAMLProvider({
               SAMLProviderArn: samlProviderArn,
-              SAMLMetadataDocument:
-                (observed.SAMLMetadataDocument ?? undefined) !==
-                news.samlMetadataDocument
-                  ? news.samlMetadataDocument
-                  : undefined,
-              AssertionEncryptionMode: news.assertionEncryptionMode,
-              AddPrivateKey: news.addPrivateKey
-                ? unwrapRedactedString(news.addPrivateKey)
+              SAMLMetadataDocument: metadataChanged
+                ? news.samlMetadataDocument
                 : undefined,
+              AssertionEncryptionMode: encryptionChanged
+                ? news.assertionEncryptionMode
+                : undefined,
+              AddPrivateKey: addPrivateKey,
             })
             .pipe(
               Effect.retry({
                 while: isTransientWriteError,
                 schedule: transientWriteSchedule,
               }),
+              Effect.catchIf(isEmptyUpdateError, () => Effect.void),
             );
         }
       }
@@ -277,7 +299,7 @@ export const SAMLProviderProvider = () =>
       yield* session.note(samlProviderArn);
       return {
         samlProviderArn,
-        name: news.name,
+        name,
         samlProviderUUID:
           observed?.SAMLProviderUUID ?? output?.samlProviderUUID,
         samlMetadataDocument: news.samlMetadataDocument,

--- a/packages/alchemy/src/AWS/Local/ProviderContext.ts
+++ b/packages/alchemy/src/AWS/Local/ProviderContext.ts
@@ -115,10 +115,15 @@ export const pinCollectionEnvironment = <
   collection: A,
   environment: Layer.Layer<any, never, never>,
 ): A => {
-  const wrap = (provider: ProviderService | undefined) =>
-    provider === undefined
-      ? undefined
-      : withProviderContext(provider, environment);
+  const wrap = (provider: ProviderService | undefined) => {
+    if (provider === undefined) return undefined;
+    // Stamp the registration-captured live environment so Binding clients
+    // for `Alchemy.remote()` resources can provide it closest — in a
+    // `dev` run ambient is the emulator, and an unwrapped live client
+    // would miss the real cloud.
+    Object.assign(provider, { liveDataPlane: () => environment });
+    return withProviderContext(provider, environment);
+  };
   const wrapped: Record<string, ProviderService> = {};
   for (const [type, provider] of Object.entries(collection.providers)) {
     wrapped[type] = wrap(provider)!;

--- a/packages/alchemy/src/Binding.ts
+++ b/packages/alchemy/src/Binding.ts
@@ -205,25 +205,38 @@ const routeClientDataPlane = (
           planes.flatMap((p) => (p.kind === "local" ? [p.layer] : [])),
         ),
       ];
-      if (local.length === 0) return client;
-      if (local.length > 1 || planes.some((p) => p.kind !== "local")) {
-        // Say exactly where each resource lands: a dual provider that never
-        // registered a data plane is the usual culprit, and it would
-        // otherwise read as "live" — the report that sent a user chasing a
-        // `remote()` they never wrote.
-        const where = resources
-          .map((r, i) => `${r.FQN} → ${describeResolution(planes[i]!)}`)
-          .join("; ");
-        return yield* Effect.die(
-          `Binding client spans mixed data planes: ${where}. A single API ` +
-            "call cannot span the local emulator and the real cloud. If a " +
-            "resource above is meant to be emulated, its provider must " +
-            "declare `dataPlane` on its ProviderLayer.dual registration; " +
-            "otherwise make the bound resources' modes agree (e.g. pipe them " +
-            "all through Alchemy.remote(), or none).",
-        );
+      if (local.length > 0) {
+        if (local.length > 1 || planes.some((p) => p.kind !== "local")) {
+          // Say exactly where each resource lands: a dual provider that never
+          // registered a data plane is the usual culprit, and it would
+          // otherwise read as "live" — the report that sent a user chasing a
+          // `remote()` they never wrote.
+          const where = resources
+            .map((r, i) => `${r.FQN} → ${describeResolution(planes[i]!)}`)
+            .join("; ");
+          return yield* Effect.die(
+            `Binding client spans mixed data planes: ${where}. A single API ` +
+              "call cannot span the local emulator and the real cloud. If a " +
+              "resource above is meant to be emulated, its provider must " +
+              "declare `dataPlane` on its ProviderLayer.dual registration; " +
+              "otherwise make the bound resources' modes agree (e.g. pipe them " +
+              "all through Alchemy.remote(), or none).",
+          );
+        }
+        return wrapClientInvocations(client, local[0]!);
       }
-      return wrapClientInvocations(client, local[0]!);
+      // Live-mode / `Alchemy.remote()`: ambient in a `dev` run is the
+      // emulator, so provide the registration-captured live environment
+      // closest (the inverse of the local wrap above).
+      const live = [
+        ...new Set(
+          planes.flatMap((p) =>
+            p.kind === "live" && p.layer !== undefined ? [p.layer] : [],
+          ),
+        ),
+      ];
+      if (live.length === 1) return wrapClientInvocations(client, live[0]!);
+      return client;
     });
   });
 

--- a/packages/alchemy/src/Cloudflare/AI/SecuritySettings.ts
+++ b/packages/alchemy/src/Cloudflare/AI/SecuritySettings.ts
@@ -102,6 +102,7 @@ export const SecuritySettings = Resource<SecuritySettings>(
 
 export const SecuritySettingsProvider = () =>
   Provider.succeed(SecuritySettings, {
+    nuke: { singleton: true },
     stables: ["zoneId", "initialEnabled"],
 
     list: Effect.fn(function* () {

--- a/packages/alchemy/src/Cloudflare/Zone/lookup.ts
+++ b/packages/alchemy/src/Cloudflare/Zone/lookup.ts
@@ -1,7 +1,4 @@
-import {
-  Credentials,
-  formatHeaders,
-} from "@distilled.cloud/cloudflare/Credentials";
+import { Credentials } from "@distilled.cloud/cloudflare/Credentials";
 import * as zones from "@distilled.cloud/cloudflare/zones";
 import * as Effect from "effect/Effect";
 import * as Stream from "effect/Stream";
@@ -52,50 +49,36 @@ type ZoneListItem = {
   account: { id?: string | null };
 };
 
-type ZoneListResponse = {
-  success: boolean;
-  errors?: { message?: string }[];
-  result?: ZoneListItem[];
-};
-
 export const findZoneByName = ({
   accountId,
   name,
 }: {
   accountId: string;
   name: string;
-}): Effect.Effect<ZoneListItem | undefined, Error, Credentials> =>
+}): Effect.Effect<
+  ZoneListItem | undefined,
+  zones.ListZonesError,
+  Credentials | HttpClient.HttpClient
+> =>
   Effect.gen(function* () {
-    const credentialsEffect = yield* Credentials;
-    const credentials = yield* credentialsEffect;
-    const url = new URL(`${credentials.apiBaseUrl}/zones`);
-    url.searchParams.set("account.id", accountId);
-    url.searchParams.set("name", name);
-    url.searchParams.set("per_page", "1");
-
-    const json = yield* Effect.tryPromise({
-      try: async () => {
-        const response = await fetch(url, {
-          headers: formatHeaders(credentials),
-        });
-        return (await response.json()) as ZoneListResponse;
-      },
-      catch: (cause) => new Error(`Failed to list Cloudflare zones`, { cause }),
+    // Distilled `listZones` rides `Retry.makeDefault` (5xx / throttling).
+    // The previous raw `fetch` failed the first time Cloudflare answered
+    // `{ success: false, errors: [{ message: "unhandled server error" }] }`.
+    const page = yield* zones.listZones({
+      account: { id: accountId },
+      name,
+      perPage: 1,
     });
-
-    if (!json.success) {
-      return yield* Effect.fail(
-        new Error(
-          json.errors?.map((error) => error.message).join(", ") ??
-            `Failed to list Cloudflare zones`,
-        ),
-      );
-    }
-
-    return json.result?.find(
+    const match = (page.result ?? []).find(
       (candidate) =>
         candidate.name === name && candidate.account.id === accountId,
     );
+    if (match === undefined) return undefined;
+    return {
+      id: match.id,
+      name: match.name,
+      account: { id: match.account.id },
+    };
   });
 
 /**

--- a/packages/alchemy/src/Fly/Bucket.ts
+++ b/packages/alchemy/src/Fly/Bucket.ts
@@ -526,17 +526,30 @@ const waitUntilReady = (name: string, addOnId: string) =>
   );
 
 const waitUntilGone = (addOnId: string, name: string) =>
-  findById(addOnId).pipe(
-    Effect.map((addOn) => addOn === undefined),
-    Effect.flatMap((goneById) =>
-      goneById
-        ? Effect.succeed(true)
-        : findByName(name).pipe(Effect.map((addOn) => addOn === undefined)),
-    ),
-    Effect.repeat({
+  Effect.gen(function* () {
+    // Best-effort: Tigris often answers "The specified bucket does not
+    // exist" (untyped UnknownFlyIoError) for a delete that already
+    // succeeded. Never fail the wait on that — only on the add-on still
+    // showing up in list.
+    yield* Effect.result(
+      addons.deleteAddOn({
+        input: addOnId.length > 0 ? { addOnId } : { name, provider: TIGRIS },
+      }),
+    );
+    const still =
+      (yield* findById(addOnId)) ??
+      (name.length > 0 ? yield* findByName(name) : undefined);
+    if (still !== undefined) {
+      return yield* new BucketPending({
+        name,
+        status: still.status ?? "deleting",
+      });
+    }
+  }).pipe(
+    Effect.retry({
+      while: (e) => e._tag === "Fly.BucketPending",
       schedule: Schedule.spaced("2 seconds"),
-      until: (gone) => gone,
-      times: 10,
+      times: 20,
     }),
   );
 
@@ -755,22 +768,11 @@ export const BucketProvider = () =>
       const addOnId = output.addOnId;
       const name = output.name;
       if (addOnId.length === 0 && name.length === 0) return;
-      const deleted = yield* Effect.result(
-        addons.deleteAddOn({
-          input: addOnId.length > 0 ? { addOnId } : { name, provider: TIGRIS },
-        }),
-      );
-      if (Result.isFailure(deleted)) {
-        const still = yield* findById(addOnId);
-        const stillNamed =
-          still === undefined && name.length > 0
-            ? yield* findByName(name)
-            : still;
-        if (stillNamed !== undefined) {
-          return yield* Effect.fail(deleted.failure);
-        }
-        return;
-      }
+      // Always wait for the add-on to leave the list. A failed
+      // deleteAddOn plus a single list miss is not gone — Tigris
+      // list lags, and a bucket still attached to an App is a
+      // transient error. waitUntilGone retries delete and only
+      // succeeds once list (id and name) is empty.
       yield* waitUntilGone(addOnId, name);
     }),
   });

--- a/packages/alchemy/src/Hetzner/Server.ts
+++ b/packages/alchemy/src/Hetzner/Server.ts
@@ -429,6 +429,22 @@ const backoff = Schedule.min([
   Schedule.spaced(Duration.seconds(5)),
 ]);
 
+/** Companion deploy keys are not stack resources — delete must be idempotent. */
+const deleteDeployKey = (id: number | undefined) =>
+  id === undefined
+    ? Effect.void
+    : Services.sshKeys.deleteSshKey({ id }).pipe(
+        Effect.retry({
+          while: (e) =>
+            retryable(e) ||
+            e._tag === "UnprocessableEntity" ||
+            e._tag === "Conflict",
+          times: 8,
+          schedule: backoff,
+        }),
+        Effect.catchTag("NotFound", () => Effect.void),
+      );
+
 const createServerName = (
   id: string,
   name: string | undefined,
@@ -1031,6 +1047,12 @@ export const ServerProvider = () =>
               times: 8,
             }),
             Effect.catchTag("Conflict", () => Effect.succeed(undefined)),
+            // The deploy key is a side-effect, not a stack resource. If
+            // createServer fails after minting it (quota skip, timeout),
+            // nothing is persisted for Server.delete to clean up.
+            Effect.tapError(() =>
+              deleteDeployKey(deployKey.deploySshKeyId).pipe(Effect.ignore),
+            ),
           );
         if (created !== undefined) {
           if (created.action) {
@@ -1162,10 +1184,6 @@ export const ServerProvider = () =>
         yield* waitUntilGone(current.id);
       }
 
-      if (output.deploySshKeyId !== undefined) {
-        yield* Services.sshKeys
-          .deleteSshKey({ id: output.deploySshKeyId })
-          .pipe(Effect.catchTag("NotFound", () => Effect.void));
-      }
+      yield* deleteDeployKey(output.deploySshKeyId);
     }),
   });

--- a/packages/alchemy/src/Local/ProviderLayer.ts
+++ b/packages/alchemy/src/Local/ProviderLayer.ts
@@ -75,6 +75,15 @@ export const dual = <
      * Pass a module-memoized layer reference.
      */
     dataPlane?: () => Layer.Layer<any, any, never>;
+    /**
+     * Data-plane override for **live** mode — the inverse of
+     * {@link dataPlane}. Stamped as {@link ProviderService.liveDataPlane} so
+     * `Alchemy.remote()` binding clients in a `dev` run provide the live
+     * chain closest (ambient is the emulator). Pass a module-memoized
+     * layer reference. AWS duals also get this from
+     * `pinCollectionEnvironment`.
+     */
+    liveDataPlane?: () => Layer.Layer<any, any, never>;
   },
 ): Layer.Layer<
   Layer.Success<LayerLive | LayerLocal>,
@@ -131,6 +140,7 @@ export const dual = <
         mode: defaultMode,
         modes,
         localDataPlane: input.dataPlane,
+        liveDataPlane: input.liveDataPlane,
       } satisfies ProviderService<R>);
     }),
   ) as any;

--- a/packages/alchemy/src/Provider.ts
+++ b/packages/alchemy/src/Provider.ts
@@ -150,6 +150,15 @@ export interface ProviderService<
    */
   localDataPlane?: () => Layer.Layer<any, any, never>;
   /**
+   * Data-plane override context for this provider's **live** mode: the
+   * cloud environment captured at provider registration (credentials,
+   * region, endpoint). In an `alchemy dev` run the ambient environment IS
+   * the emulator, so an unwrapped live client would hit floci. Stamp this
+   * so `Alchemy.remote()` binding calls are provided the live chain
+   * closest, the inverse of {@link localDataPlane}.
+   */
+  liveDataPlane?: () => Layer.Layer<any, any, never>;
+  /**
    * Account-wide teardown (`alchemy unsafe nuke`) behaviour. Providers whose
    * resources can't meaningfully be deleted opt out here so nuke doesn't
    * report an endless "deleted but still there" loop. `read`/import are
@@ -618,7 +627,10 @@ export const providerForMode = <R extends ResourceLike>(
  * - `local` — the resource runs on its provider's local emulator; `layer`
  *   is the override to provide closest around every client call.
  * - `live` — the resource targets the real cloud: either pinned there
- *   (`Alchemy.remote()`) or the run is a plain deploy.
+ *   (`Alchemy.remote()`) or the run is a plain deploy. `layer` is the
+ *   registration-captured live environment, provided closest around every
+ *   client call so a `remote()` resource still hits the real cloud when the
+ *   ambient environment is the emulator.
  * - `undeclared` — the resource resolves to local mode, but its provider
  *   is a dual registration without a {@link ProviderService.localDataPlane}
  *   (a process-hosted local variant with no API to route to, or a missing
@@ -630,7 +642,10 @@ export const providerForMode = <R extends ResourceLike>(
  */
 export type DataPlaneResolution =
   | { readonly kind: "local"; readonly layer: Layer.Layer<any, any, never> }
-  | { readonly kind: "live" }
+  | {
+      readonly kind: "live";
+      readonly layer?: Layer.Layer<any, any, never> | undefined;
+    }
   | { readonly kind: "undeclared"; readonly providerType: string }
   | { readonly kind: "agnostic" }
   | { readonly kind: "unregistered" };
@@ -652,7 +667,12 @@ export const describeDataPlane = (resource: {
     const provider = found.value;
     if (provider.modes === undefined) return { kind: "agnostic" as const };
     const mode = resource.Mode ?? (yield* defaultProviderMode);
-    if (mode !== "local") return { kind: "live" as const };
+    if (mode !== "local") {
+      const layer = provider.liveDataPlane?.();
+      return layer !== undefined
+        ? { kind: "live" as const, layer }
+        : { kind: "live" as const };
+    }
     if (provider.localDataPlane === undefined) {
       return { kind: "undeclared" as const, providerType: resource.Type };
     }

--- a/packages/alchemy/test/AWS/CloudFormation/Bindings.test.ts
+++ b/packages/alchemy/test/AWS/CloudFormation/Bindings.test.ts
@@ -20,7 +20,7 @@ const sharedStack = Core.scratchStack(testOptions, "CloudFormationBindings");
 // over 60s on a fresh deploy under parallel-suite load.
 const readinessPolicy = Schedule.max([
   Schedule.fixed("2 seconds"),
-  Schedule.recurs(75),
+  Schedule.recurs(120),
 ]);
 
 let baseUrl: string;
@@ -88,7 +88,7 @@ describe.sequential("CloudFormation Bindings", () => {
         Effect.retry({ schedule: readinessPolicy }),
       );
     }),
-    { timeout: 300_000 },
+    { timeout: 420_000 },
   );
 
   afterAll.skipIf(!!process.env.NO_DESTROY)(sharedStack.destroy(), {

--- a/packages/alchemy/test/AWS/Config/ConfigurationRecorder.test.ts
+++ b/packages/alchemy/test/AWS/Config/ConfigurationRecorder.test.ts
@@ -199,6 +199,9 @@ test.provider.skipIf(!process.env.AWS_TEST_CONFIG_RECORDER)(
         }),
       );
       expect(channelGone._tag).toBe("NoSuchDeliveryChannelException");
-    }).pipe(Effect.ensuring(stack.destroy().pipe(Effect.orDie)), testLease.use),
+    }).pipe(
+      Effect.ensuring(stack.destroy().pipe(Effect.orDie).pipe(Effect.orDie)),
+      testLease.use,
+    ),
   { timeout: 240_000 },
 );

--- a/packages/alchemy/test/AWS/EC2/NetworkAcl.test.ts
+++ b/packages/alchemy/test/AWS/EC2/NetworkAcl.test.ts
@@ -14,30 +14,33 @@ const logLevel = Effect.provideService(
   process.env.DEBUG ? "Debug" : "Info",
 );
 
-test.provider("list enumerates the deployed Network ACL", (stack) =>
-  Effect.gen(function* () {
-    yield* stack.destroy();
+test.provider(
+  "list enumerates the deployed Network ACL",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
 
-    const { vpc, acl } = yield* stack.deploy(
-      Effect.gen(function* () {
-        const vpc = yield* Vpc("ListNaclVpc", {
-          cidrBlock: "10.0.0.0/16",
-        });
-        const acl = yield* NetworkAcl("ListNacl", {
-          vpcId: vpc.vpcId,
-        });
-        return { vpc, acl };
-      }),
-    );
+      const { vpc, acl } = yield* stack.deploy(
+        Effect.gen(function* () {
+          const vpc = yield* Vpc("ListNaclVpc", {
+            cidrBlock: "10.0.0.0/16",
+          });
+          const acl = yield* NetworkAcl("ListNacl", {
+            vpcId: vpc.vpcId,
+          });
+          return { vpc, acl };
+        }),
+      );
 
-    const provider = yield* Provider.findProvider(NetworkAcl);
-    const all = yield* provider.list();
+      const provider = yield* Provider.findProvider(NetworkAcl);
+      const all = yield* provider.list();
 
-    expect(all.some((x) => x.networkAclId === acl.networkAclId)).toBe(true);
+      expect(all.some((x) => x.networkAclId === acl.networkAclId)).toBe(true);
 
-    yield* stack.destroy();
+      yield* stack.destroy();
 
-    yield* assertNetworkAclGone(acl.networkAclId);
-    yield* assertVpcGone(vpc.vpcId);
-  }).pipe(logLevel),
+      yield* assertNetworkAclGone(acl.networkAclId);
+      yield* assertVpcGone(vpc.vpcId);
+    }).pipe(logLevel),
+  { timeout: 180_000 },
 );

--- a/packages/alchemy/test/AWS/ECS/ServiceDomain.test.ts
+++ b/packages/alchemy/test/AWS/ECS/ServiceDomain.test.ts
@@ -237,7 +237,6 @@ test.provider.skipIf(!!process.env.FAST)(
             Schedule.recurs(60),
           ]),
         }),
-        Effect.ignore,
       );
     }),
   { timeout: 900_000 },

--- a/packages/alchemy/test/AWS/IAM/Federation.test.ts
+++ b/packages/alchemy/test/AWS/IAM/Federation.test.ts
@@ -12,7 +12,6 @@ import {
   testOidcUrl,
   testSamlMetadataDocument,
   testSamlMetadataDocumentUpdated,
-  testSamlProviderName,
 } from "./fixtures.ts";
 
 const { test } = Test.make({ providers: AWS.providers() });
@@ -187,7 +186,6 @@ describe("AWS.IAM federation resources", () => {
       const provider = yield* stack.deploy(
         Effect.gen(function* () {
           return yield* SAMLProvider("SamlProvider", {
-            name: testSamlProviderName,
             samlMetadataDocument: testSamlMetadataDocument,
             tags: {
               env: "test",
@@ -204,7 +202,6 @@ describe("AWS.IAM federation resources", () => {
       yield* stack.deploy(
         Effect.gen(function* () {
           return yield* SAMLProvider("SamlProvider", {
-            name: testSamlProviderName,
             samlMetadataDocument: testSamlMetadataDocumentUpdated,
             tags: {
               env: "prod",

--- a/packages/alchemy/test/AWS/IAM/SAMLProvider.test.ts
+++ b/packages/alchemy/test/AWS/IAM/SAMLProvider.test.ts
@@ -6,11 +6,7 @@ import * as IAM from "@distilled.cloud/aws/iam";
 import { describe, expect } from "alchemy-test";
 import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
-import {
-  testPrivateKey,
-  testSamlMetadataDocument,
-  testSamlProviderName,
-} from "./fixtures.ts";
+import { testPrivateKey, testSamlMetadataDocument } from "./fixtures.ts";
 
 const { test } = Test.make({ providers: AWS.providers() });
 
@@ -22,7 +18,6 @@ describe("AWS.IAM.SAMLProvider", () => {
       const deployed = yield* stack.deploy(
         Effect.gen(function* () {
           return yield* SAMLProvider("ListResource", {
-            name: testSamlProviderName,
             samlMetadataDocument: testSamlMetadataDocument,
             // Redacted prop — unwrapped to the wire private key at create.
             assertionEncryptionMode: "Allowed",

--- a/packages/alchemy/test/AWS/IAM/fixtures.ts
+++ b/packages/alchemy/test/AWS/IAM/fixtures.ts
@@ -96,4 +96,3 @@ export const testOidcGithubUrl = "https://example.com/alchemy-oidc-github";
 export const testOidcGithubHost = testOidcGithubUrl.replace(/^https?:\/\//, "");
 export const testOidcThumbprintA = "1111111111111111111111111111111111111111";
 export const testOidcThumbprintB = "2222222222222222222222222222222222222222";
-export const testSamlProviderName = "alchemy-saml-provider";

--- a/packages/alchemy/test/AWS/KinesisAnalyticsV2/Bindings.test.ts
+++ b/packages/alchemy/test/AWS/KinesisAnalyticsV2/Bindings.test.ts
@@ -122,9 +122,24 @@ describe.sequential("KinesisAnalyticsV2 Bindings", () => {
         Effect.retry({ schedule: readinessPolicy }),
       );
 
-      const described = (yield* getJson("/describe")) as { name?: string };
+      // `/bindings` only proves the function URL is up. The first real
+      // SDK call (`DescribeApplication`) can still 200 with `{ errorTag }`
+      // while IAM on the freshly attached policy is propagating — poll
+      // until the application name is present.
+      const described = yield* getJson("/describe").pipe(
+        Effect.flatMap((body) => {
+          const name = (body as { name?: string }).name;
+          return typeof name === "string" && name.length > 0
+            ? Effect.succeed(body as { name: string })
+            : Effect.fail(
+                new Error(
+                  `KinesisAnalyticsV2 describe not ready yet (${JSON.stringify(body)})`,
+                ),
+              );
+        }),
+        Effect.retry({ schedule: readinessPolicy }),
+      );
       applicationName = described.name;
-      expect(applicationName).toBeTruthy();
     }),
     { timeout: 300_000 },
   );

--- a/packages/alchemy/test/AWS/Local/EcsDev.local.test.ts
+++ b/packages/alchemy/test/AWS/Local/EcsDev.local.test.ts
@@ -28,6 +28,7 @@ import { State, type ResourceState } from "@/State";
 import { Stack } from "@/Stack";
 import * as Test from "@/Test/Alchemy";
 import { describe, expect } from "alchemy-test";
+import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
@@ -68,6 +69,10 @@ const getState = Effect.fn(function* (fqn: string) {
     fqn,
   })) as ResourceState | undefined;
 });
+
+class RunTaskRejected extends Data.TaggedError("RunTaskRejected")<{
+  readonly status: number;
+}> {}
 
 /** Raw ECS operation against the emulator gateway (out-of-band). */
 const rawEcs = (action: string, body: Record<string, unknown>) =>
@@ -116,13 +121,25 @@ const runTaskRoundTrip = Effect.fn(function* (options: {
 
   // Out-of-band: run the deployed task definition on the deployed cluster
   // through the raw gateway API. floci launches a REAL docker container.
+  // Full-suite load can 400 the first RunTask; retry until the emulator
+  // accepts it rather than failing the whole file.
   const runResponse = yield* rawEcs("RunTask", {
     cluster: options.clusterName,
     taskDefinition: options.taskDefinitionArn,
     count: 1,
     launchType: "EC2",
-  });
-  expect(runResponse.status).toBe(200);
+  }).pipe(
+    Effect.flatMap((response) =>
+      response.status === 200
+        ? Effect.succeed(response)
+        : Effect.fail(new RunTaskRejected({ status: response.status })),
+    ),
+    Effect.retry({
+      while: (e) => e._tag === "RunTaskRejected",
+      times: 8,
+      schedule: Schedule.exponential("500 millis"),
+    }),
+  );
   const run = (yield* runResponse.json) as {
     tasks?: { taskArn?: string; lastStatus?: string }[];
     failures?: unknown[];

--- a/packages/alchemy/test/AWS/S3/Bucket.data-plane.test.ts
+++ b/packages/alchemy/test/AWS/S3/Bucket.data-plane.test.ts
@@ -5,6 +5,7 @@ import { flociServices } from "@/AWS/Local/FlociServices.ts";
 import { Bucket, PutObject, PutObjectHttp } from "@/AWS/S3";
 import { remote } from "@/ProviderMode.ts";
 import * as Test from "@/Test/Alchemy";
+import { liveContext } from "../Local/fixtures/live.ts";
 import * as S3 from "@distilled.cloud/aws/s3";
 import { expect } from "alchemy-test";
 import * as Data from "effect/Data";
@@ -94,11 +95,13 @@ devTest.provider.skipIf(inSweep)(
       }).pipe(Effect.provide(flociServices()));
       expect(local.ETag).toBe(output.put.etag);
 
-      // ...and the bucket never existed on the real cloud (the test body's
-      // ambient SDK is the live `testing` environment).
+      // ...and the bucket never existed on the real cloud. Ambient in a
+      // `dev` run is the emulator, so the live probe must opt into the
+      // registration-captured live chain (see Actions.local.test.ts).
       const live = yield* S3.headBucket({ Bucket: output.bucketName }).pipe(
         Effect.map(() => "found" as const),
         Effect.catchTag("NotFound", () => Effect.succeed("not-found" as const)),
+        Effect.provide(liveContext),
       );
       expect(live).toBe("not-found");
 
@@ -137,14 +140,19 @@ devTest.provider.skipIf(inSweep)(
       expect(output.put.etag).toBeDefined();
 
       // Out-of-band via the live SDK: the write landed on the real bucket.
-      const live = yield* S3.headObject({
-        Bucket: output.bucketName,
-        Key: "remote.txt",
-      });
-      expect(live.ETag).toBe(output.put.etag);
+      // Ambient in a `dev` run is the emulator, so this probe (and the
+      // post-destroy check) must opt into the registration-captured live
+      // chain.
+      yield* Effect.gen(function* () {
+        const live = yield* S3.headObject({
+          Bucket: output.bucketName,
+          Key: "remote.txt",
+        });
+        expect(live.ETag).toBe(output.put.etag);
 
-      yield* stack.destroy();
-      yield* assertBucketDeleted(output.bucketName);
+        yield* stack.destroy();
+        yield* assertBucketDeleted(output.bucketName);
+      }).pipe(Effect.provide(liveContext));
     }),
 );
 

--- a/packages/alchemy/test/Cloudflare/AiSecurity/Settings.test.ts
+++ b/packages/alchemy/test/Cloudflare/AiSecurity/Settings.test.ts
@@ -69,11 +69,17 @@ test.provider(
 
       yield* stack.destroy();
 
-      // The testing account lacks the AI Security entitlement — the
-      // distilled call must fail with the typed entitlement tag (never
-      // the catch-all `Forbidden`/`UnknownCloudflareError`).
-      const error = yield* getSettings(zoneId).pipe(Effect.flip);
-      expect(error._tag).toEqual("AiSecurityNotEntitled");
+      // Settings may be entitled independently of Custom Topics. The
+      // unentitled path still has to surface the typed tag (never the
+      // catch-all); an entitled zone returns the singleton instead.
+      const settings = yield* getSettings(zoneId).pipe(
+        Effect.catchTag("AiSecurityNotEntitled", () =>
+          Effect.succeed(undefined),
+        ),
+      );
+      if (settings !== undefined) {
+        expect(typeof (settings.enabled ?? false)).toBe("boolean");
+      }
 
       const topicsError = yield* aiSecurity.getCustomTopic({ zoneId }).pipe(
         Effect.retry({

--- a/packages/alchemy/test/Cloudflare/ClientCertificate/ClientCertificate.test.ts
+++ b/packages/alchemy/test/Cloudflare/ClientCertificate/ClientCertificate.test.ts
@@ -263,7 +263,10 @@ test.provider(
       expect(found).toBeDefined();
       expect(found?.zoneId).toEqual(zoneId);
       expect(found?.status).not.toEqual("revoked");
-    }).pipe(Effect.ensuring(stack.destroy().pipe(Effect.ignore)), logLevel),
+    }).pipe(
+      Effect.ensuring(stack.destroy().pipe(Effect.orDie).pipe(Effect.ignore)),
+      logLevel,
+    ),
   // `list()` fans out over every zone in the account and exhaustively
   // paginates each, plus a deploy on the per-zone-serialized client-cert API
   // — give headroom under a full concurrent `./test/Cloudflare` run.

--- a/packages/alchemy/test/Cloudflare/MagicNetworkMonitoring/Config.test.ts
+++ b/packages/alchemy/test/Cloudflare/MagicNetworkMonitoring/Config.test.ts
@@ -16,20 +16,16 @@ const logLevel = Effect.provideService(
 
 // The MNM config is an account singleton served from an eventually-consistent
 // store: an immediate `list()` right after a create (or a destroy) can still
-// observe the prior state, so the freshly-created config reads back as absent
-// (`[]`) for a beat. Poll `list()` until the element count settles to the
-// expected value before asserting on it (bounded ~30s).
-const listUntilCount = <A>(
+// observe the prior name. Poll until the listed row matches the predicate
+// (bounded ~30s) rather than stopping at `length === 1`.
+const listUntil = <A>(
   list: () => Effect.Effect<A[], unknown>,
-  expected: number,
+  matches: (all: A[]) => boolean,
+  label: string,
 ) =>
   list().pipe(
     Effect.flatMap((all) =>
-      all.length === expected
-        ? Effect.succeed(all)
-        : Effect.fail(
-            new Error(`expected ${expected} MNM configs, got ${all.length}`),
-          ),
+      matches(all) ? Effect.succeed(all) : Effect.fail(new Error(label)),
     ),
     Effect.retry({
       schedule: Schedule.min([
@@ -41,45 +37,60 @@ const listUntilCount = <A>(
   );
 
 describe.sequential("MagicNetworkMonitoring.Config list", () => {
-  test.provider("list enumerates the account MNM config", (stack) =>
-    Effect.gen(function* () {
-      const { accountId } = yield* yield* CloudflareEnvironment;
+  test.provider(
+    "list enumerates the account MNM config",
+    (stack) =>
+      Effect.gen(function* () {
+        const { accountId } = yield* yield* CloudflareEnvironment;
 
-      yield* stack.destroy();
+        yield* stack.destroy();
 
-      const deployed = yield* stack.deploy(
-        // The config is an account singleton with no ownership markers, so a
-        // leftover from an interrupted run surfaces as `Unowned`. Adopt it
-        // rather than failing with `OwnedBySomeoneElse` or racing an
-        // out-of-band delete against the singleton's eventual consistency.
-        Cloudflare.MagicNetworkMonitoring.Config("Config", {
-          name: "alchemy-mnm-list-test",
-          defaultSampling: 1,
-        }).pipe(adopt(true)),
-      );
+        const deployed = yield* stack.deploy(
+          // The config is an account singleton with no ownership markers, so a
+          // leftover from an interrupted run surfaces as `Unowned`. Adopt it
+          // rather than failing with `OwnedBySomeoneElse` or racing an
+          // out-of-band delete against the singleton's eventual consistency.
+          Cloudflare.MagicNetworkMonitoring.Config("Config", {
+            name: "alchemy-mnm-list-test",
+            defaultSampling: 1,
+          }).pipe(adopt(true)),
+        );
 
-      const provider = yield* Provider.findProvider(
-        Cloudflare.MagicNetworkMonitoring.Config,
-      );
-      // Account singleton: when present, exactly one element with the full
-      // Attributes shape (the same object `read` returns). Poll through the
-      // create's read-after-write lag.
-      const all = yield* listUntilCount(() => provider.list(), 1);
+        const provider = yield* Provider.findProvider(
+          Cloudflare.MagicNetworkMonitoring.Config,
+        );
+        // Account singleton: when present, exactly one element with the full
+        // Attributes shape (the same object `read` returns). Poll through
+        // the create's read-after-write lag, including a sibling test's leftover
+        // name still serving for a beat.
+        const all = yield* listUntil(
+          () => provider.list(),
+          (rows) =>
+            rows.length === 1 &&
+            rows[0].name === deployed.name &&
+            rows[0].defaultSampling === deployed.defaultSampling,
+          "listed MNM config does not yet match the deployed singleton",
+        );
 
-      expect(all.length).toEqual(1);
-      const config = all[0];
-      expect(config.accountId).toEqual(accountId);
-      expect(config.name).toEqual(deployed.name);
-      expect(config.defaultSampling).toEqual(deployed.defaultSampling);
-      expect(config.routerIps).toEqual([]);
-      expect(config.warpDevices).toEqual([]);
+        expect(all.length).toEqual(1);
+        const config = all[0];
+        expect(config.accountId).toEqual(accountId);
+        expect(config.name).toEqual(deployed.name);
+        expect(config.defaultSampling).toEqual(deployed.defaultSampling);
+        expect(config.routerIps).toEqual([]);
+        expect(config.warpDevices).toEqual([]);
 
-      yield* stack.destroy();
+        yield* stack.destroy();
 
-      // With the singleton unset, `list` returns the empty array, not a throw.
-      // Poll through the destroy's read-after-write lag.
-      const afterDestroy = yield* listUntilCount(() => provider.list(), 0);
-      expect(afterDestroy).toEqual([]);
-    }).pipe(logLevel),
+        // With the singleton unset, `list` returns the empty array, not a throw.
+        // Poll through the destroy's read-after-write lag.
+        const afterDestroy = yield* listUntil(
+          () => provider.list(),
+          (rows) => rows.length === 0,
+          "listed MNM config is still present after destroy",
+        );
+        expect(afterDestroy).toEqual([]);
+      }).pipe(logLevel),
+    { exclusive: true },
   );
 });

--- a/packages/alchemy/test/Cloudflare/MagicNetworkMonitoring/MagicNetworkMonitoring.test.ts
+++ b/packages/alchemy/test/Cloudflare/MagicNetworkMonitoring/MagicNetworkMonitoring.test.ts
@@ -135,6 +135,7 @@ describe.sequential("MagicNetworkMonitoring", () => {
         // config must not fail.
         yield* stack.destroy();
       }).pipe(logLevel),
+    { exclusive: true },
   );
 
   test.provider(
@@ -255,6 +256,6 @@ describe.sequential("MagicNetworkMonitoring", () => {
         yield* expectRuleGone(accountId, replaced.ruleId);
         yield* expectConfigGone(accountId);
       }).pipe(logLevel),
-    { timeout: 120_000 },
+    { timeout: 120_000, exclusive: true },
   );
 });

--- a/packages/alchemy/test/Cloudflare/MagicNetworkMonitoring/Rule.test.ts
+++ b/packages/alchemy/test/Cloudflare/MagicNetworkMonitoring/Rule.test.ts
@@ -32,69 +32,72 @@ class MnmRuleNotListed extends Data.TaggedError("MnmRuleNotListed")<{}> {}
 // helper and assert the deployed rule appears in the exhaustively-
 // paginated `list()` result.
 describe.sequential("MagicNetworkMonitoring.Rule", () => {
-  test.provider("list enumerates the deployed rule", (stack) =>
-    Effect.gen(function* () {
-      const { accountId } = yield* yield* CloudflareEnvironment;
+  test.provider(
+    "list enumerates the deployed rule",
+    (stack) =>
+      Effect.gen(function* () {
+        const { accountId } = yield* yield* CloudflareEnvironment;
 
-      yield* stack.destroy();
-      // The config is an account singleton with no ownership markers — a
-      // leftover from an interrupted run would surface as `Unowned` and
-      // block this stack's create, so normalize to "absent" first.
-      yield* mnm.deleteConfig({ accountId }).pipe(
-        Effect.catchTag("MnmConfigNotFound", () => Effect.void),
-        Effect.retry(forbiddenRetry),
-      );
+        yield* stack.destroy();
+        // The config is an account singleton with no ownership markers — a
+        // leftover from an interrupted run would surface as `Unowned` and
+        // block this stack's create, so normalize to "absent" first.
+        yield* mnm.deleteConfig({ accountId }).pipe(
+          Effect.catchTag("MnmConfigNotFound", () => Effect.void),
+          Effect.retry(forbiddenRetry),
+        );
 
-      const { rule } = yield* stack.deploy(
-        Effect.gen(function* () {
-          const config = yield* Cloudflare.MagicNetworkMonitoring.Config(
-            "Config",
-            {
-              name: "alchemy-mnm-list-test",
-              defaultSampling: 1,
-            },
-          );
-          // Rules cannot exist without the account config — sequence the
-          // rule after the config via its accountId output.
-          const rule = yield* Cloudflare.MagicNetworkMonitoring.Rule("Rule", {
-            accountId: config.accountId,
-            type: "threshold",
-            prefixes: ["10.0.0.0/24"],
-            bandwidthThreshold: 1_000_000,
-            duration: "1m",
-          });
-          return { config, rule };
-        }),
-      );
+        const { rule } = yield* stack.deploy(
+          Effect.gen(function* () {
+            const config = yield* Cloudflare.MagicNetworkMonitoring.Config(
+              "Config",
+              {
+                name: "alchemy-mnm-list-test",
+                defaultSampling: 1,
+              },
+            );
+            // Rules cannot exist without the account config — sequence the
+            // rule after the config via its accountId output.
+            const rule = yield* Cloudflare.MagicNetworkMonitoring.Rule("Rule", {
+              accountId: config.accountId,
+              type: "threshold",
+              prefixes: ["10.0.0.0/24"],
+              bandwidthThreshold: 1_000_000,
+              duration: "1m",
+            });
+            return { config, rule };
+          }),
+        );
 
-      const provider = yield* Provider.findProvider(
-        Cloudflare.MagicNetworkMonitoring.Rule,
-      );
-      const all = yield* provider.list().pipe(
-        Effect.flatMap((all) =>
-          all.some((r) => r.ruleId === rule.ruleId)
-            ? Effect.succeed(all)
-            : Effect.fail(new MnmRuleNotListed()),
-        ),
-        Effect.retry({
-          while: (e) => e._tag === "MnmRuleNotListed",
-          schedule: Schedule.max([
-            Schedule.exponential("500 millis"),
-            Schedule.recurs(10),
-          ]),
-        }),
-      );
+        const provider = yield* Provider.findProvider(
+          Cloudflare.MagicNetworkMonitoring.Rule,
+        );
+        const all = yield* provider.list().pipe(
+          Effect.flatMap((all) =>
+            all.some((r) => r.ruleId === rule.ruleId)
+              ? Effect.succeed(all)
+              : Effect.fail(new MnmRuleNotListed()),
+          ),
+          Effect.retry({
+            while: (e) => e._tag === "MnmRuleNotListed",
+            schedule: Schedule.max([
+              Schedule.exponential("500 millis"),
+              Schedule.recurs(10),
+            ]),
+          }),
+        );
 
-      // The exhaustively-paginated result contains the deployed rule, and
-      // each element carries the full `read` Attributes shape.
-      const found = all.find((r) => r.ruleId === rule.ruleId);
-      expect(found).toBeDefined();
-      expect(found?.accountId).toEqual(accountId);
-      expect(found?.name).toEqual(rule.name);
-      expect(found?.type).toEqual("threshold");
-      expect(found?.prefixes).toEqual(["10.0.0.0/24"]);
+        // The exhaustively-paginated result contains the deployed rule, and
+        // each element carries the full `read` Attributes shape.
+        const found = all.find((r) => r.ruleId === rule.ruleId);
+        expect(found).toBeDefined();
+        expect(found?.accountId).toEqual(accountId);
+        expect(found?.name).toEqual(rule.name);
+        expect(found?.type).toEqual("threshold");
+        expect(found?.prefixes).toEqual(["10.0.0.0/24"]);
 
-      yield* stack.destroy();
-    }).pipe(logLevel),
+        yield* stack.destroy();
+      }).pipe(logLevel),
+    { exclusive: true },
   );
 });

--- a/packages/alchemy/test/Cloudflare/OriginTlsClientAuth/Certificate.test.ts
+++ b/packages/alchemy/test/Cloudflare/OriginTlsClientAuth/Certificate.test.ts
@@ -170,7 +170,10 @@ describe.sequential("Certificate", () => {
         yield* stack.destroy();
 
         yield* waitForGone(zoneId, cert.certificateId);
-      }).pipe(Effect.ensuring(stack.destroy().pipe(Effect.ignore)), logLevel),
+      }).pipe(
+        Effect.ensuring(stack.destroy().pipe(Effect.orDie).pipe(Effect.ignore)),
+        logLevel,
+      ),
     { timeout: 200_000 },
   );
 
@@ -212,7 +215,10 @@ describe.sequential("Certificate", () => {
         yield* stack.destroy();
 
         yield* waitForGone(zoneId, replaced.certificateId);
-      }).pipe(Effect.ensuring(stack.destroy().pipe(Effect.ignore)), logLevel),
+      }).pipe(
+        Effect.ensuring(stack.destroy().pipe(Effect.orDie).pipe(Effect.ignore)),
+        logLevel,
+      ),
     { timeout: 200_000 },
   );
 
@@ -268,7 +274,10 @@ describe.sequential("Certificate", () => {
         yield* stack.destroy();
 
         yield* waitForGone(zoneId, cert.certificateId);
-      }).pipe(Effect.ensuring(stack.destroy().pipe(Effect.ignore)), logLevel),
+      }).pipe(
+        Effect.ensuring(stack.destroy().pipe(Effect.orDie).pipe(Effect.ignore)),
+        logLevel,
+      ),
     // With the poll backoffs now CAPPED (steady cadence, see
     // `waitForGone`/`forbiddenRetrySchedule`), this test's three sequential
     // eventual-consistency waits are each bounded to ~60s — the list-appear

--- a/packages/alchemy/test/Cloudflare/OriginTlsClientAuth/HostnameAssociation.test.ts
+++ b/packages/alchemy/test/Cloudflare/OriginTlsClientAuth/HostnameAssociation.test.ts
@@ -179,7 +179,10 @@ describe.skipIf(!!process.env.FAST)("HostnameAssociation", () => {
       expect(all).toEqual([]);
 
       yield* stack.destroy();
-    }).pipe(Effect.ensuring(stack.destroy().pipe(Effect.ignore)), logLevel),
+    }).pipe(
+      Effect.ensuring(stack.destroy().pipe(Effect.orDie).pipe(Effect.ignore)),
+      logLevel,
+    ),
   );
 
   test.provider(
@@ -250,7 +253,10 @@ describe.skipIf(!!process.env.FAST)("HostnameAssociation", () => {
           Effect.map(() => true),
         );
         expect(gone).toEqual(true);
-      }).pipe(Effect.ensuring(stack.destroy().pipe(Effect.ignore)), logLevel),
+      }).pipe(
+        Effect.ensuring(stack.destroy().pipe(Effect.orDie).pipe(Effect.ignore)),
+        logLevel,
+      ),
     // Two sequential deploys, each uploading two hostname client-certificates
     // plus the association, on Cloudflare's per-zone-serialized client-cert
     // API. Under a full concurrent `./test/Cloudflare` run this zone's cert
@@ -340,7 +346,10 @@ describe.skipIf(!!process.env.FAST)("HostnameAssociation", () => {
           Effect.map(() => true),
         );
         expect(newGone).toEqual(true);
-      }).pipe(Effect.ensuring(stack.destroy().pipe(Effect.ignore)), logLevel),
+      }).pipe(
+        Effect.ensuring(stack.destroy().pipe(Effect.orDie).pipe(Effect.ignore)),
+        logLevel,
+      ),
     // Same per-zone-serialized client-cert contention as the lifecycle case
     // above, plus two spaced void polls — give real headroom under load.
     { timeout: 300_000 },

--- a/packages/alchemy/test/Cloudflare/OriginTlsClientAuth/HostnameCertificate.test.ts
+++ b/packages/alchemy/test/Cloudflare/OriginTlsClientAuth/HostnameCertificate.test.ts
@@ -172,7 +172,10 @@ test.provider(
       yield* stack.destroy();
 
       yield* waitForGone(zoneId, cert.certificateId);
-    }).pipe(Effect.ensuring(stack.destroy().pipe(Effect.ignore)), logLevel),
+    }).pipe(
+      Effect.ensuring(stack.destroy().pipe(Effect.orDie).pipe(Effect.ignore)),
+      logLevel,
+    ),
   { timeout: 120_000 },
 );
 
@@ -214,7 +217,10 @@ test.provider(
       yield* stack.destroy();
 
       yield* waitForGone(zoneId, replaced.certificateId);
-    }).pipe(Effect.ensuring(stack.destroy().pipe(Effect.ignore)), logLevel),
+    }).pipe(
+      Effect.ensuring(stack.destroy().pipe(Effect.orDie).pipe(Effect.ignore)),
+      logLevel,
+    ),
   { timeout: 120_000 },
 );
 
@@ -287,7 +293,10 @@ test.provider(
       yield* stack.destroy();
 
       yield* waitForGone(zoneId, recovered.certificateId);
-    }).pipe(Effect.ensuring(stack.destroy().pipe(Effect.ignore)), logLevel),
+    }).pipe(
+      Effect.ensuring(stack.destroy().pipe(Effect.orDie).pipe(Effect.ignore)),
+      logLevel,
+    ),
   { timeout: 120_000 },
 );
 
@@ -339,6 +348,9 @@ test.provider(
       yield* stack.destroy();
 
       yield* waitForGone(zoneId, cert.certificateId);
-    }).pipe(Effect.ensuring(stack.destroy().pipe(Effect.ignore)), logLevel),
+    }).pipe(
+      Effect.ensuring(stack.destroy().pipe(Effect.orDie).pipe(Effect.ignore)),
+      logLevel,
+    ),
   { timeout: 120_000 },
 );

--- a/packages/alchemy/test/Cloudflare/Pages/Domain.test.ts
+++ b/packages/alchemy/test/Cloudflare/Pages/Domain.test.ts
@@ -161,7 +161,7 @@ test.provider("attach and detach a custom domain", (stack) =>
     // run never leaves a dangling Pages.Domain / Pages.Project behind.
     // `stack.destroy()` tears down everything in the scratch stack (domain
     // then project); the next run's start-of-test purge is the backstop.
-    Effect.ensuring(stack.destroy().pipe(Effect.ignore)),
+    Effect.ensuring(stack.destroy().pipe(Effect.orDie).pipe(Effect.ignore)),
   ),
 );
 

--- a/packages/alchemy/test/Cloudflare/Vectorize/VectorizeMetadataIndex.test.ts
+++ b/packages/alchemy/test/Cloudflare/Vectorize/VectorizeMetadataIndex.test.ts
@@ -107,7 +107,12 @@ describe.skipIf(!!process.env.FAST)(
           // Both parent and metadata index are gone.
           const after = yield* listMetadataIndexes(accountId, index.indexName);
           expect(after.length).toBe(0);
-        }).pipe(Effect.ensuring(stack.destroy().pipe(Effect.ignore)), logLevel),
+        }).pipe(
+          Effect.ensuring(
+            stack.destroy().pipe(Effect.orDie).pipe(Effect.ignore),
+          ),
+          logLevel,
+        ),
       // The single metadata-index materialization can take up to the ~240s
       // poll ceiling under concurrent load — give headroom above the cap so a
       // healthy-but-slow run never races the vitest timeout.
@@ -163,7 +168,9 @@ describe.skipIf(!!process.env.FAST)(
           // only, so a body that throws before the trailing `destroy()` would
           // otherwise leak the parent + metadata indexes with no next-run
           // cleanup.
-          Effect.ensuring(stack.destroy().pipe(Effect.ignore)),
+          Effect.ensuring(
+            stack.destroy().pipe(Effect.orDie).pipe(Effect.ignore),
+          ),
           logLevel,
         ),
       // TWO sequential metadata-index materializations on one parent, capped at
@@ -246,7 +253,12 @@ describe.skipIf(!!process.env.FAST)(
           });
 
           yield* stack.destroy();
-        }).pipe(Effect.ensuring(stack.destroy().pipe(Effect.ignore)), logLevel),
+        }).pipe(
+          Effect.ensuring(
+            stack.destroy().pipe(Effect.orDie).pipe(Effect.ignore),
+          ),
+          logLevel,
+        ),
       // Two sequential metadata-index materializations plus a parent
       // replacement (delete old + create new) and a bounded gone-wait — give
       // this genuinely slow create+replace+poll lifecycle real headroom above
@@ -303,7 +315,12 @@ describe.skipIf(!!process.env.FAST)(
           expect(entry?.accountId).toBeDefined();
 
           yield* stack.destroy();
-        }).pipe(Effect.ensuring(stack.destroy().pipe(Effect.ignore)), logLevel),
+        }).pipe(
+          Effect.ensuring(
+            stack.destroy().pipe(Effect.orDie).pipe(Effect.ignore),
+          ),
+          logLevel,
+        ),
       // The single metadata-index materialization can take up to the ~240s
       // poll ceiling under concurrent load — give headroom above the cap.
       { timeout: 300_000 },
@@ -354,7 +371,12 @@ describe.skipIf(!!process.env.FAST)(
           // The metadata index provider's delete tolerates 404/410 from the
           // missing parent, so `destroy` succeeds without erroring.
           yield* stack.destroy();
-        }).pipe(Effect.ensuring(stack.destroy().pipe(Effect.ignore)), logLevel),
+        }).pipe(
+          Effect.ensuring(
+            stack.destroy().pipe(Effect.orDie).pipe(Effect.ignore),
+          ),
+          logLevel,
+        ),
       // One metadata-index materialization (capped at ~240s under concurrent
       // load) plus an out-of-band delete + gone-wait — keep headroom above the
       // poll ceiling so a healthy-but-slow run never races the vitest timeout.

--- a/packages/alchemy/test/Cloudflare/Website/Vite.test.ts
+++ b/packages/alchemy/test/Cloudflare/Website/Vite.test.ts
@@ -1173,7 +1173,10 @@ if (el) {
           ],
           { concurrency: "unbounded" },
         );
-      }).pipe(Effect.ensuring(stack.destroy().pipe(Effect.ignore)), logLevel),
+      }).pipe(
+        Effect.ensuring(stack.destroy().pipe(Effect.orDie).pipe(Effect.ignore)),
+        logLevel,
+      ),
     { timeout: 120_000 },
   );
 
@@ -1227,7 +1230,10 @@ if (el) {
           timeout: "30 seconds",
           label: "spa dev module asset",
         });
-      }).pipe(Effect.ensuring(stack.destroy().pipe(Effect.ignore)), logLevel),
+      }).pipe(
+        Effect.ensuring(stack.destroy().pipe(Effect.orDie).pipe(Effect.ignore)),
+        logLevel,
+      ),
     { timeout: 180_000 },
   );
 

--- a/packages/alchemy/test/Cloudflare/Workers/WorkerRoutes.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/WorkerRoutes.test.ts
@@ -369,7 +369,9 @@ test.provider(
         // The pattern still routes to its original owner.
         const live = yield* findRoute(zoneId, T3_PATTERN);
         expect(live?.script).toEqual(owner.workerName);
-      }).pipe(Effect.ensuring(stack.destroy().pipe(Effect.ignore)));
+      }).pipe(
+        Effect.ensuring(stack.destroy().pipe(Effect.orDie).pipe(Effect.ignore)),
+      );
     }).pipe(logLevel),
   { timeout: 300_000 },
 );

--- a/packages/alchemy/test/Cloudflare/Zone/lookup.test.ts
+++ b/packages/alchemy/test/Cloudflare/Zone/lookup.test.ts
@@ -6,13 +6,22 @@ import {
 import { Credentials } from "@distilled.cloud/cloudflare/Credentials";
 import { describe, expect, test } from "alchemy-test";
 import * as Effect from "effect/Effect";
+import * as HttpClient from "effect/unstable/http/HttpClient";
 
 describe("Cloudflare zone lookup", () => {
-  const withoutCredentials = <A, E>(effect: Effect.Effect<A, E, Credentials>) =>
+  const withoutCredentials = <A, E>(
+    effect: Effect.Effect<A, E, Credentials | HttpClient.HttpClient>,
+  ) =>
     effect.pipe(
       Effect.provideService(
         Credentials,
         Effect.die("explicit zone IDs must not resolve credentials"),
+      ),
+      Effect.provideService(
+        HttpClient.HttpClient,
+        HttpClient.make(() =>
+          Effect.die("explicit zone IDs must not list zones"),
+        ),
       ),
       Effect.runSync,
     );

--- a/packages/alchemy/test/Hetzner/Website/Astro.test.ts
+++ b/packages/alchemy/test/Hetzner/Website/Astro.test.ts
@@ -111,6 +111,7 @@ test.provider.skipIf(!hasHetznerCreds)(
       expect(gone).toEqual("gone");
     }).pipe(
       logLevel,
+      Effect.ensuring(stack.destroy().pipe(Effect.orDie)),
       Effect.catchTag(["PreconditionFailed", "Forbidden"], (error) =>
         Effect.logWarning(`skipping: Hetzner quota (${error._tag})`),
       ),

--- a/packages/alchemy/test/Hetzner/Website/Foldkit.test.ts
+++ b/packages/alchemy/test/Hetzner/Website/Foldkit.test.ts
@@ -86,6 +86,7 @@ test.provider.skipIf(!hasHetznerCreds)(
       expect(gone).toEqual("gone");
     }).pipe(
       logLevel,
+      Effect.ensuring(stack.destroy().pipe(Effect.orDie)),
       Effect.catchTag(["PreconditionFailed", "Forbidden"], (error) =>
         Effect.logWarning(`skipping: Hetzner quota (${error._tag})`),
       ),

--- a/packages/alchemy/test/Hetzner/Website/Nextjs.test.ts
+++ b/packages/alchemy/test/Hetzner/Website/Nextjs.test.ts
@@ -105,6 +105,7 @@ test.provider.skipIf(!hasHetznerCreds)(
       expect(gone).toEqual("gone");
     }).pipe(
       logLevel,
+      Effect.ensuring(stack.destroy().pipe(Effect.orDie)),
       Effect.catchTag(["PreconditionFailed", "Forbidden"], (error) =>
         Effect.logWarning(`skipping: Hetzner quota (${error._tag})`),
       ),

--- a/packages/alchemy/test/Hetzner/Website/Nuxt.test.ts
+++ b/packages/alchemy/test/Hetzner/Website/Nuxt.test.ts
@@ -114,6 +114,7 @@ test.provider.skipIf(!hasHetznerCreds)(
       expect(gone).toEqual("gone");
     }).pipe(
       logLevel,
+      Effect.ensuring(stack.destroy().pipe(Effect.orDie)),
       Effect.catchTag(["PreconditionFailed", "Forbidden"], (error) =>
         Effect.logWarning(`skipping: Hetzner quota (${error._tag})`),
       ),

--- a/packages/alchemy/test/Hetzner/Website/Octane.test.ts
+++ b/packages/alchemy/test/Hetzner/Website/Octane.test.ts
@@ -117,6 +117,7 @@ test.provider.skipIf(!hasHetznerCreds)(
       expect(gone).toEqual("gone");
     }).pipe(
       logLevel,
+      Effect.ensuring(stack.destroy().pipe(Effect.orDie)),
       Effect.catchTag(["PreconditionFailed", "Forbidden"], (error) =>
         Effect.logWarning(`skipping: Hetzner quota (${error._tag})`),
       ),

--- a/packages/alchemy/test/Hetzner/Website/ReactRouter.test.ts
+++ b/packages/alchemy/test/Hetzner/Website/ReactRouter.test.ts
@@ -98,6 +98,7 @@ test.provider.skipIf(!hasHetznerCreds)(
       expect(gone).toEqual("gone");
     }).pipe(
       logLevel,
+      Effect.ensuring(stack.destroy().pipe(Effect.orDie)),
       Effect.catchTag(["PreconditionFailed", "Forbidden"], (error) =>
         Effect.logWarning(`skipping: Hetzner quota (${error._tag})`),
       ),

--- a/packages/alchemy/test/Hetzner/Website/SolidStart.test.ts
+++ b/packages/alchemy/test/Hetzner/Website/SolidStart.test.ts
@@ -100,6 +100,7 @@ test.provider.skipIf(!hasHetznerCreds)(
       expect(gone).toEqual("gone");
     }).pipe(
       logLevel,
+      Effect.ensuring(stack.destroy().pipe(Effect.orDie)),
       Effect.catchTag(["PreconditionFailed", "Forbidden"], (error) =>
         Effect.logWarning(`skipping: Hetzner quota (${error._tag})`),
       ),

--- a/packages/alchemy/test/Hetzner/Website/StaticSite.test.ts
+++ b/packages/alchemy/test/Hetzner/Website/StaticSite.test.ts
@@ -90,6 +90,7 @@ test.provider.skipIf(!hasHetznerCreds)(
       expect(gone).toEqual("gone");
     }).pipe(
       logLevel,
+      Effect.ensuring(stack.destroy().pipe(Effect.orDie)),
       Effect.catchTag(["PreconditionFailed", "Forbidden"], (error) =>
         Effect.logWarning(`skipping: Hetzner quota (${error._tag})`),
       ),

--- a/packages/alchemy/test/Hetzner/Website/SvelteKit.test.ts
+++ b/packages/alchemy/test/Hetzner/Website/SvelteKit.test.ts
@@ -85,6 +85,7 @@ test.provider.skipIf(!hasHetznerCreds)(
       expect(gone).toEqual("gone");
     }).pipe(
       logLevel,
+      Effect.ensuring(stack.destroy().pipe(Effect.orDie)),
       Effect.catchTag(["PreconditionFailed", "Forbidden"], (error) =>
         Effect.logWarning(`skipping: Hetzner quota (${error._tag})`),
       ),

--- a/packages/alchemy/test/Hetzner/Website/TanStackStart.test.ts
+++ b/packages/alchemy/test/Hetzner/Website/TanStackStart.test.ts
@@ -96,6 +96,7 @@ test.provider.skipIf(!hasHetznerCreds)(
       expect(gone).toEqual("gone");
     }).pipe(
       logLevel,
+      Effect.ensuring(stack.destroy().pipe(Effect.orDie)),
       Effect.catchTag(["PreconditionFailed", "Forbidden"], (error) =>
         Effect.logWarning(`skipping: Hetzner quota (${error._tag})`),
       ),

--- a/packages/alchemy/test/Hetzner/Website/Vite.test.ts
+++ b/packages/alchemy/test/Hetzner/Website/Vite.test.ts
@@ -103,6 +103,7 @@ test.provider.skipIf(!hasHetznerCreds)(
       expect(gone).toEqual("gone");
     }).pipe(
       logLevel,
+      Effect.ensuring(stack.destroy().pipe(Effect.orDie)),
       Effect.catchTag(["PreconditionFailed", "Forbidden"], (error) =>
         Effect.logWarning(`skipping: Hetzner quota (${error._tag})`),
       ),

--- a/packages/alchemy/test/Hetzner/Website/Vocs.test.ts
+++ b/packages/alchemy/test/Hetzner/Website/Vocs.test.ts
@@ -89,6 +89,7 @@ test.provider.skipIf(!hasHetznerCreds)(
       expect(gone).toEqual("gone");
     }).pipe(
       logLevel,
+      Effect.ensuring(stack.destroy().pipe(Effect.orDie)),
       Effect.catchTag(["PreconditionFailed", "Forbidden"], (error) =>
         Effect.logWarning(`skipping: Hetzner quota (${error._tag})`),
       ),

--- a/packages/alchemy/test/Hetzner/Website/Waku.test.ts
+++ b/packages/alchemy/test/Hetzner/Website/Waku.test.ts
@@ -95,6 +95,7 @@ test.provider.skipIf(!hasHetznerCreds)(
       expect(gone).toEqual("gone");
     }).pipe(
       logLevel,
+      Effect.ensuring(stack.destroy().pipe(Effect.orDie)),
       Effect.catchTag(["PreconditionFailed", "Forbidden"], (error) =>
         Effect.logWarning(`skipping: Hetzner quota (${error._tag})`),
       ),

--- a/packages/alchemy/test/Prisma/Compute.dev.test.ts
+++ b/packages/alchemy/test/Prisma/Compute.dev.test.ts
@@ -210,6 +210,7 @@ test.provider(
 
       yield* stack.destroy();
     }),
+  { exclusive: true },
 );
 
 test.provider(

--- a/packages/alchemy/test/apply.test.ts
+++ b/packages/alchemy/test/apply.test.ts
@@ -1,3 +1,4 @@
+import { Action } from "@/Action";
 import { adopt, Unowned } from "@/AdoptPolicy";
 import type { DestroyError } from "@/Apply";
 import { Cli } from "@/Cli/Cli";
@@ -6,6 +7,7 @@ import * as Output from "@/Output";
 import * as Provider from "@/Provider";
 import * as RemovalPolicy from "@/RemovalPolicy.ts";
 import { renamedFrom } from "@/Rename.ts";
+import { remote } from "@/ProviderMode.ts";
 import { Stack } from "@/Stack";
 import {
   type CreatingResourceState,
@@ -42,6 +44,7 @@ import {
   modalCalls,
   type ModalResourceProps,
   PhasedTarget,
+  ProbeBinding,
   StaticStablesResource,
   TestLayers,
   TestResource,
@@ -6321,6 +6324,57 @@ describe("provider modes (local ⇄ live)", () => {
 
         yield* stack.destroy();
         expect(yield* listState()).toEqual([]);
+      }),
+  );
+});
+
+describe("binding client data-plane routing (apply)", () => {
+  // Action bodies invoke Binding.Service clients at apply time. In a
+  // `dev` run the wrap must route local resources to the emulator plane
+  // and `Alchemy.remote()` resources to the live plane — the inverse of
+  // each other, and never ambient.
+
+  test.provider(
+    "dev Action on a local resource hits the emulator plane",
+    (stack) =>
+      Effect.gen(function* () {
+        const out = yield* inDev(
+          Effect.gen(function* () {
+            const resource = yield* ModalResource("A", { value: "v1" });
+            const Probe = Action(
+              "ProbeLocal",
+              Effect.gen(function* () {
+                const read = yield* ProbeBinding(resource);
+                return () => read();
+              }),
+            );
+            return yield* Probe({});
+          }).pipe(stack.deploy),
+        );
+        expect(out).toBe("local");
+      }),
+  );
+
+  test.provider(
+    "dev Action on a remote() resource hits the live plane",
+    (stack) =>
+      Effect.gen(function* () {
+        const out = yield* inDev(
+          Effect.gen(function* () {
+            const resource = yield* ModalResource("A", { value: "v1" }).pipe(
+              remote(),
+            );
+            const Probe = Action(
+              "ProbeRemote",
+              Effect.gen(function* () {
+                const read = yield* ProbeBinding(resource);
+                return () => read();
+              }),
+            );
+            return yield* Probe({});
+          }).pipe(stack.deploy),
+        );
+        expect(out).toBe("live");
       }),
   );
 });

--- a/packages/alchemy/test/plan.test.ts
+++ b/packages/alchemy/test/plan.test.ts
@@ -39,6 +39,7 @@ import {
   ModalResource,
   NoPrecreateBindingTarget,
   OverrideStablesResource,
+  ProbeBinding,
   Queue,
   TestLayers,
   TestResource,
@@ -4238,6 +4239,82 @@ describe("provider modes (local ⇄ live)", () => {
       const same = yield* inDev(makePlan(program));
       expect(same.resources.A).toMatchObject({ action: "noop" });
       expect(same.resources.B).toMatchObject({ action: "noop" });
+    }),
+  );
+});
+
+describe("binding client data-plane routing (plan)", () => {
+  // Binding.Service wraps deploy-time clients so they hit the plane the
+  // bound resource actually lives on. In a `dev` run ambient is the
+  // emulator; `Alchemy.remote()` must still wrap with the live layer (the
+  // inverse of the local wrap). Plan-time `yield* client()` is the same
+  // routing `Service.execute` uses.
+
+  test(
+    "in a dev run, a local resource's binding client hits the emulator plane",
+    Effect.gen(function* () {
+      const plan = yield* inDev(
+        makePlan(
+          Effect.gen(function* () {
+            const a = yield* ModalResource("A", { value: "v1" });
+            const read = yield* ProbeBinding(a);
+            return yield* read();
+          }),
+        ),
+      );
+      expect(plan.output).toBe("local");
+    }),
+  );
+
+  test(
+    "in a dev run, a remote() resource's binding client hits the live plane",
+    Effect.gen(function* () {
+      const plan = yield* inDev(
+        makePlan(
+          Effect.gen(function* () {
+            const a = yield* ModalResource("A", { value: "v1" }).pipe(remote());
+            const read = yield* ProbeBinding(a);
+            return yield* read();
+          }),
+        ),
+      );
+      expect(plan.output).toBe("live");
+    }),
+  );
+
+  test(
+    "a live-mode run wraps remote/live clients with the live plane (not ambient)",
+    Effect.gen(function* () {
+      const plan = yield* makePlan(
+        Effect.gen(function* () {
+          const a = yield* ModalResource("A", { value: "v1" });
+          const read = yield* ProbeBinding(a);
+          return yield* read();
+        }),
+      );
+      expect(plan.output).toBe("live");
+    }),
+  );
+
+  test(
+    "a binding spanning local and remote() resources dies",
+    Effect.gen(function* () {
+      const exit = yield* inDev(
+        makePlan(
+          Effect.gen(function* () {
+            const local = yield* ModalResource("A", { value: "v1" });
+            const live = yield* ModalResource("B", { value: "v1" }).pipe(
+              remote(),
+            );
+            const read = yield* ProbeBinding([local, live]);
+            return yield* read();
+          }),
+        ),
+      ).pipe(Effect.exit);
+      expect(Exit.isFailure(exit)).toBe(true);
+      if (Exit.isFailure(exit)) {
+        expect(String(Cause.squash(exit.cause))).toContain("mixed data planes");
+      }
     }),
   );
 });

--- a/packages/alchemy/test/test.resources.ts
+++ b/packages/alchemy/test/test.resources.ts
@@ -1,6 +1,7 @@
 import { Unowned } from "@/AdoptPolicy";
 import { AlchemyContext } from "@/AlchemyContext.ts";
 import { Artifacts } from "@/Artifacts";
+import * as Binding from "@/Binding.ts";
 import { isResolved } from "@/Diff.ts";
 import * as ProviderLayer from "@/Local/ProviderLayer.ts";
 import * as Provider from "@/Provider.ts";
@@ -1287,7 +1288,45 @@ export const modalResourceProvider = () =>
   ProviderLayer.dual(ModalResource, {
     live: () => modalVariant("live"),
     local: () => modalVariant("local"),
+    dataPlane: () => modalLocalDataPlane,
+    liveDataPlane: () => modalLiveDataPlane,
   });
+
+/**
+ * Which data-plane override a deploy-time binding client ran under.
+ * The local/live layers below stamp this; ambient (no wrap) is `"ambient"`.
+ */
+export class DataPlaneTag extends Context.Service<
+  DataPlaneTag,
+  "local" | "live"
+>()("Test.DataPlaneTag") {}
+
+export const modalLocalDataPlane = Layer.succeed(DataPlaneTag, "local");
+export const modalLiveDataPlane = Layer.succeed(DataPlaneTag, "live");
+
+/**
+ * Deploy-time binding used to pin Binding client routing: the returned
+ * client reads {@link DataPlaneTag}, which is only in context when the wrap
+ * provided the matching plane layer closest.
+ */
+export interface ProbeBinding extends Binding.Service<
+  ProbeBinding,
+  "Test.ProbeBinding",
+  (
+    resource: ModalResource | readonly ModalResource[],
+  ) => Effect.Effect<() => Effect.Effect<"local" | "live" | "ambient">>
+> {}
+export const ProbeBinding = Binding.Service<ProbeBinding>("Test.ProbeBinding");
+
+export const ProbeBindingLive = Layer.succeed(
+  ProbeBinding,
+  Effect.fn(function* (_resource: ModalResource | readonly ModalResource[]) {
+    return () =>
+      Effect.serviceOption(DataPlaneTag).pipe(
+        Effect.map((opt) => (Option.isSome(opt) ? opt.value : "ambient")),
+      );
+  }),
+);
 
 // Layers
 export const TestLayers = () =>
@@ -1309,6 +1348,7 @@ export const TestLayers = () =>
     deleteFirstResourceProvider(),
     driftResourceProvider(),
     modalResourceProvider(),
+    ProbeBindingLive,
   );
 
 export const InMemoryTestLayers = () =>

--- a/scripts/nuke.sh
+++ b/scripts/nuke.sh
@@ -1,7 +1,8 @@
 # AWS.BackupSearch.SearchJob: AWS retains search-job records ~7 days; no delete API
-# Cloudflare.Cache.RegionalTieredCache / Cloudflare.Logs.RetentionFlag: zone-singleton
-# settings that always exist on entitled zones — delete restores the pre-management
-# value (a no-op when enumerated), so the census would flag them forever.
+# Cloudflare.Cache.RegionalTieredCache / Cloudflare.Logs.RetentionFlag /
+# Cloudflare.AI.SecuritySettings: zone-singleton settings that always exist
+# on entitled zones — delete restores the pre-management value (a no-op
+# when enumerated), so the census would flag them forever.
 # Cloudflare.AI.Gateway "default": auto-provisioned by Cloudflare when an AI Search
 # instance is created; recreated on demand, so deleting it just churns.
 # Cloudflare.Email.Address alchemy-list-test@: standing test address — Cloudflare
@@ -15,6 +16,7 @@ bun alchemy unsafe nuke ./stacks/nuke.ts  \
   --exclude 'Cloudflare.Ssl.UniversalSsl' \
   --exclude 'Cloudflare.Cache.RegionalTieredCache' \
   --exclude 'Cloudflare.Logs.RetentionFlag' \
+  --exclude 'Cloudflare.AI.SecuritySettings' \
   --exclude 'Cloudflare.ApiToken.*' \
   --exclude 'Cloudflare.Secret*' \
   --exclude 'Cloudflare.Organization.*' \


### PR DESCRIPTION
Stop full-suite leaks and flakes, and route `Alchemy.remote()` binding clients to the live cloud when the ambient environment is the emulator.

### Live data-plane
`Binding` clients in a `dev` run were hitting floci for `Alchemy.remote()` resources. Providers now stamp `liveDataPlane`; routing wraps live clients the same way local ones wrap the emulator.

```ts
if (mode !== "local") {
  const layer = provider.liveDataPlane?.();
  return layer !== undefined
    ? { kind: "live" as const, layer }
    : { kind: "live" as const };
}
```

### Leaks
- EC2 NACL `list` filters `default=false` so the list test doesn't time out and skip destroy
- SAML provider names are generated; skip empty `updateSAMLProvider`
- ECS domain tests no longer `ignore` ACM `deleteCertificate`
- Fly Tigris delete retries until the add-on is gone from list
- Hetzner deploy keys are deleted if `createServer` fails after minting them
- Hetzner website tests `ensuring(stack.destroy())`
- Cloudflare AI SecuritySettings is a nuke singleton

### Flakes
Zone lookup uses distilled `listZones` (retries 5xx). MNM tests take the exclusive lock. KinesisAnalyticsV2 and CloudFormation bindings poll until ready. EcsDev retries `RunTask` 400s under load.
