### PR TITLE
docs: simplify bundling and tree-shaking

### DIFF
--- a/packages/alchemy/src/AWS/AppRunner/Service.ts
+++ b/packages/alchemy/src/AWS/AppRunner/Service.ts
@@ -233,12 +233,9 @@ export interface ServiceProps extends PlatformProps {
    */
   env?: Record<string, any>;
   /**
-   * Bundler configuration for the Effect-native entrypoint: rolldown
-   * `input`/`output` overrides plus pure-annotation options (`pure`).
-   * `effect`, `@effect/*`, `alchemy`, `@alchemy.run/*`, and
-   * `@distilled.cloud/*` are annotated as pure by default so unused code
-   * from those packages is tree-shaken; list additional packages via
-   * `pure.packages`, or disable with `pure: false`.
+   * Bundler configuration for the Effect-native entrypoint. Unused
+   * `effect`, alchemy, and `@distilled.cloud` code is tree-shaken. List
+   * extra packages with `pure.packages`, or disable with `pure: false`.
    */
   build?: Bundle.BundleConfig;
   /**
@@ -463,16 +460,12 @@ export interface ServiceRuntimeContext extends HostRuntimeContext {
  * ```
  *
  * ### Bundling & Tree-shaking
- * `main` is bundled with rolldown at deploy time. Top-level calls in the
- * `effect`, `@effect/*`, `alchemy`, `@alchemy.run/*`, and
- * `@distilled.cloud/*` packages receive `#__PURE__` annotations by
- * default, so anything the service doesn't use from those packages is
- * tree-shaken out of the bundle. Any other package — including your own
- * app — is left untouched unless you list it explicitly.
+ * `main` is bundled with rolldown at deploy time. Unused `effect`,
+ * alchemy, and `@distilled.cloud` code is tree-shaken. Your app is left
+ * untouched.
  *
- * **Example:** Treat additional packages as pure
- * Pass package names (or picomatch globs) via `build.pure.packages` to
- * annotate them in addition to the defaults.
+ * **Example:** Tree-shake additional packages
+ * Only list packages with no top-level side effects.
  * ```typescript
  * {
  *   main: import.meta.url,
@@ -482,18 +475,7 @@ export interface ServiceRuntimeContext extends HostRuntimeContext {
  * }
  * ```
  *
- * Listing a package annotates calls whose result is bound (variable
- * initializers, exports) — safe anywhere. If a listed package also
- * declares `"sideEffects": false` (or `[]`) in its `package.json`, that
- * combination opts it into full annotation: top-level calls whose result
- * is discarded (e.g. `router.on("/path", handler)` registrations) are
- * also marked pure and deleted under minification when unused. Only list
- * a `sideEffects: false` package if its modules really are free of
- * meaningful top-level side effects. The `effect`, `alchemy`, and
- * `@distilled.cloud` defaults declare exactly that, on purpose — their
- * modules are designed to be fully tree-shakeable.
- *
- * **Example:** Disable pure annotations
+ * **Example:** Turn it off
  * ```typescript
  * {
  *   main: import.meta.url,

--- a/packages/alchemy/src/AWS/AppRunner/Service.ts
+++ b/packages/alchemy/src/AWS/AppRunner/Service.ts
@@ -234,8 +234,9 @@ export interface ServiceProps extends PlatformProps {
   env?: Record<string, any>;
   /**
    * Bundler configuration for the Effect-native entrypoint. Unused
-   * `effect`, alchemy, and `@distilled.cloud` code is tree-shaken. List
-   * extra packages with `pure.packages`, or disable with `pure: false`.
+   * code is tree-shaken. `effect`, alchemy, and `@distilled.cloud` are
+   * marked pure so unused parts prune more aggressively. List extra
+   * packages with `pure.packages`, or disable with `pure: false`.
    */
   build?: Bundle.BundleConfig;
   /**
@@ -460,11 +461,12 @@ export interface ServiceRuntimeContext extends HostRuntimeContext {
  * ```
  *
  * ### Bundling & Tree-shaking
- * `main` is bundled with rolldown at deploy time. Unused `effect`,
- * alchemy, and `@distilled.cloud` code is tree-shaken. Your app is left
- * untouched.
+ * `main` is bundled with rolldown at deploy time. Unused code is
+ * tree-shaken. `effect`, alchemy, and `@distilled.cloud` are marked
+ * pure so unused parts prune more aggressively. Your app is not
+ * marked pure.
  *
- * **Example:** Tree-shake additional packages
+ * **Example:** Mark additional packages as pure
  * Only list packages with no top-level side effects.
  * ```typescript
  * {

--- a/packages/alchemy/src/AWS/Batch/JobDefinition.ts
+++ b/packages/alchemy/src/AWS/Batch/JobDefinition.ts
@@ -171,8 +171,9 @@ export interface JobDefinitionProps extends PlatformProps {
   propagateTags?: boolean;
   /**
    * Bundler configuration for the Effect-native entrypoint. Unused
-   * `effect`, alchemy, and `@distilled.cloud` code is tree-shaken. List
-   * extra packages with `pure.packages`, or disable with `pure: false`.
+   * code is tree-shaken. `effect`, alchemy, and `@distilled.cloud` are
+   * marked pure so unused parts prune more aggressively. List extra
+   * packages with `pure.packages`, or disable with `pure: false`.
    */
   build?: Bundle.BundleConfig;
   /**
@@ -355,11 +356,12 @@ const createJobDefinitionRuntimeContext = (
  * ```
  *
  * ### Bundling & Tree-shaking
- * `main` is bundled with rolldown at deploy time. Unused `effect`,
- * alchemy, and `@distilled.cloud` code is tree-shaken. Your app is left
- * untouched.
+ * `main` is bundled with rolldown at deploy time. Unused code is
+ * tree-shaken. `effect`, alchemy, and `@distilled.cloud` are marked
+ * pure so unused parts prune more aggressively. Your app is not
+ * marked pure.
  *
- * **Example:** Tree-shake additional packages
+ * **Example:** Mark additional packages as pure
  * Only list packages with no top-level side effects.
  * ```typescript
  * {

--- a/packages/alchemy/src/AWS/Batch/JobDefinition.ts
+++ b/packages/alchemy/src/AWS/Batch/JobDefinition.ts
@@ -170,12 +170,9 @@ export interface JobDefinitionProps extends PlatformProps {
    */
   propagateTags?: boolean;
   /**
-   * Bundler configuration for the Effect-native entrypoint: rolldown
-   * `input`/`output` overrides plus pure-annotation options (`pure`).
-   * `effect`, `@effect/*`, `alchemy`, `@alchemy.run/*`, and
-   * `@distilled.cloud/*` are annotated as pure by default so unused code
-   * from those packages is tree-shaken; list additional packages via
-   * `pure.packages`, or disable with `pure: false`.
+   * Bundler configuration for the Effect-native entrypoint. Unused
+   * `effect`, alchemy, and `@distilled.cloud` code is tree-shaken. List
+   * extra packages with `pure.packages`, or disable with `pure: false`.
    */
   build?: Bundle.BundleConfig;
   /**
@@ -358,16 +355,12 @@ const createJobDefinitionRuntimeContext = (
  * ```
  *
  * ### Bundling & Tree-shaking
- * `main` is bundled with rolldown at deploy time. Top-level calls in the
- * `effect`, `@effect/*`, `alchemy`, `@alchemy.run/*`, and
- * `@distilled.cloud/*` packages receive `#__PURE__` annotations by
- * default, so anything the job doesn't use from those packages is
- * tree-shaken out of the bundle. Any other package — including your own
- * app — is left untouched unless you list it explicitly.
+ * `main` is bundled with rolldown at deploy time. Unused `effect`,
+ * alchemy, and `@distilled.cloud` code is tree-shaken. Your app is left
+ * untouched.
  *
- * **Example:** Treat additional packages as pure
- * Pass package names (or picomatch globs) via `build.pure.packages` to
- * annotate them in addition to the defaults.
+ * **Example:** Tree-shake additional packages
+ * Only list packages with no top-level side effects.
  * ```typescript
  * {
  *   main: import.meta.url,
@@ -377,18 +370,7 @@ const createJobDefinitionRuntimeContext = (
  * }
  * ```
  *
- * Listing a package annotates calls whose result is bound (variable
- * initializers, exports) — safe anywhere. If a listed package also
- * declares `"sideEffects": false` (or `[]`) in its `package.json`, that
- * combination opts it into full annotation: top-level calls whose result
- * is discarded (e.g. `router.on("/path", handler)` registrations) are
- * also marked pure and deleted under minification when unused. Only list
- * a `sideEffects: false` package if its modules really are free of
- * meaningful top-level side effects. The `effect`, `alchemy`, and
- * `@distilled.cloud` defaults declare exactly that, on purpose — their
- * modules are designed to be fully tree-shakeable.
- *
- * **Example:** Disable pure annotations
+ * **Example:** Turn it off
  * ```typescript
  * {
  *   main: import.meta.url,

--- a/packages/alchemy/src/AWS/EC2/Instance.ts
+++ b/packages/alchemy/src/AWS/EC2/Instance.ts
@@ -124,8 +124,9 @@ export interface InstanceProps extends PlatformProps {
   env?: Record<string, any>;
   /**
    * Bundler configuration for the hosted process entrypoint. Unused
-   * `effect`, alchemy, and `@distilled.cloud` code is tree-shaken. List
-   * extra packages with `pure.packages`, or disable with `pure: false`.
+   * code is tree-shaken. `effect`, alchemy, and `@distilled.cloud` are
+   * marked pure so unused parts prune more aggressively. List extra
+   * packages with `pure.packages`, or disable with `pure: false`.
    */
   build?: Bundle.BundleConfig;
   /**
@@ -306,11 +307,12 @@ export type InstanceRuntimeContext = Ec2HostRuntimeContext;
  * ```
  *
  * ### Bundling & Tree-shaking
- * `main` is bundled with rolldown at deploy time. Unused `effect`,
- * alchemy, and `@distilled.cloud` code is tree-shaken. Your app is left
- * untouched.
+ * `main` is bundled with rolldown at deploy time. Unused code is
+ * tree-shaken. `effect`, alchemy, and `@distilled.cloud` are marked
+ * pure so unused parts prune more aggressively. Your app is not
+ * marked pure.
  *
- * **Example:** Tree-shake additional packages
+ * **Example:** Mark additional packages as pure
  * Only list packages with no top-level side effects.
  * ```typescript
  * {

--- a/packages/alchemy/src/AWS/EC2/Instance.ts
+++ b/packages/alchemy/src/AWS/EC2/Instance.ts
@@ -123,12 +123,9 @@ export interface InstanceProps extends PlatformProps {
    */
   env?: Record<string, any>;
   /**
-   * Bundler configuration for the hosted process entrypoint: rolldown
-   * `input`/`output` overrides plus pure-annotation options (`pure`).
-   * `effect`, `@effect/*`, `alchemy`, `@alchemy.run/*`, and
-   * `@distilled.cloud/*` are annotated as pure by default so unused code
-   * from those packages is tree-shaken; list additional packages via
-   * `pure.packages`, or disable with `pure: false`.
+   * Bundler configuration for the hosted process entrypoint. Unused
+   * `effect`, alchemy, and `@distilled.cloud` code is tree-shaken. List
+   * extra packages with `pure.packages`, or disable with `pure: false`.
    */
   build?: Bundle.BundleConfig;
   /**
@@ -309,16 +306,12 @@ export type InstanceRuntimeContext = Ec2HostRuntimeContext;
  * ```
  *
  * ### Bundling & Tree-shaking
- * `main` is bundled with rolldown at deploy time. Top-level calls in the
- * `effect`, `@effect/*`, `alchemy`, `@alchemy.run/*`, and
- * `@distilled.cloud/*` packages receive `#__PURE__` annotations by
- * default, so anything the hosted program doesn't use from those packages is
- * tree-shaken out of the bundle. Any other package — including your own
- * app — is left untouched unless you list it explicitly.
+ * `main` is bundled with rolldown at deploy time. Unused `effect`,
+ * alchemy, and `@distilled.cloud` code is tree-shaken. Your app is left
+ * untouched.
  *
- * **Example:** Treat additional packages as pure
- * Pass package names (or picomatch globs) via `build.pure.packages` to
- * annotate them in addition to the defaults.
+ * **Example:** Tree-shake additional packages
+ * Only list packages with no top-level side effects.
  * ```typescript
  * {
  *   main: import.meta.url,
@@ -328,18 +321,7 @@ export type InstanceRuntimeContext = Ec2HostRuntimeContext;
  * }
  * ```
  *
- * Listing a package annotates calls whose result is bound (variable
- * initializers, exports) — safe anywhere. If a listed package also
- * declares `"sideEffects": false` (or `[]`) in its `package.json`, that
- * combination opts it into full annotation: top-level calls whose result
- * is discarded (e.g. `router.on("/path", handler)` registrations) are
- * also marked pure and deleted under minification when unused. Only list
- * a `sideEffects: false` package if its modules really are free of
- * meaningful top-level side effects. The `effect`, `alchemy`, and
- * `@distilled.cloud` defaults declare exactly that, on purpose — their
- * modules are designed to be fully tree-shakeable.
- *
- * **Example:** Disable pure annotations
+ * **Example:** Turn it off
  * ```typescript
  * {
  *   main: import.meta.url,

--- a/packages/alchemy/src/AWS/EC2/hosted.ts
+++ b/packages/alchemy/src/AWS/EC2/hosted.ts
@@ -68,9 +68,10 @@ export interface Ec2HostedProps extends PlatformProps {
   /** Environment variables injected into the hosted runtime. */
   env?: Record<string, any>;
   /**
-   * Overrides for the rolldown bundling of `main`. Unused `effect`,
-   * alchemy, and `@distilled.cloud` code is tree-shaken. List extra
-   * packages with `pure.packages`, or disable with `pure: false`.
+   * Overrides for the rolldown bundling of `main`. Unused code is
+   * tree-shaken. `effect`, alchemy, and `@distilled.cloud` are marked
+   * pure so unused parts prune more aggressively. List extra packages
+   * with `pure.packages`, or disable with `pure: false`.
    */
   build?: Bundle.BundleConfig;
   /** Managed policy ARNs attached to the instance role. */

--- a/packages/alchemy/src/AWS/EC2/hosted.ts
+++ b/packages/alchemy/src/AWS/EC2/hosted.ts
@@ -68,11 +68,9 @@ export interface Ec2HostedProps extends PlatformProps {
   /** Environment variables injected into the hosted runtime. */
   env?: Record<string, any>;
   /**
-   * Overrides for the rolldown bundling of `main`: `input`/`output`
-   * overrides plus pure-annotation options (`pure`). `effect`, `@effect/*`,
-   * `alchemy`, `@alchemy.run/*`, and `@distilled.cloud/*` are annotated as
-   * pure by default so unused code from those packages is tree-shaken; list
-   * additional packages via `pure.packages`, or disable with `pure: false`.
+   * Overrides for the rolldown bundling of `main`. Unused `effect`,
+   * alchemy, and `@distilled.cloud` code is tree-shaken. List extra
+   * packages with `pure.packages`, or disable with `pure: false`.
    */
   build?: Bundle.BundleConfig;
   /** Managed policy ARNs attached to the instance role. */

--- a/packages/alchemy/src/AWS/ECR/ImageSource.ts
+++ b/packages/alchemy/src/AWS/ECR/ImageSource.ts
@@ -90,8 +90,9 @@ export interface BundledImageSource {
    */
   handler?: string;
   /**
-   * Bundler configuration for the entrypoint. Unused `effect`, alchemy,
-   * and `@distilled.cloud` code is tree-shaken. List extra packages with
+   * Bundler configuration for the entrypoint. Unused code is tree-shaken.
+   * `effect`, alchemy, and `@distilled.cloud` are marked pure so unused
+   * parts prune more aggressively. List extra packages with
    * `pure.packages`, or disable with `pure: false`.
    */
   build?: Bundle.BundleConfig;

--- a/packages/alchemy/src/AWS/ECR/ImageSource.ts
+++ b/packages/alchemy/src/AWS/ECR/ImageSource.ts
@@ -90,11 +90,9 @@ export interface BundledImageSource {
    */
   handler?: string;
   /**
-   * Bundler configuration for the entrypoint: rolldown `input`/`output`
-   * overrides plus pure-annotation options (`pure`). `effect`, `@effect/*`,
-   * `alchemy`, `@alchemy.run/*`, and `@distilled.cloud/*` are annotated as
-   * pure by default so unused code from those packages is tree-shaken; list
-   * additional packages via `pure.packages`, or disable with `pure: false`.
+   * Bundler configuration for the entrypoint. Unused `effect`, alchemy,
+   * and `@distilled.cloud` code is tree-shaken. List extra packages with
+   * `pure.packages`, or disable with `pure: false`.
    */
   build?: Bundle.BundleConfig;
 }

--- a/packages/alchemy/src/AWS/ECS/Service.ts
+++ b/packages/alchemy/src/AWS/ECS/Service.ts
@@ -1060,16 +1060,12 @@ export interface ServiceRuntimeContext extends HostRuntimeContext {
  * ```
  *
  * ### Bundling & Tree-shaking
- * `main` is bundled with rolldown at deploy time. Top-level calls in the
- * `effect`, `@effect/*`, `alchemy`, `@alchemy.run/*`, and
- * `@distilled.cloud/*` packages receive `#__PURE__` annotations by
- * default, so anything the service doesn't use from those packages is
- * tree-shaken out of the bundle. Any other package — including your own
- * app — is left untouched unless you list it explicitly.
+ * `main` is bundled with rolldown at deploy time. Unused `effect`,
+ * alchemy, and `@distilled.cloud` code is tree-shaken. Your app is left
+ * untouched.
  *
- * **Example:** Treat additional packages as pure
- * Pass package names (or picomatch globs) via `build.pure.packages` to
- * annotate them in addition to the defaults.
+ * **Example:** Tree-shake additional packages
+ * Only list packages with no top-level side effects.
  * ```typescript
  * {
  *   main: import.meta.url,
@@ -1079,18 +1075,7 @@ export interface ServiceRuntimeContext extends HostRuntimeContext {
  * }
  * ```
  *
- * Listing a package annotates calls whose result is bound (variable
- * initializers, exports) — safe anywhere. If a listed package also
- * declares `"sideEffects": false` (or `[]`) in its `package.json`, that
- * combination opts it into full annotation: top-level calls whose result
- * is discarded (e.g. `router.on("/path", handler)` registrations) are
- * also marked pure and deleted under minification when unused. Only list
- * a `sideEffects: false` package if its modules really are free of
- * meaningful top-level side effects. The `effect`, `alchemy`, and
- * `@distilled.cloud` defaults declare exactly that, on purpose — their
- * modules are designed to be fully tree-shakeable.
- *
- * **Example:** Disable pure annotations
+ * **Example:** Turn it off
  * ```typescript
  * {
  *   main: import.meta.url,

--- a/packages/alchemy/src/AWS/ECS/Service.ts
+++ b/packages/alchemy/src/AWS/ECS/Service.ts
@@ -1060,11 +1060,12 @@ export interface ServiceRuntimeContext extends HostRuntimeContext {
  * ```
  *
  * ### Bundling & Tree-shaking
- * `main` is bundled with rolldown at deploy time. Unused `effect`,
- * alchemy, and `@distilled.cloud` code is tree-shaken. Your app is left
- * untouched.
+ * `main` is bundled with rolldown at deploy time. Unused code is
+ * tree-shaken. `effect`, alchemy, and `@distilled.cloud` are marked
+ * pure so unused parts prune more aggressively. Your app is not
+ * marked pure.
  *
- * **Example:** Tree-shake additional packages
+ * **Example:** Mark additional packages as pure
  * Only list packages with no top-level side effects.
  * ```typescript
  * {

--- a/packages/alchemy/src/AWS/ECS/Task.ts
+++ b/packages/alchemy/src/AWS/ECS/Task.ts
@@ -390,11 +390,12 @@ export { createContainerRuntimeContext } from "../../Server/Process.ts";
  * ```
  *
  * ### Bundling & Tree-shaking
- * `main` is bundled with rolldown at deploy time. Unused `effect`,
- * alchemy, and `@distilled.cloud` code is tree-shaken. Your app is left
- * untouched.
+ * `main` is bundled with rolldown at deploy time. Unused code is
+ * tree-shaken. `effect`, alchemy, and `@distilled.cloud` are marked
+ * pure so unused parts prune more aggressively. Your app is not
+ * marked pure.
  *
- * **Example:** Tree-shake additional packages
+ * **Example:** Mark additional packages as pure
  * Only list packages with no top-level side effects.
  * ```typescript
  * {

--- a/packages/alchemy/src/AWS/ECS/Task.ts
+++ b/packages/alchemy/src/AWS/ECS/Task.ts
@@ -390,16 +390,12 @@ export { createContainerRuntimeContext } from "../../Server/Process.ts";
  * ```
  *
  * ### Bundling & Tree-shaking
- * `main` is bundled with rolldown at deploy time. Top-level calls in the
- * `effect`, `@effect/*`, `alchemy`, `@alchemy.run/*`, and
- * `@distilled.cloud/*` packages receive `#__PURE__` annotations by
- * default, so anything the task doesn't use from those packages is
- * tree-shaken out of the bundle. Any other package — including your own
- * app — is left untouched unless you list it explicitly.
+ * `main` is bundled with rolldown at deploy time. Unused `effect`,
+ * alchemy, and `@distilled.cloud` code is tree-shaken. Your app is left
+ * untouched.
  *
- * **Example:** Treat additional packages as pure
- * Pass package names (or picomatch globs) via `build.pure.packages` to
- * annotate them in addition to the defaults.
+ * **Example:** Tree-shake additional packages
+ * Only list packages with no top-level side effects.
  * ```typescript
  * {
  *   main: import.meta.url,
@@ -409,18 +405,7 @@ export { createContainerRuntimeContext } from "../../Server/Process.ts";
  * }
  * ```
  *
- * Listing a package annotates calls whose result is bound (variable
- * initializers, exports) — safe anywhere. If a listed package also
- * declares `"sideEffects": false` (or `[]`) in its `package.json`, that
- * combination opts it into full annotation: top-level calls whose result
- * is discarded (e.g. `router.on("/path", handler)` registrations) are
- * also marked pure and deleted under minification when unused. Only list
- * a `sideEffects: false` package if its modules really are free of
- * meaningful top-level side effects. The `effect`, `alchemy`, and
- * `@distilled.cloud` defaults declare exactly that, on purpose — their
- * modules are designed to be fully tree-shakeable.
- *
- * **Example:** Disable pure annotations
+ * **Example:** Turn it off
  * ```typescript
  * {
  *   main: import.meta.url,

--- a/packages/alchemy/src/AWS/Lambda/Function.ts
+++ b/packages/alchemy/src/AWS/Lambda/Function.ts
@@ -327,8 +327,9 @@ export interface FunctionZipProps extends FunctionCommonProps {
   /**
    * Bundler configuration for {@link main}: rolldown input options, `output`
    * overrides, `install` for native packages, `pure`, and the bundle analyzer.
-   * Unused `effect`, alchemy, and `@distilled.cloud` code is tree-shaken.
-   * List extra packages with `pure.packages`, or disable with `pure: false`.
+   * Unused code is tree-shaken. `effect`, alchemy, and `@distilled.cloud`
+   * are marked pure so unused parts prune more aggressively. List extra
+   * packages with `pure.packages`, or disable with `pure: false`.
    */
   build?: FunctionBuildOptions;
   uploadSourceMap?: boolean;
@@ -781,11 +782,12 @@ export const normalizeFunctionUrl = (
  * ```
  *
  * ### Bundling & Tree-shaking
- * `main` is bundled with rolldown at deploy time. Unused `effect`,
- * alchemy, and `@distilled.cloud` code is tree-shaken. Your app is left
- * untouched.
+ * `main` is bundled with rolldown at deploy time. Unused code is
+ * tree-shaken. `effect`, alchemy, and `@distilled.cloud` are marked
+ * pure so unused parts prune more aggressively. Your app is not
+ * marked pure.
  *
- * **Example:** Tree-shake additional packages
+ * **Example:** Mark additional packages as pure
  * Only list packages with no top-level side effects.
  * ```typescript
  * const func = yield* AWS.Lambda.Function("ApiFunction", {

--- a/packages/alchemy/src/AWS/Lambda/Function.ts
+++ b/packages/alchemy/src/AWS/Lambda/Function.ts
@@ -325,13 +325,10 @@ export interface FunctionZipProps extends FunctionCommonProps {
    */
   layers?: LayerRef[];
   /**
-   * Bundler configuration for {@link main}: rolldown input options (flat),
-   * `output` overrides, `install` for native packages, plus pure-annotation
-   * options (`pure`) and the bundle analyzer. Top-level calls in `effect`,
-   * `@effect/*`, `alchemy`, `@alchemy.run/*`, and `@distilled.cloud/*` are
-   * annotated as pure by default so unused code from those packages is
-   * tree-shaken; list additional packages via `pure.packages`, or disable
-   * with `pure: false`.
+   * Bundler configuration for {@link main}: rolldown input options, `output`
+   * overrides, `install` for native packages, `pure`, and the bundle analyzer.
+   * Unused `effect`, alchemy, and `@distilled.cloud` code is tree-shaken.
+   * List extra packages with `pure.packages`, or disable with `pure: false`.
    */
   build?: FunctionBuildOptions;
   uploadSourceMap?: boolean;
@@ -784,20 +781,12 @@ export const normalizeFunctionUrl = (
  * ```
  *
  * ### Bundling & Tree-shaking
- * `main` is bundled with rolldown at deploy time. Top-level calls in the
- * `effect`, `@effect/*`, `alchemy`, `@alchemy.run/*`, and
- * `@distilled.cloud/*` packages receive `#__PURE__` annotations by
- * default, so anything the function doesn't use from those packages is
- * tree-shaken out of the bundle. Any other package — including your own
- * app — is left untouched unless you list it explicitly.
+ * `main` is bundled with rolldown at deploy time. Unused `effect`,
+ * alchemy, and `@distilled.cloud` code is tree-shaken. Your app is left
+ * untouched.
  *
- * **Example:** Treat additional packages as pure
- * Pass package names (or picomatch globs) via `build.pure.packages` to
- * annotate them in addition to the defaults. Listing a package that also
- * declares `"sideEffects": false` (or `[]`) in its `package.json` opts it
- * into full annotation — top-level calls whose result is discarded are
- * deleted under minification when unused — so only list packages whose
- * modules really are free of meaningful top-level side effects.
+ * **Example:** Tree-shake additional packages
+ * Only list packages with no top-level side effects.
  * ```typescript
  * const func = yield* AWS.Lambda.Function("ApiFunction", {
  *   main: "./src/handler.ts",
@@ -807,7 +796,7 @@ export const normalizeFunctionUrl = (
  * });
  * ```
  *
- * **Example:** Disable pure annotations
+ * **Example:** Turn it off
  * ```typescript
  * const func = yield* AWS.Lambda.Function("ApiFunction", {
  *   main: "./src/handler.ts",

--- a/packages/alchemy/src/AWS/Lambda/MicrovmImage.ts
+++ b/packages/alchemy/src/AWS/Lambda/MicrovmImage.ts
@@ -89,8 +89,9 @@ export interface MicrovmImageProps {
 
   /**
    * Bundler configuration for {@link main} (effectful mode). Unused
-   * `effect`, alchemy, and `@distilled.cloud` code is tree-shaken. List
-   * extra packages with `pure.packages`, or disable with `pure: false`.
+   * code is tree-shaken. `effect`, alchemy, and `@distilled.cloud` are
+   * marked pure so unused parts prune more aggressively. List extra
+   * packages with `pure.packages`, or disable with `pure: false`.
    */
   build?: Bundle.BundleConfig;
 
@@ -404,11 +405,12 @@ export type MicrovmImageShape = Main<MicrovmImageServices>;
  * ```
  *
  * ### Bundling & Tree-shaking
- * `main` is bundled with rolldown at deploy time. Unused `effect`,
- * alchemy, and `@distilled.cloud` code is tree-shaken. Your app is left
- * untouched.
+ * `main` is bundled with rolldown at deploy time. Unused code is
+ * tree-shaken. `effect`, alchemy, and `@distilled.cloud` are marked
+ * pure so unused parts prune more aggressively. Your app is not
+ * marked pure.
  *
- * **Example:** Tree-shake additional packages
+ * **Example:** Mark additional packages as pure
  * Only list packages with no top-level side effects.
  * ```typescript
  * {

--- a/packages/alchemy/src/AWS/Lambda/MicrovmImage.ts
+++ b/packages/alchemy/src/AWS/Lambda/MicrovmImage.ts
@@ -88,12 +88,9 @@ export interface MicrovmImageProps {
   external?: string[];
 
   /**
-   * Bundler configuration for {@link main} (effectful mode): rolldown
-   * `input`/`output` overrides plus pure-annotation options (`pure`).
-   * `effect`, `@effect/*`, `alchemy`, `@alchemy.run/*`, and
-   * `@distilled.cloud/*` are annotated as pure by default so unused code
-   * from those packages is tree-shaken; list additional packages via
-   * `pure.packages`, or disable with `pure: false`.
+   * Bundler configuration for {@link main} (effectful mode). Unused
+   * `effect`, alchemy, and `@distilled.cloud` code is tree-shaken. List
+   * extra packages with `pure.packages`, or disable with `pure: false`.
    */
   build?: Bundle.BundleConfig;
 
@@ -407,16 +404,12 @@ export type MicrovmImageShape = Main<MicrovmImageServices>;
  * ```
  *
  * ### Bundling & Tree-shaking
- * `main` is bundled with rolldown at deploy time. Top-level calls in the
- * `effect`, `@effect/*`, `alchemy`, `@alchemy.run/*`, and
- * `@distilled.cloud/*` packages receive `#__PURE__` annotations by
- * default, so anything the MicroVM program doesn't use from those packages is
- * tree-shaken out of the bundle. Any other package — including your own
- * app — is left untouched unless you list it explicitly.
+ * `main` is bundled with rolldown at deploy time. Unused `effect`,
+ * alchemy, and `@distilled.cloud` code is tree-shaken. Your app is left
+ * untouched.
  *
- * **Example:** Treat additional packages as pure
- * Pass package names (or picomatch globs) via `build.pure.packages` to
- * annotate them in addition to the defaults.
+ * **Example:** Tree-shake additional packages
+ * Only list packages with no top-level side effects.
  * ```typescript
  * {
  *   main: import.meta.url,
@@ -426,18 +419,7 @@ export type MicrovmImageShape = Main<MicrovmImageServices>;
  * }
  * ```
  *
- * Listing a package annotates calls whose result is bound (variable
- * initializers, exports) — safe anywhere. If a listed package also
- * declares `"sideEffects": false` (or `[]`) in its `package.json`, that
- * combination opts it into full annotation: top-level calls whose result
- * is discarded (e.g. `router.on("/path", handler)` registrations) are
- * also marked pure and deleted under minification when unused. Only list
- * a `sideEffects: false` package if its modules really are free of
- * meaningful top-level side effects. The `effect`, `alchemy`, and
- * `@distilled.cloud` defaults declare exactly that, on purpose — their
- * modules are designed to be fully tree-shakeable.
- *
- * **Example:** Disable pure annotations
+ * **Example:** Turn it off
  * ```typescript
  * {
  *   main: import.meta.url,

--- a/packages/alchemy/src/Bundle/Bundle.ts
+++ b/packages/alchemy/src/Bundle/Bundle.ts
@@ -86,8 +86,9 @@ export interface BundleExtraOptions {
  * rolldown input/output overrides plus the {@link BundleExtraOptions}
  * (pure-annotation packages via `pure`, bundle analyzer).
  *
- * Unused `effect`, alchemy, and `@distilled.cloud` code is tree-shaken.
- * List extra packages with `pure.packages`, or disable with `pure: false`.
+ * Unused code is tree-shaken. `effect`, alchemy, and `@distilled.cloud`
+ * are marked pure so unused parts prune more aggressively. List extra
+ * packages with `pure.packages`, or disable with `pure: false`.
  */
 export interface BundleConfig extends BundleExtraOptions {
   /**

--- a/packages/alchemy/src/Bundle/Bundle.ts
+++ b/packages/alchemy/src/Bundle/Bundle.ts
@@ -86,11 +86,8 @@ export interface BundleExtraOptions {
  * rolldown input/output overrides plus the {@link BundleExtraOptions}
  * (pure-annotation packages via `pure`, bundle analyzer).
  *
- * Top-level calls in `effect`, `@effect/*`, `alchemy`, `@alchemy.run/*`,
- * and `@distilled.cloud/*` are annotated as pure by default so unused
- * code from those packages is tree-shaken out of the bundle; list
- * additional packages via `pure.packages`, or disable annotation with
- * `pure: false`.
+ * Unused `effect`, alchemy, and `@distilled.cloud` code is tree-shaken.
+ * List extra packages with `pure.packages`, or disable with `pure: false`.
  */
 export interface BundleConfig extends BundleExtraOptions {
   /**

--- a/packages/alchemy/src/Cloudflare/Containers/Container.ts
+++ b/packages/alchemy/src/Cloudflare/Containers/Container.ts
@@ -358,16 +358,12 @@ export type Container<Id extends string = string> = Named<Id> & {
  * ```
  *
  * ### Bundling & Tree-shaking
- * `main` is bundled with rolldown at deploy time. Top-level calls in the
- * `effect`, `@effect/*`, `alchemy`, `@alchemy.run/*`, and
- * `@distilled.cloud/*` packages receive `#__PURE__` annotations by
- * default, so anything the container program doesn't use from those packages is
- * tree-shaken out of the bundle. Any other package — including your own
- * app — is left untouched unless you list it explicitly.
+ * `main` is bundled with rolldown at deploy time. Unused `effect`,
+ * alchemy, and `@distilled.cloud` code is tree-shaken. Your app is left
+ * untouched.
  *
- * **Example:** Treat additional packages as pure
- * Pass package names (or picomatch globs) via `build.pure.packages` to
- * annotate them in addition to the defaults.
+ * **Example:** Tree-shake additional packages
+ * Only list packages with no top-level side effects.
  * ```typescript
  * {
  *   main: import.meta.url,
@@ -377,18 +373,7 @@ export type Container<Id extends string = string> = Named<Id> & {
  * }
  * ```
  *
- * Listing a package annotates calls whose result is bound (variable
- * initializers, exports) — safe anywhere. If a listed package also
- * declares `"sideEffects": false` (or `[]`) in its `package.json`, that
- * combination opts it into full annotation: top-level calls whose result
- * is discarded (e.g. `router.on("/path", handler)` registrations) are
- * also marked pure and deleted under minification when unused. Only list
- * a `sideEffects: false` package if its modules really are free of
- * meaningful top-level side effects. The `effect`, `alchemy`, and
- * `@distilled.cloud` defaults declare exactly that, on purpose — their
- * modules are designed to be fully tree-shakeable.
- *
- * **Example:** Disable pure annotations
+ * **Example:** Turn it off
  * ```typescript
  * {
  *   main: import.meta.url,

--- a/packages/alchemy/src/Cloudflare/Containers/Container.ts
+++ b/packages/alchemy/src/Cloudflare/Containers/Container.ts
@@ -358,11 +358,12 @@ export type Container<Id extends string = string> = Named<Id> & {
  * ```
  *
  * ### Bundling & Tree-shaking
- * `main` is bundled with rolldown at deploy time. Unused `effect`,
- * alchemy, and `@distilled.cloud` code is tree-shaken. Your app is left
- * untouched.
+ * `main` is bundled with rolldown at deploy time. Unused code is
+ * tree-shaken. `effect`, alchemy, and `@distilled.cloud` are marked
+ * pure so unused parts prune more aggressively. Your app is not
+ * marked pure.
  *
- * **Example:** Tree-shake additional packages
+ * **Example:** Mark additional packages as pure
  * Only list packages with no top-level side effects.
  * ```typescript
  * {

--- a/packages/alchemy/src/Cloudflare/Containers/ContainerApplication.ts
+++ b/packages/alchemy/src/Cloudflare/Containers/ContainerApplication.ts
@@ -262,8 +262,9 @@ export interface EffectfulContainerProps extends ContainerApplicationPropsBase {
    */
   autoInstallExternals?: boolean;
   /**
-   * Bundler configuration for {@link main}. Unused `effect`, alchemy, and
-   * `@distilled.cloud` code is tree-shaken. List extra packages with
+   * Bundler configuration for {@link main}. Unused code is tree-shaken.
+   * `effect`, alchemy, and `@distilled.cloud` are marked pure so unused
+   * parts prune more aggressively. List extra packages with
    * `pure.packages`, or disable with `pure: false`.
    */
   build?: Bundle.BundleConfig;
@@ -479,11 +480,12 @@ export type ContainerShape = Main<ContainerServices>;
  * bundled program is still layered on top.
  *
  * ### Bundling & Tree-shaking
- * `main` is bundled with rolldown at deploy time. Unused `effect`,
- * alchemy, and `@distilled.cloud` code is tree-shaken. Your app is left
- * untouched.
+ * `main` is bundled with rolldown at deploy time. Unused code is
+ * tree-shaken. `effect`, alchemy, and `@distilled.cloud` are marked
+ * pure so unused parts prune more aggressively. Your app is not
+ * marked pure.
  *
- * **Example:** Tree-shake additional packages
+ * **Example:** Mark additional packages as pure
  * Only list packages with no top-level side effects.
  * ```typescript
  * {

--- a/packages/alchemy/src/Cloudflare/Containers/ContainerApplication.ts
+++ b/packages/alchemy/src/Cloudflare/Containers/ContainerApplication.ts
@@ -262,11 +262,9 @@ export interface EffectfulContainerProps extends ContainerApplicationPropsBase {
    */
   autoInstallExternals?: boolean;
   /**
-   * Bundler configuration for {@link main}: rolldown `input`/`output`
-   * overrides plus pure-annotation options (`pure`). `effect`, `@effect/*`,
-   * `alchemy`, `@alchemy.run/*`, and `@distilled.cloud/*` are annotated as
-   * pure by default so unused code from those packages is tree-shaken; list
-   * additional packages via `pure.packages`, or disable with `pure: false`.
+   * Bundler configuration for {@link main}. Unused `effect`, alchemy, and
+   * `@distilled.cloud` code is tree-shaken. List extra packages with
+   * `pure.packages`, or disable with `pure: false`.
    */
   build?: Bundle.BundleConfig;
 }
@@ -481,16 +479,12 @@ export type ContainerShape = Main<ContainerServices>;
  * bundled program is still layered on top.
  *
  * ### Bundling & Tree-shaking
- * `main` is bundled with rolldown at deploy time. Top-level calls in the
- * `effect`, `@effect/*`, `alchemy`, `@alchemy.run/*`, and
- * `@distilled.cloud/*` packages receive `#__PURE__` annotations by
- * default, so anything the container program doesn't use from those packages is
- * tree-shaken out of the bundle. Any other package — including your own
- * app — is left untouched unless you list it explicitly.
+ * `main` is bundled with rolldown at deploy time. Unused `effect`,
+ * alchemy, and `@distilled.cloud` code is tree-shaken. Your app is left
+ * untouched.
  *
- * **Example:** Treat additional packages as pure
- * Pass package names (or picomatch globs) via `build.pure.packages` to
- * annotate them in addition to the defaults.
+ * **Example:** Tree-shake additional packages
+ * Only list packages with no top-level side effects.
  * ```typescript
  * {
  *   main: import.meta.url,
@@ -500,18 +494,7 @@ export type ContainerShape = Main<ContainerServices>;
  * }
  * ```
  *
- * Listing a package annotates calls whose result is bound (variable
- * initializers, exports) — safe anywhere. If a listed package also
- * declares `"sideEffects": false` (or `[]`) in its `package.json`, that
- * combination opts it into full annotation: top-level calls whose result
- * is discarded (e.g. `router.on("/path", handler)` registrations) are
- * also marked pure and deleted under minification when unused. Only list
- * a `sideEffects: false` package if its modules really are free of
- * meaningful top-level side effects. The `effect`, `alchemy`, and
- * `@distilled.cloud` defaults declare exactly that, on purpose — their
- * modules are designed to be fully tree-shakeable.
- *
- * **Example:** Disable pure annotations
+ * **Example:** Turn it off
  * ```typescript
  * {
  *   main: import.meta.url,

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -1774,17 +1774,12 @@ export const isSelf = (value: unknown): value is Self =>
  * ```
  *
  * ### Bundling & Tree-shaking
- * `main` is bundled with rolldown at deploy time. Top-level calls in the
- * `effect`, `@effect/*`, `alchemy`, `@alchemy.run/*`, and
- * `@distilled.cloud/*` packages receive `#__PURE__` annotations by
- * default, so anything the Worker doesn't use from those packages is
- * tree-shaken out of the bundle. Any other
- * package — including your own app — is left untouched unless you list
- * it explicitly.
+ * `main` is bundled with rolldown at deploy time. Unused `effect`,
+ * alchemy, and `@distilled.cloud` code is tree-shaken. Your app is left
+ * untouched.
  *
- * **Example:** Treat additional packages as pure
- * Pass package names (or picomatch globs) via `build.pure.packages` to
- * annotate them in addition to the defaults.
+ * **Example:** Tree-shake additional packages
+ * Only list packages with no top-level side effects.
  * ```typescript
  * {
  *   main: "./src/worker.ts",
@@ -1794,18 +1789,7 @@ export const isSelf = (value: unknown): value is Self =>
  * }
  * ```
  *
- * Listing a package annotates calls whose result is bound (variable
- * initializers, exports) — safe anywhere. If a listed package also
- * declares `"sideEffects": false` (or `[]`) in its `package.json`, that
- * combination opts it into full annotation: top-level calls whose result
- * is discarded (e.g. `router.on("/path", handler)` registrations) are
- * also marked pure and deleted under minification when unused. Only list
- * a `sideEffects: false` package if its modules really are free of
- * meaningful top-level side effects. The `effect`, `alchemy`, and
- * `@distilled.cloud` defaults declare exactly that, on purpose — their
- * modules are designed to be fully tree-shakeable.
- *
- * **Example:** Disable pure annotations
+ * **Example:** Turn it off
  * ```typescript
  * {
  *   main: "./src/worker.ts",

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -1774,11 +1774,12 @@ export const isSelf = (value: unknown): value is Self =>
  * ```
  *
  * ### Bundling & Tree-shaking
- * `main` is bundled with rolldown at deploy time. Unused `effect`,
- * alchemy, and `@distilled.cloud` code is tree-shaken. Your app is left
- * untouched.
+ * `main` is bundled with rolldown at deploy time. Unused code is
+ * tree-shaken. `effect`, alchemy, and `@distilled.cloud` are marked
+ * pure so unused parts prune more aggressively. Your app is not
+ * marked pure.
  *
- * **Example:** Tree-shake additional packages
+ * **Example:** Mark additional packages as pure
  * Only list packages with no top-level side effects.
  * ```typescript
  * {

--- a/packages/alchemy/src/Docker/Service.ts
+++ b/packages/alchemy/src/Docker/Service.ts
@@ -417,16 +417,12 @@ export interface ServiceRuntimeContext extends HostRuntimeContext {
  * ```
  *
  * ### Bundling & Tree-shaking
- * `main` is bundled with rolldown at deploy time. Top-level calls in the
- * `effect`, `@effect/*`, `alchemy`, `@alchemy.run/*`, and
- * `@distilled.cloud/*` packages receive `#__PURE__` annotations by
- * default, so anything the service doesn't use from those packages is
- * tree-shaken out of the bundle. Any other package — including your own
- * app — is left untouched unless you list it explicitly.
+ * `main` is bundled with rolldown at deploy time. Unused `effect`,
+ * alchemy, and `@distilled.cloud` code is tree-shaken. Your app is left
+ * untouched.
  *
- * **Example:** Treat additional packages as pure
- * Pass package names (or picomatch globs) via `build.pure.packages` to
- * annotate them in addition to the defaults.
+ * **Example:** Tree-shake additional packages
+ * Only list packages with no top-level side effects.
  * ```typescript
  * {
  *   main: import.meta.url,
@@ -436,18 +432,7 @@ export interface ServiceRuntimeContext extends HostRuntimeContext {
  * }
  * ```
  *
- * Listing a package annotates calls whose result is bound (variable
- * initializers, exports) — safe anywhere. If a listed package also
- * declares `"sideEffects": false` (or `[]`) in its `package.json`, that
- * combination opts it into full annotation: top-level calls whose result
- * is discarded (e.g. `router.on("/path", handler)` registrations) are
- * also marked pure and deleted under minification when unused. Only list
- * a `sideEffects: false` package if its modules really are free of
- * meaningful top-level side effects. The `effect`, `alchemy`, and
- * `@distilled.cloud` defaults declare exactly that, on purpose — their
- * modules are designed to be fully tree-shakeable.
- *
- * **Example:** Disable pure annotations
+ * **Example:** Turn it off
  * ```typescript
  * {
  *   main: import.meta.url,

--- a/packages/alchemy/src/Docker/Service.ts
+++ b/packages/alchemy/src/Docker/Service.ts
@@ -417,11 +417,12 @@ export interface ServiceRuntimeContext extends HostRuntimeContext {
  * ```
  *
  * ### Bundling & Tree-shaking
- * `main` is bundled with rolldown at deploy time. Unused `effect`,
- * alchemy, and `@distilled.cloud` code is tree-shaken. Your app is left
- * untouched.
+ * `main` is bundled with rolldown at deploy time. Unused code is
+ * tree-shaken. `effect`, alchemy, and `@distilled.cloud` are marked
+ * pure so unused parts prune more aggressively. Your app is not
+ * marked pure.
  *
- * **Example:** Tree-shake additional packages
+ * **Example:** Mark additional packages as pure
  * Only list packages with no top-level side effects.
  * ```typescript
  * {

--- a/packages/alchemy/src/Docker/ServiceImage.ts
+++ b/packages/alchemy/src/Docker/ServiceImage.ts
@@ -31,11 +31,9 @@ export interface BundledServiceSource {
   handler?: string;
   port?: number;
   /**
-   * Bundler configuration for `main`: rolldown `input`/`output` overrides
-   * plus pure-annotation options (`pure`). `effect`, `@effect/*`,
-   * `alchemy`, `@alchemy.run/*`, and `@distilled.cloud/*` are annotated as
-   * pure by default so unused code from those packages is tree-shaken; list
-   * additional packages via `pure.packages`, or disable with `pure: false`.
+   * Bundler configuration for `main`. Unused `effect`, alchemy, and
+   * `@distilled.cloud` code is tree-shaken. List extra packages with
+   * `pure.packages`, or disable with `pure: false`.
    */
   build?: Bundle.BundleConfig;
 }

--- a/packages/alchemy/src/Docker/ServiceImage.ts
+++ b/packages/alchemy/src/Docker/ServiceImage.ts
@@ -31,8 +31,9 @@ export interface BundledServiceSource {
   handler?: string;
   port?: number;
   /**
-   * Bundler configuration for `main`. Unused `effect`, alchemy, and
-   * `@distilled.cloud` code is tree-shaken. List extra packages with
+   * Bundler configuration for `main`. Unused code is tree-shaken.
+   * `effect`, alchemy, and `@distilled.cloud` are marked pure so unused
+   * parts prune more aggressively. List extra packages with
    * `pure.packages`, or disable with `pure: false`.
    */
   build?: Bundle.BundleConfig;

--- a/packages/alchemy/src/Kubernetes/ClusterAdapter.ts
+++ b/packages/alchemy/src/Kubernetes/ClusterAdapter.ts
@@ -164,8 +164,9 @@ export interface WorkloadImageSource {
   main?: string;
   handler?: string;
   /**
-   * Bundler configuration for `main`. Unused `effect`, alchemy, and
-   * `@distilled.cloud` code is tree-shaken. List extra packages with
+   * Bundler configuration for `main`. Unused code is tree-shaken.
+   * `effect`, alchemy, and `@distilled.cloud` are marked pure so unused
+   * parts prune more aggressively. List extra packages with
    * `pure.packages`, or disable with `pure: false`.
    */
   build?: Bundle.BundleConfig;

--- a/packages/alchemy/src/Kubernetes/ClusterAdapter.ts
+++ b/packages/alchemy/src/Kubernetes/ClusterAdapter.ts
@@ -164,11 +164,9 @@ export interface WorkloadImageSource {
   main?: string;
   handler?: string;
   /**
-   * Bundler configuration for `main`: rolldown `input`/`output` overrides
-   * plus pure-annotation options (`pure`). `effect`, `@effect/*`,
-   * `alchemy`, `@alchemy.run/*`, and `@distilled.cloud/*` are annotated as
-   * pure by default so unused code from those packages is tree-shaken; list
-   * additional packages via `pure.packages`, or disable with `pure: false`.
+   * Bundler configuration for `main`. Unused `effect`, alchemy, and
+   * `@distilled.cloud` code is tree-shaken. List extra packages with
+   * `pure.packages`, or disable with `pure: false`.
    */
   build?: Bundle.BundleConfig;
   context?: string;

--- a/packages/alchemy/src/Kubernetes/Deployment.ts
+++ b/packages/alchemy/src/Kubernetes/Deployment.ts
@@ -355,16 +355,12 @@ export interface DeploymentRuntimeContext extends HostRuntimeContext {
  * ```
  *
  * ### Bundling & Tree-shaking
- * `main` is bundled with rolldown at deploy time. Top-level calls in the
- * `effect`, `@effect/*`, `alchemy`, `@alchemy.run/*`, and
- * `@distilled.cloud/*` packages receive `#__PURE__` annotations by
- * default, so anything the deployment doesn't use from those packages is
- * tree-shaken out of the bundle. Any other package — including your own
- * app — is left untouched unless you list it explicitly.
+ * `main` is bundled with rolldown at deploy time. Unused `effect`,
+ * alchemy, and `@distilled.cloud` code is tree-shaken. Your app is left
+ * untouched.
  *
- * **Example:** Treat additional packages as pure
- * Pass package names (or picomatch globs) via `build.pure.packages` to
- * annotate them in addition to the defaults.
+ * **Example:** Tree-shake additional packages
+ * Only list packages with no top-level side effects.
  * ```typescript
  * {
  *   main: import.meta.url,
@@ -374,18 +370,7 @@ export interface DeploymentRuntimeContext extends HostRuntimeContext {
  * }
  * ```
  *
- * Listing a package annotates calls whose result is bound (variable
- * initializers, exports) — safe anywhere. If a listed package also
- * declares `"sideEffects": false` (or `[]`) in its `package.json`, that
- * combination opts it into full annotation: top-level calls whose result
- * is discarded (e.g. `router.on("/path", handler)` registrations) are
- * also marked pure and deleted under minification when unused. Only list
- * a `sideEffects: false` package if its modules really are free of
- * meaningful top-level side effects. The `effect`, `alchemy`, and
- * `@distilled.cloud` defaults declare exactly that, on purpose — their
- * modules are designed to be fully tree-shakeable.
- *
- * **Example:** Disable pure annotations
+ * **Example:** Turn it off
  * ```typescript
  * {
  *   main: import.meta.url,

--- a/packages/alchemy/src/Kubernetes/Deployment.ts
+++ b/packages/alchemy/src/Kubernetes/Deployment.ts
@@ -355,11 +355,12 @@ export interface DeploymentRuntimeContext extends HostRuntimeContext {
  * ```
  *
  * ### Bundling & Tree-shaking
- * `main` is bundled with rolldown at deploy time. Unused `effect`,
- * alchemy, and `@distilled.cloud` code is tree-shaken. Your app is left
- * untouched.
+ * `main` is bundled with rolldown at deploy time. Unused code is
+ * tree-shaken. `effect`, alchemy, and `@distilled.cloud` are marked
+ * pure so unused parts prune more aggressively. Your app is not
+ * marked pure.
  *
- * **Example:** Tree-shake additional packages
+ * **Example:** Mark additional packages as pure
  * Only list packages with no top-level side effects.
  * ```typescript
  * {

--- a/packages/alchemy/src/Kubernetes/Job.ts
+++ b/packages/alchemy/src/Kubernetes/Job.ts
@@ -315,16 +315,12 @@ export interface JobRuntimeContext extends HostRuntimeContext {
  * ```
  *
  * ### Bundling & Tree-shaking
- * `main` is bundled with rolldown at deploy time. Top-level calls in the
- * `effect`, `@effect/*`, `alchemy`, `@alchemy.run/*`, and
- * `@distilled.cloud/*` packages receive `#__PURE__` annotations by
- * default, so anything the job doesn't use from those packages is
- * tree-shaken out of the bundle. Any other package — including your own
- * app — is left untouched unless you list it explicitly.
+ * `main` is bundled with rolldown at deploy time. Unused `effect`,
+ * alchemy, and `@distilled.cloud` code is tree-shaken. Your app is left
+ * untouched.
  *
- * **Example:** Treat additional packages as pure
- * Pass package names (or picomatch globs) via `build.pure.packages` to
- * annotate them in addition to the defaults.
+ * **Example:** Tree-shake additional packages
+ * Only list packages with no top-level side effects.
  * ```typescript
  * {
  *   main: import.meta.url,
@@ -334,18 +330,7 @@ export interface JobRuntimeContext extends HostRuntimeContext {
  * }
  * ```
  *
- * Listing a package annotates calls whose result is bound (variable
- * initializers, exports) — safe anywhere. If a listed package also
- * declares `"sideEffects": false` (or `[]`) in its `package.json`, that
- * combination opts it into full annotation: top-level calls whose result
- * is discarded (e.g. `router.on("/path", handler)` registrations) are
- * also marked pure and deleted under minification when unused. Only list
- * a `sideEffects: false` package if its modules really are free of
- * meaningful top-level side effects. The `effect`, `alchemy`, and
- * `@distilled.cloud` defaults declare exactly that, on purpose — their
- * modules are designed to be fully tree-shakeable.
- *
- * **Example:** Disable pure annotations
+ * **Example:** Turn it off
  * ```typescript
  * {
  *   main: import.meta.url,

--- a/packages/alchemy/src/Kubernetes/Job.ts
+++ b/packages/alchemy/src/Kubernetes/Job.ts
@@ -315,11 +315,12 @@ export interface JobRuntimeContext extends HostRuntimeContext {
  * ```
  *
  * ### Bundling & Tree-shaking
- * `main` is bundled with rolldown at deploy time. Unused `effect`,
- * alchemy, and `@distilled.cloud` code is tree-shaken. Your app is left
- * untouched.
+ * `main` is bundled with rolldown at deploy time. Unused code is
+ * tree-shaken. `effect`, alchemy, and `@distilled.cloud` are marked
+ * pure so unused parts prune more aggressively. Your app is not
+ * marked pure.
  *
- * **Example:** Tree-shake additional packages
+ * **Example:** Mark additional packages as pure
  * Only list packages with no top-level side effects.
  * ```typescript
  * {

--- a/packages/alchemy/src/Prisma/Compute.ts
+++ b/packages/alchemy/src/Prisma/Compute.ts
@@ -585,16 +585,12 @@ const isEffectNativeCompute = (props: ComputeProps) =>
  * ```
  *
  * ### Bundling & Tree-shaking
- * `main` is bundled with rolldown at deploy time. Top-level calls in the
- * `effect`, `@effect/*`, `alchemy`, `@alchemy.run/*`, and
- * `@distilled.cloud/*` packages receive `#__PURE__` annotations by
- * default, so anything the app doesn't use from those packages is
- * tree-shaken out of the bundle. Any other package — including your own
- * app — is left untouched unless you list it explicitly.
+ * `main` is bundled with rolldown at deploy time. Unused `effect`,
+ * alchemy, and `@distilled.cloud` code is tree-shaken. Your app is left
+ * untouched.
  *
- * **Example:** Treat additional packages as pure
- * Pass package names (or picomatch globs) via `bundle.extra.pure.packages` to
- * annotate them in addition to the defaults.
+ * **Example:** Tree-shake additional packages
+ * Only list packages with no top-level side effects.
  * ```typescript
  * {
  *   main: "./src/app.ts",
@@ -604,18 +600,7 @@ const isEffectNativeCompute = (props: ComputeProps) =>
  * }
  * ```
  *
- * Listing a package annotates calls whose result is bound (variable
- * initializers, exports) — safe anywhere. If a listed package also
- * declares `"sideEffects": false` (or `[]`) in its `package.json`, that
- * combination opts it into full annotation: top-level calls whose result
- * is discarded (e.g. `router.on("/path", handler)` registrations) are
- * also marked pure and deleted under minification when unused. Only list
- * a `sideEffects: false` package if its modules really are free of
- * meaningful top-level side effects. The `effect`, `alchemy`, and
- * `@distilled.cloud` defaults declare exactly that, on purpose — their
- * modules are designed to be fully tree-shakeable.
- *
- * **Example:** Disable pure annotations
+ * **Example:** Turn it off
  * ```typescript
  * {
  *   main: "./src/app.ts",

--- a/packages/alchemy/src/Prisma/Compute.ts
+++ b/packages/alchemy/src/Prisma/Compute.ts
@@ -585,11 +585,12 @@ const isEffectNativeCompute = (props: ComputeProps) =>
  * ```
  *
  * ### Bundling & Tree-shaking
- * `main` is bundled with rolldown at deploy time. Unused `effect`,
- * alchemy, and `@distilled.cloud` code is tree-shaken. Your app is left
- * untouched.
+ * `main` is bundled with rolldown at deploy time. Unused code is
+ * tree-shaken. `effect`, alchemy, and `@distilled.cloud` are marked
+ * pure so unused parts prune more aggressively. Your app is not
+ * marked pure.
  *
- * **Example:** Tree-shake additional packages
+ * **Example:** Mark additional packages as pure
  * Only list packages with no top-level side effects.
  * ```typescript
  * {


### PR DESCRIPTION
Unused code is tree-shaken. `effect`, alchemy, and `@distilled.cloud` are marked pure so unused parts prune more aggressively. Your app is not marked pure.

```ts
build: {
  pure: { packages: ["my-lib", "@my-scope/*"] },
  // or pure: false
}
```
