### PR TITLE
feat(planetscale): expose Postgres private connection details for AWS Privatelink etc.

### DIFF
--- a/packages/alchemy/src/Planetscale/Postgres/PostgresDefaultRole.ts
+++ b/packages/alchemy/src/Planetscale/Postgres/PostgresDefaultRole.ts
@@ -62,8 +62,16 @@ export interface PostgresDefaultRoleAttributes {
   databaseName: string;
   /** Direct connection URL for the database (Redacted). */
   connectionUrl: Redacted.Redacted<string>;
-  /** Pooled connection URL via PSBouncer (Redacted). */
+  /** Pooled connection URL via PgBouncer (Redacted). */
   connectionUrlPooled: Redacted.Redacted<string>;
+  /**
+   * Private connection host or DNS zone for this branch, supplied by
+   * PlanetScale. GCP Private Service Connect requires an endpoint name before
+   * this DNS zone.
+   */
+  privateHost: string;
+  /** Service name for this branch supplied by PlanetScale to establish a private connection. */
+  privateConnectionServiceName: string;
   /** Inherited roles. */
   inheritedRoles: InheritedRole[];
   /** Resolved organization slug. */
@@ -144,7 +152,11 @@ export const PostgresDefaultRoleProvider = () =>
           branch: output.branch,
         })
         .pipe(
-          Effect.map(() => output),
+          Effect.map((role) => ({
+            ...output,
+            privateHost: role.private_access_host_url,
+            privateConnectionServiceName: role.private_connection_service_name,
+          })),
           Effect.catchTag("NotFound", () => Effect.succeed(undefined)),
         );
     }),
@@ -171,11 +183,16 @@ export const PostgresDefaultRoleProvider = () =>
 
       // 2. Sync (no-op) — we own the role and it still exists in the
       //    cloud. Default roles have nothing mutable in place: their
-      //    plaintext password isn't retrievable, so we re-emit the
-      //    persisted attributes unchanged. diff() forces a replace
-      //    when database/branch change.
+      //    plaintext password isn't retrievable, so we retain the cached
+      //    credentials while refreshing the private connection details.
+      //    diff() forces a replace when database/branch change.
       if (output && observed) {
-        return output;
+        return {
+          ...output,
+          privateHost: observed.private_access_host_url,
+          privateConnectionServiceName:
+            observed.private_connection_service_name,
+        };
       }
 
       // 3. Adoption guard — observed exists but we have no prior
@@ -225,6 +242,8 @@ export const PostgresDefaultRoleProvider = () =>
         databaseName: data.database_name,
         connectionUrl: Redacted.make(connectionUrl),
         connectionUrlPooled: Redacted.make(connectionUrlPooled),
+        privateHost: data.private_access_host_url,
+        privateConnectionServiceName: data.private_connection_service_name,
         inheritedRoles: data.inherited_roles as InheritedRole[],
         organization,
         database: databaseName,
@@ -290,6 +309,9 @@ export const PostgresDefaultRoleProvider = () =>
                                     databaseName: role.database_name,
                                     connectionUrl: Redacted.make(""),
                                     connectionUrlPooled: Redacted.make(""),
+                                    privateHost: role.private_access_host_url,
+                                    privateConnectionServiceName:
+                                      role.private_connection_service_name,
                                     inheritedRoles:
                                       role.inherited_roles as InheritedRole[],
                                     organization,

