### PR TITLE
feat(planetscale): expose Postgres private connection details

### DIFF
--- a/packages/alchemy/src/Planetscale/Postgres/PostgresDefaultRole.ts
+++ b/packages/alchemy/src/Planetscale/Postgres/PostgresDefaultRole.ts
@@ -62,8 +62,12 @@ export interface PostgresDefaultRoleAttributes {
   databaseName: string;
   /** Direct connection URL for the database (Redacted). */
   connectionUrl: Redacted.Redacted<string>;
-  /** Pooled connection URL via PSBouncer (Redacted). */
+  /** Pooled connection URL via PgBouncer (Redacted). */
   connectionUrlPooled: Redacted.Redacted<string>;
+  /** Private connection host or DNS zone supplied by PlanetScale. */
+  privateHost: string;
+  /** Service name supplied by PlanetScale to establish a private connection. */
+  privateConnectionServiceName: string;
   /** Inherited roles. */
   inheritedRoles: InheritedRole[];
   /** Resolved organization slug. */
@@ -144,7 +148,11 @@ export const PostgresDefaultRoleProvider = () =>
           branch: output.branch,
         })
         .pipe(
-          Effect.map(() => output),
+          Effect.map((role) => ({
+            ...output,
+            privateHost: role.private_access_host_url,
+            privateConnectionServiceName: role.private_connection_service_name,
+          })),
           Effect.catchTag("NotFound", () => Effect.succeed(undefined)),
         );
     }),
@@ -171,11 +179,16 @@ export const PostgresDefaultRoleProvider = () =>
 
       // 2. Sync (no-op) — we own the role and it still exists in the
       //    cloud. Default roles have nothing mutable in place: their
-      //    plaintext password isn't retrievable, so we re-emit the
-      //    persisted attributes unchanged. diff() forces a replace
-      //    when database/branch change.
+      //    plaintext password isn't retrievable, so we retain the cached
+      //    credentials while refreshing the private connection details.
+      //    diff() forces a replace when database/branch change.
       if (output && observed) {
-        return output;
+        return {
+          ...output,
+          privateHost: observed.private_access_host_url,
+          privateConnectionServiceName:
+            observed.private_connection_service_name,
+        };
       }
 
       // 3. Adoption guard — observed exists but we have no prior
@@ -225,6 +238,8 @@ export const PostgresDefaultRoleProvider = () =>
         databaseName: data.database_name,
         connectionUrl: Redacted.make(connectionUrl),
         connectionUrlPooled: Redacted.make(connectionUrlPooled),
+        privateHost: data.private_access_host_url,
+        privateConnectionServiceName: data.private_connection_service_name,
         inheritedRoles: data.inherited_roles as InheritedRole[],
         organization,
         database: databaseName,
@@ -290,6 +305,9 @@ export const PostgresDefaultRoleProvider = () =>
                                     databaseName: role.database_name,
                                     connectionUrl: Redacted.make(""),
                                     connectionUrlPooled: Redacted.make(""),
+                                    privateHost: role.private_access_host_url,
+                                    privateConnectionServiceName:
+                                      role.private_connection_service_name,
                                     inheritedRoles:
                                       role.inherited_roles as InheritedRole[],
                                     organization,

