### PR TITLE
fix(cli): stream apply notes in plain mode and stop wrapping log lines

### DIFF
--- a/packages/alchemy/package.json
+++ b/packages/alchemy/package.json
@@ -422,7 +422,7 @@
     "@alchemy.run/cloudflare-runtime": "workspace:*",
     "@alchemy.run/floci": "workspace:*",
     "@alchemy.run/node-utils": "workspace:*",
-    "@alchemy.run/sigil": "0.0.0-alpha.5",
+    "@alchemy.run/sigil": "0.0.0-alpha.6",
     "@aws-sdk/credential-providers": "catalog:aws",
     "@distilled.cloud/aws": "workspace:*",
     "@distilled.cloud/axiom": "workspace:*",

--- a/packages/alchemy/src/Alchemist/Progress.ts
+++ b/packages/alchemy/src/Alchemist/Progress.ts
@@ -80,6 +80,9 @@ const spanEventOf = (
           "alchemy.resource.fqn": event.fqn,
           "alchemy.resource.logical_id": event.id,
           "alchemy.apply.message": event.message,
+          ...(event.kind === undefined
+            ? {}
+            : { "alchemy.apply.note.kind": event.kind }),
         },
       };
     case "state.bootstrap.started":

--- a/packages/alchemy/src/Apply.ts
+++ b/packages/alchemy/src/Apply.ts
@@ -612,12 +612,13 @@ const executeNode = (
 
     const scopedSession = {
       ...session,
-      note: (note: string) =>
+      note: (note, options?) =>
         session.emit({
           fqn,
           id: logicalId,
           _tag: "apply.resource.note",
           message: note,
+          kind: options?.kind,
         }),
     } satisfies ScopedPlanStatusSession;
 
@@ -1693,12 +1694,13 @@ const converge = Effect.fn(function* (
 
       const scopedSession = {
         ...session,
-        note: (note: string) =>
+        note: (note, options?) =>
           session.emit({
             fqn,
             id: logicalId,
             _tag: "apply.resource.note",
             message: note,
+            kind: options?.kind,
           }),
       } satisfies ScopedPlanStatusSession;
 
@@ -2055,12 +2057,13 @@ const collectGarbage = Effect.fn(function* (
 
         const scopedSession = {
           ...session,
-          note: (note: string) =>
+          note: (note, options?) =>
             session.emit({
               fqn,
               id: logicalId,
               _tag: "apply.resource.note",
               message: note,
+              kind: options?.kind,
             }),
         } satisfies ScopedPlanStatusSession;
 

--- a/packages/alchemy/src/Cli/LoggingCli.ts
+++ b/packages/alchemy/src/Cli/LoggingCli.ts
@@ -274,6 +274,7 @@ export const LoggingCli = Layer.succeed(
         const started = new Map<string, number>();
         const terminal = new Map<string, ApplyStatus>();
         const notes = new Map<string, string>();
+        const statusNotes = new Map<string, string>();
         return {
           // Progress is an Effect log record, just like provider and build
           // diagnostics, so the append-only renderer gives every line the
@@ -283,12 +284,18 @@ export const LoggingCli = Layer.succeed(
               Effect.flatMap((now) =>
                 Effect.suspend(() => {
                   if (event._tag === "apply.resource.note") {
+                    // `status` notes only surface as the settle line's suffix;
+                    // everything else streams, deduping consecutive repeats.
+                    if (event.kind === "status") {
+                      statusNotes.set(event.fqn, event.message);
+                      return Effect.void;
+                    }
+                    if (notes.get(event.fqn) === event.message)
+                      return Effect.void;
                     notes.set(event.fqn, event.message);
-                    return terminal.has(event.fqn)
-                      ? Effect.logInfo(
-                          `${tag(event.fqn)} ${blue(event.message)}`,
-                        )
-                      : Effect.void;
+                    return Effect.logInfo(
+                      `${tag(event.fqn)} ${blue(event.message)}`,
+                    );
                   }
                   const id = event.bindingId
                     ? `${event.fqn}/${event.bindingId}`
@@ -312,7 +319,7 @@ export const LoggingCli = Layer.succeed(
                     from === undefined
                       ? ""
                       : ` ${dim(`(${formatElapsed(now - from)})`)}`;
-                  const message = event.message ?? notes.get(event.fqn);
+                  const message = event.message ?? statusNotes.get(event.fqn);
                   // Failures carry their error as the message — paint it
                   // red so the line reads as the error line for that
                   // resource, without waiting for the final cause dump.

--- a/packages/alchemy/src/Cli/components/view/Runtime.tsx
+++ b/packages/alchemy/src/Cli/components/view/Runtime.tsx
@@ -413,7 +413,7 @@ export const makeRuntime = (
       const parts = `${buffers[stream]}${data}`.split(/\r?\n/);
       buffers[stream] = parts.pop() ?? "";
       for (const line of parts) {
-        store.appendStatic(<AnsiText>{line || " "}</AnsiText>);
+        store.appendStatic(<AnsiText wrap="none">{line || " "}</AnsiText>);
       }
     };
     const sigil = render(
@@ -447,7 +447,7 @@ export const makeRuntime = (
         ? () => {
             for (const stream of ["stdout", "stderr"] as const) {
               if (buffers[stream] !== "") {
-                store.appendStatic(<Text>{buffers[stream]}</Text>);
+                store.appendStatic(<Text wrap="none">{buffers[stream]}</Text>);
                 buffers[stream] = "";
               }
             }

--- a/packages/alchemy/src/Cli/components/view/StackOutputs.tsx
+++ b/packages/alchemy/src/Cli/components/view/StackOutputs.tsx
@@ -13,7 +13,9 @@ function StackOutputs({ value }: StackOutputsProps) {
   return (
     <Box flexDirection="column">
       {output.split("\n").map((line, index) => (
-        <AnsiText key={index}>{line || " "}</AnsiText>
+        <AnsiText key={index} wrap="none">
+          {line || " "}
+        </AnsiText>
       ))}
     </Box>
   );

--- a/packages/alchemy/src/Cloudflare/Workers/Assets.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Assets.ts
@@ -463,7 +463,7 @@ export const uploadAssets = Effect.fn(function* (
   // stopped, and a fresh session with nothing left to upload returns
   // the completion JWT directly.
   const runSession = Effect.fn(function* () {
-    yield* note("Checking assets...");
+    yield* note("Checking assets...", { kind: "status" });
     const session = dispatchNamespace
       ? yield* wfp.createDispatchNamespaceScriptAssetUpload({
           accountId,

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
@@ -1285,6 +1285,7 @@ export const LiveWorkerProvider = () =>
           if (desired.length > 0 || previous.length > 0 || live.length > 0) {
             yield* session.note(
               `Reconciling Cron Triggers (${desired.length}) ...`,
+              { kind: "status" },
             );
           }
 
@@ -2912,7 +2913,9 @@ export const LiveWorkerProvider = () =>
           parentName,
         );
         const compatibility = getCompatibility(news);
-        yield* session.note(`Uploading version of ${parentName} ...`);
+        yield* session.note(`Uploading version of ${parentName} ...`, {
+          kind: "status",
+        });
         const created = yield* workers
           .createScriptVersion({
             accountId,
@@ -2962,6 +2965,7 @@ export const LiveWorkerProvider = () =>
         if (traffic > 0) {
           yield* session.note(
             `Deploying version at ${traffic}% of ${parentName}'s traffic ...`,
+            { kind: "status" },
           );
           deploymentId = yield* deployVersionTraffic({
             accountId,
@@ -3022,7 +3026,9 @@ export const LiveWorkerProvider = () =>
                 }),
               );
             }
-            yield* session.note("Reconciling version-affinity rules ...");
+            yield* session.note("Reconciling version-affinity rules ...", {
+              kind: "status",
+            });
           }
           const placed = yield* reconcileAffinityRules({
             scriptName: parentName,
@@ -3264,7 +3270,9 @@ export const LiveWorkerProvider = () =>
         const sizeKB = size / 1024;
         const sizeMB = sizeKB / 1024;
         const bundleSize = `${sizeKB > 1024 ? `${sizeMB.toFixed(2)} MB` : `${sizeKB.toFixed(2)} KB`}`;
-        yield* session.note(`Uploading worker (${bundleSize}) ...`);
+        yield* session.note(`Uploading worker (${bundleSize}) ...`, {
+          kind: "status",
+        });
 
         // Read existing worker settings for migration tracking
         const oldSettings =
@@ -3645,6 +3653,7 @@ export const LiveWorkerProvider = () =>
           }
           yield* session.note(
             `Uploading version of ${name} (${bundleSize}) ...`,
+            { kind: "status" },
           );
           const created = yield* workers
             .createScriptVersion({
@@ -3688,6 +3697,7 @@ export const LiveWorkerProvider = () =>
           if (rolloutTraffic > 0) {
             yield* session.note(
               `Deploying version at ${rolloutTraffic}% of traffic ...`,
+              { kind: "status" },
             );
             deploymentId = yield* deployVersionTraffic({
               accountId,
@@ -3819,6 +3829,7 @@ export const LiveWorkerProvider = () =>
         ) {
           yield* session.note(
             `${workersDev.enabled || workersDev.previewsEnabled ? "Enabling" : "Disabling"} workers.dev subdomain...`,
+            { kind: "status" },
           );
           // Cloudflare's script registry is eventually consistent — for the
           // first few hundred ms after `putScript` returns, POST /subdomain
@@ -3898,6 +3909,7 @@ export const LiveWorkerProvider = () =>
             : [];
           yield* session.note(
             `Reconciling custom domains (${desiredHostnames.length}) ...`,
+            { kind: "status" },
           );
           // Capture hostname → zone for *currently attached* domains before
           // reconcile detaches removed ones — a removed redirect hostname's
@@ -3943,6 +3955,7 @@ export const LiveWorkerProvider = () =>
         if (desiredRoutes.length > 0 || previousRoutes.length > 0) {
           yield* session.note(
             `Reconciling worker routes (${desiredRoutes.length}) ...`,
+            { kind: "status" },
           );
         }
         const routes = yield* reconcileRoutes(
@@ -4000,7 +4013,9 @@ export const LiveWorkerProvider = () =>
                 }),
               );
             }
-            yield* session.note("Reconciling version-affinity rules ...");
+            yield* session.note("Reconciling version-affinity rules ...", {
+              kind: "status",
+            });
           }
           const placed = yield* reconcileAffinityRules({
             scriptName: name,
@@ -4690,7 +4705,7 @@ export const LiveWorkerProvider = () =>
               `Cloudflare Worker precreate: reusing existing ${name}`,
             );
           } else {
-            yield* session.note("Pre-creating worker...");
+            yield* session.note("Pre-creating worker...", { kind: "status" });
             const compatibility = getCompatibility(news);
             const mainModule = "main.js";
             const placeholderScript = `${doClasses.length > 0 ? 'import { DurableObject } from "cloudflare:workers";\n\n' : ""}export default { fetch() { return new Response("Alchemy worker is being deployed...") } };\n${doClasses

--- a/packages/alchemy/src/Command/Command.ts
+++ b/packages/alchemy/src/Command/Command.ts
@@ -385,8 +385,16 @@ export const CommandExecutorLive = () =>
             const execution = Effect.all(
               {
                 exitCode: child.exitCode,
-                stdout: collect(child.stdout, session.note, redactor),
-                stderr: collect(child.stderr, session.note, redactor),
+                stdout: collect(
+                  child.stdout,
+                  (line) => session.note(line, { kind: "output" }),
+                  redactor,
+                ),
+                stderr: collect(
+                  child.stderr,
+                  (line) => session.note(line, { kind: "output" }),
+                  redactor,
+                ),
               },
               { concurrency: "unbounded" },
             ).pipe(mapError(props));

--- a/packages/alchemy/src/Docker/Docker.ts
+++ b/packages/alchemy/src/Docker/Docker.ts
@@ -640,7 +640,12 @@ export const DockerLive = Layer.effect(
             session
               ? Stream.tapSink(
                   Sink.make<string>()(
-                    flow(Stream.splitLines, Stream.runForEach(session.note)),
+                    flow(
+                      Stream.splitLines,
+                      Stream.runForEach((line) =>
+                        session.note(line, { kind: "output" }),
+                      ),
+                    ),
                   ),
                 )
               : undefined,

--- a/packages/alchemy/src/Drift.ts
+++ b/packages/alchemy/src/Drift.ts
@@ -162,12 +162,13 @@ const runDrift = (
 
       const scopedSession = {
         ...session,
-        note: (note: string) =>
+        note: (note, options?) =>
           session.emit({
             fqn,
             id: logicalId,
             _tag: "apply.resource.note",
             message: note,
+            kind: options?.kind,
           }),
       } satisfies ScopedPlanStatusSession;
 

--- a/packages/alchemy/src/Report.ts
+++ b/packages/alchemy/src/Report.ts
@@ -35,12 +35,21 @@ export type ApplyStatus =
 
 export type ApplyEvent = ResourceAnnotated | ResourceStatusChanged;
 
+/**
+ * How append-only renderers surface a note (the interactive view treats every
+ * kind the same): `"status"` is transient spinner text that plain mode folds
+ * into the settle line's suffix, `"output"` is verbatim tool output streamed
+ * line by line, and `undefined` is a one-shot informational note.
+ */
+export type NoteKind = "status" | "output";
+
 export interface ResourceAnnotated {
   _tag: "apply.resource.note";
   /** Fully-qualified resource or action name used to target its plan row. */
   fqn: string;
   id: string;
   message: string;
+  kind?: NoteKind;
 }
 
 export interface ResourceStatusChanged {
@@ -289,7 +298,10 @@ export interface PlanningStatusSession {
 }
 
 export interface ScopedPlanStatusSession extends PlanStatusSession {
-  note: (note: string) => Effect.Effect<void>;
+  note: (
+    note: string,
+    options?: { readonly kind?: NoteKind },
+  ) => Effect.Effect<void>;
 }
 
 export interface PlanDisplayOptions {

--- a/packages/alchemy/test/Cli/CliKit.test.tsx
+++ b/packages/alchemy/test/Cli/CliKit.test.tsx
@@ -234,16 +234,17 @@ it("ignores state explorer responses from before a refresh", async () => {
   }
 });
 
-it("prints stack outputs using inspect", () => {
+it("prints stack outputs using inspect without wrapping long lines", () => {
   const { service } = makeStatic();
   const apiUrl =
     "https://cloudflareworkerexample-api-clxp5k3fbtqacxdev7mx7uuxmw.testing-2b2.workers.dev";
+  // Narrow width: `wrap="none"` output lines must overflow, not break.
   const output = service.output.format(
     stackOutputsView({
       apiUrl,
       metadata: { region: "us-east-1", replicas: 2 },
     }),
-    { columns: 10_000 },
+    { columns: 40 },
   );
 
   expect(output).toBe(

--- a/packages/alchemy/test/Cli/LoggingCli.test.ts
+++ b/packages/alchemy/test/Cli/LoggingCli.test.ts
@@ -66,3 +66,52 @@ it.effect("emits plain progress through the Effect logger", () => {
     expect(messages).toEqual([["Plan: 1 to create"], ["[Worker] create"]]);
   }).pipe(Effect.provide(LoggingCli), Effect.provide(Logger.layer([logger])));
 });
+
+it.effect("streams apply notes as they arrive", () => {
+  const messages: string[] = [];
+  const logger = Logger.make<unknown, void>((options) => {
+    messages.push(String((options.message as unknown[])[0]));
+  });
+  return Effect.gen(function* () {
+    const cli = yield* Cli;
+    const session = yield* cli.startApplySession(
+      planWith([updateNode({ v: 1 }, { v: 2 }, "Website")]),
+    );
+
+    const note = (message: string, kind?: "status" | "output") =>
+      session.emit({
+        _tag: "apply.resource.note",
+        fqn: "Website",
+        id: "Website",
+        message,
+        kind,
+      });
+    const status = (status: "updating" | "updated") =>
+      session.emit({
+        _tag: "apply.resource.status",
+        fqn: "Website",
+        id: "Website",
+        type: "Cloudflare::Worker",
+        status,
+      });
+
+    yield* status("updating");
+    yield* note("Uploading worker (1.2 MB) ...", "status");
+    yield* note("build output line", "output");
+    yield* note("Uploaded 0 of 5195 assets...");
+    yield* note("Uploaded 490 of 5195 assets...");
+    // spinner-style refresh of the same message is deduped
+    yield* note("Uploaded 490 of 5195 assets...");
+    yield* note("Reconciling custom domains (1) ...", "status");
+    yield* status("updated");
+
+    const progress = messages.slice(3); // skip plan preview + blank line
+    expect(progress).toEqual([
+      "[Website] updating",
+      "[Website] build output line",
+      "[Website] Uploaded 0 of 5195 assets...",
+      "[Website] Uploaded 490 of 5195 assets...",
+      "[Website] updated — Reconciling custom domains (1) ... (0ms)",
+    ]);
+  }).pipe(Effect.provide(LoggingCli), Effect.provide(Logger.layer([logger])));
+});

--- a/packages/alchemy/test/provider-mode.test.ts
+++ b/packages/alchemy/test/provider-mode.test.ts
@@ -443,6 +443,7 @@ describe("provider modes", () => {
         // A local instance whose attrs carry a `url` announces it.
         expect(notes).toContainEqual({
           _tag: "apply.resource.note",
+          fqn: "A",
           id: "A",
           message: "ready at http://localhost:1337",
         });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5344,8 +5344,8 @@ importers:
         specifier: workspace:*
         version: link:../node-utils
       '@alchemy.run/sigil':
-        specifier: 0.0.0-alpha.5
-        version: 0.0.0-alpha.5(@types/react@19.2.18)(react-devtools-core@7.0.1)(react@19.2.8)
+        specifier: 0.0.0-alpha.6
+        version: 0.0.0-alpha.6(@types/react@19.2.18)(react-devtools-core@7.0.1)(react@19.2.8)
       '@aws-sdk/credential-providers':
         specifier: catalog:aws
         version: 3.1095.0
@@ -6060,8 +6060,8 @@ packages:
   '@actions/io@1.1.3':
     resolution: {integrity: sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==}
 
-  '@alchemy.run/sigil@0.0.0-alpha.5':
-    resolution: {integrity: sha512-meY3ccl6PO2Hw4bbhTwmdQHTJJ22b2KXey+U6HDotHGNMeyDi5Vu5d4O44vbqOONNRzpTg8AQCaqXgA5RcuAgw==}
+  '@alchemy.run/sigil@0.0.0-alpha.6':
+    resolution: {integrity: sha512-kbFZCNxVv1rIkuJcq23hELB3aF63zZDKMgrBLRzOtVaweAJ2ZCEKfRqC1iWgaUh/J4vERDvFE/tnNiipfwOHyQ==}
     engines: {node: '>=22'}
     peerDependencies:
       '@types/react': '>=19.2.0'
@@ -19070,7 +19070,7 @@ snapshots:
 
   '@actions/io@1.1.3': {}
 
-  '@alchemy.run/sigil@0.0.0-alpha.5(@types/react@19.2.18)(react-devtools-core@7.0.1)(react@19.2.8)':
+  '@alchemy.run/sigil@0.0.0-alpha.6(@types/react@19.2.18)(react-devtools-core@7.0.1)(react@19.2.8)':
     dependencies:
       react: 19.2.8
       react-reconciler: 0.33.0(react@19.2.8)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -174,7 +174,7 @@ patchedDependencies:
   "@astrojs/starlight@0.41.7": patches/@astrojs%2Fstarlight@0.41.7.patch
   starlight-blog@0.28.0: patches/starlight-blog@0.28.0.patch
 minimumReleaseAgeExclude:
-  - '@alchemy.run/sigil@0.0.0-alpha.5'
+  - '@alchemy.run/sigil@0.0.0-alpha.6'
   - '@effect/atom-react@4.0.0-rc.112'
   - '@effect/platform-bun@4.0.0-rc.112'
   - '@effect/platform-node-shared@4.0.0-rc.112'


### PR DESCRIPTION
Since the CLI overhaul (#1235), plain (non-TTY / CI) deploy logs lost everything that happens *during* resource work, and long lines get broken mid-token. Compare the Website deploy before and after the overhaul: 9000+ streamed `[Build]` lines and `[Website] Uploaded 490 of 5195 assets...` progress became a 4-minute silent gap ending in `updated — Complete! (236.2s)`.

### Problem 1: apply notes dropped in plain mode

`LoggingCli.startApplySession` buffered every `apply.resource.note` into a map and only printed a note if its resource had *already settled* (`terminal.has(fqn)`), surfacing just the last one as the `updated — <message>` suffix. Since notes fire while work is in flight, build output and upload progress never printed. The emitters (Build piping child stdout via `session.note`, the assets uploader) were unchanged by the overhaul — the events reached the renderer and were swallowed there. The gating existed for a reason: streaming *every* note verbatim would also replay each worker reconcile's transient spinner ticks.

Fixed by streaming notes and making the distinction explicit — `ResourceAnnotated` gains a `kind`:

```ts
export type NoteKind = "status" | "output";
// "status"  → transient spinner text; plain mode folds the last one into the
//             settle line's "— message" suffix instead of streaming it
// "output"  → verbatim tool output (child stdout/stderr, docker build logs);
//             always streamed
// undefined → one-shot informational note; streamed
```

- `Command.ts` child stdout/stderr and `Docker.ts` build logs emit `kind: "output"`
- WorkerProvider's per-phase ticks (`Uploading worker (1.2 MB) ...`, `Reconciling custom domains (2) ...`, 12 sites) and Assets' `Checking assets...` emit `kind: "status"`
- consecutive duplicate notes are deduped; the interactive view is unchanged (every kind still replaces the row's live message)
- the note kind is stamped on the `alchemy.apply.resource.note` telemetry span

### Problem 2: long lines hard-wrapped mid-token

Two symptoms, one cause: stack outputs printed URLs broken at exactly column 80 in CI, and captured log lines (e.g. `INFO (#430): ... {"oldDoClassNameByLogicalId":{},...}`) word-wrapped where the JSON starts. Sigil renders through a fixed-width cell screen; a non-TTY stdout has no width, so capability detection falls back to 80 and yoga breaks the line.

Fixed in Sigil `0.0.0-alpha.6` with `textWrap: "none"` — text keeps its intrinsic width and the screen grows the touched rows on demand, so lines reach stdout whole and the terminal (or CI log viewer) owns soft-wrapping. Applied to the two log surfaces:

```tsx
// captured stdio transcript (Runtime.tsx) and stack outputs (StackOutputs.tsx)
<AnsiText wrap="none">{line}</AnsiText>
```

### Also

- `provider-mode.test.ts` had a pre-existing red assertion (strict-equal against a note shape missing `fqn`, which #1235 added to the event) — fixed
- regression tests: note streaming/dedup/status-suffix in `LoggingCli.test.ts`, unwrapped stack outputs at `columns: 40` in `CliKit.test.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
