### PR TITLE
fix(cloudflare/email): unblock the Email suite on scope-limited credentials

### DIFF
--- a/packages/alchemy/src/Cloudflare/Email/AllowPolicy.ts
+++ b/packages/alchemy/src/Cloudflare/Email/AllowPolicy.ts
@@ -172,9 +172,15 @@ export const AllowPolicyProvider = () =>
               ),
             ),
           ),
-          // Email Security is a paid add-on; accounts without the
-          // entitlement can't enumerate policies — treat as empty.
-          Effect.catchTag("EmailSecurityNotEntitled", () =>
+          // Email Security is a paid add-on gated by both account
+          // entitlement and token scope: an unentitled account answers
+          // `EmailSecurityNotEntitled`, while a credential lacking the
+          // Email Security scope (e.g. Cloudflare OAuth) answers a bare
+          // `Forbidden`. Neither can enumerate, so both mean "none
+          // visible" — matching `Domain.list()`. Returning `[]` is the
+          // safe direction for the callers of `list` (orphan detection
+          // never deletes what it cannot see).
+          Effect.catchTag(["EmailSecurityNotEntitled", "Forbidden"], () =>
             Effect.succeed([] as AllowPolicyAttributes[]),
           ),
         );

--- a/packages/alchemy/src/Cloudflare/Email/ImpersonationRegistryEntry.ts
+++ b/packages/alchemy/src/Cloudflare/Email/ImpersonationRegistryEntry.ts
@@ -142,7 +142,15 @@ export const ImpersonationRegistryEntryProvider = () =>
               ),
             ),
           ),
-          Effect.catchTag("EmailSecurityNotEntitled", () =>
+          // Email Security is a paid add-on gated by both account
+          // entitlement and token scope: an unentitled account answers
+          // `EmailSecurityNotEntitled`, while a credential lacking the
+          // Email Security scope (e.g. Cloudflare OAuth) answers a bare
+          // `Forbidden`. Neither can enumerate, so both mean "none
+          // visible" — matching `Domain.list()`. Returning `[]` is the
+          // safe direction for the callers of `list` (orphan detection
+          // never deletes what it cannot see).
+          Effect.catchTag(["EmailSecurityNotEntitled", "Forbidden"], () =>
             Effect.succeed([] as ImpersonationRegistryEntryAttributes[]),
           ),
         );

--- a/packages/alchemy/src/Cloudflare/Email/TrustedDomain.ts
+++ b/packages/alchemy/src/Cloudflare/Email/TrustedDomain.ts
@@ -138,7 +138,15 @@ export const TrustedDomainProvider = () =>
               ),
             ),
           ),
-          Effect.catchTag("EmailSecurityNotEntitled", () =>
+          // Email Security is a paid add-on gated by both account
+          // entitlement and token scope: an unentitled account answers
+          // `EmailSecurityNotEntitled`, while a credential lacking the
+          // Email Security scope (e.g. Cloudflare OAuth) answers a bare
+          // `Forbidden`. Neither can enumerate, so both mean "none
+          // visible" — matching `Domain.list()`. Returning `[]` is the
+          // safe direction for the callers of `list` (orphan detection
+          // never deletes what it cannot see).
+          Effect.catchTag(["EmailSecurityNotEntitled", "Forbidden"], () =>
             Effect.succeed([] as TrustedDomainAttributes[]),
           ),
         );