--- a/packages/alchemy/src/Planetscale/Postgres/PostgresRole.ts
+++ b/packages/alchemy/src/Planetscale/Postgres/PostgresRole.ts
@@ -115,11 +115,15 @@ export interface PostgresRoleAttributes {
   databaseName: string;
   /** Parsed direct (port 5432) connection components ready to feed into Cloudflare Hyperdrive. */
   origin: PostgresOrigin;
-  /** Parsed pooled (PSBouncer, port 6432) connection components, e.g. for a Hyperdrive `dev` origin. */
+  /** Parsed pooled (PgBouncer, port 6432) connection components, e.g. for a Hyperdrive `dev` origin. */
   pooledOrigin: PostgresOrigin;
+  /** Private connection host or DNS zone supplied by PlanetScale. */
+  privateHost: string;
+  /** Service name supplied by PlanetScale to establish a private connection. */
+  privateConnectionServiceName: string;
   /** Direct connection URL for the database (Redacted). */
   connectionUrl: Redacted.Redacted<string>;
-  /** Pooled connection URL via PSBouncer (port 6432, Redacted). */
+  /** Pooled connection URL via PgBouncer (port 6432, Redacted). */
   connectionUrlPooled: Redacted.Redacted<string>;
   /** Inherited roles. */
   inheritedRoles: InheritedRole[];
@@ -495,6 +499,8 @@ const buildAttributes = (
     name: string;
     expires_at: string | null;
     access_host_url: string;
+    private_access_host_url: string;
+    private_connection_service_name: string;
     username: string;
     database_name: string;
     ttl: number | null;
@@ -521,6 +527,8 @@ const buildAttributes = (
     password,
     connectionUrl: Redacted.make(connectionUrl),
     connectionUrlPooled: Redacted.make(connectionUrlPooled),
+    privateHost: role.private_access_host_url,
+    privateConnectionServiceName: role.private_connection_service_name,
     inheritedRoles: context.inheritedRoles,
     successor: context.successor,
     organization: context.organization,

--- a/packages/alchemy/test/Planetscale/Postgres/PostgresRole.test.ts
+++ b/packages/alchemy/test/Planetscale/Postgres/PostgresRole.test.ts
@@ -18,6 +18,15 @@ const logLevel = Effect.provideService(
   MinimumLogLevel,
   process.env.DEBUG ? "Debug" : "Info",
 );
+
+const expectPrivateConnectionDetails = (role: {
+  privateHost: string;
+  privateConnectionServiceName: string;
+}) => {
+  expect(role.privateHost).toEqual(expect.any(String));
+  expect(role.privateConnectionServiceName).toEqual(expect.any(String));
+};
+
 describe
   .skipIf(!process.env.PLANETSCALE_TEST)
   .concurrent("PostgresRole", () => {
@@ -39,6 +48,7 @@ describe
             database: expect.any(String),
             branch: expect.any(String),
           });
+          expectPrivateConnectionDetails(r);
         }
       }).pipe(logLevel),
     );
@@ -105,6 +115,7 @@ describe
             database: expect.any(String),
             branch: expect.any(String),
           });
+          expectPrivateConnectionDetails(r);
         }
       }).pipe(logLevel),
     );
@@ -185,6 +196,19 @@ describe
             branch: "main",
             organization: database.organization,
           });
+          expectPrivateConnectionDetails(role1);
+
+          const defaultRoleFromApi = yield* ps.getDefaultRole({
+            organization: database.organization,
+            database: database.name,
+            branch: "main",
+          });
+          expect(role1.privateConnectionServiceName).toEqual(
+            defaultRoleFromApi.private_connection_service_name,
+          );
+          expect(role1.privateHost).toEqual(
+            defaultRoleFromApi.private_access_host_url,
+          );
 
           // Second: create again without forceReset — should fail (default already exists)
           const exit = yield* stack
@@ -285,6 +309,18 @@ describe
             username: expect.any(String),
             password: expect.any(Object),
           });
