### PR TITLE
feat(cli): profile tab scrolling, --profile flag, v0 store migration

### DIFF
--- a/packages/alchemy/src/Auth/AuthProvider.ts
+++ b/packages/alchemy/src/Auth/AuthProvider.ts
@@ -69,14 +69,14 @@ export class NeedsReauth extends Schema.TaggedError<NeedsReauth>()(
  * top later without touching call sites.
  */
 export const refreshHint = (provider: string, profileName: string): string =>
-  `Run \`alchemy profile refresh ${profileName} --provider ${provider}\`.`;
+  `Run \`alchemy profile refresh --profile ${profileName} --provider ${provider}\`.`;
 
 /** {@link refreshHint}'s sibling for reconfiguration. */
 export const reconfigureHint = (
   provider: string,
   profileName: string,
 ): string =>
-  `Run \`alchemy profile edit ${profileName} --reconfigure ${provider}\` to reconfigure.`;
+  `Run \`alchemy profile edit --profile ${profileName} --reconfigure ${provider}\` to reconfigure.`;
 
 export class AuthProviders extends Context.Service<
   AuthProviders,

--- a/packages/alchemy/src/Auth/Credentials.ts
+++ b/packages/alchemy/src/Auth/Credentials.ts
@@ -89,7 +89,7 @@ export const CredentialsStoreLive = Layer.effect(
           ),
         );
         const command = yield* profileCommandHint(
-          `alchemy profile edit ${profile} --reconfigure ${provider}`,
+          `alchemy profile edit --profile ${profile} --reconfigure ${provider}`,
         );
         return yield* Schema.decodeUnknownEffect(schema)(json).pipe(
           Effect.mapError(

--- a/packages/alchemy/src/Auth/Demand.ts
+++ b/packages/alchemy/src/Auth/Demand.ts
@@ -106,7 +106,7 @@ export const credentialsRequired = (
 ): Effect.Effect<never, CredentialsRequired> =>
   Effect.gen(function* () {
     const command = yield* profileCommandHint(
-      `alchemy profile edit ${profileName} --add ${demand.provider}`,
+      `alchemy profile edit --profile ${profileName} --add ${demand.provider}`,
     );
     return yield* new CredentialsRequired({
       provider: demand.provider,

--- a/packages/alchemy/src/Auth/Profile.ts
+++ b/packages/alchemy/src/Auth/Profile.ts
@@ -1,3 +1,4 @@
+import * as Clock from "effect/Clock";
 import * as Config from "effect/Config";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
@@ -15,7 +16,12 @@ import { profileCommandHint } from "../Util/interactive.ts";
 import { AuthError } from "./AuthProvider.ts";
 import type { AuthProvider } from "./AuthProvider.ts";
 import { withLock, withProfileCredentialsLock } from "./Lock.ts";
-import { configFilePath, profileCredentialsDirPath } from "./Paths.ts";
+import {
+  configFilePath,
+  credentialsDirPath,
+  profileCredentialsDirPath,
+  rootDir,
+} from "./Paths.ts";
 
 export {
   configFilePath,
@@ -327,7 +333,12 @@ export const ProfileStoreLive = Layer.effect(
       };
     };
 
-    const readManifest = Effect.suspend(() => {
+    /**
+     * Read + decode the raw manifest file. `undefined` when the file does
+     * not exist; decode failures are typed `ProfileError`s that leave the
+     * file untouched.
+     */
+    const decodeStoredManifest = Effect.suspend(() => {
       const manifestPath = configFilePath();
       return fs.readFileString(manifestPath).pipe(
         Effect.flatMap((data) =>
@@ -354,45 +365,33 @@ export const ProfileStoreLive = Layer.effect(
             ),
           ),
         ),
-        Effect.flatMap((stored) =>
-          // Versions 0 and 1 (flat pre-id manifests) migrate in memory and
-          // are upgraded on the next `writeManifest`, which always stamps
-          // the current version.
-          stored.version <= PROFILE_MANIFEST_VERSION
-            ? Effect.sync(() => {
-                // Manifests from the short-lived stored-default-selection
-                // scheme carry a `defaultProfile` key; the built-in `default`
-                // profile replaced it, so the key is dropped — the removal is
-                // persisted by the next manifest write.
-                const { defaultProfile: _dropped, ...rest } = stored;
-                return {
-                  ...rest,
-                  version: PROFILE_MANIFEST_VERSION,
-                  profiles: Object.fromEntries(
-                    Object.entries(stored.profiles).map(([name, value]) => [
-                      name,
-                      normalizeProfile(name, value),
-                    ]),
-                  ),
-                } satisfies ProfileManifest;
-              })
-            : Effect.fail(
-                new ProfileError({
-                  message:
-                    `Profile manifest version ${stored.version} is not supported by this Alchemy version. ` +
-                    "The file was left untouched.",
-                }),
-              ),
-        ),
         Effect.catchReason("PlatformError", "NotFound", () =>
-          Effect.succeed(emptyManifest()),
+          Effect.succeed(undefined),
         ),
-        // The built-in `default` profile always exists from the reader's
-        // perspective; the synthesized entry is persisted by the next
-        // manifest write.
-        Effect.map(withDefaultProfile),
       );
     });
+
+    /**
+     * Normalize a decoded manifest to the current shape: stamp the version,
+     * drop the short-lived stored-default-selection `defaultProfile` key,
+     * and normalize each profile entry (pre-id entries get their name as id,
+     * legacy `method: "env"` provider entries are dropped).
+     */
+    const toCurrentManifest = (
+      stored: typeof StoredManifestSchema.Type,
+    ): ProfileManifest => {
+      const { defaultProfile: _dropped, ...rest } = stored;
+      return {
+        ...rest,
+        version: PROFILE_MANIFEST_VERSION,
+        profiles: Object.fromEntries(
+          Object.entries(stored.profiles).map(([name, value]) => [
+            name,
+            normalizeProfile(name, value),
+          ]),
+        ),
+      } satisfies ProfileManifest;
+    };
 
     const writeManifest = (config: ProfileManifest) =>
       Effect.suspend(() => {
@@ -410,6 +409,113 @@ export const ProfileStoreLive = Layer.effect(
             ),
           );
       });
+
+    /**
+     * One-shot on-disk upgrade of a pre-v2 store. The credential storage
+     * layout changed with the manifest (renamed file keys, schema-validated
+     * contents), so stored secrets from a v0/v1 store cannot be trusted to
+     * load — instead of migrating values, the whole legacy state is moved
+     * into `~/.alchemy/.v0-profiles-<timestamp>/` and the manifest is
+     * rewritten in the current format with every profile/provider entry
+     * kept. Providers then report
+     * a clean "credentials not found — reconfigure" instead of a schema
+     * error, and the backup allows manual recovery.
+     *
+     * Runs under its own cross-process lock (distinct from
+     * `profiles-manifest`, which may already be held by `modifyManifest`
+     * when this is reached) and re-checks the stored version after
+     * acquisition, so concurrent processes migrate exactly once.
+     */
+    const migrateLegacyStore = provideLockServices(
+      withLock(
+        "profiles-migrate",
+        Effect.gen(function* () {
+          const stored = yield* decodeStoredManifest;
+          if (
+            stored === undefined ||
+            stored.version >= PROFILE_MANIFEST_VERSION
+          ) {
+            return;
+          }
+          const now = yield* Clock.currentTimeMillis;
+          const stamp = new Date(now)
+            .toISOString()
+            .slice(0, 19)
+            .replaceAll(":", "-");
+          const backupDir = path.join(rootDir(), `.v0-profiles-${stamp}`);
+          const credentialsBackupDir = path.join(backupDir, "credentials");
+          yield* fs.makeDirectory(backupDir, { recursive: true });
+          // The backup holds credential secrets — keep it owner-only.
+          yield* fs.chmod(backupDir, 0o700);
+          yield* fs.copyFile(
+            configFilePath(),
+            path.join(backupDir, "profiles.json"),
+          );
+          // The manifest predates the current storage layout, so every file
+          // under credentials/ does too — move them all into the backup.
+          const credentialsRoot = credentialsDirPath();
+          const entries = yield* fs
+            .readDirectory(credentialsRoot)
+            .pipe(
+              Effect.catchReason("PlatformError", "NotFound", () =>
+                Effect.succeed<string[]>([]),
+              ),
+            );
+          for (const entry of entries) {
+            const profileDir = path.join(credentialsRoot, entry);
+            const info = yield* fs.stat(profileDir);
+            if (info.type !== "Directory") continue;
+            const files = yield* fs.readDirectory(profileDir);
+            const target = path.join(credentialsBackupDir, entry);
+            yield* fs.makeDirectory(target, { recursive: true });
+            for (const file of files) {
+              yield* fs.rename(
+                path.join(profileDir, file),
+                path.join(target, file),
+              );
+            }
+            // Now empty (every entry was renamed away); the next credential
+            // write recreates it with 0o700.
+            yield* fs
+              .remove(profileDir, { recursive: true })
+              .pipe(Effect.ignore);
+          }
+          yield* writeManifest(toCurrentManifest(stored));
+          yield* Effect.logWarning(
+            "Alchemy's profile storage layout changed: your profiles were kept, but connected accounts " +
+              "must be configured again — run `alchemy profile`. The previous profiles.json and " +
+              `credential files were backed up to '${backupDir}'.`,
+          );
+        }),
+      ),
+    );
+
+    const readManifest = decodeStoredManifest.pipe(
+      Effect.flatMap((stored) =>
+        stored !== undefined && stored.version < PROFILE_MANIFEST_VERSION
+          ? // Pre-v2 store: upgrade it on disk (backing up the legacy
+            // manifest + credential files), then re-read the result.
+            migrateLegacyStore.pipe(Effect.andThen(decodeStoredManifest))
+          : Effect.succeed(stored),
+      ),
+      Effect.flatMap((stored) =>
+        stored === undefined
+          ? Effect.succeed(emptyManifest())
+          : stored.version <= PROFILE_MANIFEST_VERSION
+            ? Effect.succeed(toCurrentManifest(stored))
+            : Effect.fail(
+                new ProfileError({
+                  message:
+                    `Profile manifest version ${stored.version} is not supported by this Alchemy version. ` +
+                    "The file was left untouched.",
+                }),
+              ),
+      ),
+      // The built-in `default` profile always exists from the reader's
+      // perspective; the synthesized entry is persisted by the next
+      // manifest write.
+      Effect.map(withDefaultProfile),
+    );
 
     /**
      * Run `f` against the freshly-read manifest under the cross-process

--- a/packages/alchemy/src/Auth/Profile.ts
+++ b/packages/alchemy/src/Auth/Profile.ts
@@ -656,7 +656,7 @@ export const ProfileStoreLive = Layer.effect(
           new AuthError({
             message:
               `No credentials configured for '${auth.name}' in profile '${profileName}'. ` +
-              `Run \`${yield* profileCommandHint(`alchemy profile edit ${profileName} --add ${auth.name}`)}\` to connect it.`,
+              `Run \`${yield* profileCommandHint(`alchemy profile edit --profile ${profileName} --add ${auth.name}`)}\` to connect it.`,
           }),
         );
       });

--- a/packages/alchemy/src/Auth/Profile.ts
+++ b/packages/alchemy/src/Auth/Profile.ts
@@ -1,5 +1,5 @@
-import * as Clock from "effect/Clock";
 import * as Config from "effect/Config";
+import * as DateTime from "effect/DateTime";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
@@ -437,19 +437,24 @@ export const ProfileStoreLive = Layer.effect(
           ) {
             return;
           }
-          const now = yield* Clock.currentTimeMillis;
-          const stamp = new Date(now)
-            .toISOString()
+          // Second precision, `:` swapped out for a filename-safe stamp.
+          const stamp = DateTime.formatIso(yield* DateTime.now)
             .slice(0, 19)
             .replaceAll(":", "-");
-          const backupDir = path.join(rootDir(), `.v0-profiles-${stamp}`);
-          const credentialsBackupDir = path.join(backupDir, "credentials");
+          const backupDir = pathService.join(
+            rootDir(),
+            `.v0-profiles-${stamp}`,
+          );
+          const credentialsBackupDir = pathService.join(
+            backupDir,
+            "credentials",
+          );
           yield* fs.makeDirectory(backupDir, { recursive: true });
           // The backup holds credential secrets — keep it owner-only.
           yield* fs.chmod(backupDir, 0o700);
           yield* fs.copyFile(
             configFilePath(),
-            path.join(backupDir, "profiles.json"),
+            pathService.join(backupDir, "profiles.json"),
           );
           // The manifest predates the current storage layout, so every file
           // under credentials/ does too — move them all into the backup.
@@ -462,16 +467,16 @@ export const ProfileStoreLive = Layer.effect(
               ),
             );
           for (const entry of entries) {
-            const profileDir = path.join(credentialsRoot, entry);
+            const profileDir = pathService.join(credentialsRoot, entry);
             const info = yield* fs.stat(profileDir);
             if (info.type !== "Directory") continue;
             const files = yield* fs.readDirectory(profileDir);
-            const target = path.join(credentialsBackupDir, entry);
+            const target = pathService.join(credentialsBackupDir, entry);
             yield* fs.makeDirectory(target, { recursive: true });
             for (const file of files) {
               yield* fs.rename(
-                path.join(profileDir, file),
-                path.join(target, file),
+                pathService.join(profileDir, file),
+                pathService.join(target, file),
               );
             }
             // Now empty (every entry was renamed away); the next credential
@@ -482,9 +487,9 @@ export const ProfileStoreLive = Layer.effect(
           }
           yield* writeManifest(toCurrentManifest(stored));
           yield* Effect.logWarning(
-            "Alchemy's profile storage layout changed: your profiles were kept, but connected accounts " +
-              "must be configured again — run `alchemy profile`. The previous profiles.json and " +
-              `credential files were backed up to '${backupDir}'.`,
+            "Alchemy's profile storage layout changed: your profiles were kept, but some connected " +
+              "accounts must be configured again — run `alchemy profile`. The previous profiles.json " +
+              `and credential files were backed up to '${backupDir}'.`,
           );
         }),
       ),

--- a/packages/alchemy/src/Cli/CliKit/theme.ts
+++ b/packages/alchemy/src/Cli/CliKit/theme.ts
@@ -63,6 +63,8 @@ export const theme = {
     bullet: "·",
     overflowUp: "↑",
     overflowDown: "↓",
+    overflowLeft: "‹",
+    overflowRight: "›",
   },
   /**
    * Key-hint labels for KeyBar footers. Resolve through `useKeyGlyphs()`
@@ -107,6 +109,8 @@ export const asciiGlyphs: { readonly [Key in GlyphName]: string } = {
   bullet: ".",
   overflowUp: "^",
   overflowDown: "v",
+  overflowLeft: "<",
+  overflowRight: ">",
 };
 
 export const glyphsFor = (unicode: boolean) =>

--- a/packages/alchemy/src/Cli/commands/profile/commands.ts
+++ b/packages/alchemy/src/Cli/commands/profile/commands.ts
@@ -17,7 +17,7 @@ import * as CliKit from "../../../Cli/CliKit/index.ts";
 import { resolveProfileName } from "../../../Auth/Resolve.ts";
 
 import { exitDeclined, failWithHelp, UserInputError } from "../errors.ts";
-import { config, envFile, yes } from "../flags.ts";
+import { config, envFile, profile, yes } from "../flags.ts";
 import { instrumentCommand } from "../instrument.ts";
 import {
   deleteProfileFlow,
@@ -28,29 +28,12 @@ import {
 } from "./flows.ts";
 import { profileHub } from "./hub.ts";
 
-const showProfile = Argument.string("profile").pipe(
-  Argument.withDescription("Profile to inspect"),
-  Argument.optional,
-);
-
 const profileName = Argument.string("name").pipe(
   Argument.withDescription("Profile name"),
 );
 
 const newProfileName = Argument.string("new-name").pipe(
   Argument.withDescription("New profile name"),
-  Argument.optional,
-);
-
-const editProfileName = Argument.string("profile").pipe(
-  Argument.withDescription(
-    "Profile whose connected accounts should be managed",
-  ),
-  Argument.optional,
-);
-
-const refreshProfileName = Argument.string("profile").pipe(
-  Argument.withDescription("Profile whose credentials should be refreshed"),
   Argument.optional,
 );
 
@@ -63,13 +46,13 @@ const refreshProviders = Flag.string("provider").pipe(
 
 const showCommand = Command.make(
   "show",
-  { name: showProfile, envFile, main: config },
-  instrumentCommand("profile.show", (a: { name: Option.Option<string> }) => ({
-    "alchemy.profile": Option.getOrUndefined(a.name) ?? "",
+  { profile, envFile, main: config },
+  instrumentCommand("profile.show", (a: { profile: string | undefined }) => ({
+    "alchemy.profile": a.profile ?? "",
   }))(
-    Effect.fn(function* ({ name, envFile, main }) {
+    Effect.fn(function* ({ profile, envFile, main }) {
       const activeProfile = yield* resolveProfileName(envFile, undefined);
-      const profileName = Option.getOrUndefined(name) ?? activeProfile;
+      const profileName = profile ?? activeProfile;
       yield* showProfileFlow({
         profileName,
         activeProfile,
@@ -120,7 +103,7 @@ const createCommand = Command.make(
     Effect.fn(function* ({ name }) {
       yield* Profiles.create({ name });
       yield* CliKit.accessors.output.success(
-        `Created profile '${name}'. Run \`alchemy profile edit ${name}\` to connect accounts.`,
+        `Created profile '${name}'. Run \`alchemy profile edit --profile ${name}\` to connect accounts.`,
       );
     }),
   ),
@@ -267,7 +250,7 @@ const resolveSetValues = Effect.fn(function* (
 const editCommand = Command.make(
   "edit",
   {
-    name: editProfileName,
+    profile,
     add: addProviders,
     reconfigure: reconfigureProviders,
     remove: removeProviders,
@@ -279,19 +262,19 @@ const editCommand = Command.make(
   instrumentCommand(
     "profile.edit",
     (a: {
-      name: Option.Option<string>;
+      profile: string | undefined;
       add: ReadonlyArray<string>;
       reconfigure: ReadonlyArray<string>;
       remove: ReadonlyArray<string>;
     }) => ({
-      "alchemy.profile": Option.getOrUndefined(a.name) ?? "",
+      "alchemy.profile": a.profile ?? "",
       "alchemy.add": a.add.join(","),
       "alchemy.re_configure": a.reconfigure.join(","),
       "alchemy.remove": a.remove.join(","),
     }),
   )(
     Effect.fn(function* ({
-      name,
+      profile,
       add,
       reconfigure,
       remove,
@@ -300,9 +283,7 @@ const editCommand = Command.make(
       envFile,
       main,
     }) {
-      const selectedProfile =
-        Option.getOrUndefined(name) ??
-        (yield* resolveProfileName(envFile, undefined));
+      const selectedProfile = yield* resolveProfileName(envFile, profile);
       let configureInput:
         | { method?: string; values: Record<string, string> }
         | undefined;
@@ -375,22 +356,20 @@ const editCommand = Command.make(
 const refreshCommand = Command.make(
   "refresh",
   {
-    name: refreshProfileName,
+    profile,
     providers: refreshProviders,
     envFile,
     main: config,
   },
   instrumentCommand(
     "profile.refresh",
-    (a: { name: Option.Option<string>; providers: ReadonlyArray<string> }) => ({
-      "alchemy.profile": Option.getOrUndefined(a.name) ?? "",
+    (a: { profile: string | undefined; providers: ReadonlyArray<string> }) => ({
+      "alchemy.profile": a.profile ?? "",
       "alchemy.providers": a.providers.join(","),
     }),
   )(
-    Effect.fn(function* ({ name, providers, envFile, main }) {
-      const selectedProfile =
-        Option.getOrUndefined(name) ??
-        (yield* resolveProfileName(envFile, undefined));
+    Effect.fn(function* ({ profile, providers, envFile, main }) {
+      const selectedProfile = yield* resolveProfileName(envFile, profile);
       const refreshStarted = new Map<string, number>();
       yield* Profiles.refresh({
         profile: selectedProfile,

--- a/packages/alchemy/src/Cli/components/ui/Feedback.tsx
+++ b/packages/alchemy/src/Cli/components/ui/Feedback.tsx
@@ -1,6 +1,7 @@
 /** @jsxImportSource react */
 import { useAnimation } from "@alchemy.run/sigil";
 import type { ReactNode } from "react";
+import stringWidth from "string-width";
 import {
   spinnerFramesFor,
   statusColor,
@@ -13,7 +14,7 @@ import {
   useCliEnvironment,
   useGlyphs,
 } from "./Environment.tsx";
-import { Box } from "./Layout.tsx";
+import { Box, tabsWindow } from "./Layout.tsx";
 import { Text } from "./Typography.tsx";
 
 export interface StatusProps {
@@ -209,15 +210,44 @@ type TabsProps = {
 
 export function Tabs({ tabs, active }: TabsProps) {
   const glyphs = useGlyphs();
+  const { columns } = useCliEnvironment();
+  const gap = 1;
+  const activeIndex = Math.max(
+    0,
+    tabs.findIndex((tab) => tab.id === active),
+  );
+  // chip width = paddingX (2) + optional marker glyph + space + label
+  const widths = tabs.map(
+    (tab) =>
+      2 +
+      stringWidth(tab.label) +
+      (tab.marked ? stringWidth(glyphs.selected) + 1 : 0),
+  );
+  const totalWidth =
+    widths.reduce((sum, width) => sum + width, 0) +
+    Math.max(0, tabs.length - 1) * gap;
+  const contentWidth = Math.max(1, columns - theme.space.indent);
+  const { start, end } =
+    totalWidth <= contentWidth
+      ? { start: 0, end: tabs.length }
+      : // reserve an arrow cell + gap on each side so the window stays put
+        // whether or not the edge arrows render
+        tabsWindow(
+          widths,
+          activeIndex,
+          Math.max(1, contentWidth - 2 * (1 + gap)),
+          gap,
+        );
   return (
     <Box
       width="100%"
-      gap={1}
+      gap={gap}
       paddingLeft={theme.space.indent}
       marginBottom={1}
       aria-role="tablist"
     >
-      {tabs.map((tab) => {
+      {start > 0 ? <Text tone="muted">{glyphs.overflowLeft}</Text> : null}
+      {tabs.slice(start, end).map((tab) => {
         const selected = tab.id === active;
         return (
           <Box
@@ -245,6 +275,9 @@ export function Tabs({ tabs, active }: TabsProps) {
           </Box>
         );
       })}
+      {end < tabs.length ? (
+        <Text tone="muted">{glyphs.overflowRight}</Text>
+      ) : null}
     </Box>
   );
 }

--- a/packages/alchemy/src/Cli/components/ui/Layout.tsx
+++ b/packages/alchemy/src/Cli/components/ui/Layout.tsx
@@ -158,6 +158,41 @@ export const listWindow = (
 };
 
 /**
+ * Horizontal window over variable-width items (tab chips): expands around
+ * `active` — alternating right/left so the selection stays roughly centered —
+ * until `available` columns are exhausted. Returns `[start, end)` like
+ * {@link listWindow}; `active` is always inside the window.
+ */
+export const tabsWindow = (
+  widths: ReadonlyArray<number>,
+  active: number,
+  available: number,
+  gap = 1,
+): { readonly start: number; readonly end: number } => {
+  if (widths.length === 0) return { start: 0, end: 0 };
+  const cursor = Math.max(0, Math.min(active, widths.length - 1));
+  let start = cursor;
+  let end = cursor + 1;
+  let used = widths[cursor]!;
+  let takeRight = true;
+  while (true) {
+    const canRight =
+      end < widths.length && used + gap + widths[end]! <= available;
+    const canLeft = start > 0 && used + gap + widths[start - 1]! <= available;
+    if (!canRight && !canLeft) break;
+    if ((takeRight && canRight) || !canLeft) {
+      used += gap + widths[end]!;
+      end++;
+    } else {
+      start--;
+      used += gap + widths[start]!;
+    }
+    takeRight = !takeRight;
+  }
+  return { start, end };
+};
+
+/**
  * Window for prompt lists that render "↑ N more"/"↓ N more" indicator rows:
  * reserves two of `visibleCount`'s rows for the indicators when overflowing so
  * the widget stays within the requested height.

--- a/packages/alchemy/src/Railway/AuthProvider.ts
+++ b/packages/alchemy/src/Railway/AuthProvider.ts
@@ -457,7 +457,7 @@ export const RailwayAuth = AuthProviderLayer<
                       new AuthError({
                         message:
                           `Railway: ${RAILWAY_API_TOKEN_ENV} is not set. Export it, or run ` +
-                          `\`alchemy profile edit ${profileName} --reconfigure ${RAILWAY_AUTH_PROVIDER_NAME}\` to switch methods.`,
+                          `\`alchemy profile edit --profile ${profileName} --reconfigure ${RAILWAY_AUTH_PROVIDER_NAME}\` to switch methods.`,
                       }),
                     ),
               ),

--- a/packages/alchemy/test/AWS/Local/CredentialFreeDev.local.test.ts
+++ b/packages/alchemy/test/AWS/Local/CredentialFreeDev.local.test.ts
@@ -302,7 +302,7 @@ test.provider(
         expect(error.message).toContain("AWS credentials are required");
         expect(error.message).toContain("RemoteBucket");
         expect(error.message).toContain(
-          `alchemy profile edit ${NO_CREDS_PROFILE} --add AWS`,
+          `alchemy profile edit --profile ${NO_CREDS_PROFILE} --add AWS`,
         );
         expect(error.message).toContain("Alchemy.remote()");
       }

--- a/packages/alchemy/test/Auth/Migration.test.ts
+++ b/packages/alchemy/test/Auth/Migration.test.ts
@@ -1,0 +1,210 @@
+import { AuthProviders } from "@/Auth/AuthProvider.ts";
+import {
+  PROFILE_MANIFEST_VERSION,
+  ProfileStore,
+  ProfileStoreLive,
+} from "@/Auth/Profile.ts";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { expect, it } from "alchemy-test";
+import * as ConfigProvider from "effect/ConfigProvider";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import path from "pathe";
+
+const FIXTURE_HOME = path.join(import.meta.dirname, "fixtures/v0-home");
+
+const testLayer = () =>
+  ProfileStoreLive.pipe(
+    Layer.provideMerge(
+      Layer.mergeAll(
+        Layer.succeed(AuthProviders, {}),
+        ConfigProvider.layer(ConfigProvider.fromUnknown({})),
+        NodeServices.layer,
+      ),
+    ),
+  );
+
+/**
+ * Point `ALCHEMY_HOME` at a scoped temp directory seeded from a fixture
+ * tree, so store operations never touch the developer's real `~/.alchemy`.
+ * Tests using this must be `exclusive` — the env var is process-global.
+ */
+const withFixtureHome = <A, E, R>(
+  fixture: string | undefined,
+  effect: (home: string) => Effect.Effect<A, E, R>,
+) =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const dir = yield* fs.makeTempDirectoryScoped({
+      prefix: "alchemy-migrate-",
+    });
+    if (fixture !== undefined) {
+      yield* fs.copyFile(
+        path.join(fixture, "profiles.json"),
+        path.join(dir, "profiles.json"),
+      );
+      yield* fs.copy(
+        path.join(fixture, "credentials"),
+        path.join(dir, "credentials"),
+      );
+    }
+    const previous = process.env.ALCHEMY_HOME;
+    yield* Effect.acquireRelease(
+      Effect.sync(() => {
+        process.env.ALCHEMY_HOME = dir;
+      }),
+      () =>
+        Effect.sync(() => {
+          if (previous === undefined) delete process.env.ALCHEMY_HOME;
+          else process.env.ALCHEMY_HOME = previous;
+        }),
+    );
+    return yield* effect(dir);
+  }).pipe(Effect.scoped, Effect.provide(testLayer()));
+
+it.live(
+  "migrates a full v0 store: entries kept, credentials dropped into a backup",
+  () =>
+    withFixtureHome(FIXTURE_HOME, (home) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const store = yield* ProfileStore;
+
+        // The first read performs the on-disk migration.
+        const manifest = yield* store.readManifest;
+
+        // Every profile and provider entry survives (ids backfilled from the
+        // profile name), except legacy `method: "env"` entries.
+        expect(Object.keys(manifest.profiles).sort()).toEqual([
+          "default",
+          "work",
+        ]);
+        expect(manifest.profiles.default?.id).toBe("default");
+        expect(manifest.profiles.work?.id).toBe("work");
+        expect(manifest.profiles.default?.providers.Cloudflare?.method).toBe(
+          "oauth",
+        );
+        expect(manifest.profiles.default?.providers.AWS?.method).toBe("sso");
+        expect(manifest.profiles.default?.providers.Neon).toBeUndefined();
+        expect(manifest.profiles.work?.providers.GitHub?.method).toBe("stored");
+        expect(manifest.profiles.work?.providers.Axiom?.method).toBe("stored");
+        expect(manifest.profiles.work?.providers.Cloudflare?.method).toBe(
+          "stored",
+        );
+
+        // The manifest on disk is upgraded in place, keeping provider
+        // details like the SSO profile and OAuth scopes.
+        const onDisk = JSON.parse(
+          yield* fs.readFileString(path.join(home, "profiles.json")),
+        );
+        expect(onDisk.version).toBe(PROFILE_MANIFEST_VERSION);
+        expect(onDisk.profiles.work.id).toBe("work");
+        expect(onDisk.profiles.default.providers.AWS.ssoProfile).toBe("dev");
+        expect(onDisk.profiles.default.providers.Cloudflare.scopes).toEqual([
+          "account:read",
+          "workers:write",
+        ]);
+        expect(onDisk.profiles.default.providers.Neon).toBeUndefined();
+
+        // The original manifest and every credential file are preserved in
+        // a timestamped backup for manual recovery.
+        const backups = (yield* fs.readDirectory(home)).filter((entry) =>
+          entry.startsWith(".v0-profiles-"),
+        );
+        expect(backups).toHaveLength(1);
+        const backupDir = path.join(home, backups[0]!);
+        const backedUp = JSON.parse(
+          yield* fs.readFileString(path.join(backupDir, "profiles.json")),
+        );
+        expect(backedUp.version).toBe(0);
+        // v0 profiles are flat provider maps (no `providers` wrapper).
+        expect(backedUp.profiles.default.Neon.method).toBe("env");
+        const oauth = JSON.parse(
+          yield* fs.readFileString(
+            path.join(backupDir, "credentials/default/cf-oauth.json"),
+          ),
+        );
+        expect(oauth.refresh).toBe("v0-refresh-token");
+        for (const file of [
+          "credentials/default/cloudflare-state-store.json",
+          "credentials/work/gh-stored.json",
+          "credentials/work/axiom-stored.json",
+          "credentials/work/cf-stored.json",
+        ]) {
+          expect(yield* fs.exists(path.join(backupDir, file))).toBe(true);
+        }
+
+        // The live credential store is empty — providers report a clean
+        // "not configured" instead of loading stale v0 secrets.
+        expect(yield* fs.exists(path.join(home, "credentials/default"))).toBe(
+          false,
+        );
+        expect(yield* fs.exists(path.join(home, "credentials/work"))).toBe(
+          false,
+        );
+
+        // Idempotent: a second read is a plain current-version read — no new
+        // backup dir, and the existing one is untouched.
+        const again = yield* store.readManifest;
+        expect(again.profiles.work?.providers.GitHub?.method).toBe("stored");
+        expect(
+          (yield* fs.readDirectory(home)).filter((entry) =>
+            entry.startsWith(".v0-profiles-"),
+          ),
+        ).toHaveLength(1);
+        expect(
+          JSON.parse(
+            yield* fs.readFileString(path.join(backupDir, "profiles.json")),
+          ).version,
+        ).toBe(0);
+      }),
+    ),
+  { exclusive: true },
+);
+
+it.live(
+  "leaves a current-version store untouched (no backup, credentials kept)",
+  () =>
+    withFixtureHome(undefined, (home) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        yield* fs.writeFileString(
+          path.join(home, "profiles.json"),
+          JSON.stringify({
+            version: PROFILE_MANIFEST_VERSION,
+            profiles: {
+              default: { id: "default", providers: {} },
+              work: {
+                id: "work-id",
+                providers: { Neon: { method: "stored" } },
+              },
+            },
+          }),
+        );
+        yield* fs.makeDirectory(path.join(home, "credentials/work"), {
+          recursive: true,
+        });
+        yield* fs.writeFileString(
+          path.join(home, "credentials/work/neon-stored.json"),
+          JSON.stringify({ apiKey: "current-key" }),
+        );
+
+        const store = yield* ProfileStore;
+        const manifest = yield* store.readManifest;
+
+        expect(manifest.profiles.work?.id).toBe("work-id");
+        expect(
+          (yield* fs.readDirectory(home)).filter((entry) =>
+            entry.startsWith(".v0-profiles-"),
+          ),
+        ).toHaveLength(0);
+        expect(
+          yield* fs.exists(
+            path.join(home, "credentials/work/neon-stored.json"),
+          ),
+        ).toBe(true);
+      }),
+    ),
+  { exclusive: true },
+);

--- a/packages/alchemy/test/Auth/Profile.test.ts
+++ b/packages/alchemy/test/Auth/Profile.test.ts
@@ -177,7 +177,7 @@ it.live(
 
         expect(error).toBeInstanceOf(AuthError);
         expect((error as AuthError).message).toContain(
-          `alchemy profile edit explicit-login --add ${FAKE_PROVIDER}`,
+          `alchemy profile edit --profile explicit-login --add ${FAKE_PROVIDER}`,
         );
         expect(state.configureCalls).toBe(0);
       }),

--- a/packages/alchemy/test/Auth/fixtures/v0-home/credentials/default/cf-oauth.json
+++ b/packages/alchemy/test/Auth/fixtures/v0-home/credentials/default/cf-oauth.json
@@ -1,0 +1,7 @@
+{
+  "type": "oauth",
+  "access": "v0-access-token",
+  "refresh": "v0-refresh-token",
+  "expires": 1700000000000,
+  "scopes": ["account:read", "workers:write"]
+}

--- a/packages/alchemy/test/Auth/fixtures/v0-home/credentials/default/cloudflare-state-store.json
+++ b/packages/alchemy/test/Auth/fixtures/v0-home/credentials/default/cloudflare-state-store.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://alchemy-state.v0-example.workers.dev",
+  "authToken": "v0-state-store-token"
+}

--- a/packages/alchemy/test/Auth/fixtures/v0-home/credentials/work/axiom-stored.json
+++ b/packages/alchemy/test/Auth/fixtures/v0-home/credentials/work/axiom-stored.json
@@ -1,0 +1,5 @@
+{
+  "type": "apiToken",
+  "apiToken": "xaat-v0-token",
+  "apiBaseUrl": "https://api.axiom.co"
+}

--- a/packages/alchemy/test/Auth/fixtures/v0-home/credentials/work/cf-stored.json
+++ b/packages/alchemy/test/Auth/fixtures/v0-home/credentials/work/cf-stored.json
@@ -1,0 +1,5 @@
+{
+  "type": "apiToken",
+  "apiToken": "v0-cf-api-token",
+  "accountId": "0123456789abcdef0123456789abcdef"
+}

--- a/packages/alchemy/test/Auth/fixtures/v0-home/credentials/work/gh-stored.json
+++ b/packages/alchemy/test/Auth/fixtures/v0-home/credentials/work/gh-stored.json
@@ -1,0 +1,4 @@
+{
+  "type": "pat",
+  "token": "ghp_v0token"
+}

--- a/packages/alchemy/test/Auth/fixtures/v0-home/profiles.json
+++ b/packages/alchemy/test/Auth/fixtures/v0-home/profiles.json
@@ -1,0 +1,31 @@
+{
+  "version": 0,
+  "profiles": {
+    "default": {
+      "Cloudflare": {
+        "method": "oauth",
+        "scopes": ["account:read", "workers:write"],
+        "accountId": "0123456789abcdef0123456789abcdef"
+      },
+      "AWS": {
+        "method": "sso",
+        "ssoProfile": "dev"
+      },
+      "Neon": {
+        "method": "env"
+      }
+    },
+    "work": {
+      "GitHub": {
+        "method": "stored"
+      },
+      "Axiom": {
+        "method": "stored"
+      },
+      "Cloudflare": {
+        "method": "stored",
+        "credentialType": "apiToken"
+      }
+    }
+  }
+}

--- a/packages/alchemy/test/Cli/CliKit.test.tsx
+++ b/packages/alchemy/test/Cli/CliKit.test.tsx
@@ -27,6 +27,7 @@ import {
   TextField,
   useLiveStore,
 } from "@/Cli/components/ui/index.ts";
+import { tabsWindow } from "@/Cli/components/ui/Layout.tsx";
 import { makeRuntime } from "@/Cli/components/view/Runtime.tsx";
 import { isInProgress } from "@/Cli/components/view/statusStyle.ts";
 import { makeResourceLogger, makeResourceOutput } from "@/Cli/Output.ts";
@@ -1474,6 +1475,68 @@ it.effect(
       expect(rendered).toContain("2/4");
     }),
 );
+
+it.effect("tabs scroll horizontally instead of wrapping when overflowing", () =>
+  Effect.gen(function* () {
+    const { service } = makeStatic();
+    const tabs = Array.from({ length: 20 }, (_, i) => {
+      const label = `profile-${String(i + 1).padStart(2, "0")}`;
+      return { id: label, label, marked: i === 0 };
+    });
+
+    // Active tab in the middle: window centers on it, arrows on both sides.
+    const middle = yield* service.output.render(
+      <Tabs tabs={tabs} active="profile-10" />,
+    );
+    expect(middle).toContain("profile-10");
+    expect(middle).toContain("‹");
+    expect(middle).toContain("›");
+    expect(middle).not.toContain("profile-01");
+    expect(middle).not.toContain("profile-20");
+    // every rendered tab stays on the single tab row — no wrapped chips
+    expect(middle.trimEnd()).not.toContain("\n");
+
+    // Active tab at the start: no left arrow, right arrow only.
+    const first = yield* service.output.render(
+      <Tabs tabs={tabs} active="profile-01" />,
+    );
+    expect(first).toContain("profile-01");
+    expect(first).not.toContain("‹");
+    expect(first).toContain("›");
+
+    // Active tab at the end: left arrow only.
+    const last = yield* service.output.render(
+      <Tabs tabs={tabs} active="profile-20" />,
+    );
+    expect(last).toContain("profile-20");
+    expect(last).toContain("‹");
+    expect(last).not.toContain("›");
+
+    // Everything fits: no arrows at all.
+    const fitting = yield* service.output.render(
+      <Tabs tabs={tabs.slice(0, 3)} active="profile-02" />,
+    );
+    expect(fitting).toContain("profile-01");
+    expect(fitting).toContain("profile-03");
+    expect(fitting).not.toContain("‹");
+    expect(fitting).not.toContain("›");
+  }),
+);
+
+it("tabsWindow keeps the active tab visible within the available width", () => {
+  // 5 chips of width 12, gap 1, 74 columns → 5 fit exactly around the middle
+  const widths = Array.from({ length: 20 }, () => 12);
+  expect(tabsWindow(widths, 9, 74)).toEqual({ start: 7, end: 12 });
+  // at the edges the window pins to the boundary
+  expect(tabsWindow(widths, 0, 74)).toEqual({ start: 0, end: 5 });
+  expect(tabsWindow(widths, 19, 74)).toEqual({ start: 15, end: 20 });
+  // active always inside, even when nothing else fits
+  expect(tabsWindow(widths, 3, 12)).toEqual({ start: 3, end: 4 });
+  expect(tabsWindow(widths, 3, 5)).toEqual({ start: 3, end: 4 });
+  // out-of-range active clamps; empty input yields an empty window
+  expect(tabsWindow(widths, 99, 74)).toEqual({ start: 15, end: 20 });
+  expect(tabsWindow([], 0, 74)).toEqual({ start: 0, end: 0 });
+});
 
 it.live(
   "state explorer confirms deletes inline and keeps its position afterwards",

--- a/packages/alchemy/test/Cli/UserErrors.test.ts
+++ b/packages/alchemy/test/Cli/UserErrors.test.ts
@@ -19,7 +19,7 @@ it.effect("renders auth failures as user-facing CLI errors", () =>
       Effect.fail(
         new AuthError({
           message:
-            "Cloudflare credentials need refreshing. Run: alchemy profile refresh admin --provider Cloudflare",
+            "Cloudflare credentials need refreshing. Run: alchemy profile refresh --profile admin --provider Cloudflare",
         }),
       ),
     ).pipe(
@@ -30,7 +30,7 @@ it.effect("renders auth failures as user-facing CLI errors", () =>
     expect(Result.isFailure(result)).toBe(true);
     expect(errors).toHaveLength(1);
     expect(errors[0]).toContain("error:");
-    expect(errors[0]).toContain("alchemy profile refresh admin");
+    expect(errors[0]).toContain("alchemy profile refresh --profile admin");
     expect(errors[0]).not.toContain("at Effect.fn");
   }),
 );

--- a/packages/alchemy/test/Prisma/AuthProvider.test.ts
+++ b/packages/alchemy/test/Prisma/AuthProvider.test.ts
@@ -101,7 +101,7 @@ describe("Prisma auth provider", () => {
 
         expect(error._tag).toBe("NeedsReauth");
         expect(error.message).toContain(
-          "alchemy profile refresh default --provider Prisma",
+          "alchemy profile refresh --profile default --provider Prisma",
         );
       }).pipe(Effect.provide(testLayer())),
   );

--- a/website/src/content/docs/aws/local-development.mdx
+++ b/website/src/content/docs/aws/local-development.mdx
@@ -182,7 +182,7 @@ If a remote resource needs credentials you don't have,
 AWS credentials are required, but none are configured for profile 'default'.
 These resources require AWS credentials:
   - ProdSecret (runs against the real cloud via Alchemy.remote())
-Run `alchemy profile edit default --add AWS` to configure credentials, or set CI=1 to use environment-variable credentials.
+Run `alchemy profile edit --profile default --add AWS` to configure credentials, or set CI=1 to use environment-variable credentials.
 ```
 
 Switching a resource between local and live (or dev → deploy)

--- a/website/src/content/docs/aws/setup.mdx
+++ b/website/src/content/docs/aws/setup.mdx
@@ -97,7 +97,7 @@ SSO, or to configure a separate `prod` profile):
 ```sh
 alchemy profile edit --reconfigure AWS
 alchemy profile create prod
-alchemy profile edit prod --add AWS
+alchemy profile edit --profile prod --add AWS
 ```
 
 Inspect what's stored (secrets are redacted):

--- a/website/src/content/docs/aws/tutorial/part-1.mdx
+++ b/website/src/content/docs/aws/tutorial/part-1.mdx
@@ -195,7 +195,7 @@ credentials directly. See [Setup](/aws/setup) for the full walkthrough.
 To re-run the credential prompt later (e.g. to switch from stored
 keys to SSO), use `alchemy profile edit --reconfigure AWS`. For a
 separate profile, run `alchemy profile create prod` followed by
-`alchemy profile edit prod`.
+`alchemy profile edit --profile prod`.
 :::
 
 <Terminal content={`[u]Plan[/u]: [g]1 to create[/g]

--- a/website/src/content/docs/aws/tutorial/part-5.mdx
+++ b/website/src/content/docs/aws/tutorial/part-5.mdx
@@ -61,7 +61,7 @@ alchemy profile create admin
 Connect AWS to the new profile:
 
 ```sh
-alchemy profile edit admin --add AWS
+alchemy profile edit --profile admin --add AWS
 ```
 
 Choose an AWS credential (SSO, access keys, etc.) that's authorized

--- a/website/src/content/docs/cli/profile.mdx
+++ b/website/src/content/docs/cli/profile.mdx
@@ -68,7 +68,7 @@ fails if the name already exists. You do not need to create `default`.
 
 ```sh
 alchemy profile create production
-alchemy profile edit production
+alchemy profile edit --profile production
 ```
 
 ## profile rename
@@ -97,7 +97,7 @@ rewritten; update it separately if it names the old profile.
 ## profile edit
 
 ```sh
-alchemy profile edit [profile] [flags]
+alchemy profile edit [flags]
 ```
 
 Without action flags, the command shows connected accounts and opens a menu of
@@ -141,9 +141,9 @@ methods stay interactive-only.
 In a non-interactive session (no terminal, CI, coding agents), the menu can't
 open. The command prints its usage and exits non-zero. Use the action flags.
 
-| Argument / option         | Description                                                |
+| Option                    | Description                                                |
 | ------------------------- | ---------------------------------------------------------- |
-| `[profile]`               | Profile to manage; defaults to the effective current one   |
+| `--profile <name>`        | Profile to manage; defaults to the effective current one   |
 | `--add <provider>`        | Connect a provider (repeatable)                            |
 | `--reconfigure <provider>` | Re-run a connected provider's configuration (repeatable)  |
 | `--remove <provider>`     | Log out a provider and disconnect it (repeatable)          |
@@ -157,11 +157,11 @@ open. The command prints its usage and exits non-zero. Use the action flags.
 alchemy profile edit
 
 # Manage a named profile interactively
-alchemy profile edit work
+alchemy profile edit --profile work
 
 # Direct, non-interactive-friendly forms
 alchemy profile edit --add cloudflare
-alchemy profile edit work --reconfigure cloudflare
+alchemy profile edit --profile work --reconfigure cloudflare
 alchemy profile edit --remove cloudflare
 
 # Several changes at once
@@ -178,7 +178,7 @@ op read op://vault/neon/key | alchemy profile edit --add neon --set apiKey=-
 ## profile refresh
 
 ```sh
-alchemy profile refresh [profile] [options]
+alchemy profile refresh [options]
 ```
 
 Refresh authentication for every connected provider without changing its
@@ -194,7 +194,7 @@ names are matched case-insensitively.
 
 | Option                | Description                                                |
 | --------------------- | ---------------------------------------------------------- |
-| `[profile]`           | Profile to refresh; defaults to the effective current one  |
+| `--profile <name>`    | Profile to refresh; defaults to the effective current one  |
 | `--provider <name>`   | Refresh only this connected provider; may be repeated      |
 | `--env-file <path>`   | Load environment variables and current-profile selection  |
 | `--config, -c <file>` | Stack entrypoint used to discover custom auth providers    |
@@ -204,7 +204,7 @@ names are matched case-insensitively.
 alchemy profile refresh
 
 # Refresh AWS in a named profile
-alchemy profile refresh production --provider AWS
+alchemy profile refresh --profile production --provider AWS
 ```
 
 ## profile current
@@ -252,7 +252,7 @@ In a non-interactive session each profile prints as one
 ## profile show
 
 ```sh
-alchemy profile show [profile] [options]
+alchemy profile show [options]
 ```
 
 Show a profile's providers as a table with authentication method, credential
@@ -277,9 +277,9 @@ If the profile doesn't exist, the command fails (non-zero exit) and lists
 the available profile names. If none exist, it suggests
 `alchemy profile create <name>`.
 
-| Argument / option   | Description                                                     |
+| Option              | Description                                                     |
 | ------------------- | --------------------------------------------------------------- |
-| `[profile]`         | Profile to inspect; defaults to the effective current one       |
+| `--profile <name>`  | Profile to inspect; defaults to the effective current one       |
 | `--env-file <path>` | Load environment variables from a file                          |
 | `--config, -c <file>` | Stack entrypoint used to discover custom auth providers       |
 
@@ -288,7 +288,7 @@ the available profile names. If none exist, it suggests
 alchemy profile show
 
 # Show a named profile
-alchemy profile show prod
+alchemy profile show --profile prod
 ```
 
 ## profile delete

--- a/website/src/content/docs/cloudflare/setup.mdx
+++ b/website/src/content/docs/cloudflare/setup.mdx
@@ -87,7 +87,7 @@ handy for separating work and personal accounts, or staging and prod credentials
 ```sh
 # Log into a separate profile
 alchemy profile create prod
-alchemy profile edit prod
+alchemy profile edit --profile prod
 
 # Deploy with it
 alchemy deploy --stage prod --profile prod

--- a/website/src/content/docs/cloudflare/tutorial/part-1.mdx
+++ b/website/src/content/docs/cloudflare/tutorial/part-1.mdx
@@ -254,7 +254,7 @@ variables or `wrangler login` required.
 To re-run the credential prompt later (e.g. to switch from OAuth to
 an API token), use `alchemy profile edit --reconfigure Cloudflare`.
 For a separate profile, run `alchemy profile create prod` followed by
-`alchemy profile edit prod`.
+`alchemy profile edit --profile prod`.
 :::
 
 <Terminal content={`[u]Plan[/u]: [g]1 to create[/g]

--- a/website/src/content/docs/cloudflare/tutorial/part-5.mdx
+++ b/website/src/content/docs/cloudflare/tutorial/part-5.mdx
@@ -58,7 +58,7 @@ create a dedicated `admin` profile:
 
 ```sh
 alchemy profile create admin
-alchemy profile edit admin --add Cloudflare
+alchemy profile edit --profile admin --add Cloudflare
 ```
 
 When prompted for a Cloudflare credential, pick one of:

--- a/website/src/content/docs/environments/auth-providers.mdx
+++ b/website/src/content/docs/environments/auth-providers.mdx
@@ -238,7 +238,7 @@ const fresh =
         Effect.mapError(
           (e) =>
             new AuthError({
-              message: "Cloudflare OAuth refresh failed. Run: alchemy profile refresh default --provider Cloudflare",
+              message: "Cloudflare OAuth refresh failed. Run: alchemy profile refresh --profile default --provider Cloudflare",
               cause: e,
             }),
         ),

--- a/website/src/content/docs/environments/ci.mdx
+++ b/website/src/content/docs/environments/ci.mdx
@@ -332,7 +332,7 @@ Rather than hand those rights to your default
 
 ```sh
 alchemy profile create admin
-alchemy profile edit admin
+alchemy profile edit --profile admin
 ```
 
 :::danger[Heads up]
@@ -603,7 +603,7 @@ not sensitive).
 
 Your `--profile admin` AWS credentials need IAM admin rights for
 this stack: it creates an `OpenIDConnectProvider` and an IAM `Role`.
-Run `alchemy profile edit admin --add AWS` and choose a credential
+Run `alchemy profile edit --profile admin --add AWS` and choose a credential
 (SSO/OIDC, access keys, etc.) that's authorized for IAM
 administration.
 

--- a/website/src/content/docs/environments/profiles.mdx
+++ b/website/src/content/docs/environments/profiles.mdx
@@ -35,7 +35,7 @@ alchemy profile edit
 # connect accounts to the `default` profile
 
 alchemy profile create work
-alchemy profile edit work
+alchemy profile edit --profile work
 alchemy deploy --profile work
 # uses profile `work`; plain `alchemy deploy` uses `default`
 ```
@@ -52,11 +52,11 @@ To re-run that flow at any time:
 alchemy profile edit
 
 # Re-configure one account directly
-alchemy profile edit work --reconfigure Cloudflare
+alchemy profile edit --profile work --reconfigure Cloudflare
 
 # Log into a separate profile
 alchemy profile create prod
-alchemy profile edit prod
+alchemy profile edit --profile prod
 ```
 
 Refreshing credentials is separate from reconfiguration. Refresh preserves the
@@ -67,7 +67,7 @@ selected authentication method, account, and scopes:
 alchemy profile refresh
 
 # Refresh only AWS SSO
-alchemy profile refresh work --provider AWS
+alchemy profile refresh --profile work --provider AWS
 ```
 
 Alchemy refreshes supported credentials lazily. If interaction is required,
@@ -88,7 +88,7 @@ redacted):
 
 ```sh
 alchemy profile show
-alchemy profile show prod
+alchemy profile show --profile prod
 ```
 
 Sample output:

--- a/website/src/content/docs/fly/setup.mdx
+++ b/website/src/content/docs/fly/setup.mdx
@@ -107,7 +107,7 @@ alchemy profile edit --reconfigure Fly
 
 # Or connect Fly in a separate `prod` profile
 alchemy profile create prod
-alchemy profile edit prod --add Fly
+alchemy profile edit --profile prod --add Fly
 ```
 
 Inspect what's stored (secrets are redacted):

--- a/website/src/content/docs/getting-started.mdx
+++ b/website/src/content/docs/getting-started.mdx
@@ -122,7 +122,7 @@ Full command reference: [CLI](/cli).
 To re-run the credential prompt later (e.g. to switch from OAuth to
 an API token), use `alchemy profile edit --reconfigure Cloudflare`.
 For a separate profile, run `alchemy profile create prod` followed by
-`alchemy profile edit prod`.
+`alchemy profile edit --profile prod`.
 See [Profiles](/environments/profiles) for the full picture.
 :::
 

--- a/website/src/content/docs/hetzner/setup.mdx
+++ b/website/src/content/docs/hetzner/setup.mdx
@@ -98,7 +98,7 @@ separate `prod` profile):
 ```sh
 alchemy profile
 alchemy profile create prod
-alchemy profile edit prod
+alchemy profile edit --profile prod
 ```
 
 Inspect what's stored (secrets are redacted):