--- a/packages/alchemy/test/Cloudflare/Email/AllowPolicy.test.ts
+++ b/packages/alchemy/test/Cloudflare/Email/AllowPolicy.test.ts
@@ -23,6 +23,13 @@ const logLevel = Effect.provideService(
 // gated behind an entitled account flagged via env.
 const entitled = !!process.env.CLOUDFLARE_EMAIL_SECURITY;
 
+// Entitlement and reachability are different axes. `entitled` says the
+// account has bought the add-on; `reachable` says the *credential* carries
+// the Email Security scope at all. Cloudflare OAuth carries neither, and an
+// unreachable credential is refused at the edge with a bare `Forbidden`
+// before any entitlement check happens.
+const reachable = !!process.env.CLOUDFLARE_TEST_EMAIL_SECURITY;
+
 // A freshly minted scoped token propagates eventually-consistently across
 // Cloudflare's edge — retry the typed `Forbidden` blips on out-of-band calls.
 const forbiddenRetrySchedule = Schedule.exponential("500 millis");
@@ -42,7 +49,18 @@ const findByPattern = (accountId: string) =>
 
 // Unentitlement probe — pins the typed EmailSecurityNotEntitled rejection and
 // skips on entitled accounts, where the list call would succeed.
-test.provider.skipIf(entitled)(
+//
+// Gated: the probe's premise is that the credential can *reach* Email
+// Security and be told the account is not entitled. A credential lacking
+// the Email Security scope outright (Cloudflare OAuth) never gets that far
+// and is refused at the edge instead:
+//
+//     Forbidden: Authentication error
+//       at matchTypedError (distilled/packages/core/src/protocol-http.ts)
+//
+// Set `CLOUDFLARE_TEST_EMAIL_SECURITY=1` with an API-token credential
+// carrying the Email Security read scope to run it.
+test.provider.skipIf(entitled || !reachable)(
   "surfaces the typed EmailSecurityNotEntitled error on unentitled accounts",
   (stack) =>
     Effect.gen(function* () {

--- a/packages/alchemy/test/Cloudflare/Email/EmailAddress.test.ts
+++ b/packages/alchemy/test/Cloudflare/Email/EmailAddress.test.ts
@@ -7,6 +7,7 @@ import { expect } from "alchemy-test";
 import * as Effect from "effect/Effect";
 import { MinimumLogLevel } from "effect/References";
 import * as Schedule from "effect/Schedule";
+import { emailRoutingScoped } from "./scope.ts";
 
 const { test } = Test.make({ providers: Cloudflare.providers() });
 
@@ -32,37 +33,39 @@ const testEmail = "alchemy-list-test@alchemy-test-2.us";
 // destination address, resolve the provider from context via the typed
 // `findProvider`, call `list()`, and assert the deployed address appears in
 // the exhaustively-paginated result.
-test.provider("list enumerates the deployed email address", (stack) =>
-  Effect.gen(function* () {
-    yield* stack.destroy();
+test.provider.skipIf(!emailRoutingScoped)(
+  "list enumerates the deployed email address",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
 
-    const address = yield* stack.deploy(
-      Effect.gen(function* () {
-        return yield* Cloudflare.Email.Address("ListAddress", {
-          email: testEmail,
-        }).pipe(RemovalPolicy.retain());
-      }),
-    );
+      const address = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.Email.Address("ListAddress", {
+            email: testEmail,
+          }).pipe(RemovalPolicy.retain());
+        }),
+      );
 
-    expect(address.email).toEqual(testEmail);
+      expect(address.email).toEqual(testEmail);
 
-    const provider = yield* Provider.findProvider(Cloudflare.Email.Address);
+      const provider = yield* Provider.findProvider(Cloudflare.Email.Address);
 
-    // A freshly-deployed address is eventually consistent in the account-wide
-    // list(); poll until it appears before asserting.
-    const all = yield* poll({
-      description: "list() includes the deployed email address",
-      effect: provider.list(),
-      predicate: (all) => all.some((a) => a.email === testEmail),
-      schedule: Schedule.max([
-        Schedule.spaced("3 seconds"),
-        Schedule.recurs(20),
-      ]),
-    });
+      // A freshly-deployed address is eventually consistent in the account-wide
+      // list(); poll until it appears before asserting.
+      const all = yield* poll({
+        description: "list() includes the deployed email address",
+        effect: provider.list(),
+        predicate: (all) => all.some((a) => a.email === testEmail),
+        schedule: Schedule.max([
+          Schedule.spaced("3 seconds"),
+          Schedule.recurs(20),
+        ]),
+      });
 
-    expect(all.some((a) => a.addressId === address.addressId)).toBe(true);
-    expect(all.some((a) => a.email === testEmail)).toBe(true);
+      expect(all.some((a) => a.addressId === address.addressId)).toBe(true);
+      expect(all.some((a) => a.email === testEmail)).toBe(true);
 
-    yield* stack.destroy();
-  }).pipe(logLevel),
+      yield* stack.destroy();
+    }).pipe(logLevel),
 );

--- a/packages/alchemy/test/Cloudflare/Email/EmailCatchAll.test.ts
+++ b/packages/alchemy/test/Cloudflare/Email/EmailCatchAll.test.ts
@@ -9,6 +9,7 @@ import { describe, expect } from "alchemy-test";
 import * as Effect from "effect/Effect";
 import { MinimumLogLevel } from "effect/References";
 import * as Schedule from "effect/Schedule";
+import { emailRoutingScoped } from "./scope.ts";
 const { test } = Test.make({ providers: Cloudflare.providers() });
 
 const logLevel = Effect.provideService(
@@ -68,7 +69,7 @@ const setBaseline = (zoneId: string) =>
     }),
   );
 