--- a/packages/alchemy/src/Planetscale/Postgres/PostgresDefaultRole.ts
+++ b/packages/alchemy/src/Planetscale/Postgres/PostgresDefaultRole.ts
@@ -62,7 +62,7 @@ export interface PostgresDefaultRoleAttributes {
   databaseName: string;
   /** Direct connection URL for the database (Redacted). */
   connectionUrl: Redacted.Redacted<string>;
-  /** Pooled connection URL via PgBouncer (Redacted). */
+  /** Pooled connection URL via PSBouncer (Redacted). */
   connectionUrlPooled: Redacted.Redacted<string>;
   /**
    * Private connection host or DNS zone for this branch, supplied by

--- a/packages/alchemy/src/Planetscale/Postgres/PostgresRole.ts
+++ b/packages/alchemy/src/Planetscale/Postgres/PostgresRole.ts
@@ -115,11 +115,19 @@ export interface PostgresRoleAttributes {
   databaseName: string;
   /** Parsed direct (port 5432) connection components ready to feed into Cloudflare Hyperdrive. */
   origin: PostgresOrigin;
-  /** Parsed pooled (PSBouncer, port 6432) connection components, e.g. for a Hyperdrive `dev` origin. */
+  /** Parsed pooled (PgBouncer, port 6432) connection components, e.g. for a Hyperdrive `dev` origin. */
   pooledOrigin: PostgresOrigin;
+  /**
+   * Private connection host or DNS zone for this branch, supplied by
+   * PlanetScale. GCP Private Service Connect requires an endpoint name before
+   * this DNS zone.
+   */
+  privateHost: string;
+  /** Service name for this branch supplied by PlanetScale to establish a private connection. */
+  privateConnectionServiceName: string;
   /** Direct connection URL for the database (Redacted). */
   connectionUrl: Redacted.Redacted<string>;
-  /** Pooled connection URL via PSBouncer (port 6432, Redacted). */
+  /** Pooled connection URL via PgBouncer (port 6432, Redacted). */
   connectionUrlPooled: Redacted.Redacted<string>;
   /** Inherited roles. */
   inheritedRoles: InheritedRole[];
@@ -495,6 +503,8 @@ const buildAttributes = (
     name: string;
     expires_at: string | null;
     access_host_url: string;
+    private_access_host_url: string;
+    private_connection_service_name: string;
     username: string;
     database_name: string;
     ttl: number | null;
@@ -521,6 +531,8 @@ const buildAttributes = (
     password,
     connectionUrl: Redacted.make(connectionUrl),
     connectionUrlPooled: Redacted.make(connectionUrlPooled),
+    privateHost: role.private_access_host_url,
+    privateConnectionServiceName: role.private_connection_service_name,
     inheritedRoles: context.inheritedRoles,
     successor: context.successor,
     organization: context.organization,

--- a/packages/alchemy/src/Planetscale/Postgres/PostgresRole.ts
+++ b/packages/alchemy/src/Planetscale/Postgres/PostgresRole.ts
@@ -115,7 +115,7 @@ export interface PostgresRoleAttributes {
   databaseName: string;
   /** Parsed direct (port 5432) connection components ready to feed into Cloudflare Hyperdrive. */
   origin: PostgresOrigin;
-  /** Parsed pooled (PgBouncer, port 6432) connection components, e.g. for a Hyperdrive `dev` origin. */
+  /** Parsed pooled (PSBouncer, port 6432) connection components, e.g. for a Hyperdrive `dev` origin. */
   pooledOrigin: PostgresOrigin;
   /**
    * Private connection host or DNS zone for this branch, supplied by
@@ -127,7 +127,7 @@ export interface PostgresRoleAttributes {
   privateConnectionServiceName: string;
   /** Direct connection URL for the database (Redacted). */
   connectionUrl: Redacted.Redacted<string>;
-  /** Pooled connection URL via PgBouncer (port 6432, Redacted). */
+  /** Pooled connection URL via PSBouncer (port 6432, Redacted). */
   connectionUrlPooled: Redacted.Redacted<string>;
   /** Inherited roles. */
   inheritedRoles: InheritedRole[];

--- a/packages/alchemy/test/Planetscale/Postgres/PostgresRole.test.ts
+++ b/packages/alchemy/test/Planetscale/Postgres/PostgresRole.test.ts
@@ -18,6 +18,7 @@ const logLevel = Effect.provideService(
   MinimumLogLevel,
   process.env.DEBUG ? "Debug" : "Info",
 );
+
 describe
   .skipIf(!process.env.PLANETSCALE_TEST)
   .concurrent("PostgresRole", () => {
@@ -38,6 +39,8 @@ describe
             organization: expect.any(String),
             database: expect.any(String),
             branch: expect.any(String),
+            privateHost: expect.any(String),
+            privateConnectionServiceName: expect.any(String),
           });
         }
       }).pipe(logLevel),
@@ -104,6 +107,8 @@ describe
             organization: expect.any(String),
             database: expect.any(String),
             branch: expect.any(String),
+            privateHost: expect.any(String),
+            privateConnectionServiceName: expect.any(String),
           });
         }
       }).pipe(logLevel),
