### PR TITLE
fix(aws/website): dev-connectable site URLs; green test:aws:floci with floci 1.6.0-alchemy.9

### DIFF
--- a/packages/alchemy/src/AWS/Website/StaticSite.ts
+++ b/packages/alchemy/src/AWS/Website/StaticSite.ts
@@ -760,15 +760,19 @@ export const makeKvSite = Effect.fn("AWS.Website.KvSite")(function* (
     // Precedence: the canonical domain, then aliases in declaration
     // order, then the CloudFront default domain (only while
     // `cloudfrontUrl` is enabled). Redirect hostnames never appear.
+    //
+    // `dist.url` rather than an interpolated
+    // `https://${dist.domainName}` (same as Router): the distribution
+    // knows its own address, which is `https://{id}.cloudfront.net` on
+    // AWS and `http://localhost:{port}` under `alchemy dev`, where that
+    // AWS hostname resolves to nothing.
     urls = domain
       ? [
           Output.interpolate`https://${domain.name}`,
           ...(domain.aliases ?? []).map((alias) => `https://${alias}`),
-          ...(props.cloudfrontUrl !== false
-            ? [Output.interpolate`https://${dist.domainName}`]
-            : []),
+          ...(props.cloudfrontUrl !== false ? [dist.url] : []),
         ]
-      : [Output.interpolate`https://${dist.domainName}`];
+      : [dist.url];
   }
 
   // The edge router signs S3 origin requests with OAC (sigv4, see

--- a/packages/alchemy/src/Command/Dev.ts
+++ b/packages/alchemy/src/Command/Dev.ts
@@ -218,7 +218,15 @@ const ANSI_REGEX = /\x1b\[[0-9;]*m/g;
  */
 export const extractUrl = (text: string) => {
   const clean = text.replaceAll(ANSI_REGEX, "");
-  return clean.match(LOCAL_URL_REGEX)?.[0] ?? clean.match(URL_REGEX)?.[0];
+  const url = clean.match(LOCAL_URL_REGEX)?.[0] ?? clean.match(URL_REGEX)?.[0];
+  // Some dev servers print their *bind* address (Nuxt: `http://0.0.0.0:3000`),
+  // which is not a connectable host. Normalize the unspecified address to
+  // `localhost` so consumers of `url` — browser links, Router dev routing,
+  // the emulated CloudFront edge dialing the origin — can actually reach it.
+  return url?.replace(
+    /^(https?:\/\/)(?:0\.0\.0\.0|\[::\]|\[0+:0+:0+:0+:0+:0+:0+:0+\])(?=[:/]|$)/,
+    "$1localhost",
+  );
 };
 
 const isLocalUrl = (url: string) => LOCAL_URL_REGEX.test(url);

--- a/packages/alchemy/src/Website/Server.ts
+++ b/packages/alchemy/src/Website/Server.ts
@@ -457,6 +457,21 @@ const resolveDevPort = Effect.fn(function* (options: {
 });
 
 /**
+ * A framework dev server may advertise its *bind* address — nuxt echoes the
+ * host it was told to listen on, so a Router-attached site (which binds
+ * `0.0.0.0` to be reachable from the emulator container) reports
+ * `http://0.0.0.0:{port}/`. The unspecified address is not a connectable
+ * host: normalize it to `localhost` for the `url` attribute (browser links,
+ * Router dev routing, the emulated CloudFront edge dialing the origin). The
+ * server itself still listens on every interface.
+ */
+const normalizeAdvertisedUrl = (url: string) =>
+  url.replace(
+    /^(https?:\/\/)(?:0\.0\.0\.0|\[::\]|\[0+(?::0+){7}\])(?=[:/]|$)/,
+    "$1localhost",
+  );
+
+/**
  * The `alchemy dev` variant: runs the framework's own dev server (native
  * HMR through the framework's kit — nuxt, astro, ...) inside the dev
  * sidecar, so it survives user-code hot reloads. Restarts when the
@@ -536,7 +551,7 @@ export const ServerProviderLocal = () =>
             distDir: undefined,
             clientDir: undefined,
             serverEntry: undefined,
-            url,
+            url: normalizeAdvertisedUrl(url),
             hash: { input: undefined, output: undefined },
           };
         }),

--- a/packages/alchemy/test/AWS/Website/Astro.test.ts
+++ b/packages/alchemy/test/AWS/Website/Astro.test.ts
@@ -28,7 +28,13 @@ const fixtureEntries = [
   "public",
 ];
 
-describe.skipIf(!runLive)("AWS.Website.Astro", () => {
+// Skipped under the floci runner: in dev the composite deploys only the
+// framework dev server (no Lambda/S3/CloudFront), so this test's live
+// topology assertions are meaningless there. Dev behavior is covered by
+// the co-located Astro.local.test.ts suite.
+const runEmulated = process.env.ALCHEMY_TEST_DEV === "1";
+
+describe.skipIf(!runLive || runEmulated)("AWS.Website.Astro", () => {
   test.provider(
     "deploys SSR on a streaming Lambda URL with S3 assets behind CloudFront",
     (stack) =>

--- a/packages/alchemy/test/AWS/Website/Foldkit.test.ts
+++ b/packages/alchemy/test/AWS/Website/Foldkit.test.ts
@@ -36,7 +36,13 @@ const fixtureEntries = [
   "public",
 ];
 
-describe.skipIf(!runLive)("AWS.Website.Foldkit", () => {
+// Skipped under the floci runner: in dev the composite deploys only the
+// framework dev server (no Lambda/S3/CloudFront), so this test's live
+// topology assertions are meaningless there. Dev behavior is covered by
+// the co-located Foldkit.local.test.ts suite.
+const runEmulated = process.env.ALCHEMY_TEST_DEV === "1";
+
+describe.skipIf(!runLive || runEmulated)("AWS.Website.Foldkit", () => {
   // The resource's reason to exist: a Foldkit app routes on the client, so
   // the deployment is assets-only and deep links fall back to the shell
   // without the caller configuring anything.

--- a/packages/alchemy/test/AWS/Website/Nextjs.test.ts
+++ b/packages/alchemy/test/AWS/Website/Nextjs.test.ts
@@ -63,7 +63,13 @@ const run = (options: {
     return Effect.sync(() => child.kill("SIGKILL"));
   });
 
-describe.skipIf(!runLive)("AWS.Website.Nextjs", () => {
+// Skipped under the floci runner: in dev the composite deploys only the
+// framework dev server (no Lambda/S3/CloudFront), so this test's live
+// topology assertions are meaningless there. Dev behavior is covered by
+// the co-located Nextjs.local.test.ts suite.
+const runEmulated = process.env.ALCHEMY_TEST_DEV === "1";
+
+describe.skipIf(!runLive || runEmulated)("AWS.Website.Nextjs", () => {
   test.provider(
     "deploys the OpenNext topology: streaming SSR Lambda, S3 assets, image optimizer, ISR wiring",
     (stack) =>

--- a/packages/alchemy/test/AWS/Website/Nuxt.test.ts
+++ b/packages/alchemy/test/AWS/Website/Nuxt.test.ts
@@ -29,8 +29,15 @@ const fixtureEntries = [
   "public",
 ];
 
+// Under the floci runner the standalone composite deploys only the framework
+// dev server (no Lambda/S3/CloudFront), so the standalone test below is
+// live-only; the shared-Router test runs in both modes because the Router
+// pipeline deploys fully against the emulator, which serves the router's
+// edge on a local plain-HTTP port.
+const runEmulated = process.env.ALCHEMY_TEST_DEV === "1";
+
 describe.skipIf(!runLive)("AWS.Website.Nuxt", () => {
-  test.provider(
+  test.provider.skipIf(runEmulated)(
     "deploys SSR on a streaming Lambda URL with S3 assets behind CloudFront",
     (stack) =>
       Effect.gen(function* () {
@@ -151,7 +158,11 @@ describe.skipIf(!runLive)("AWS.Website.Nuxt", () => {
         );
 
         const url = deployed.router.url as string;
-        expect(url).toMatch(/^https:\/\//);
+        // `https://{id}.cloudfront.net` live; the emulator serves the
+        // router's edge on a local plain-HTTP port.
+        expect(url).toMatch(
+          runEmulated ? /^http:\/\/localhost:\d+/ : /^https:\/\//,
+        );
 
         // SSR through the ROUTER's distribution (the site registered
         // itself in the router's KV store — no site-owned distribution).

--- a/packages/alchemy/test/AWS/Website/Octane.test.ts
+++ b/packages/alchemy/test/AWS/Website/Octane.test.ts
@@ -31,7 +31,13 @@ const fixtureEntries = [
   "public",
 ];
 
-describe.skipIf(!runLive)("AWS.Website.Octane", () => {
+// Skipped under the floci runner: in dev the composite deploys only the
+// framework dev server (no Lambda/S3/CloudFront), so this test's live
+// topology assertions are meaningless there. Dev behavior is covered by
+// the co-located Octane.local.test.ts suite.
+const runEmulated = process.env.ALCHEMY_TEST_DEV === "1";
+
+describe.skipIf(!runLive || runEmulated)("AWS.Website.Octane", () => {
   test.provider(
     "deploys SSR on a streaming Lambda URL with S3 assets behind CloudFront",
     (stack) =>

--- a/packages/alchemy/test/AWS/Website/ReactRouter.test.ts
+++ b/packages/alchemy/test/AWS/Website/ReactRouter.test.ts
@@ -34,8 +34,15 @@ const fixtureEntries = [
   "public",
 ];
 
+// Under the floci runner the standalone composite deploys only the framework
+// dev server (no Lambda/S3/CloudFront), so the standalone test below is
+// live-only; the shared-Router test runs in both modes because the Router
+// pipeline deploys fully against the emulator, which serves the router's
+// edge on a local plain-HTTP port.
+const runEmulated = process.env.ALCHEMY_TEST_DEV === "1";
+
 describe.skipIf(!runLive)("AWS.Website.ReactRouter", () => {
-  test.provider(
+  test.provider.skipIf(runEmulated)(
     "deploys SSR on a streaming Lambda URL with S3 assets behind CloudFront",
     (stack) =>
       Effect.gen(function* () {
@@ -150,7 +157,11 @@ describe.skipIf(!runLive)("AWS.Website.ReactRouter", () => {
         );
 
         const url = deployed.router.url as string;
-        expect(url).toMatch(/^https:\/\//);
+        // `https://{id}.cloudfront.net` live; the emulator serves the
+        // router's edge on a local plain-HTTP port.
+        expect(url).toMatch(
+          runEmulated ? /^http:\/\/localhost:\d+/ : /^https:\/\//,
+        );
 
         // SSR through the ROUTER's distribution (the site registered itself
         // in the router's KV store — no site-owned distribution).

--- a/packages/alchemy/test/AWS/Website/Router.test.ts
+++ b/packages/alchemy/test/AWS/Website/Router.test.ts
@@ -55,10 +55,11 @@ describe.skipIf(!runLive)("AWS.Website.Router", () => {
         expect(deployed.router.kvStoreArn).toBeDefined();
 
         // urls contract (cloudfront-default arm): a router without a
-        // domain serves only at its CloudFront default domain, and `url`
-        // is always `urls[0]`.
+        // domain serves only at the distribution's own URL (its CloudFront
+        // default domain live, a local edge port under the emulator), and
+        // `url` is always `urls[0]`.
         expect(deployed.router.urls).toEqual([
-          `https://${deployed.router.distribution.domainName}`,
+          deployed.router.distribution.url,
         ]);
         expect(deployed.router.url).toBe(deployed.router.urls[0]);
         // A path-only attached site inherits the router's primary URL.

--- a/packages/alchemy/test/AWS/Website/SolidStart.test.ts
+++ b/packages/alchemy/test/AWS/Website/SolidStart.test.ts
@@ -33,8 +33,15 @@ const fixtureEntries = [
   "public",
 ];
 
+// Under the floci runner the standalone composite deploys only the framework
+// dev server (no Lambda/S3/CloudFront), so the standalone test below is
+// live-only; the shared-Router test runs in both modes because the Router
+// pipeline deploys fully against the emulator, which serves the router's
+// edge on a local plain-HTTP port.
+const runEmulated = process.env.ALCHEMY_TEST_DEV === "1";
+
 describe.skipIf(!runLive)("AWS.Website.SolidStart", () => {
-  test.provider(
+  test.provider.skipIf(runEmulated)(
     "deploys SSR on a streaming Lambda URL with S3 assets behind CloudFront",
     (stack) =>
       Effect.gen(function* () {
@@ -155,7 +162,11 @@ describe.skipIf(!runLive)("AWS.Website.SolidStart", () => {
         );
 
         const url = deployed.router.url as string;
-        expect(url).toMatch(/^https:\/\//);
+        // `https://{id}.cloudfront.net` live; the emulator serves the
+        // router's edge on a local plain-HTTP port.
+        expect(url).toMatch(
+          runEmulated ? /^http:\/\/localhost:\d+/ : /^https:\/\//,
+        );
 
         // SSR through the ROUTER's distribution (the site registered
         // itself in the router's KV store — no site-owned distribution).

--- a/packages/alchemy/test/AWS/Website/StaticSite.test.ts
+++ b/packages/alchemy/test/AWS/Website/StaticSite.test.ts
@@ -18,6 +18,12 @@ const { test } = Test.make({ providers: AWS.providers() });
 // as the AWS.CloudFront suites).
 const runLive = !process.env.FAST;
 
+// Under the floci runner the full pipeline (bucket + files + KVS +
+// distribution) deploys against the emulator, which serves the
+// distribution's edge on a local plain-HTTP port — so the whole test runs
+// in both modes; only the URL-shape assertions differ.
+const runEmulated = process.env.ALCHEMY_TEST_DEV === "1";
+
 const fixtureDir = fileURLToPath(
   new URL("./fixtures/static-site", import.meta.url),
 );
@@ -47,14 +53,16 @@ describe.skipIf(!runLive)("AWS.Website.StaticSite", () => {
         );
 
         const url = spa.site.url! as string;
-        expect(url).toMatch(/^https:\/\//);
+        // `https://{id}.cloudfront.net` live; the emulator serves the
+        // distribution's edge on a local plain-HTTP port.
+        expect(url).toMatch(
+          runEmulated ? /^http:\/\/localhost:\d+/ : /^https:\/\//,
+        );
 
         // urls contract (cloudfront-default arm): a domain-less site
-        // serves only at its CloudFront default domain, and `url` is
+        // serves only at the distribution's own URL, and `url` is
         // always `urls[0]`.
-        expect(spa.site.urls).toEqual([
-          `https://${spa.site.distribution!.domainName}`,
-        ]);
+        expect(spa.site.urls).toEqual([spa.site.distribution!.url]);
         expect(url).toBe(spa.site.urls[0]);
 
         // Root serves the index page. Generous first-request budget: the

--- a/packages/alchemy/test/AWS/Website/SvelteKit.test.ts
+++ b/packages/alchemy/test/AWS/Website/SvelteKit.test.ts
@@ -27,7 +27,13 @@ const tempRoot = pathe.resolve(import.meta.dirname, "../../../.tmp");
 
 const fixtureEntries = [".gitignore", "package.json", "src", "static"];
 
-describe.skipIf(!runLive)("AWS.Website.SvelteKit", () => {
+// Skipped under the floci runner: in dev the composite deploys only the
+// framework dev server (no Lambda/S3/CloudFront), so this test's live
+// topology assertions are meaningless there. Dev behavior is covered by
+// the co-located SvelteKit.local.test.ts suite.
+const runEmulated = process.env.ALCHEMY_TEST_DEV === "1";
+
+describe.skipIf(!runLive || runEmulated)("AWS.Website.SvelteKit", () => {
   test.provider(
     "deploys SSR on a streaming Lambda URL with S3 assets behind CloudFront",
     (stack) =>

--- a/packages/alchemy/test/AWS/Website/TanStackStart.test.ts
+++ b/packages/alchemy/test/AWS/Website/TanStackStart.test.ts
@@ -33,8 +33,15 @@ const fixtureEntries = [
   "public",
 ];
 
+// Under the floci runner the standalone composite deploys only the framework
+// dev server (no Lambda/S3/CloudFront), so the standalone test below is
+// live-only; the shared-Router test runs in both modes because the Router
+// pipeline deploys fully against the emulator, which serves the router's
+// edge on a local plain-HTTP port.
+const runEmulated = process.env.ALCHEMY_TEST_DEV === "1";
+
 describe.skipIf(!runLive)("AWS.Website.TanStackStart", () => {
-  test.provider(
+  test.provider.skipIf(runEmulated)(
     "deploys SSR on a streaming Lambda URL with S3 assets behind CloudFront",
     (stack) =>
       Effect.gen(function* () {
@@ -149,7 +156,11 @@ describe.skipIf(!runLive)("AWS.Website.TanStackStart", () => {
         );
 
         const url = deployed.router.url as string;
-        expect(url).toMatch(/^https:\/\//);
+        // `https://{id}.cloudfront.net` live; the emulator serves the
+        // router's edge on a local plain-HTTP port.
+        expect(url).toMatch(
+          runEmulated ? /^http:\/\/localhost:\d+/ : /^https:\/\//,
+        );
 
         // SSR through the ROUTER's distribution (the site registered itself
         // in the router's KV store — no site-owned distribution).

--- a/packages/alchemy/test/AWS/Website/Vite.test.ts
+++ b/packages/alchemy/test/AWS/Website/Vite.test.ts
@@ -35,7 +35,11 @@ const staticFixtureDir = pathe.resolve(
 // hoisted node_modules (the fixture has no node_modules).
 const tempRoot = pathe.resolve(import.meta.dirname, "../../../.tmp");
 
-describe.skipIf(!runLive)("AWS.Website.Vite", () => {
+// Also skipped under the floci runner (`runEmulated`): in dev the composite
+// deploys nothing but the vite dev server, so the live CloudFront topology
+// this test asserts never exists. The emulated pipeline test below and
+// Vite.local.test.ts cover the dev-mode behavior.
+describe.skipIf(!runLive || runEmulated)("AWS.Website.Vite", () => {
   test.provider(
     "deploys the vite build to S3 behind CloudFront with SPA fallback",
     (stack) =>

--- a/packages/alchemy/test/AWS/Website/Waku.test.ts
+++ b/packages/alchemy/test/AWS/Website/Waku.test.ts
@@ -28,7 +28,13 @@ const fixtureEntries = [
   "public",
 ];
 
-describe.skipIf(!runLive)("AWS.Website.Waku", () => {
+// Skipped under the floci runner: in dev the composite deploys only the
+// framework dev server (no Lambda/S3/CloudFront), so this test's live
+// topology assertions are meaningless there. Dev behavior is covered by
+// the co-located Waku.local.test.ts suite.
+const runEmulated = process.env.ALCHEMY_TEST_DEV === "1";
+
+describe.skipIf(!runLive || runEmulated)("AWS.Website.Waku", () => {
   test.provider(
     "deploys RSC SSR on a streaming Lambda URL with S3 assets behind CloudFront",
     (stack) =>

--- a/packages/alchemy/test/Command/Dev.test.ts
+++ b/packages/alchemy/test/Command/Dev.test.ts
@@ -491,6 +491,17 @@ describe("extractUrl", () => {
     ).toBe("https://docs.astro.build/en/guides/x/");
   });
 
+  it("normalizes a bind-all address to localhost", () => {
+    // Nuxt prints its *bind* address (`0.0.0.0`), which is not a
+    // connectable host — consumers of `url` must be able to dial it.
+    expect(Command.extractUrl("Listening on http://0.0.0.0:3000/")).toBe(
+      "http://localhost:3000/",
+    );
+    expect(Command.extractUrl("Listening on http://[::]:3000/")).toBe(
+      "http://localhost:3000/",
+    );
+  });
+
   it("strips ANSI escapes before matching", () => {
     expect(Command.extractUrl("\x1b[36mhttp://localhost:5173/\x1b[0m")).toBe(
       "http://localhost:5173/",

--- a/packages/floci/src/index.ts
+++ b/packages/floci/src/index.ts
@@ -37,7 +37,7 @@ import * as path from "node:path";
  * workflow. Bumping this pin (with a new `x.y.z-alchemy.N` tag) is how an
  * emulator change reaches users.
  */
-export const DEFAULT_FLOCI_IMAGE = "ghcr.io/alchemy-run/floci:1.6.0-alchemy.8";
+export const DEFAULT_FLOCI_IMAGE = "ghcr.io/alchemy-run/floci:1.6.0-alchemy.9";
 
 /** Default gateway port (LocalStack-compatible). */
 export const DEFAULT_FLOCI_PORT = 4566;

--- a/scripts/test-aws-floci.ts
+++ b/scripts/test-aws-floci.ts
@@ -93,7 +93,26 @@ for (const root of requestedRoots) {
 }
 
 process.env.ALCHEMY_TEST_DEV = "1";
-process.env.ALCHEMY_FLOCI_IMAGE ??= "floci:dev";
+
+// Prefer a locally built `floci:dev` (pnpm floci:build) when it exists —
+// that's how unreleased emulator patches get exercised by this suite. When
+// it doesn't, leave the env unset so the floci package resolves the pinned
+// release image; hard-defaulting to a missing image fails every suite's
+// `docker run` before a single test can run.
+if (!process.env.ALCHEMY_FLOCI_IMAGE) {
+  const devImage = Bun.spawnSync(
+    ["docker", "image", "inspect", "floci:dev"],
+    { stdout: "ignore", stderr: "ignore" },
+  );
+  if (devImage.exitCode === 0) {
+    process.env.ALCHEMY_FLOCI_IMAGE = "floci:dev";
+    console.log("test:aws:floci: using locally built floci:dev image");
+  } else {
+    console.log(
+      "test:aws:floci: no local floci:dev image (pnpm floci:build) — using the pinned release image",
+    );
+  }
+}
 
 if (!flags.includes("--profile")) {
   flags.unshift("--profile", "testing");


### PR DESCRIPTION
Gets `test:aws:floci` fully green (was 21 failed): two product fixes for dev-mode site URLs, dev-aware Website suites, and the floci `1.6.0-alchemy.9` bump carrying the emulator fixes ([alchemy-run/floci#7](https://github.com/alchemy-run/floci/pull/7)).

### StaticSite `urls` follow the distribution

```diff
 urls = domain
   ? [
       Output.interpolate`https://${domain.name}`,
       ...(domain.aliases ?? []).map((alias) => `https://${alias}`),
-      ...(props.cloudfrontUrl !== false
-        ? [Output.interpolate`https://${dist.domainName}`]
-        : []),
+      ...(props.cloudfrontUrl !== false ? [dist.url] : []),
     ]
-  : [Output.interpolate`https://${dist.domainName}`];
+  : [dist.url];
```

Same rationale as Router: the distribution knows its own address — `https://{id}.cloudfront.net` live, `http://localhost:{port}` under `alchemy dev`, where the cloudfront.net hostname resolves to nothing.

### Dev servers advertise a connectable host

Router-attached dev servers bind `0.0.0.0` so the emulator container can reach them via the host gateway, and nuxt echoes that *bind* address in its printed URL. `http://0.0.0.0:{port}` flowed into the Router's KV origin metadata as a host the emulated edge can't dial. `Website/Server` (and `Command.Dev`'s `extractUrl`) now normalize the unspecified address:

```ts
url.replace(
  /^(https?:\/\/)(?:0\.0\.0\.0|\[::\]|\[0+(?::0+){7}\])(?=[:/]|$)/,
  "$1localhost",
)
```

The server still listens on every interface; only the advertised `url` changes.

### Dev-aware Website suites

- Standalone composite tests (SvelteKit, Astro, Nextjs, Waku, Octane, Vite, Foldkit, and the standalone half of ReactRouter/Nuxt/SolidStart/TanStackStart) skip under `ALCHEMY_TEST_DEV=1`: in dev the composite deploys only the framework dev server, so the live topology they assert never exists — the co-located `*.local.test.ts` suites own that mode.
- Router, StaticSite, and the shared-Router tests run fully against the emulated pipeline (SSR through the local edge, KV routing, S3 assets, SPA fallback, real 404s); `urls` contracts compare against `distribution.url` and the scheme assertion branches on the runner mode.
- `test:aws:floci` prefers a locally built `floci:dev` image when one exists, falling back to the pinned release.

### floci 1.6.0-alchemy.9

`DEFAULT_FLOCI_IMAGE` and the submodule pointer move to the release built from [alchemy-run/floci#7](https://github.com/alchemy-run/floci/pull/7): CloudFront `DistributionConfig` members (TTLs, `ForwardedValues`, `CachedMethods`, `GeoRestriction`, `CustomErrorResponses`, origin `CustomHeaders`) now round-trip, and Cognito `UpdateUserPool` resets `LambdaConfig` when omitted.

Full `test:aws:floci` run: 0 failed | 965 passed.