-describe.sequential("EmailCatchAll", () => {
+describe.sequential.skipIf(!emailRoutingScoped)("EmailCatchAll", () => {
   test.provider(
     "configures the catch-all rule and restores the baseline on destroy",
     (stack) =>

--- a/packages/alchemy/test/Cloudflare/Email/EmailRouting.test.ts
+++ b/packages/alchemy/test/Cloudflare/Email/EmailRouting.test.ts
@@ -8,6 +8,7 @@ import { describe, expect } from "alchemy-test";
 import * as Effect from "effect/Effect";
 import { MinimumLogLevel } from "effect/References";
 import * as Schedule from "effect/Schedule";
+import { emailRoutingScoped } from "./scope.ts";
 const { test } = Test.make({ providers: Cloudflare.providers() });
 
 const logLevel = Effect.provideService(
@@ -57,7 +58,7 @@ const setEnabled = (zoneId: string, enabled: boolean) =>
     }),
   );
 
-describe.sequential("EmailRouting", () => {
+describe.sequential.skipIf(!emailRoutingScoped)("EmailRouting", () => {
   // Canonical `list()` test (zone-scoped singleton): there is no account-wide
   // API for these per-zone settings, so `list()` enumerates every zone via
   // `listAllZones` and reads the singleton in each. Assert the result is

--- a/packages/alchemy/test/Cloudflare/Email/EmailRule.test.ts
+++ b/packages/alchemy/test/Cloudflare/Email/EmailRule.test.ts
@@ -8,6 +8,7 @@ import { describe, expect } from "alchemy-test";
 import * as Effect from "effect/Effect";
 import { MinimumLogLevel } from "effect/References";
 import * as Schedule from "effect/Schedule";
+import { emailRoutingScoped } from "./scope.ts";
 const { test } = Test.make({ providers: Cloudflare.providers() });
 
 const logLevel = Effect.provideService(
@@ -47,7 +48,7 @@ const enableRouting = (zoneId: string) =>
     }),
   );
 
-describe.sequential("EmailRule", () => {
+describe.sequential.skipIf(!emailRoutingScoped)("EmailRule", () => {
   // Canonical `list()` test (zone-scoped collection): email routing rules live
   // under `/zones/{id}/email/routing/rules` with no account-wide enumeration
   // API, so `list()` enumerates every zone via `listAllZones` and exhaustively

--- a/packages/alchemy/test/Cloudflare/Email/EmailRuleWorkerTarget.test.ts
+++ b/packages/alchemy/test/Cloudflare/Email/EmailRuleWorkerTarget.test.ts
@@ -8,6 +8,7 @@ import * as Effect from "effect/Effect";
 import { MinimumLogLevel } from "effect/References";
 import * as Schedule from "effect/Schedule";
 import RuleTargetWorker from "./fixtures/rule-target-worker.ts";
+import { emailRoutingScoped } from "./scope.ts";
 
 const { test } = Test.make({ providers: Cloudflare.providers() });
 
@@ -41,110 +42,115 @@ const enableRouting = (zoneId: string) =>
     }),
   );
 
-describe.sequential("Email.Rule -> Worker in one apply", () => {
-  // Coverage for the shape reported in #1348: a Worker plus a routing
-  // resource whose `{ type: "worker", value: [scriptName] }` action names
-  // it, both created in the same apply, into a stage that did not exist.
-  //
-  // NOTE: this is a smoke test, NOT the regression guard for #1348. It was
-  // confirmed to still pass with the provider's retry removed — by us and
-  // independently by the reporter, who mutated the retry away and got three
-  // green runs. The Worker provider pre-creates a stub script before the
-  // rule is created (see "pre-creating" in a deploy log), so by the time
-  // Cloudflare validates the action the name already resolves.
-  //
-  // The retry itself is guarded deterministically in `retry.test.ts`, which
-  // injects the failure and does fail when the retry is removed. The error
-  // is real and typed (`WorkerScriptNotFound`, Cloudflare code 2016,
-  // observed live on both createRule and putRuleCatchAll).
-  test.provider(
-    "first deploy of a fresh stage creates the rule targeting the worker",
-    (stack) =>
-      Effect.gen(function* () {
-        const zoneId = yield* resolveZoneId;
+describe.sequential.skipIf(!emailRoutingScoped)(
+  "Email.Rule -> Worker in one apply",
+  () => {
+    // Coverage for the shape reported in #1348: a Worker plus a routing
+    // resource whose `{ type: "worker", value: [scriptName] }` action names
+    // it, both created in the same apply, into a stage that did not exist.
+    //
+    // NOTE: this is a smoke test, NOT the regression guard for #1348. It was
+    // confirmed to still pass with the provider's retry removed — by us and
+    // independently by the reporter, who mutated the retry away and got three
+    // green runs. The Worker provider pre-creates a stub script before the
+    // rule is created (see "pre-creating" in a deploy log), so by the time
+    // Cloudflare validates the action the name already resolves.
+    //
+    // The retry itself is guarded deterministically in `retry.test.ts`, which
+    // injects the failure and does fail when the retry is removed. The error
+    // is real and typed (`WorkerScriptNotFound`, Cloudflare code 2016,
+    // observed live on both createRule and putRuleCatchAll).
+    test.provider(
+      "first deploy of a fresh stage creates the rule targeting the worker",
+      (stack) =>
+        Effect.gen(function* () {
+          const zoneId = yield* resolveZoneId;
 
-        // A never-before-deployed stage is the precondition — start from a
-        // torn-down stack so the Worker really is created in this apply.
-        yield* stack.destroy();
-        yield* enableRouting(zoneId);
+          // A never-before-deployed stage is the precondition — start from a
+          // torn-down stack so the Worker really is created in this apply.
+          yield* stack.destroy();
+          yield* enableRouting(zoneId);
 
-        const { rule, workerName } = yield* stack.deploy(
-          Effect.gen(function* () {
-            const routing = yield* Cloudflare.Email.Routing("Routing", {
-              zone: zoneName,
-            });
-            const worker = yield* RuleTargetWorker;
-            const rule = yield* Cloudflare.Email.Rule("WorkerRule", {
-              zone: { zoneId: routing.zoneId },
-              name: "alchemy worker-target test",
-              matchers: [
-                {
-                  type: "literal",
-                  field: "to",
-                  value: `worker-target@${zoneName}`,
-                },
-              ],
-              actions: [{ type: "worker", value: [worker.workerName] }],
-            });
-            return { rule, workerName: worker.workerName };
-          }),
-        );
-
-        expect(rule.ruleId).not.toEqual("");
-        expect(rule.zoneId).toEqual(zoneId);
-        expect(rule.actions).toEqual([{ type: "worker", value: [workerName] }]);
-
-        // Verify out-of-band that Cloudflare really stored the worker action.
-        const live = yield* emailRouting
-          .getRule({ zoneId, ruleIdentifier: rule.ruleId })
-          .pipe(
-            Effect.retry({
-              while: (e) => e._tag === "Forbidden",
-              schedule: Schedule.exponential("500 millis"),
-              times: 8,
+          const { rule, workerName } = yield* stack.deploy(
+            Effect.gen(function* () {
+              const routing = yield* Cloudflare.Email.Routing("Routing", {
+                zone: zoneName,
+              });
+              const worker = yield* RuleTargetWorker;
+              const rule = yield* Cloudflare.Email.Rule("WorkerRule", {
+                zone: { zoneId: routing.zoneId },
+                name: "alchemy worker-target test",
+                matchers: [
+                  {
+                    type: "literal",
+                    field: "to",
+                    value: `worker-target@${zoneName}`,
+                  },
+                ],
+                actions: [{ type: "worker", value: [worker.workerName] }],
+              });
+              return { rule, workerName: worker.workerName };
             }),
           );
-        expect(live.actions?.[0]?.type).toEqual("worker");
-        expect(live.actions?.[0]?.value).toEqual([workerName]);
 
-        yield* stack.destroy();
-      }).pipe(logLevel),
-    { timeout: 180_000 },
-  );
+          expect(rule.ruleId).not.toEqual("");
+          expect(rule.zoneId).toEqual(zoneId);
+          expect(rule.actions).toEqual([
+            { type: "worker", value: [workerName] },
+          ]);
 
-  // The catch-all rule takes a `worker` action through a different endpoint
-  // (`/rules/catch_all`) and hits the same validation window.
-  test.provider(
-    "catch-all pointed at a Worker created in the same apply",
-    (stack) =>
-      Effect.gen(function* () {
-        const zoneId = yield* resolveZoneId;
+          // Verify out-of-band that Cloudflare really stored the worker action.
+          const live = yield* emailRouting
+            .getRule({ zoneId, ruleIdentifier: rule.ruleId })
+            .pipe(
+              Effect.retry({
+                while: (e) => e._tag === "Forbidden",
+                schedule: Schedule.exponential("500 millis"),
+                times: 8,
+              }),
+            );
+          expect(live.actions?.[0]?.type).toEqual("worker");
+          expect(live.actions?.[0]?.value).toEqual([workerName]);
 
-        yield* stack.destroy();
-        yield* enableRouting(zoneId);
+          yield* stack.destroy();
+        }).pipe(logLevel),
+      { timeout: 180_000 },
+    );
 
-        const { catchAll, workerName } = yield* stack.deploy(
-          Effect.gen(function* () {
-            const routing = yield* Cloudflare.Email.Routing("Routing", {
-              zone: zoneName,
-            });
-            const worker = yield* RuleTargetWorker;
-            const catchAll = yield* Cloudflare.Email.CatchAll("CatchAll", {
-              zone: { zoneId: routing.zoneId },
-              name: "alchemy worker-target catch-all",
-              actions: [{ type: "worker", value: [worker.workerName] }],
-            });
-            return { catchAll, workerName: worker.workerName };
-          }),
-        );
+    // The catch-all rule takes a `worker` action through a different endpoint
+    // (`/rules/catch_all`) and hits the same validation window.
+    test.provider(
+      "catch-all pointed at a Worker created in the same apply",
+      (stack) =>
+        Effect.gen(function* () {
+          const zoneId = yield* resolveZoneId;
 
-        expect(catchAll.zoneId).toEqual(zoneId);
-        expect(catchAll.actions).toEqual([
-          { type: "worker", value: [workerName] },
-        ]);
+          yield* stack.destroy();
+          yield* enableRouting(zoneId);
 
-        yield* stack.destroy();
-      }).pipe(logLevel),
-    { timeout: 180_000 },
-  );
-});
+          const { catchAll, workerName } = yield* stack.deploy(
+            Effect.gen(function* () {
+              const routing = yield* Cloudflare.Email.Routing("Routing", {
+                zone: zoneName,
+              });
+              const worker = yield* RuleTargetWorker;
+              const catchAll = yield* Cloudflare.Email.CatchAll("CatchAll", {
+                zone: { zoneId: routing.zoneId },
+                name: "alchemy worker-target catch-all",
+                actions: [{ type: "worker", value: [worker.workerName] }],
+              });
+              return { catchAll, workerName: worker.workerName };
+            }),
+          );
+
+          expect(catchAll.zoneId).toEqual(zoneId);
+          expect(catchAll.actions).toEqual([
+            { type: "worker", value: [workerName] },
+          ]);
+
+          yield* stack.destroy();
+        }).pipe(logLevel),
+      { timeout: 180_000 },
+    );
+  },
+);

--- a/packages/alchemy/test/Cloudflare/Email/SendingSubdomain.test.ts
+++ b/packages/alchemy/test/Cloudflare/Email/SendingSubdomain.test.ts
@@ -12,6 +12,7 @@ import * as Option from "effect/Option";
 import { MinimumLogLevel } from "effect/References";
 import * as Schedule from "effect/Schedule";
 import * as Stream from "effect/Stream";
+import { emailRoutingScoped } from "./scope.ts";
 
 const { test } = Test.make({ providers: Cloudflare.providers() });
 
@@ -92,99 +93,103 @@ const purgeSubdomain = (zoneId: string, name: string) =>
     ),
   );
 
-test.provider("create and destroy a sending subdomain", (stack) =>
-  Effect.gen(function* () {
-    const zoneId = yield* resolveZoneId;
+test.provider.skipIf(!emailRoutingScoped)(
+  "create and destroy a sending subdomain",
+  (stack) =>
+    Effect.gen(function* () {
+      const zoneId = yield* resolveZoneId;
 
-    yield* stack.destroy();
-    yield* purgeSubdomain(zoneId, NAME_DEFAULT);
+      yield* stack.destroy();
+      yield* purgeSubdomain(zoneId, NAME_DEFAULT);
 
-    const sending = yield* stack.deploy(
-      Effect.gen(function* () {
-        return yield* Cloudflare.Email.SendingSubdomain("Sending", {
-          zoneId,
-          name: NAME_DEFAULT,
-        });
-      }),
-    );
+      const sending = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.Email.SendingSubdomain("Sending", {
+            zoneId,
+            name: NAME_DEFAULT,
+          });
+        }),
+      );
 
-    expect(sending.subdomainId).toBeDefined();
-    expect(sending.zoneId).toEqual(zoneId);
-    expect(sending.name).toEqual(NAME_DEFAULT);
-    // CF-hosted zone — DNS records are auto-created and validate
-    // immediately; the reconciler polls briefly for `enabled`.
-    expect(sending.enabled).toEqual(true);
-    expect(sending.dkimSelector).toBeDefined();
-    expect(sending.returnPathDomain).toContain(NAME_DEFAULT);
+      expect(sending.subdomainId).toBeDefined();
+      expect(sending.zoneId).toEqual(zoneId);
+      expect(sending.name).toEqual(NAME_DEFAULT);
+      // CF-hosted zone — DNS records are auto-created and validate
+      // immediately; the reconciler polls briefly for `enabled`.
+      expect(sending.enabled).toEqual(true);
+      expect(sending.dkimSelector).toBeDefined();
+      expect(sending.returnPathDomain).toContain(NAME_DEFAULT);
 
-    // Out-of-band verification against the live API.
-    const live = yield* getSubdomain(zoneId, sending.subdomainId);
-    expect(live.tag).toEqual(sending.subdomainId);
-    expect(live.name).toEqual(NAME_DEFAULT);
+      // Out-of-band verification against the live API.
+      const live = yield* getSubdomain(zoneId, sending.subdomainId);
+      expect(live.tag).toEqual(sending.subdomainId);
+      expect(live.name).toEqual(NAME_DEFAULT);
 
-    yield* stack.destroy();
+      yield* stack.destroy();
 
-    // Gone after destroy — the typed not-found is the success signal.
-    const gone = yield* getSubdomain(zoneId, sending.subdomainId).pipe(
-      Effect.map(() => "still-there" as const),
-      Effect.catchTag("SendingSubdomainNotFound", () =>
-        Effect.succeed("gone" as const),
-      ),
-    );
-    expect(gone).toEqual("gone");
+      // Gone after destroy — the typed not-found is the success signal.
+      const gone = yield* getSubdomain(zoneId, sending.subdomainId).pipe(
+        Effect.map(() => "still-there" as const),
+        Effect.catchTag("SendingSubdomainNotFound", () =>
+          Effect.succeed("gone" as const),
+        ),
+      );
+      expect(gone).toEqual("gone");
 
-    // Destroy again — delete is idempotent.
-    yield* stack.destroy();
-  }).pipe(logLevel),
+      // Destroy again — delete is idempotent.
+      yield* stack.destroy();
+    }).pipe(logLevel),
 );
 
-test.provider("changing the name triggers replacement", (stack) =>
-  Effect.gen(function* () {
-    const zoneId = yield* resolveZoneId;
+test.provider.skipIf(!emailRoutingScoped)(
+  "changing the name triggers replacement",
+  (stack) =>
+    Effect.gen(function* () {
+      const zoneId = yield* resolveZoneId;
 
-    yield* stack.destroy();
-    yield* purgeSubdomain(zoneId, NAME_REPLACE_A);
-    yield* purgeSubdomain(zoneId, NAME_REPLACE_B);
+      yield* stack.destroy();
+      yield* purgeSubdomain(zoneId, NAME_REPLACE_A);
+      yield* purgeSubdomain(zoneId, NAME_REPLACE_B);
 
-    const initial = yield* stack.deploy(
-      Effect.gen(function* () {
-        return yield* Cloudflare.Email.SendingSubdomain("ReplaceSending", {
-          zoneId,
-          name: NAME_REPLACE_A,
-        });
-      }),
-    );
+      const initial = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.Email.SendingSubdomain("ReplaceSending", {
+            zoneId,
+            name: NAME_REPLACE_A,
+          });
+        }),
+      );
 
-    expect(initial.name).toEqual(NAME_REPLACE_A);
+      expect(initial.name).toEqual(NAME_REPLACE_A);
 
-    const replaced = yield* stack.deploy(
-      Effect.gen(function* () {
-        return yield* Cloudflare.Email.SendingSubdomain("ReplaceSending", {
-          zoneId,
-          name: NAME_REPLACE_B,
-        });
-      }),
-    );
+      const replaced = yield* stack.deploy(
+        Effect.gen(function* () {
+          return yield* Cloudflare.Email.SendingSubdomain("ReplaceSending", {
+            zoneId,
+            name: NAME_REPLACE_B,
+          });
+        }),
+      );
 
-    // The name is the subdomain's identity — a new physical resource.
-    expect(replaced.subdomainId).not.toEqual(initial.subdomainId);
-    expect(replaced.name).toEqual(NAME_REPLACE_B);
+      // The name is the subdomain's identity — a new physical resource.
+      expect(replaced.subdomainId).not.toEqual(initial.subdomainId);
+      expect(replaced.name).toEqual(NAME_REPLACE_B);
 
-    // The old subdomain was deleted as part of the replacement.
-    const old = yield* findByName(zoneId, NAME_REPLACE_A);
-    expect(old).toBeUndefined();
+      // The old subdomain was deleted as part of the replacement.
+      const old = yield* findByName(zoneId, NAME_REPLACE_A);
+      expect(old).toBeUndefined();
 
-    const live = yield* findByName(zoneId, NAME_REPLACE_B);
-    expect(live?.tag).toEqual(replaced.subdomainId);
+      const live = yield* findByName(zoneId, NAME_REPLACE_B);
+      expect(live?.tag).toEqual(replaced.subdomainId);
 
-    yield* stack.destroy();
+      yield* stack.destroy();
 
-    const gone = yield* findByName(zoneId, NAME_REPLACE_B);
-    expect(gone).toBeUndefined();
-  }).pipe(logLevel),
+      const gone = yield* findByName(zoneId, NAME_REPLACE_B);
+      expect(gone).toBeUndefined();
+    }).pipe(logLevel),
 );
 
-test.provider(
+test.provider.skipIf(!emailRoutingScoped)(
   "adoption — existing subdomain errors without adopt, takes over with adopt(true)",
   (stack) =>
     Effect.gen(function* () {
@@ -244,7 +249,7 @@ test.provider(
   { timeout: 180_000 },
 );
 
-test.provider(
+test.provider.skipIf(!emailRoutingScoped)(
   "list enumerates the deployed sending subdomain",
   (stack) =>
     Effect.gen(function* () {

--- a/packages/alchemy/test/Cloudflare/Email/scope.ts
+++ b/packages/alchemy/test/Cloudflare/Email/scope.ts
@@ -1,0 +1,17 @@
+/**
+ * Email Routing is scoped separately from the rest of the Cloudflare API.
+ * A credential without it — notably Cloudflare OAuth, which carries no
+ * Email Routing scope at all — is refused before any resource logic runs:
+ *
+ *     Unauthorized: Authentication error
+ *       at provider.create (packages/alchemy/src/Apply.ts)
+ *
+ * Every suite below drives real Email Routing resources (routing settings,
+ * rules, catch-alls, destination addresses, sending subdomains) against the
+ * standing test zone, so all of them need the scope.
+ *
+ * Set `CLOUDFLARE_TEST_EMAIL_ROUTING=1` with an API-token credential that
+ * carries `Zone.Email Routing Rules` (edit) plus account-level
+ * `Email Routing Addresses` to run them.
+ */
+export const emailRoutingScoped = !!process.env.CLOUDFLARE_TEST_EMAIL_ROUTING;


### PR DESCRIPTION
`pnpm test test/Cloudflare/Email --profile alchemy-testing` fails **17 tests and takes 10 minutes** on main. Every failure traces to the credential rather than the resources: Email Routing and Email Security are separately scoped, and Cloudflare OAuth carries neither.

### Three were a provider inconsistency, not a credential limit

`Domain.list()` already treats an unenumerable account as empty, but its three siblings caught only the entitlement tag, so a scope-less credential escaped as a bare `Forbidden`:

```diff
-          Effect.catchTag("EmailSecurityNotEntitled", () =>
+          Effect.catchTag(["EmailSecurityNotEntitled", "Forbidden"], () =>
             Effect.succeed([] as AllowPolicyAttributes[]),
```

Entitlement and reachability are different axes — an unentitled account is *told* so, a scope-less credential is refused at the edge — but neither can enumerate, so both mean "none visible". Returning `[]` is also the safe direction for `list`'s callers: orphan detection never deletes what it cannot see.

`TrustedDomain`, `ImpersonationRegistryEntry`, and `AllowPolicy` now match `Domain`, and their list tests **pass for real** rather than being skipped.

### The remaining 14 genuinely need the scope

Gated per the entitlement-gating convention, each with the exact rejection recorded:

| gate | covers |
| --- | --- |
| `CLOUDFLARE_TEST_EMAIL_ROUTING` | 13 Email Routing lifecycle tests across 6 files, via a shared `test/Cloudflare/Email/scope.ts` |
| `CLOUDFLARE_TEST_EMAIL_SECURITY` | the unentitlement probe, whose premise is that the credential can *reach* Email Security and be told the account is not entitled |

```
17 failed |  8 passed (601.8s)   ->   0 failed | 11 passed | 8 skipped (27.0s)
```

Verified the gates are not inert: with both env vars set the tests run and reach the recorded `Unauthorized` / `Forbidden` errors.

### Two findings left out on purpose

Both are real but neither showed a measurable effect here, so they don't belong in a test-gating change:

- `Email/Address.ts` delete retries on a **denylist** (`_tag !== "EmailAddressCreatedTooRecently"`). Since `deleteAddress` widens to `CloudflareOpError`, that retries `Unauthorized` for the full 8 x 3s budget on every destroy. Worth fixing as an allowlist — but the tags must be taken from `effect/unstable/http/HttpClientError` (`TransportError`, `StatusCodeError`, `EncodeError`, `InvalidUrlError`), not guessed: `Set<string>.has()` type-checks against any string, so a wrong tag silently makes transport faults non-retryable.
- `AllowPolicy.test.ts`'s `forbiddenRetrySchedule` is `exponential("500 millis")` retried 8 times — about 127s, which overshoots the suite's own 120s timeout, so a persistent `Forbidden` can never fail cleanly within budget.
