### PR TITLE
chore(ci): fix website deploy starvation, broken PR cleanup, and prod dispatch

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -2,14 +2,20 @@ name: Website
 
 on:
   # Manual override — deploys unconditionally on whatever branch it's run
-  # from (use this to force a prod deploy from main without a release).
+  # from. Toggle `prod` to force a production deploy without a release.
   workflow_dispatch:
+    inputs:
+      prod:
+        description: "Deploy to production (alchemy.run) instead of the branch stage"
+        type: boolean
+        default: false
   # Release commits update package manifests, so packages/** keeps production
   # deploys automatic without redeploying the site for unrelated main commits.
   push:
     branches:
       - main
     paths:
+      - "distilled"
       - "website/**"
       - "packages/**"
       - "scripts/generate-api-reference.ts"
@@ -18,6 +24,7 @@ on:
       - "pnpm-lock.yaml"
       - "pnpm-workspace.yaml"
       - "tsconfig.json"
+      - "turbo.json"
       - ".github/workflows/website.yml"
   pull_request:
     # `labeled` so adding `deploy-website` on an open PR triggers a
@@ -29,6 +36,7 @@ on:
       - labeled
       - closed
     paths:
+      - "distilled"
       - "website/**"
       - "packages/**"
       - "scripts/generate-api-reference.ts"
@@ -37,15 +45,20 @@ on:
       - "pnpm-lock.yaml"
       - "pnpm-workspace.yaml"
       - "tsconfig.json"
+      - "turbo.json"
       - ".github/workflows/website.yml"
 
 concurrency:
-  group: deploy-website-${{ github.ref }}
+  group: deploy-website-${{ github.event_name == 'pull_request' &&
+    format('pr-{0}', github.event.number) || (inputs.prod ||
+    startsWith(github.event.head_commit.message, 'chore(release):')) &&
+    'prod' || (github.ref == 'refs/heads/main' && 'main' || github.ref_name)
+    }}
   cancel-in-progress: false
 
 env:
   STAGE: ${{ github.event_name == 'pull_request' && format('pr-{0}',
-    github.event.number) || (github.event_name == 'workflow_dispatch' ||
+    github.event.number) || (inputs.prod ||
     startsWith(github.event.head_commit.message, 'chore(release):')) && 'prod' ||
     (github.ref == 'refs/heads/main' && 'main' || github.ref_name) }}
 
@@ -53,8 +66,8 @@ jobs:
   deploy:
     name: Deploy
     # Deploy every push to main. Release commits (`chore(release): x.y.z`)
-    # and manual dispatches deploy production; other main commits deploy to
-    # main.alchemy.run. On PRs, require BOTH:
+    # and dispatches with `prod` toggled deploy production; other main
+    # commits deploy to main.alchemy.run. On PRs, require BOTH:
     #   - the PR is internal (forks can't access bot/Cloudflare secrets
     #     so `create-github-app-token` would error immediately), AND
     #   - the PR carries the `deploy-website` label (opt-in — most PRs
@@ -169,22 +182,24 @@ jobs:
         # bundle anything. Skip native postinstalls and the root prepare build.
         run: pnpm install --frozen-lockfile --ignore-scripts
 
-      - name: Install Doppler CLI
-        uses: dopplerhq/cli-action@4819d808ab99e5cde19a0637a16536a4038fad73 # v4
-
+      # Allowlist, not denylist: cleanup must only ever destroy pr-N stages,
+      # so refuse anything else outright (prod/main/preview-base) even if a
+      # future STAGE refactor changes what a pull_request event resolves to.
       - name: Safety Check
         run: |-
-          if [ "${{ env.STAGE }}" = "prod" ]; then
-            echo "ERROR: Cannot destroy prod environment in cleanup job"
-            exit 1
-          fi
+          case "${{ env.STAGE }}" in
+            pr-[0-9]*) ;;
+            *)
+              echo "ERROR: cleanup only destroys pr-* stages, got '${{ env.STAGE }}'"
+              exit 1
+              ;;
+          esac
 
       - name: Destroy Preview Environment
         working-directory: website
-        run: >-
-          doppler run --project "$DOPPLER_PROJECT" --config "$DOPPLER_CONFIG"
-          -- bun alchemy destroy --stage "$STAGE" --yes
+        run: bun alchemy destroy --stage "$STAGE" --yes
         env:
-          DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
           PULL_REQUEST: ${{ github.event.number }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.TEST_CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.TEST_CLOUDFLARE_ACCOUNT_ID }}
           GITHUB_TOKEN: ${{ steps.bot-token.outputs.token }}


### PR DESCRIPTION
The 2.0.0-beta.76 prod website deploy never ran: its run was created (the path filter matched fine) but cancelled while queued. `github.ref` on pull_request `closed` events resolves to the **base branch** (the merge ref is gone by then), so every merged PR fired a cleanup run into `deploy-website-refs/heads/main` — the same concurrency group as main pushes. GitHub keeps one pending run per group, the closed-PR run (whose deploy job just skips) kept winning the slot, and 7 main deploys were cancelled this way in one day, including the release's prod deploy. Prod is still on beta.75.

- Key the concurrency group by target stage instead of ref (same expression as `env.STAGE`), so closed-PR cleanups queue under `pr-N` and a queued `prod` deploy can't be superseded by a later non-release main push:

  ```diff
  -  group: deploy-website-${{ github.ref }}
  +  group: deploy-website-${{ github.event_name == 'pull_request' &&
  +    format('pr-{0}', github.event.number) || (inputs.prod ||
  +    startsWith(github.event.head_commit.message, 'chore(release):')) &&
  +    'prod' || (github.ref == 'refs/heads/main' && 'main' || github.ref_name) }}
  ```

- The cleanup job has failed on every PR close since Doppler was dropped from deploys: the workflow-level `DOPPLER_PROJECT`/`DOPPLER_CONFIG` env was deleted but cleanup still ran `doppler run --project "" --config ""` → `Doppler Error: You must specify a project`. PR previews live on the test account, so destroy now uses `TEST_CLOUDFLARE_*` secrets directly, like the deploy job:

  ```diff
  -        run: >-
  -          doppler run --project "$DOPPLER_PROJECT" --config "$DOPPLER_CONFIG"
  -          -- bun alchemy destroy --stage "$STAGE" --yes
  +        run: bun alchemy destroy --stage "$STAGE" --yes
  ```

  The Safety Check is now an allowlist (`pr-[0-9]*` only) instead of denying just `prod`.

- `workflow_dispatch` gains a `prod` toggle: off deploys the branch stage (main → main.alchemy.run), on deploys alchemy.run — previously every dispatch went to prod unconditionally, and there was no way to redeploy prod-vs-main deliberately after a starved release.

- Path filters gain `distilled` and `turbo.json` (a submodule bump changes generated docs; the workflow restores a Turbo cache but ignored turbo config changes), matching check.yml.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