+          expectPrivateConnectionDetails(role);
+
+          const roleFromApi = yield* ps.getRole({
+            id: role.id,
+            database: database.name,
+            organization: database.organization,
+            branch: "main",
+          });
+          expect(role.privateConnectionServiceName).toEqual(
+            roleFromApi.private_connection_service_name,
+          );
+          expect(role.privateHost).toEqual(roleFromApi.private_access_host_url);
 
           // Update role with different ttl (should trigger replacement)
           const { updatedRole } = yield* stack.deploy(

--- a/website/src/content/docs/planetscale/data/credentials.mdx
+++ b/website/src/content/docs/planetscale/data/credentials.mdx
@@ -93,7 +93,7 @@ password syncs in place on the next deploy.
 Credentials expose parsed connection components ready to feed into
 consumers like [Cloudflare Hyperdrive](/cloudflare/data/hyperdrive).
 `PostgresRole` has two: `origin` is the direct connection (port
-5432), `pooledOrigin` goes through PSBouncer (port 6432):
+5432), `pooledOrigin` goes through PgBouncer (port 6432):
 
 ```typescript
 import * as Cloudflare from "alchemy/Cloudflare";
@@ -107,6 +107,34 @@ const hyperdrive = yield* Cloudflare.Hyperdrive.Connection("app-hyperdrive", {
 `MySQLPassword` exposes a single `origin`, and `PostgresDefaultRole`
 carries the same direct/pooled endpoints as `Redacted` URL strings
 (`connectionUrl` / `connectionUrlPooled`), as does `PostgresRole`.
+
+## Private Postgres connections
+
+For PlanetScale Postgres branches, roles expose the private host and
+service name without copying them from the dashboard. On AWS, use the
+service name to create an Interface VPC endpoint:
+
+```typescript
+import * as AWS from "alchemy/AWS";
+
+yield* AWS.EC2.VpcEndpoint("postgres-private-link", {
+  vpcId: vpc.vpcId,
+  serviceName: reader.privateConnectionServiceName,
+  vpcEndpointType: "Interface",
+  subnetIds: [privateSubnet.subnetId],
+  securityGroupIds: [databaseSecurityGroup.groupId],
+  privateDnsEnabled: true,
+});
+
+const privateOrigin = { ...reader.origin, host: reader.privateHost };
+const privatePooledOrigin = {
+  ...reader.pooledOrigin,
+  host: reader.privateHost,
+};
+```
+
+For GCP Private Service Connect, combine the endpoint name configured
+in GCP with `privateHost` before connecting.
 
 ## Where next
 

--- a/website/src/content/docs/planetscale/data/postgres.mdx
+++ b/website/src/content/docs/planetscale/data/postgres.mdx
@@ -122,7 +122,7 @@ into consumers like [Cloudflare Hyperdrive](/cloudflare/data/hyperdrive):
 
 - `role.origin` — the **direct** connection (port 5432). Use it where
   the consumer does its own pooling, e.g. as a Hyperdrive origin.
-- `role.pooledOrigin` — the **pooled** connection via PSBouncer
+- `role.pooledOrigin` — the **pooled** connection via PgBouncer
   (port 6432). Use it where each request would otherwise open a fresh
   direct connection, e.g. Hyperdrive's local-dev origin.
 
@@ -138,6 +138,37 @@ const hyperdrive = yield* Cloudflare.Hyperdrive.Connection("app-hyperdrive", {
 If you need a URL instead of components, `connectionUrl` and
 `connectionUrlPooled` carry the same direct/pooled endpoints as
 `Redacted` connection strings (`sslmode=verify-full`).
+
+## Connect privately with AWS PrivateLink
+
+Postgres roles expose the branch's provider-neutral private connection
+details. For AWS PrivateLink, pass `privateConnectionServiceName` to
+an Interface VPC endpoint. With private DNS enabled, use
+`privateHost` for workloads in that VPC:
+
+```typescript
+import * as AWS from "alchemy/AWS";
+import * as Cloudflare from "alchemy/Cloudflare";
+
+const endpoint = yield* AWS.EC2.VpcEndpoint("postgres-private-link", {
+  vpcId: vpc.vpcId,
+  serviceName: role.privateConnectionServiceName,
+  vpcEndpointType: "Interface",
+  subnetIds: [privateSubnet.subnetId],
+  securityGroupIds: [databaseSecurityGroup.groupId],
+  privateDnsEnabled: true,
+});
+
+const hyperdrive = yield* Cloudflare.Hyperdrive.Connection("private-db", {
+  origin: { ...role.origin, host: role.privateHost }, // direct, port 5432
+  dev: { ...role.pooledOrigin, host: role.privateHost }, // PgBouncer, port 6432
+});
+```
+
+For GCP Private Service Connect, `privateHost` is the private DNS zone;
+prepend the endpoint name configured in GCP before connecting.
+`PostgresDefaultRole` exposes the same details, though `PostgresRole`
+remains the safer choice for applications.
 
 ## Where next
 


### PR DESCRIPTION
## Summary
- expose PlanetScale's provider-neutral private host and service name from PostgresRole and PostgresDefaultRole
- document AWS PrivateLink composition with AWS.EC2.VpcEndpoint and existing role origins
- do not synthesize private URLs or origins: GCP Private Service Connect requires a user-chosen endpoint name in addition to the returned private host

## Security and lifecycle
- passwords and existing connection URLs remain Redacted
- this is additive observed state only: no props, diff rules, or replacement behavior change
- read, reconcile, and list map the SDK response, so existing resources gain the attributes on refresh

## Verification
- provider behavior tests assert private host and service-name mapping for create and list paths
- targeted PlanetScale plan-stability tests pass; live PlanetScale tests are gated on PLANETSCALE_TEST
- provider lint and API JSDoc checks pass