@@ -184,7 +189,21 @@ describe
             databaseName: "postgres",
             branch: "main",
             organization: database.organization,
+            privateHost: expect.any(String),
+            privateConnectionServiceName: expect.any(String),
           });
+
+          const defaultRoleFromApi = yield* ps.getDefaultRole({
+            organization: database.organization,
+            database: database.name,
+            branch: "main",
+          });
+          expect(role1.privateConnectionServiceName).toEqual(
+            defaultRoleFromApi.private_connection_service_name,
+          );
+          expect(role1.privateHost).toEqual(
+            defaultRoleFromApi.private_access_host_url,
+          );
 
           // Second: create again without forceReset — should fail (default already exists)
           const exit = yield* stack
@@ -284,7 +303,20 @@ describe
             host: expect.any(String),
             username: expect.any(String),
             password: expect.any(Object),
+            privateHost: expect.any(String),
+            privateConnectionServiceName: expect.any(String),
           });
+
+          const roleFromApi = yield* ps.getRole({
+            id: role.id,
+            database: database.name,
+            organization: database.organization,
+            branch: "main",
+          });
+          expect(role.privateConnectionServiceName).toEqual(
+            roleFromApi.private_connection_service_name,
+          );
+          expect(role.privateHost).toEqual(roleFromApi.private_access_host_url);
 
           // Update role with different ttl (should trigger replacement)
           const { updatedRole } = yield* stack.deploy(

--- a/website/src/content/docs/planetscale/data/credentials.mdx
+++ b/website/src/content/docs/planetscale/data/credentials.mdx
@@ -93,7 +93,7 @@ password syncs in place on the next deploy.
 Credentials expose parsed connection components ready to feed into
 consumers like [Cloudflare Hyperdrive](/cloudflare/data/hyperdrive).
 `PostgresRole` has two: `origin` is the direct connection (port
-5432), `pooledOrigin` goes through PgBouncer (port 6432):
+5432), `pooledOrigin` goes through PSBouncer (port 6432):
 
 ```typescript
 import * as Cloudflare from "alchemy/Cloudflare";
@@ -107,34 +107,6 @@ const hyperdrive = yield* Cloudflare.Hyperdrive.Connection("app-hyperdrive", {
 `MySQLPassword` exposes a single `origin`, and `PostgresDefaultRole`
 carries the same direct/pooled endpoints as `Redacted` URL strings
 (`connectionUrl` / `connectionUrlPooled`), as does `PostgresRole`.
-
-## Private Postgres connections
-
-For PlanetScale Postgres branches, roles expose the private host and
-service name without copying them from the dashboard. On AWS, use the
-service name to create an Interface VPC endpoint:
-
-```typescript
-import * as AWS from "alchemy/AWS";
-
-yield* AWS.EC2.VpcEndpoint("postgres-private-link", {
-  vpcId: vpc.vpcId,
-  serviceName: reader.privateConnectionServiceName,
-  vpcEndpointType: "Interface",
-  subnetIds: [privateSubnet.subnetId],
-  securityGroupIds: [databaseSecurityGroup.groupId],
-  privateDnsEnabled: true,
-});
-
-const privateOrigin = { ...reader.origin, host: reader.privateHost };
-const privatePooledOrigin = {
-  ...reader.pooledOrigin,
-  host: reader.privateHost,
-};
-```
-
-For GCP Private Service Connect, combine the endpoint name configured
-in GCP with `privateHost` before connecting.
 
 ## Where next
 

--- a/website/src/content/docs/planetscale/data/credentials.mdx
+++ b/website/src/content/docs/planetscale/data/credentials.mdx
@@ -93,7 +93,7 @@ password syncs in place on the next deploy.
 Credentials expose parsed connection components ready to feed into
 consumers like [Cloudflare Hyperdrive](/cloudflare/data/hyperdrive).
 `PostgresRole` has two: `origin` is the direct connection (port
-5432), `pooledOrigin` goes through PSBouncer (port 6432):
+5432), `pooledOrigin` goes through PgBouncer (port 6432):
 
 ```typescript
 import * as Cloudflare from "alchemy/Cloudflare";
