### PR TITLE
docs(testing): document Test.make({ dev: true }) local-dev mode

### DIFF
--- a/website/src/content/docs/aws/local-development.mdx
+++ b/website/src/content/docs/aws/local-development.mdx
@@ -215,6 +215,27 @@ implementation, so it only ever sees emulated resources — no
 cloud credentials are involved and nothing in a real AWS account
 can be touched.
 
+## Test against the local stack
+
+The [test harness](/testing/test-harness) has the same dev mode —
+`Test.make({ dev: true })` (available on both the Bun and Vitest
+adapters, off by default) runs the suite's `deploy(Stack)` against
+the local emulator instead of the real account, no separate
+`alchemy dev` terminal needed:
+
+```typescript
+const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
+  providers: AWS.providers(),
+  dev: true,
+});
+```
+
+Lambda functions run in local containers, the emulated services
+back them, and function URL outputs point at the local gateway —
+so the same HTTP assertions run with zero cloud credentials. See
+[Test harness → dev](/testing/test-harness#dev) for the full
+semantics.
+
 ## Where next
 
 - [Local development](/environments/local-development) — the
@@ -224,5 +245,7 @@ can be touched.
   under `alchemy dev`.
 - [Stages](/environments/stages) — how live-in-dev resources stay
   isolated per developer.
+- [Testing](/testing) — run the same test suite against the local
+  emulator with `Test.make({ dev: true })`.
 - [Local Providers](/infrastructure-as-code/local-provider) —
   build the local implementation of a resource.

--- a/website/src/content/docs/cloudflare/compute/add-a-workflow.mdx
+++ b/website/src/content/docs/cloudflare/compute/add-a-workflow.mdx
@@ -452,6 +452,28 @@ The polling loop should see the workflow transition through
 `running` and finish in `complete` within ~5 seconds (most of which
 is the `sleep("cooldown", "2 seconds")` cooldown).
 
+## Test it locally
+
+The same test runs entirely on your machine — no separate
+workerd/vitest setup needed. Add `dev: true` to `Test.make` and the
+whole stack (Worker, Workflow, KV, Durable Objects) boots in a
+local workerd with real step semantics — tasks checkpoint, sleeps
+park, replays skip completed steps:
+
+```diff lang="typescript"
+const { test, beforeAll, deploy } = Test.make({
+  providers: Cloudflare.providers(),
+  state: Cloudflare.state(),
++  dev: true,
+});
+```
+
+`stack.url` now points at `http://localhost:<port>`, and the
+start/poll assertions run unchanged against the local workflow. See
+[Test harness → dev](/testing/test-harness#dev) for the option's
+full semantics, and [Local development](/cloudflare/local-development)
+for what else runs locally.
+
 Your app now spans a Worker, a Vite frontend, Durable Objects,
 hibernatable WebSockets, a Container, and a Workflow — all
 deploying from CI thanks to [Part 5](/cloudflare/tutorial/part-5). From here,

--- a/website/src/content/docs/cloudflare/local-development.mdx
+++ b/website/src/content/docs/cloudflare/local-development.mdx
@@ -188,6 +188,27 @@ export default Cloudflare.Worker("Worker", {
 });
 ```
 
+## Test against the local stack
+
+The [test harness](/testing/test-harness) has the same dev mode —
+`Test.make({ dev: true })` (available on both the Bun and Vitest
+adapters, off by default) runs the suite's `deploy(Stack)` against
+the local simulators instead of the cloud, no separate
+`alchemy dev` terminal needed:
+
+```typescript
+const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
+  providers: Cloudflare.providers(),
+  dev: true,
+});
+```
+
+Workers, Durable Objects, Workflows, and the simulated bindings all
+run in workerd exactly as described above, and the stack's `url`
+points at `http://localhost:<port>`. See
+[Test harness → dev](/testing/test-harness#dev) and
+[Tutorial Part 4](/cloudflare/tutorial/part-4).
+
 ## Where next
 
 - [Local development](/environments/local-development) — the
@@ -197,5 +218,7 @@ export default Cloudflare.Worker("Worker", {
   framework dev servers under `alchemy dev`.
 - [Stages](/environments/stages) — how live-in-dev resources stay
   isolated per developer.
+- [Testing](/testing) — run the same test suite against the local
+  simulators with `Test.make({ dev: true })`.
 - [Local Providers](/infrastructure-as-code/local-provider) —
   build the local implementation of a resource.

--- a/website/src/content/docs/environments/local-development.mdx
+++ b/website/src/content/docs/environments/local-development.mdx
@@ -154,6 +154,16 @@ is torn down. Dev state never silently becomes cloud state.
 
 To automate the deploy side, see the [CI guide](/environments/ci).
 
+## Testing in dev mode
+
+The [test harness](/testing/test-harness) has the same switch:
+`Test.make({ dev: true })` (off by default, on both the Bun and
+Vitest adapters) runs a suite's `deploy(Stack)` against the local
+emulators — Cloudflare in workerd, AWS in Docker — instead of the
+real cloud, so integration tests run on your machine with no cloud
+calls and no separate `alchemy dev` terminal. See
+[Test harness → dev](/testing/test-harness#dev).
+
 ## Where next
 
 - [Cloudflare local development](/cloudflare/local-development) — what runs in workerd and which bindings are simulated.
@@ -161,4 +171,5 @@ To automate the deploy side, see the [CI guide](/environments/ci).
 - [CI](/environments/ci) — deploy the same stack from GitHub Actions with PR previews.
 - [Stages](/environments/stages) — how `dev_$USER`, `pr-42`, and `prod` stay isolated.
 - [Dev servers](/command/dev-servers) — run any framework dev server as a `Command.Dev` resource in the dev loop.
+- [Testing](/testing) — run the same test suite against the local emulators with `Test.make({ dev: true })`.
 - [Local Providers](/infrastructure-as-code/local-provider) — build the local implementation of a resource.

--- a/website/src/content/docs/testing/index.mdx
+++ b/website/src/content/docs/testing/index.mdx
@@ -1,9 +1,9 @@
 ---
 title: Testing
-description: How Alchemy tests work — real clouds, one Stack deploy per suite, isolated stages, deploy → assert → destroy.
+description: How Alchemy tests work — real clouds by default, local emulators on demand, one Stack deploy per suite, isolated stages, deploy → assert → destroy.
 ---
 
-Alchemy tests run against real clouds — no mocks, no emulators. A suite deploys a real Stack once, runs assertions against live resources, and tears it back down: deploy → assert → destroy.
+Alchemy tests run against real clouds by default — no mocks. A suite deploys a real Stack once, runs assertions against live resources, and tears it back down: deploy → assert → destroy. The same suite can also run entirely on your machine — see [Local mode](#local-mode-dev-true) below.
 
 ## One deploy per suite
 
@@ -42,6 +42,21 @@ Test.make({ providers, stage: "ci-pr-42" });
 
 The per-call form is covered in [Test harness → stage](/testing/test-harness#stage).
 
+## Local mode (`dev: true`)
+
+The harness has the same local-dev mode as [`alchemy dev`](/environments/local-development). It's off by default; flip it on and the whole suite runs against local emulators — Cloudflare Workers, Durable Objects, KV, R2, D1, Queues, and Workflows in workerd, AWS Lambda/ECS and the emulated AWS surface in a local Docker emulator — with no cloud calls:
+
+```typescript
+Test.make({
+  providers: Cloudflare.providers(),
+  dev: true,
+});
+```
+
+Nothing else changes: `deploy(Stack)` boots the stack locally and the tests drive `http://localhost:<port>` instead of the cloud. There's no need for a separate testing setup (e.g. workerd + a vitest plugin) — the harness runs your real Stack in the same local runtimes `alchemy dev` uses. Omit the flag and set `ALCHEMY_DEV=1` in your shell to keep one test file that runs locally on your laptop and live in CI.
+
+Full option semantics: [Test harness → dev](/testing/test-harness#dev).
+
 ## Where next
 
 - [Testing a Stack](/testing/testing-a-stack) — deploy a Stack and drive it over HTTP, end to end.
@@ -49,3 +64,4 @@ The per-call form is covered in [Test harness → stage](/testing/test-harness#s
 - [Test harness](/testing/test-harness) — every `Test.make` option, hook, and variant.
 - [Observability](/testing/observability) — wire exporters, monitors, and alarms into the same Stack.
 - [Tutorial Part 3](/cloudflare/tutorial/part-3) — your first integration test, walked through step by step.
+- [Tutorial Part 4](/cloudflare/tutorial/part-4) — running the same tests against local emulators with `dev: true`.

--- a/website/src/content/docs/testing/test-harness.mdx
+++ b/website/src/content/docs/testing/test-harness.mdx
@@ -46,6 +46,9 @@ Test.make({
   state,       // optional
   profile,     // optional
   stage,       // optional
+  dev,         // optional — run the suite against local emulators
+  adopt,       // optional
+  sidecar,     // optional — defaults to dev
 });
 ```
 
@@ -111,6 +114,58 @@ afterAll.skipIf(!process.env.CI)(destroy(Stack, { stage: "ci-pr-42" }));
 
 A unique stage per PR or test run lets multiple suites run in
 parallel against the same provider account without colliding.
+
+### `dev`
+
+Off by default — tests deploy to the real cloud. `dev: true` runs
+the whole file in local-dev mode, the same wiring as
+[`alchemy dev`](/environments/local-development): Cloudflare
+Workers, Durable Objects, KV, R2, D1, Queues, and Workflows run in
+workerd with local simulators, and AWS Lambda/ECS plus the
+emulated AWS surface run in a local Docker emulator. No cloud
+account is touched for emulated resources.
+
+```typescript
+Test.make({
+  providers: Cloudflare.providers(),
+  dev: true,  // deploy(Stack) boots workerd / Docker simulators
+});
+```
+
+Everything else in the file is unchanged — `beforeAll(deploy(Stack))`
+boots the stack locally and the outputs (`url`, ids) point at the
+local instances, so the same HTTP assertions run against
+`http://localhost:<port>`. Local resource ids are `dev:`-prefixed,
+which doubles as proof no cloud call ran. `Alchemy.remote()` still
+pins individual resources live, exactly as it does under
+`alchemy dev`.
+
+When omitted, the flag falls back to the `ALCHEMY_DEV` env var —
+leave it out of the file and set `ALCHEMY_DEV=1` locally to run the
+same suite against emulators while CI runs it live. Separately,
+`ALCHEMY_TEST_DEV=1` **overrides** the option in both directions —
+use it to force an entire existing suite through local providers
+without editing each `Test.make`.
+
+What each cloud emulates is covered in
+[Cloudflare local development](/cloudflare/local-development) and
+[AWS local development](/aws/local-development); the step-by-step
+walkthrough is [Cloudflare Tutorial Part 4](/cloudflare/tutorial/part-4).
+
+### `adopt`
+
+Engine-level adoption policy for the run, matching the CLI's
+`--adopt` flag. When `true`, a resource with no prior state whose
+physical counterpart already exists in the cloud is adopted via
+`provider.read` instead of failing. Defaults to `false`.
+
+### `sidecar`
+
+Only meaningful in dev mode, and defaults to the resolved `dev`
+flag: dev tests run local providers behind the same RPC sidecar
+process the real `alchemy dev` command uses. `sidecar: false` runs
+them in-process instead — useful when debugging provider code,
+since there's no child process between you and the breakpoint.
 
 ## Hooks
 

--- a/website/src/content/docs/testing/testing-a-stack.mdx
+++ b/website/src/content/docs/testing/testing-a-stack.mdx
@@ -69,6 +69,19 @@ bun test test/integ.test.ts
 
 The first run deploys; re-runs diff and skip unchanged Resources, and tests default to the isolated `test` [stage](/environments/stages) so they never clobber your dev deployment.
 
+## Run it locally with dev mode
+
+The same suite can run entirely on your machine. `dev: true` gives the file [`alchemy dev`](/environments/local-development) semantics — Workers, Durable Objects, KV, R2, D1, Queues, and Workflows run in workerd, AWS Lambda and its emulated services run in Docker — so `deploy(Stack)` boots local simulators and the `url` output points at `http://localhost:<port>`:
+
+```typescript
+const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
+  providers: Cloudflare.providers(),
+  dev: true,
+});
+```
+
+Every assertion below works unchanged against the local stack. To keep one file that runs locally on your laptop and live in CI, omit the flag and set `ALCHEMY_DEV=1` in your shell instead — see [Test harness → dev](/testing/test-harness#dev) for the full semantics and [Tutorial Part 4](/cloudflare/tutorial/part-4) for the walkthrough.
+
 ## Drive the live URL
 
 `HttpClient` is already in scope in every test Effect:


### PR DESCRIPTION
A user asked how to test Cloudflare Workflows locally and assumed workerd + the Cloudflare vitest plugin was the way, because our docs never mention the harness's `dev` option. No Alchemy page actually recommends the vitest plugin — the gap was that `Test.make({ dev: true })` was undocumented outside Tutorial Part 4, and the testing overview opened with "no mocks, no emulators".

```ts
const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
  providers: Cloudflare.providers(),
  dev: true, // deploy(Stack) boots workerd / Docker emulators instead of the cloud
});
```

- `testing/test-harness.mdx` — add `dev`, `adopt`, and `sidecar` to the options reference, including the `ALCHEMY_DEV` fallback and `ALCHEMY_TEST_DEV` override
- `testing/index.mdx` — soften the opener to "real clouds by default — no mocks" and add a "Local mode" section
- `testing/testing-a-stack.mdx` — add a "Run it locally with dev mode" section
- `cloudflare/compute/add-a-workflow.mdx` — add "Test it locally": the existing Workflow integration test runs unchanged in local workerd with real step semantics via a one-line `dev: true` diff
- `cloudflare/local-development.mdx`, `aws/local-development.mdx`, `environments/local-development.mdx` — add "test against the local stack" sections cross-linking the harness reference
