### PR TITLE
fix(cli): prompt for approval in plain interactive mode

### DIFF
--- a/packages/alchemy/src/Cli/LoggingCli.ts
+++ b/packages/alchemy/src/Cli/LoggingCli.ts
@@ -1,8 +1,10 @@
 import * as Clock from "effect/Clock";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Prompt from "effect/unstable/cli/Prompt";
 import type { ActionApply, ActionDelete, CRUD, Plan } from "../Plan.ts";
 import { Cli, type PlanDisplayOptions } from "../Report.ts";
+import { canPromptOnStdin } from "../Util/interactive.ts";
 import { NonInteractiveTerminal } from "./CliKit/errors.ts";
 import { ansiFg, colorsEnabled, theme } from "./CliKit/index.ts";
 import { formatElapsed } from "./Format.ts";
@@ -204,154 +206,173 @@ const colorYamlLine = (
   return `${key.indent}${color(key.key)}${key.value}`;
 };
 
-export const LoggingCli = Layer.succeed(
+export const LoggingCli = Layer.effect(
   Cli,
-  Cli.of({
-    startPlanningSession: (label, _detail, title) =>
-      Effect.gen(function* () {
-        // Same information as the interactive session, one plain line per
-        // change: the title header carries the operation + stage once, each
-        // phase prints as it starts, and the settle line carries the total
-        // planning time (the spinner's implicit "how long did that take").
-        const startedAt = yield* Clock.currentTimeMillis;
-        if (title !== undefined) yield* Effect.logInfo(bold(title));
-        yield* Effect.logInfo(dim(label));
-        let closed = false;
-        let lastLabel = label;
-        const write = (nextLabel: string, _nextDetail?: string) =>
-          Effect.suspend(() => {
-            // Repeated updates within one phase (spinner detail refreshes)
-            // carry nothing new for a line-per-change log.
-            if (closed || nextLabel === lastLabel) return Effect.void;
-            lastLabel = nextLabel;
-            return Effect.logInfo(dim(nextLabel));
-          });
-        const finish = (message: string, paint: (s: string) => string) =>
-          Effect.suspend(() => {
-            if (closed) return Effect.void;
-            closed = true;
-            return Clock.currentTimeMillis.pipe(
-              Effect.flatMap((now) =>
-                Effect.logInfo(
-                  `${paint(message)} ${dim(`(${formatElapsed(now - startedAt)})`)}`,
+  Effect.gen(function* () {
+    // Captured at layer build so `approvePlan` keeps the CLIService signature
+    // (no requirements on the returned Effects).
+    const promptContext = yield* Effect.context<Prompt.Environment>();
+    const confirm = (options: Prompt.ConfirmOptions) =>
+      Prompt.confirm(options).pipe(
+        Effect.catchTag("QuitError", () => Effect.succeed(false)),
+        Effect.provideContext(promptContext),
+      );
+    return Cli.of({
+      startPlanningSession: (label, _detail, title) =>
+        Effect.gen(function* () {
+          // Same information as the interactive session, one plain line per
+          // change: the title header carries the operation + stage once, each
+          // phase prints as it starts, and the settle line carries the total
+          // planning time (the spinner's implicit "how long did that take").
+          const startedAt = yield* Clock.currentTimeMillis;
+          if (title !== undefined) yield* Effect.logInfo(bold(title));
+          yield* Effect.logInfo(dim(label));
+          let closed = false;
+          let lastLabel = label;
+          const write = (nextLabel: string, _nextDetail?: string) =>
+            Effect.suspend(() => {
+              // Repeated updates within one phase (spinner detail refreshes)
+              // carry nothing new for a line-per-change log.
+              if (closed || nextLabel === lastLabel) return Effect.void;
+              lastLabel = nextLabel;
+              return Effect.logInfo(dim(nextLabel));
+            });
+          const finish = (message: string, paint: (s: string) => string) =>
+            Effect.suspend(() => {
+              if (closed) return Effect.void;
+              closed = true;
+              return Clock.currentTimeMillis.pipe(
+                Effect.flatMap((now) =>
+                  Effect.logInfo(
+                    `${paint(message)} ${dim(`(${formatElapsed(now - startedAt)})`)}`,
+                  ),
+                ),
+              );
+            });
+          return {
+            update: write,
+            succeed: (message = "Plan ready") => finish(message, green),
+            fail: (message = "Planning failed") => finish(message, red),
+            close: Effect.sync(() => {
+              closed = true;
+            }),
+          };
+        }),
+      approvePlan: (plan, options) =>
+        Effect.gen(function* () {
+          for (const line of formatPlanLines(plan, options))
+            yield* Effect.logInfo(line);
+          if (canPromptOnStdin()) {
+            return yield* confirm(
+              plan.destroy === true
+                ? { message: "Destroy these resources?", initial: false }
+                : { message: "Apply this plan?", initial: true },
+            );
+          }
+          return yield* Effect.fail(
+            new NonInteractiveTerminal({
+              operation: "approve deployment plan",
+              message:
+                "Cannot approve this operation without terminal input. Pass --yes to continue.",
+            }),
+          );
+        }),
+      displayPlan: (plan, options) =>
+        Effect.gen(function* () {
+          for (const line of formatPlanLines(plan, options))
+            yield* Effect.logInfo(line);
+        }),
+      startApplySession: (plan, options) =>
+        Effect.gen(function* () {
+          for (const line of formatPlanLines(plan, options))
+            yield* Effect.logInfo(line);
+          yield* Effect.logInfo("");
+
+          const startedAt = yield* Clock.currentTimeMillis;
+          const started = new Map<string, number>();
+          const terminal = new Map<string, ApplyStatus>();
+          const notes = new Map<string, string>();
+          const statusNotes = new Map<string, string>();
+          return {
+            // Progress is an Effect log record, just like provider and build
+            // diagnostics, so the append-only renderer gives every line the
+            // same timestamp / level / fiber prefix.
+            emit: (event: ApplyEvent) =>
+              Clock.currentTimeMillis.pipe(
+                Effect.flatMap((now) =>
+                  Effect.suspend(() => {
+                    if (event._tag === "apply.resource.note") {
+                      // `status` notes only surface as the settle line's suffix;
+                      // everything else streams, deduping consecutive repeats.
+                      if (event.kind === "status") {
+                        statusNotes.set(event.fqn, event.message);
+                        return Effect.void;
+                      }
+                      if (notes.get(event.fqn) === event.message)
+                        return Effect.void;
+                      notes.set(event.fqn, event.message);
+                      return Effect.logInfo(
+                        `${tag(event.fqn)} ${blue(event.message)}`,
+                      );
+                    }
+                    const id = event.bindingId
+                      ? `${event.fqn}/${event.bindingId}`
+                      : event.fqn;
+                    const mode = modeSuffix({
+                      mode: event.providerMode,
+                      priorMode: event.fromProviderMode,
+                      defaultMode: plan.defaultMode,
+                    });
+                    if (!isTerminal(event.status)) {
+                      if (!isActive(event.status)) return Effect.void;
+                      if (!started.has(id)) started.set(id, now);
+                      return Effect.logInfo(
+                        `${tag(id)} ${dim(event.status)}${mode}`,
+                      );
+                    }
+                    terminal.set(id, event.status);
+                    const status = statusColor(event.status)(event.status);
+                    const from = started.get(id);
+                    const took =
+                      from === undefined
+                        ? ""
+                        : ` ${dim(`(${formatElapsed(now - from)})`)}`;
+                    const message = event.message ?? statusNotes.get(event.fqn);
+                    // Failures carry their error as the message — paint it
+                    // red so the line reads as the error line for that
+                    // resource, without waiting for the final cause dump.
+                    const msg = message
+                      ? ` ${dim("—")} ${event.status === "fail" ? red(message) : message}`
+                      : "";
+                    return Effect.logInfo(
+                      `${tag(id)} ${status}${mode}${msg}${took}`,
+                    );
+                  }),
                 ),
               ),
-            );
-          });
-        return {
-          update: write,
-          succeed: (message = "Plan ready") => finish(message, green),
-          fail: (message = "Planning failed") => finish(message, red),
-          close: Effect.sync(() => {
-            closed = true;
-          }),
-        };
-      }),
-    approvePlan: (plan, options) =>
-      Effect.gen(function* () {
-        for (const line of formatPlanLines(plan, options))
-          yield* Effect.logInfo(line);
-        return yield* Effect.die(
-          new NonInteractiveTerminal({
-            operation: "approve deployment plan",
-            message:
-              "Cannot approve this operation without terminal input. Pass --yes to continue.",
-          }),
-        );
-      }),
-    displayPlan: (plan, options) =>
-      Effect.gen(function* () {
-        for (const line of formatPlanLines(plan, options))
-          yield* Effect.logInfo(line);
-      }),
-    startApplySession: (plan, options) =>
-      Effect.gen(function* () {
-        for (const line of formatPlanLines(plan, options))
-          yield* Effect.logInfo(line);
-        yield* Effect.logInfo("");
-
-        const startedAt = yield* Clock.currentTimeMillis;
-        const started = new Map<string, number>();
-        const terminal = new Map<string, ApplyStatus>();
-        const notes = new Map<string, string>();
-        const statusNotes = new Map<string, string>();
-        return {
-          // Progress is an Effect log record, just like provider and build
-          // diagnostics, so the append-only renderer gives every line the
-          // same timestamp / level / fiber prefix.
-          emit: (event: ApplyEvent) =>
-            Clock.currentTimeMillis.pipe(
-              Effect.flatMap((now) =>
-                Effect.suspend(() => {
-                  if (event._tag === "apply.resource.note") {
-                    // `status` notes only surface as the settle line's suffix;
-                    // everything else streams, deduping consecutive repeats.
-                    if (event.kind === "status") {
-                      statusNotes.set(event.fqn, event.message);
-                      return Effect.void;
-                    }
-                    if (notes.get(event.fqn) === event.message)
-                      return Effect.void;
-                    notes.set(event.fqn, event.message);
-                    return Effect.logInfo(
-                      `${tag(event.fqn)} ${blue(event.message)}`,
-                    );
-                  }
-                  const id = event.bindingId
-                    ? `${event.fqn}/${event.bindingId}`
-                    : event.fqn;
-                  const mode = modeSuffix({
-                    mode: event.providerMode,
-                    priorMode: event.fromProviderMode,
-                    defaultMode: plan.defaultMode,
-                  });
-                  if (!isTerminal(event.status)) {
-                    if (!isActive(event.status)) return Effect.void;
-                    if (!started.has(id)) started.set(id, now);
-                    return Effect.logInfo(
-                      `${tag(id)} ${dim(event.status)}${mode}`,
-                    );
-                  }
-                  terminal.set(id, event.status);
-                  const status = statusColor(event.status)(event.status);
-                  const from = started.get(id);
-                  const took =
-                    from === undefined
-                      ? ""
-                      : ` ${dim(`(${formatElapsed(now - from)})`)}`;
-                  const message = event.message ?? statusNotes.get(event.fqn);
-                  // Failures carry their error as the message — paint it
-                  // red so the line reads as the error line for that
-                  // resource, without waiting for the final cause dump.
-                  const msg = message
-                    ? ` ${dim("—")} ${event.status === "fail" ? red(message) : message}`
-                    : "";
-                  return Effect.logInfo(
-                    `${tag(id)} ${status}${mode}${msg}${took}`,
+            done: (outcome) =>
+              Clock.currentTimeMillis.pipe(
+                Effect.flatMap((now) => {
+                  const statuses = [...terminal.values()];
+                  const failed = statuses.filter((s) => s === "fail").length;
+                  const skipped = statuses.filter(
+                    (s) => s === "skipped",
+                  ).length;
+                  const succeeded = terminal.size - failed - skipped;
+                  const parts = [green(`${succeeded} succeeded`)];
+                  if (failed) parts.push(red(`${failed} failed`));
+                  if (skipped) parts.push(dim(`${skipped} skipped`));
+                  return Effect.logInfo("").pipe(
+                    Effect.andThen(
+                      Effect.logInfo(
+                        `${bold(outcome === "success" ? "Done:" : "Failed:")} ${parts.join(dim(", "))} ${dim(`(${formatElapsed(now - startedAt)})`)}`,
+                      ),
+                    ),
                   );
                 }),
               ),
-            ),
-          done: (outcome) =>
-            Clock.currentTimeMillis.pipe(
-              Effect.flatMap((now) => {
-                const statuses = [...terminal.values()];
-                const failed = statuses.filter((s) => s === "fail").length;
-                const skipped = statuses.filter((s) => s === "skipped").length;
-                const succeeded = terminal.size - failed - skipped;
-                const parts = [green(`${succeeded} succeeded`)];
-                if (failed) parts.push(red(`${failed} failed`));
-                if (skipped) parts.push(dim(`${skipped} skipped`));
-                return Effect.logInfo("").pipe(
-                  Effect.andThen(
-                    Effect.logInfo(
-                      `${bold(outcome === "success" ? "Done:" : "Failed:")} ${parts.join(dim(", "))} ${dim(`(${formatElapsed(now - startedAt)})`)}`,
-                    ),
-                  ),
-                );
-              }),
-            ),
-        };
-      }),
+          };
+        }),
+    });
   }),
 );

--- a/packages/alchemy/src/Cli/commands/deploy.ts
+++ b/packages/alchemy/src/Cli/commands/deploy.ts
@@ -195,13 +195,24 @@ const runStack = Effect.fn(function* (options: StackCommandOptions) {
     return yield* cli.displayPlan(snapshot.native, display);
   }
 
-  if (
-    !options.yes &&
-    Stacks.hasChanges(snapshot.summary) &&
-    !(yield* cli.approvePlan(snapshot.native, display))
-  ) {
-    yield* CliKit.accessors.output.info(`${operation} aborted: plan declined.`);
-    return yield* exitDeclined;
+  if (!options.yes && Stacks.hasChanges(snapshot.summary)) {
+    const approved = yield* cli.approvePlan(snapshot.native, display).pipe(
+      Effect.tap((approved) =>
+        approved
+          ? Effect.void
+          : CliKit.accessors.output.info(
+              `${operation} aborted: plan declined.`,
+            ),
+      ),
+      Effect.catchTag("NonInteractiveTerminal", () =>
+        CliKit.accessors.output
+          .warning(
+            `Cannot prompt for approval in a non-interactive terminal. Nothing was changed — re-run with --yes to ${operation.toLowerCase()}.`,
+          )
+          .pipe(Effect.as(false)),
+      ),
+    );
+    if (!approved) return yield* exitDeclined;
   }
 
   const result = yield* Stacks.apply(snapshot).pipe(

--- a/packages/alchemy/src/Cli/main.ts
+++ b/packages/alchemy/src/Cli/main.ts
@@ -163,7 +163,10 @@ const services = Layer.mergeAll(
   ConfigProvider.layer(ConfigProvider.fromEnv()),
   TelemetryLive,
   routeCacheLayer,
-  Layer.provideMerge(selectCliServices(), CliKit.layer()),
+  Layer.provide(
+    Layer.provideMerge(selectCliServices(), CliKit.layer()),
+    PlatformServices,
+  ),
   // Debug run log under ~/.alchemy/logs — the console noise floor stays at
   // Info, but full causes and auth-flow breadcrumbs land in the file so
   // support can ask users for it.

--- a/packages/alchemy/src/Cli/selectCli.ts
+++ b/packages/alchemy/src/Cli/selectCli.ts
@@ -1,9 +1,13 @@
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as CliOutput from "effect/unstable/cli/CliOutput";
+import type * as Prompt from "effect/unstable/cli/Prompt";
+import type { Cli } from "../Report.ts";
 import { CliKit } from "./CliKit/CliKit.ts";
 import { LoggingCli } from "./LoggingCli.ts";
 import { plainCliFormatter } from "./PlainCliFormatter.ts";
+
+type SelectedCli = Layer.Layer<Cli, never, CliKit | Prompt.Environment>;
 
 /** Select the interactive or append-only root renderer. */
 export const selectCliServices = () =>
@@ -11,13 +15,14 @@ export const selectCliServices = () =>
     Effect.gen(function* () {
       const cli = yield* CliKit;
       if (!cli.terminal.input) {
-        return Layer.mergeAll(
+        const plain: SelectedCli = Layer.mergeAll(
           LoggingCli,
           CliOutput.layer(plainCliFormatter({ columns: cli.terminal.columns })),
         );
+        return plain;
       }
 
-      return yield* Effect.promise(async () => {
+      return yield* Effect.promise<SelectedCli>(async () => {
         const { sigilCli } = await import("./components/view/SigilCli.tsx");
         const { brandedCliFormatter } =
           await import("./components/view/Help.tsx");

--- a/packages/alchemy/src/Util/interactive.ts
+++ b/packages/alchemy/src/Util/interactive.ts
@@ -11,32 +11,85 @@ import * as Effect from "effect/Effect";
  * Kept in `Util` (rather than `Cli`) so `Auth` can depend on it without
  * pulling in the CLI layer.
  */
-export const isNonInteractive = (): boolean => {
-  const env = process.env;
-  // An explicit CLI flag beats every env-based heuristic. Checked via argv
-  // because capability detection runs while the CLI's service layers are
-  // built, before the command parser has produced flag values. Only scan up
-  // to a `--` separator so a positional argument that happens to be the
-  // literal text "--no-input" is not mistaken for the flag.
+// An explicit CLI flag beats every env-based heuristic. Checked via argv
+// because capability detection runs while the CLI's service layers are
+// built, before the command parser has produced flag values. Only scan up
+// to a `--` separator so a positional argument that happens to be the
+// literal text "--no-input" is not mistaken for the flag.
+const hasNoInputFlag = (): boolean => {
   const separator = process.argv.indexOf("--");
   const flagArgs =
     separator === -1 ? process.argv : process.argv.slice(0, separator);
-  if (flagArgs.includes("--no-input")) return true;
+  return flagArgs.includes("--no-input");
+};
+
+// Known coding-agent env vars, ported from unjs/std-env (src/agents.ts).
+// Best-effort — the isTTY checks at the call sites already catch most cases
+// since agents typically pipe stdin/stdout. std-env's kiro check
+// (TERM_PROGRAM=kiro gated on no-TTY) is deliberately omitted: both call
+// sites only reach this function when stdin/stdout ARE a TTY, where that
+// check would never match.
+const isAgentEnv = (env: NodeJS.ProcessEnv): boolean =>
+  !!(
+    // explicit override supported by std-env
+    env.AI_AGENT ||
+    // claude
+    env.CLAUDECODE ||
+    env.CLAUDE_CODE ||
+    env.CLAUDE_CODE_ENTRYPOINT ||
+    // replit
+    env.REPL_ID ||
+    // gemini
+    env.GEMINI_CLI ||
+    // codex
+    env.CODEX_SANDBOX ||
+    env.CODEX_THREAD_ID ||
+    env.CODEX_CLI ||
+    // opencode
+    env.OPENCODE ||
+    // auggie
+    env.AUGMENT_AGENT ||
+    // goose
+    env.GOOSE_PROVIDER ||
+    // junie
+    env.JUNIE_DATA ||
+    env.JUNIE_SHIM_PATH ||
+    // aider
+    env.AIDER_MODEL ||
+    // pi
+    /\.pi[\\/]agent/.test(env.PATH ?? "") ||
+    // devin
+    /devin/.test(env.EDITOR ?? "") ||
+    // cursor
+    env.CURSOR_AGENT
+  );
+
+export const isNonInteractive = (): boolean => {
+  const env = process.env;
+  if (hasNoInputFlag()) return true;
   if (env.ALCHEMY_PLAIN === "1" || env.ALCHEMY_NO_TUI === "1") return true;
   if (env.ALCHEMY_TUI === "1") return false;
   if (!process.stdin.isTTY || !process.stdout.isTTY) return true;
   if (env.CI) return true;
-  // Known coding-agent env vars. These are best-effort — the isTTY check
-  // above already catches most cases since agents typically pipe stdout.
-  if (
-    env.CLAUDECODE ||
-    env.CLAUDE_CODE_ENTRYPOINT ||
-    env.CURSOR_AGENT ||
-    env.AIDER_MODEL ||
-    env.CODEX_CLI
-  )
-    return true;
+  if (isAgentEnv(env)) return true;
   return false;
+};
+
+/**
+ * Whether a plain line-based prompt can still read an answer from stdin.
+ *
+ * Distinct from {@link isNonInteractive}: `ALCHEMY_PLAIN` / `ALCHEMY_NO_TUI`
+ * turn off the TUI *rendering*, not input — a human running plain mode in a
+ * terminal can still answer a `[y/n]` question. Agents and CI pipe stdin
+ * (or set their env markers) and land `false`.
+ */
+export const canPromptOnStdin = (): boolean => {
+  const env = process.env;
+  if (hasNoInputFlag()) return false;
+  if (!process.stdin.isTTY || !process.stdout.isTTY) return false;
+  if (env.CI) return false;
+  if (isAgentEnv(env)) return false;
+  return true;
 };
 
 export interface InteractionCapabilities {

--- a/packages/alchemy/test/Cli/LoggingCli.test.ts
+++ b/packages/alchemy/test/Cli/LoggingCli.test.ts
@@ -1,5 +1,7 @@
 import { LoggingCli, formatPlanLines } from "@/Cli/LoggingCli.ts";
 import { Cli } from "@/Report.ts";
+import { PlatformServices } from "@/Util/PlatformServices.ts";
+import * as Layer from "effect/Layer";
 import { describe, expect, it, test } from "alchemy-test";
 import * as Effect from "effect/Effect";
 import * as Logger from "effect/Logger";
@@ -64,7 +66,10 @@ it.effect("emits plain progress through the Effect logger", () => {
     yield* cli.displayPlan(planWith([createNode({}, "Worker")]));
 
     expect(messages).toEqual([["Plan: 1 to create"], ["[Worker] create"]]);
-  }).pipe(Effect.provide(LoggingCli), Effect.provide(Logger.layer([logger])));
+  }).pipe(
+    Effect.provide(Layer.provide(LoggingCli, PlatformServices)),
+    Effect.provide(Logger.layer([logger])),
+  );
 });
 
 it.effect("streams apply notes as they arrive", () => {
@@ -113,5 +118,8 @@ it.effect("streams apply notes as they arrive", () => {
       "[Website] Uploaded 490 of 5195 assets...",
       "[Website] updated — Reconciling custom domains (1) ... (0ms)",
     ]);
-  }).pipe(Effect.provide(LoggingCli), Effect.provide(Logger.layer([logger])));
+  }).pipe(
+    Effect.provide(Layer.provide(LoggingCli, PlatformServices)),
+    Effect.provide(Logger.layer([logger])),
+  );
 });


### PR DESCRIPTION
- Allow TTY users to approve plain-mode plans, including destroy confirmation
- Handle non-interactive terminals with a clear --yes warning
- Expand agent detection and cover the logging CLI dependency changes