@@ -107,6 +107,34 @@ const hyperdrive = yield* Cloudflare.Hyperdrive.Connection("app-hyperdrive", {
 `MySQLPassword` exposes a single `origin`, and `PostgresDefaultRole`
 carries the same direct/pooled endpoints as `Redacted` URL strings
 (`connectionUrl` / `connectionUrlPooled`), as does `PostgresRole`.
+
+## Private Postgres connections
+
+For PlanetScale Postgres branches, roles expose the private host and
+service name without copying them from the dashboard. On AWS, use the
+service name to create an Interface VPC endpoint:
+
+```typescript
+import * as AWS from "alchemy/AWS";
+
+yield* AWS.EC2.VpcEndpoint("postgres-private-link", {
+  vpcId: vpc.vpcId,
+  serviceName: reader.privateConnectionServiceName,
+  vpcEndpointType: "Interface",
+  subnetIds: [privateSubnet.subnetId],
+  securityGroupIds: [databaseSecurityGroup.groupId],
+  privateDnsEnabled: true,
+});
+
+const privateOrigin = { ...reader.origin, host: reader.privateHost };
+const privatePooledOrigin = {
+  ...reader.pooledOrigin,
+  host: reader.privateHost,
+};
+```
+
+For GCP Private Service Connect, combine the endpoint name configured
+in GCP with `privateHost` before connecting.
 
 ## Where next
 

--- a/website/src/content/docs/planetscale/data/postgres.mdx
+++ b/website/src/content/docs/planetscale/data/postgres.mdx
@@ -170,32 +170,6 @@ prepend the endpoint name configured in GCP before connecting.
 `PostgresDefaultRole` exposes the same details, though `PostgresRole`
 remains the safer choice for applications.
 
-### Why these outputs exist
-
-PlanetScale returns the private host and service name through role
-responses, but both are shared by every role on a branch. Exposing
-them lets one Stack declare the endpoint and the workload together,
-instead of copying connection details from the dashboard into a second
-system. Alchemy deliberately does not synthesize private URLs: GCP
-needs the endpoint name you choose in addition to `privateHost`.
-
-### Verifying an AWS PrivateLink deployment
-
-The provider tests verify PlanetScale's field mapping. A full private
-network test needs an entitled PlanetScale Postgres database and AWS
-resources in the same region. A future opt-in integration test should:
-
-1. Deploy a `PostgresRole`, VPC, Interface `VpcEndpoint`, subnets, and
-   security group permitting TCP ports 5432 and 6432.
-2. Assert the endpoint's `serviceName` equals
-   `role.privateConnectionServiceName`, then resolve `role.privateHost`
-   from a Lambda or EC2 instance in the VPC.
-3. Run a database query through the private host on both ports and
-   confirm that the resolved address is private.
-
-Keep this behind `PLANETSCALE_AWS_PRIVATELINK_TEST=1`: it provisions
-real, billable AWS and PlanetScale infrastructure.
-
 ## Where next
 
 - [Migrations](/planetscale/data/migrations) — `migrations` and

--- a/website/src/content/docs/planetscale/data/postgres.mdx
+++ b/website/src/content/docs/planetscale/data/postgres.mdx
@@ -148,7 +148,6 @@ an Interface VPC endpoint. With private DNS enabled, use
 
 ```typescript
 import * as AWS from "alchemy/AWS";
-import * as Cloudflare from "alchemy/Cloudflare";
 
 const endpoint = yield* AWS.EC2.VpcEndpoint("postgres-private-link", {
   vpcId: vpc.vpcId,
@@ -157,11 +156,6 @@ const endpoint = yield* AWS.EC2.VpcEndpoint("postgres-private-link", {
   subnetIds: [privateSubnet.subnetId],
   securityGroupIds: [databaseSecurityGroup.groupId],
   privateDnsEnabled: true,
-});
-
-const hyperdrive = yield* Cloudflare.Hyperdrive.Connection("private-db", {
-  origin: { ...role.origin, host: role.privateHost }, // direct, port 5432
-  dev: { ...role.pooledOrigin, host: role.privateHost }, // PSBouncer, port 6432
 });
 ```
 

--- a/website/src/content/docs/planetscale/data/postgres.mdx
+++ b/website/src/content/docs/planetscale/data/postgres.mdx
@@ -122,7 +122,7 @@ into consumers like [Cloudflare Hyperdrive](/cloudflare/data/hyperdrive):
 
 - `role.origin` — the **direct** connection (port 5432). Use it where
   the consumer does its own pooling, e.g. as a Hyperdrive origin.
-- `role.pooledOrigin` — the **pooled** connection via PgBouncer
+- `role.pooledOrigin` — the **pooled** connection via PSBouncer
   (port 6432). Use it where each request would otherwise open a fresh
   direct connection, e.g. Hyperdrive's local-dev origin.
 
@@ -161,7 +161,7 @@ const endpoint = yield* AWS.EC2.VpcEndpoint("postgres-private-link", {
 
 const hyperdrive = yield* Cloudflare.Hyperdrive.Connection("private-db", {
   origin: { ...role.origin, host: role.privateHost }, // direct, port 5432
-  dev: { ...role.pooledOrigin, host: role.privateHost }, // PgBouncer, port 6432
+  dev: { ...role.pooledOrigin, host: role.privateHost }, // PSBouncer, port 6432
 });
 ```
 

--- a/website/src/content/docs/planetscale/data/postgres.mdx
+++ b/website/src/content/docs/planetscale/data/postgres.mdx
@@ -122,7 +122,7 @@ into consumers like [Cloudflare Hyperdrive](/cloudflare/data/hyperdrive):
 
 - `role.origin` — the **direct** connection (port 5432). Use it where
   the consumer does its own pooling, e.g. as a Hyperdrive origin.
-- `role.pooledOrigin` — the **pooled** connection via PSBouncer
+- `role.pooledOrigin` — the **pooled** connection via PgBouncer
   (port 6432). Use it where each request would otherwise open a fresh
   direct connection, e.g. Hyperdrive's local-dev origin.
 
@@ -138,6 +138,63 @@ const hyperdrive = yield* Cloudflare.Hyperdrive.Connection("app-hyperdrive", {
 If you need a URL instead of components, `connectionUrl` and
 `connectionUrlPooled` carry the same direct/pooled endpoints as
 `Redacted` connection strings (`sslmode=verify-full`).
+
+## Connect privately with AWS PrivateLink
+
+Postgres roles expose the branch's provider-neutral private connection
+details. For AWS PrivateLink, pass `privateConnectionServiceName` to
+an Interface VPC endpoint. With private DNS enabled, use
+`privateHost` for workloads in that VPC:
+
+```typescript
+import * as AWS from "alchemy/AWS";
+import * as Cloudflare from "alchemy/Cloudflare";
+
+const endpoint = yield* AWS.EC2.VpcEndpoint("postgres-private-link", {
+  vpcId: vpc.vpcId,
+  serviceName: role.privateConnectionServiceName,
+  vpcEndpointType: "Interface",
+  subnetIds: [privateSubnet.subnetId],
+  securityGroupIds: [databaseSecurityGroup.groupId],
+  privateDnsEnabled: true,
+});
+
+const hyperdrive = yield* Cloudflare.Hyperdrive.Connection("private-db", {
+  origin: { ...role.origin, host: role.privateHost }, // direct, port 5432
+  dev: { ...role.pooledOrigin, host: role.privateHost }, // PgBouncer, port 6432
+});
+```
+
+For GCP Private Service Connect, `privateHost` is the private DNS zone;
+prepend the endpoint name configured in GCP before connecting.
+`PostgresDefaultRole` exposes the same details, though `PostgresRole`
+remains the safer choice for applications.
+
+### Why these outputs exist
+
+PlanetScale returns the private host and service name through role
+responses, but both are shared by every role on a branch. Exposing
+them lets one Stack declare the endpoint and the workload together,
+instead of copying connection details from the dashboard into a second
+system. Alchemy deliberately does not synthesize private URLs: GCP
+needs the endpoint name you choose in addition to `privateHost`.
+
+### Verifying an AWS PrivateLink deployment
+
+The provider tests verify PlanetScale's field mapping. A full private
+network test needs an entitled PlanetScale Postgres database and AWS
+resources in the same region. A future opt-in integration test should:
+
+1. Deploy a `PostgresRole`, VPC, Interface `VpcEndpoint`, subnets, and
+   security group permitting TCP ports 5432 and 6432.
+2. Assert the endpoint's `serviceName` equals
+   `role.privateConnectionServiceName`, then resolve `role.privateHost`
+   from a Lambda or EC2 instance in the VPC.
+3. Run a database query through the private host on both ports and
+   confirm that the resolved address is private.
+
+Keep this behind `PLANETSCALE_AWS_PRIVATELINK_TEST=1`: it provisions
+real, billable AWS and PlanetScale infrastructure.
 
 ## Where next
 


### PR DESCRIPTION
## Summary

PlanetScale returns `private_access_host_url` and `private_connection_service_name` with Postgres role responses, but Alchemy previously dropped both values.

That made private connectivity less straightforward to compose from Alchemy alone: applications had to copy the service name and private host from the PlanetScale dashboard, or call the underlying SDK themselves, before creating an AWS Interface VPC endpoint.

Expose the two raw PlanetScale values on both `PostgresRole` and `PostgresDefaultRole`:

```ts
const role = yield* Planetscale.PostgresRole("app", { database });

const endpoint = yield* AWS.EC2.VpcEndpoint("planetscale", {
  vpcId: vpc.vpcId,
  serviceName: role.privateConnectionServiceName,
  vpcEndpointType: "Interface",
  subnetIds: [subnetA.subnetId, subnetB.subnetId],
  securityGroupIds: [endpointSecurityGroup.groupId],
  privateDnsEnabled: true,
});
```

The fields are branch-scoped in PlanetScale, although they are returned from role endpoints. They are mapped during create, read, reconcile, and list, so existing resources receive them on their next refresh.

This intentionally exposes only the raw values. It does not synthesize private URLs or origins: GCP Private Service Connect requires a user-chosen endpoint name in addition to `privateHost`, so a generic private URL would be incorrect.

No props, diff rules, or replacement behavior change. Passwords and existing connection URLs remain `Redacted`.

PlanetScale documents retrieving the Private Host and Private Service Name from role details, using the service name for the cloud endpoint, then using the private host from workloads: <https://planetscale.com/docs/postgres/connecting/private-connections/aws-privatelink>