--- a/website/src/content/docs/railway/setup.mdx
+++ b/website/src/content/docs/railway/setup.mdx
@@ -108,7 +108,7 @@ alchemy profile edit --reconfigure Railway
 
 # Or connect Railway in a separate `prod` profile
 alchemy profile create prod
-alchemy profile edit prod --add Railway
+alchemy profile edit --profile prod --add Railway
 ```
 
 Inspect what's stored (secrets are redacted):


### PR DESCRIPTION
Three profile fixes: the dashboard's tab strip scrolls instead of wrapping, `show`/`edit`/`refresh` select the profile with `--profile`, and pre-overhaul (v0) stores migrate on first read with a full backup.

### Tab strip scrolling

`Tabs` now windows its chips against the terminal width. When the profiles overflow, only the tabs that fit render, with `‹`/`›` arrows on whichever side has hidden entries; the active tab is always scrolled into view (stateless `tabsWindow` helper, same idiom as `listWindow`).

### `--profile` flag

```sh
# before
alchemy profile show prod
alchemy profile edit work --reconfigure Cloudflare

# after
alchemy profile show --profile prod
alchemy profile edit --profile work --reconfigure Cloudflare
```

`show`/`edit`/`refresh` drop their positional profile for the shared `--profile` flag (defaults to `$ALCHEMY_PROFILE` / `default`). The remaining positionals — `create <name>`, `delete <name>`, `rename <name> [new-name]` — consistently mean the name being created or changed. All embedded command hints and docs updated.

### v0 store migration

The profiles overhaul (#1234) renamed credential file keys (`aws.json` → `aws-stored.json`, `cf-stored.json` → `cloudflare-stored.json`, …) and schema-validated their contents, silently orphaning v0-era files. The first read of a pre-v2 `profiles.json` now upgrades the store on disk, under its own cross-process lock:

- the old manifest and every credential file move to `~/.alchemy/.v0-profiles-<timestamp>/` for manual recovery
- the manifest is rewritten in the current format with every profile/provider entry kept (ids backfilled, legacy `method: "env"` entries dropped)
- providers then report a clean typed `NeedsReauth` with a reconfigure hint instead of loading stale secrets

Covered by a fixture test over a checked-in full v0 home, plus a guard that current-version stores are never touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
