### PR TITLE
fix(cli): show feedback during slow shutdowns

### DIFF
--- a/packages/alchemy/src/Cli/CliKit/index.ts
+++ b/packages/alchemy/src/Cli/CliKit/index.ts
@@ -6,7 +6,7 @@ export {
   NonInteractiveTerminal,
   TerminalCancelled,
 } from "./errors.ts";
-export { glyphsFor, theme, type GlyphName } from "./theme.ts";
+export { glyphsFor, spinnerFramesFor, theme, type GlyphName } from "./theme.ts";
 export {
   ANSI_BOLD,
   ANSI_DIM,

--- a/packages/alchemy/src/Cli/CliKit/theme.ts
+++ b/packages/alchemy/src/Cli/CliKit/theme.ts
@@ -112,6 +112,23 @@ export const asciiGlyphs: { readonly [Key in GlyphName]: string } = {
 export const glyphsFor = (unicode: boolean) =>
   unicode ? theme.glyph : asciiGlyphs;
 
+const spinnerFrames = [
+  "⠋",
+  "⠙",
+  "⠹",
+  "⠸",
+  "⠼",
+  "⠴",
+  "⠦",
+  "⠧",
+  "⠇",
+  "⠏",
+] as const;
+const asciiSpinnerFrames = ["-", "\\", "|", "/"] as const;
+
+export const spinnerFramesFor = (unicode: boolean): readonly string[] =>
+  unicode ? spinnerFrames : asciiSpinnerFrames;
+
 export type StatusVariant = "info" | "success" | "warning" | "error";
 
 export const statusColor = (variant: StatusVariant): string =>

--- a/packages/alchemy/src/Cli/commands/dev.ts
+++ b/packages/alchemy/src/Cli/commands/dev.ts
@@ -19,7 +19,10 @@ import {
   profile,
   resolveConfig,
 } from "./flags.ts";
-import { suppressInterruptMessages } from "./errors.ts";
+import {
+  installShutdownFeedback,
+  suppressInterruptMessages,
+} from "./errors.ts";
 
 /**
  * Trust the Floci emulator CA in `alchemy dev` so cross-cloud data planes
@@ -50,6 +53,9 @@ export const devCommand = Command.make(
       // terminal and announces the Ctrl+C shutdown. Without this, a SIGINT
       // hits both processes and the interrupt message prints twice.
       yield* suppressInterruptMessages;
+      // Feedback stays silent here (suppressed — the exec child owns the
+      // terminal); this install is for the force-quit on a second Ctrl+C.
+      yield* installShutdownFeedback;
       const options = yield* Schema.encodeEffect(DevOptions)(args);
       const fs = yield* FileSystem.FileSystem;
       // Set on THIS process too, so the RPC spawner's sidecars (and the workerd
@@ -91,7 +97,14 @@ export const devCommand = Command.make(
           [SPAWNER_URL_ENV_KEY]: spawner.url,
         },
         extendEnv: true,
+        // Same process group as this supervisor: the exec child owns the
+        // terminal (TUI stdin), so the tty's Ctrl+C must reach it directly.
         detached: false,
+        // The watcher won't die while its inner exec child is still shutting
+        // down — it forwards SIGTERM to the child and lingers. Without this
+        // bound the kill finalizer waits on it forever (the double-Ctrl+C
+        // hang); with it, a stuck shutdown escalates to SIGKILL.
+        forceKillAfter: "3 seconds",
       });
       yield* child.exitCode;
     },

--- a/packages/alchemy/src/Cli/commands/errors.ts
+++ b/packages/alchemy/src/Cli/commands/errors.ts
@@ -60,17 +60,22 @@ const SHUTDOWN_FEEDBACK_DELAY_MS = 200;
  * which is exactly the window this has to render through.
  */
 export const installShutdownFeedback = Effect.sync(() => {
-  let received = false;
+  let firstSignalAt: number | undefined;
   const onSignal = () => {
-    if (received) {
+    if (firstSignalAt !== undefined) {
+      // Watchers and runners in the chain (`node --watch`, pnpm) forward the
+      // tty's SIGINT to their children, so ONE ^C can be delivered twice
+      // within milliseconds. Only a press after the feedback delay — when the
+      // "Ctrl+C again" hint can even be visible — means "force quit".
+      if (Date.now() - firstSignalAt < SHUTDOWN_FEEDBACK_DELAY_MS) return;
       if (!interruptMessagesSuppressed) {
         process.stderr.write("\nForce quitting.\n");
       }
       process.exit(EXIT_CANCELLED);
     }
-    received = true;
+    firstSignalAt = Date.now();
     if (interruptMessagesSuppressed) return;
-    const startedAt = Date.now();
+    const startedAt = firstSignalAt;
     const elapsed = () => Math.round((Date.now() - startedAt) / 1000);
     const timer = setTimeout(() => {
       if (process.stderr.isTTY) {

--- a/packages/alchemy/src/Cli/commands/errors.ts
+++ b/packages/alchemy/src/Cli/commands/errors.ts
@@ -12,6 +12,7 @@ import {
   ansiFg,
   colorsEnabled,
   glyphsFor,
+  spinnerFramesFor,
   theme,
   unicodeEnabled,
 } from "../CliKit/index.ts";
@@ -47,6 +48,54 @@ export const exitDeclined = setExitCode(1);
 let interruptMessagesSuppressed = false;
 export const suppressInterruptMessages = Effect.sync(() => {
   interruptMessagesSuppressed = true;
+});
+
+const SHUTDOWN_FEEDBACK_DELAY_MS = 200;
+
+/**
+ * Shutdown feedback on SIGINT/SIGTERM: silent when teardown finishes within
+ * 200ms, otherwise a spinner (TTY) or periodic log lines (plain). A second
+ * signal force-quits. Raw stderr + unref'd timers on purpose — the Effect
+ * runtime (and any `Runtime.Teardown` hook) only settles after finalizers,
+ * which is exactly the window this has to render through.
+ */
+export const installShutdownFeedback = Effect.sync(() => {
+  let received = false;
+  const onSignal = () => {
+    if (received) {
+      if (!interruptMessagesSuppressed) {
+        process.stderr.write("\nForce quitting.\n");
+      }
+      process.exit(EXIT_CANCELLED);
+    }
+    received = true;
+    if (interruptMessagesSuppressed) return;
+    const startedAt = Date.now();
+    const elapsed = () => Math.round((Date.now() - startedAt) / 1000);
+    const timer = setTimeout(() => {
+      if (process.stderr.isTTY) {
+        const frames = spinnerFramesFor(unicodeEnabled());
+        let frame = 0;
+        const spin = setInterval(() => {
+          process.stderr.write(
+            `\r${frames[frame++ % frames.length]} Shutting down... (Ctrl+C again to force quit) `,
+          );
+        }, 80);
+        spin.unref();
+      } else {
+        process.stderr.write(
+          "Shutting down — waiting for cleanup to finish (Ctrl+C again to force quit)\n",
+        );
+        const report = setInterval(() => {
+          process.stderr.write(`Still shutting down (${elapsed()}s)\n`);
+        }, 5000);
+        report.unref();
+      }
+    }, SHUTDOWN_FEEDBACK_DELAY_MS);
+    timer.unref();
+  };
+  process.on("SIGINT", onSignal);
+  process.on("SIGTERM", onSignal);
 });
 
 export const handleCancellation = <A, E, R>(self: Effect.Effect<A, E, R>) =>

--- a/packages/alchemy/src/Cli/commands/errors.ts
+++ b/packages/alchemy/src/Cli/commands/errors.ts
@@ -69,7 +69,11 @@ export const installShutdownFeedback = Effect.sync(() => {
       // "Ctrl+C again" hint can even be visible — means "force quit".
       if (Date.now() - firstSignalAt < SHUTDOWN_FEEDBACK_DELAY_MS) return;
       if (!interruptMessagesSuppressed) {
-        process.stderr.write("\nForce quitting.\n");
+        process.stderr.write(
+          colorsEnabled()
+            ? `\n${ANSI_DIM}Force quitting.${ANSI_RESET}\n`
+            : "\nForce quitting.\n",
+        );
       }
       process.exit(EXIT_CANCELLED);
     }

--- a/packages/alchemy/src/Cli/components/ui/Feedback.tsx
+++ b/packages/alchemy/src/Cli/components/ui/Feedback.tsx
@@ -2,6 +2,7 @@
 import { useAnimation } from "@alchemy.run/sigil";
 import type { ReactNode } from "react";
 import {
+  spinnerFramesFor,
   statusColor,
   statusPaint,
   theme,
@@ -121,25 +122,11 @@ export function KeyBar({ keys, marginTop = 1 }: KeyBarProps) {
   );
 }
 
-const SPINNER_FRAMES = [
-  "⠋",
-  "⠙",
-  "⠹",
-  "⠸",
-  "⠼",
-  "⠴",
-  "⠦",
-  "⠧",
-  "⠇",
-  "⠏",
-] as const;
-const ASCII_SPINNER_FRAMES = ["-", "\\", "|", "/"] as const;
-
 export const useSpinnerFrame = (): string => {
   const { unicode } = useCliEnvironment();
-  const frames = unicode ? SPINNER_FRAMES : ASCII_SPINNER_FRAMES;
+  const frames = spinnerFramesFor(unicode);
   const { frame } = useAnimation({ interval: 80 });
-  return frames[frame % frames.length] ?? ASCII_SPINNER_FRAMES[0];
+  return frames[frame % frames.length] ?? "-";
 };
 
 /**

--- a/packages/alchemy/src/Cli/exec.ts
+++ b/packages/alchemy/src/Cli/exec.ts
@@ -20,7 +20,7 @@ import { PlatformServices } from "../Util/PlatformServices.ts";
 import * as Stacks from "../Alchemist/routes/stack.ts";
 import { DevOptions } from "./DevOptions.ts";
 import { ConsoleLogLive } from "./GlobalLog.ts";
-import { handleCliErrors } from "./commands/errors.ts";
+import { handleCliErrors, installShutdownFeedback } from "./commands/errors.ts";
 import { renderApply, renderPlanning } from "./commands/render.ts";
 import * as CliKit from "./CliKit/index.ts";
 import { selectCliServices } from "./selectCli.ts";
@@ -113,6 +113,7 @@ const makeExec = () => {
     JSON.parse(process.env.ALCHEMY_EXEC_OPTIONS!),
   );
   return Effect.gen(function* () {
+    yield* installShutdownFeedback;
     // Subscribe to the spawner's sidecar log stream BEFORE the stack runs:
     // this process owns the terminal renderer, so sidecar output printed
     // here lands in chronological order with the run's own lines instead of

--- a/packages/alchemy/src/Local/RpcSpawner.ts
+++ b/packages/alchemy/src/Local/RpcSpawner.ts
@@ -141,7 +141,14 @@ export const make = Effect.fn(function* ({
         // test runner's reporter/TUI. The drain below is mandatory — an
         // unread pipe eventually fills and blocks the child.
         stderr: "pipe",
-        detached: false,
+        // `detached` deliberately unset: the spawner defaults to a new process
+        // group on POSIX (and none on Windows, where a detached console child
+        // has its own quirks). A terminal Ctrl+C must NOT reach the sidecar
+        // directly — its lifecycle belongs to this process's finalizer (the
+        // bounded kill below), and a sidecar tearing itself down concurrently
+        // yanks local providers out from under the exec child mid-shutdown.
+        // As a group leader the kill also reaps the sidecar's own children
+        // (workerd, emulators) instead of orphaning them.
         env: {
           [RPC_SERVER_ENVIRONMENT_KEY]: JSON.stringify(environment),
           ...pipedColorEnv(),

--- a/packages/alchemy/test/Cli/fixtures/shutdown-feedback-fixture.ts
+++ b/packages/alchemy/test/Cli/fixtures/shutdown-feedback-fixture.ts
@@ -1,0 +1,29 @@
+// Relative import (not `@/` alias) so this fixture runs as a bare bun/node
+// child without a paths-aware loader. Excluded from the test project's
+// typecheck (see tsconfig.test.json) because the relative path crosses
+// composite-project boundaries.
+import * as Effect from "effect/Effect";
+import {
+  installShutdownFeedback,
+  suppressInterruptMessages,
+} from "../../../src/Cli/commands/errors.ts";
+
+if (process.env.SHUTDOWN_FIXTURE_SUPPRESS === "1") {
+  Effect.runSync(suppressInterruptMessages);
+}
+Effect.runSync(installShutdownFeedback);
+
+// Simulates a teardown that takes this long after the first SIGINT. Without
+// it the fixture never exits on its own (a hanging cleanup).
+const exitAfter = Number.parseInt(
+  process.env.SHUTDOWN_FIXTURE_EXIT_AFTER_MS ?? "",
+  10,
+);
+if (Number.isFinite(exitAfter)) {
+  process.once("SIGINT", () => {
+    setTimeout(() => process.exit(0), exitAfter);
+  });
+}
+
+console.log("ready");
+setInterval(() => {}, 1000);

--- a/packages/alchemy/test/Cli/shutdownFeedback.test.ts
+++ b/packages/alchemy/test/Cli/shutdownFeedback.test.ts
@@ -89,6 +89,29 @@ describe("shutdown feedback", () => {
   );
 
   it.live(
+    "a duplicate SIGINT within the feedback delay does not force-quit",
+    () =>
+      Effect.gen(function* () {
+        // `node --watch` and pnpm forward the tty's SIGINT to their children,
+        // so one ^C can be delivered twice back-to-back — that must read as
+        // ONE press, not a force-quit.
+        const fixture = yield* spawnFixture();
+        yield* fixture.sigint;
+        yield* fixture.sigint;
+        yield* waitForStderr(
+          fixture.stderr,
+          "Shutting down — waiting for cleanup",
+        );
+        expect(fixture.stderr()).not.toContain("Force quitting");
+        // A distinct press after the hint is visible still force-quits.
+        yield* fixture.sigint;
+        expect(yield* fixture.handle.exitCode).toBe(130);
+        expect(fixture.stderr()).toContain("Force quitting.");
+      }).pipe(Effect.scoped, Effect.provide(PlatformServices)),
+    { timeout: 30_000 },
+  );
+
+  it.live(
     "a shutdown finishing within the delay stays silent",
     () =>
       Effect.gen(function* () {

--- a/packages/alchemy/test/Cli/shutdownFeedback.test.ts
+++ b/packages/alchemy/test/Cli/shutdownFeedback.test.ts
@@ -1,0 +1,122 @@
+import { PlatformServices } from "@/Util/PlatformServices.ts";
+import { describe, expect, it } from "alchemy-test";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import * as Schedule from "effect/Schedule";
+import * as Stream from "effect/Stream";
+import * as ChildProcess from "effect/unstable/process/ChildProcess";
+import { fileURLToPath } from "node:url";
+
+const FIXTURE = fileURLToPath(
+  new URL("./fixtures/shutdown-feedback-fixture.ts", import.meta.url),
+);
+
+/**
+ * Spawn the fixture (piped stdio, so the feedback takes the non-TTY log-line
+ * branch), wait for its ready line, and expose accumulated stderr.
+ */
+const spawnFixture = (env: Record<string, string> = {}) =>
+  Effect.gen(function* () {
+    const handle = yield* ChildProcess.make("bun", [FIXTURE], {
+      env,
+      extendEnv: true,
+      stdin: "ignore",
+      stdout: "pipe",
+      stderr: "pipe",
+      killSignal: "SIGTERM",
+      forceKillAfter: "1 second",
+    });
+    const chunks: string[] = [];
+    yield* handle.stderr.pipe(
+      Stream.decodeText,
+      Stream.runForEach((chunk) =>
+        Effect.sync(() => {
+          chunks.push(chunk);
+        }),
+      ),
+      Effect.ignore,
+      Effect.forkScoped,
+    );
+    yield* handle.stdout.pipe(
+      Stream.decodeText,
+      Stream.splitLines,
+      Stream.filter((line) => line.includes("ready")),
+      Stream.take(1),
+      Stream.runDrain,
+      Effect.timeout(Duration.seconds(10)),
+    );
+    return {
+      handle,
+      sigint: Effect.sync(() => process.kill(handle.pid, "SIGINT")),
+      stderr: () => chunks.join(""),
+    };
+  });
+
+const waitForStderr = (read: () => string, text: string) =>
+  Effect.sync(read).pipe(
+    Effect.repeat({
+      schedule: Schedule.spaced(Duration.millis(50)),
+      until: (output) => output.includes(text),
+      times: 100,
+    }),
+    Effect.flatMap((output) =>
+      output.includes(text)
+        ? Effect.void
+        : Effect.fail(
+            new Error(
+              `stderr never contained ${JSON.stringify(text)}: ${output}`,
+            ),
+          ),
+    ),
+  );
+
+describe("shutdown feedback", () => {
+  it.live(
+    "a hanging shutdown surfaces feedback and a second SIGINT force-quits with 130",
+    () =>
+      Effect.gen(function* () {
+        const fixture = yield* spawnFixture();
+        yield* fixture.sigint;
+        yield* waitForStderr(
+          fixture.stderr,
+          "Shutting down — waiting for cleanup",
+        );
+        yield* fixture.sigint;
+        expect(yield* fixture.handle.exitCode).toBe(130);
+        expect(fixture.stderr()).toContain("Force quitting.");
+      }).pipe(Effect.scoped, Effect.provide(PlatformServices)),
+    { timeout: 30_000 },
+  );
+
+  it.live(
+    "a shutdown finishing within the delay stays silent",
+    () =>
+      Effect.gen(function* () {
+        const fixture = yield* spawnFixture({
+          SHUTDOWN_FIXTURE_EXIT_AFTER_MS: "50",
+        });
+        yield* fixture.sigint;
+        expect(yield* fixture.handle.exitCode).toBe(0);
+        expect(fixture.stderr()).not.toContain("Shutting down");
+      }).pipe(Effect.scoped, Effect.provide(PlatformServices)),
+    { timeout: 30_000 },
+  );
+
+  it.live(
+    "a suppressed process (dev supervisor) stays silent but still force-quits",
+    () =>
+      Effect.gen(function* () {
+        const fixture = yield* spawnFixture({
+          SHUTDOWN_FIXTURE_SUPPRESS: "1",
+        });
+        yield* fixture.sigint;
+        // Past the 200ms feedback delay — suppression must keep this quiet.
+        yield* Effect.sleep(Duration.millis(500));
+        expect(fixture.stderr()).not.toContain("Shutting down");
+        yield* fixture.sigint;
+        expect(yield* fixture.handle.exitCode).toBe(130);
+        expect(fixture.stderr()).not.toContain("Force quitting");
+      }).pipe(Effect.scoped, Effect.provide(PlatformServices)),
+    { timeout: 30_000 },
+  );
+});

--- a/packages/alchemy/test/Local/RpcSpawner.test.ts
+++ b/packages/alchemy/test/Local/RpcSpawner.test.ts
@@ -29,6 +29,7 @@ import {
   canOpenWebSocket,
   isAlive,
   openWebSocket,
+  pgidOf,
   pidListeningOn,
 } from "./fixtures/process-effect.ts";
 
@@ -156,6 +157,25 @@ describe(`Local.RpcSpawner (runtime=${typeof globalThis.Bun !== "undefined" ? "b
         const a = yield* post(url, samplePayload(FIXTURE_TS_URL));
         const b = yield* post(url, samplePayload(FIXTURE_B_TS_URL));
         expect(a).not.toBe(b);
+      }).pipe(Effect.provide(services)),
+    { timeout: 60_000 },
+  );
+
+  it.live(
+    "sidecars lead their own process group (a terminal Ctrl+C cannot reach them)",
+    () =>
+      Effect.gen(function* () {
+        // POSIX-only: Windows has no process groups; the spawner leaves
+        // sidecars attached there (detached console children have their own
+        // quirks) and Ctrl+C delivery works differently anyway.
+        if (process.platform === "win32") return;
+        const url = yield* RpcSpawner.useSync((spawner) => spawner.url);
+        const wsUrl = yield* post(url, samplePayload(FIXTURE_TS_URL));
+        const pid = yield* pidListeningOn(wsUrl);
+        if (pid === undefined || Number.isNaN(pid)) return;
+        // Group leader (pgid === pid) proves the sidecar was spawned
+        // detached: the tty's foreground-group signals stop at this process.
+        expect(yield* pgidOf(pid)).toBe(pid);
       }).pipe(Effect.provide(services)),
     { timeout: 60_000 },
   );

--- a/packages/alchemy/test/Local/fixtures/process-effect.ts
+++ b/packages/alchemy/test/Local/fixtures/process-effect.ts
@@ -90,6 +90,20 @@ export const pidListeningOn = (wsUrl: string) => {
   );
 };
 
+/**
+ * POSIX process-group id of a pid via `ps` (no Node API exposes another
+ * process's pgid). Returns NaN when the pid is gone.
+ */
+export const pgidOf = (pid: number) =>
+  ChildProcess.make("ps", ["-o", "pgid=", "-p", String(pid)], {
+    stdout: "pipe",
+  }).pipe(
+    Effect.flatMap((handle) =>
+      handle.stdout.pipe(Stream.decodeText, Stream.mkString),
+    ),
+    Effect.map((stdout) => Number.parseInt(stdout.trim(), 10)),
+  );
+
 /** Send a signal to a pid we don't own a handle to. */
 export const killPid = (
   pid: number,

--- a/packages/alchemy/tsconfig.test.json
+++ b/packages/alchemy/tsconfig.test.json
@@ -2,6 +2,7 @@
   "extends": "../../tsconfig.base.json",
   "include": ["package.json", "test"],
   "exclude": [
+    "test/Cli/fixtures/shutdown-feedback-fixture.ts",
     "test/Local/fixtures/rpc-server-entry.ts",
     "test/Local/fixtures/rpc-server-entry-b.ts",
     "test/Local/fixtures/rpc-server-logs.ts",


### PR DESCRIPTION
Fix the `alchemy dev` double-Ctrl+C hang and make slow shutdowns visible instead of a dead prompt.

One Ctrl+C hit the whole foreground process group at once: the RPC sidecars tore themselves down out from under the exec child mid-shutdown, `node --watch` won't exit while its inner child lives (and forwards SIGTERM to it instead of dying), and the supervisor's kill finalizer waited on the watcher with no bound.

- `RpcSpawner`: stop forcing `detached: false` — sidecars now lead their own process group on POSIX (the spawner default), so the tty's Ctrl+C never reaches them and the existing bounded kill reaps their workerd/emulator children via group kill
- `dev`: bound the watch child's kill finalizer so a stuck shutdown escalates to SIGKILL

```diff
  const child = yield* ChildProcess.make(command[0], command.slice(1), {
    ...
+   forceKillAfter: "3 seconds",
  });
```

- shutdown feedback (dev-only, installed by the `dev` command and the exec child): silent when teardown finishes within 200ms, otherwise a spinner (TTY) or periodic log lines (plain/CI); a second Ctrl+C force-quits with exit 130

```
^C
Shutting down — waiting for cleanup to finish (Ctrl+C again to force quit)
Still shutting down (5s)
^C
Force quitting.
```

Spinner frames moved from `Feedback.tsx` into `CliKit/theme.ts` (`spinnerFramesFor`) so the TUI hook and the raw shutdown path share one definition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
