### PR TITLE
fix(cli)!: honor ALCHEMY_STAGE instead of STAGE

### DIFF
--- a/packages/alchemy/src/Cli/commands/deploy.ts
+++ b/packages/alchemy/src/Cli/commands/deploy.ts
@@ -18,7 +18,7 @@ import {
   force,
   optionalConfig,
   profile,
-  resolveConfig,
+  resolveStackArgs,
   stage,
   yes,
 } from "./flags.ts";
@@ -229,7 +229,7 @@ export const deployCommand = Command.make(
     detectDrift,
   },
   (args) =>
-    resolveConfig(args).pipe(
+    resolveStackArgs("live")(args).pipe(
       Effect.flatMap(instrumentCommand("deploy", stackSpanAttrs)(runStack)),
     ),
 );
@@ -246,7 +246,7 @@ export const destroyCommand = Command.make(
     profile,
   },
   (args) =>
-    resolveConfig(args).pipe(
+    resolveStackArgs("live")(args).pipe(
       Effect.flatMap(
         instrumentCommand(
           "destroy",
@@ -272,7 +272,7 @@ export const planCommand = Command.make(
     detailed,
   },
   (args) =>
-    resolveConfig(args).pipe(
+    resolveStackArgs("live")(args).pipe(
       Effect.flatMap(
         instrumentCommand(
           "plan",

--- a/packages/alchemy/src/Cli/commands/dev.ts
+++ b/packages/alchemy/src/Cli/commands/dev.ts
@@ -17,7 +17,7 @@ import {
   devStage,
   optionalConfig,
   profile,
-  resolveConfig,
+  resolveStackArgs,
 } from "./flags.ts";
 import { suppressInterruptMessages } from "./errors.ts";
 
@@ -45,7 +45,7 @@ export const devCommand = Command.make(
   },
   Effect.fn(
     function* (rawArgs) {
-      const args = yield* resolveConfig(rawArgs);
+      const args = yield* resolveStackArgs("dev")(rawArgs);
       // This process is only the exec child's supervisor; the child owns the
       // terminal and announces the Ctrl+C shutdown. Without this, a SIGINT
       // hits both processes and the interrupt message prints twice.

--- a/packages/alchemy/src/Cli/commands/drift.ts
+++ b/packages/alchemy/src/Cli/commands/drift.ts
@@ -8,7 +8,7 @@ import { Cli } from "../../Report.ts";
 import * as CliKit from "../CliKit/index.ts";
 import { planDecisionScreen } from "../components/view/PlanDecision.tsx";
 
-import { config, envFile, profile, stage } from "./flags.ts";
+import { config, envFile, profile, resolveStage, stage } from "./flags.ts";
 import { instrumentCommand } from "./instrument.ts";
 import { renderApply, renderPlanning } from "./render.ts";
 
@@ -93,10 +93,15 @@ export const driftCommand = Command.make(
     stage,
     profile,
   },
-  instrumentCommand("drift", (args: SyncArgs & { repair: boolean }) => ({
-    "alchemy.stage": args.stage,
-    "alchemy.profile": args.profile,
-    "alchemy.main": args.main,
-    "alchemy.repair": args.repair,
-  }))((args) => routeDrift(args)),
+  (args) =>
+    resolveStage("live", args.stage, args.envFile).pipe(
+      Effect.flatMap((stage) =>
+        instrumentCommand("drift", (a: SyncArgs & { repair: boolean }) => ({
+          "alchemy.stage": a.stage,
+          "alchemy.profile": a.profile,
+          "alchemy.main": a.main,
+          "alchemy.repair": a.repair,
+        }))((resolved) => routeDrift(resolved))({ ...args, stage }),
+      ),
+    ),
 ).pipe(Command.withDescription("Detect infrastructure drift"));

--- a/packages/alchemy/src/Cli/commands/flags.ts
+++ b/packages/alchemy/src/Cli/commands/flags.ts
@@ -1,12 +1,13 @@
 import * as Clock from "effect/Clock";
 import * as Config from "effect/Config";
+import * as ConfigProvider from "effect/ConfigProvider";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
 import * as Argument from "effect/unstable/cli/Argument";
-import * as CliError from "effect/unstable/cli/CliError";
 import * as Flag from "effect/unstable/cli/Flag";
+import { loadConfigProvider } from "../../Util/ConfigProvider.ts";
 import { UserInputError } from "./errors.ts";
 
 export const USER = Config.string("USER").pipe(
@@ -14,10 +15,12 @@ export const USER = Config.string("USER").pipe(
   Config.withDefault("unknown"),
 );
 
-export const STAGE = Config.string("STAGE").pipe(
+export const ALCHEMY_STAGE = Config.string("ALCHEMY_STAGE").pipe(
   Config.option,
   Effect.map(Option.getOrUndefined),
 );
+
+const STAGE_NAME_PATTERN = /^[a-z0-9]+([-_a-z0-9]+)*$/i;
 
 const makeStageFlag = (kind: "live" | "dev") =>
   Flag.string("stage").pipe(
@@ -26,29 +29,11 @@ const makeStageFlag = (kind: "live" | "dev") =>
     ),
     Flag.withDescription(
       kind === "live"
-        ? "Stage to deploy to, defaults to live_${USER}"
-        : "Stage to use for dev, defaults to dev_${USER}",
+        ? "Stage to deploy to. Defaults to $ALCHEMY_STAGE or live_${USER}"
+        : "Stage to use for dev. Defaults to $ALCHEMY_STAGE or dev_${USER}",
     ),
     Flag.optional,
     Flag.map(Option.getOrUndefined),
-    Flag.mapEffect(
-      Effect.fn(function* (stage) {
-        if (stage) return stage;
-        return yield* STAGE.pipe(
-          Effect.catch(() =>
-            Effect.fail(new CliError.MissingOption({ option: "stage" })),
-          ),
-          Effect.flatMap((configured) =>
-            configured === undefined
-              ? USER.pipe(
-                  Effect.map((user) => `${kind}_${user}`),
-                  Effect.catch(() => Effect.succeed("unknown")),
-                )
-              : Effect.succeed(configured),
-          ),
-        );
-      }),
-    ),
   );
 
 /** `--stage` for deploy / destroy / plan / logs / drift. Default: `live_$USER`. */
@@ -56,6 +41,39 @@ export const stage = makeStageFlag("live");
 
 /** `--stage` for `alchemy dev`. Default: `dev_$USER`. */
 export const devStage = makeStageFlag("dev");
+
+/**
+ * Resolve the target stage after the command's dotenv provider is known.
+ * `--stage` wins; otherwise `$ALCHEMY_STAGE` from process env / `--env-file`
+ * / `.env`; otherwise `live_$USER` or `dev_$USER`.
+ *
+ * `$STAGE` is not consulted. Use `$ALCHEMY_STAGE` so stage selection
+ * matches `$ALCHEMY_PROFILE`.
+ */
+export const resolveStage = Effect.fn(function* (
+  kind: "live" | "dev",
+  override: string | undefined,
+  envFile: Option.Option<string>,
+) {
+  if (override) return override;
+  const provider = yield* loadConfigProvider(envFile);
+  const configured = yield* ALCHEMY_STAGE.pipe(
+    Effect.provideService(ConfigProvider.ConfigProvider, provider),
+    Effect.catch(() => Effect.succeed(undefined)),
+  );
+  if (configured !== undefined && configured !== "") {
+    if (!STAGE_NAME_PATTERN.test(configured)) {
+      return yield* new UserInputError({
+        message: `Invalid $ALCHEMY_STAGE '${configured}'. Must match [a-z0-9]+([-_a-z0-9]+)*.`,
+      });
+    }
+    return configured;
+  }
+  return yield* USER.pipe(
+    Effect.map((user) => `${kind}_${user}`),
+    Effect.catch(() => Effect.succeed(`${kind}_unknown`)),
+  );
+});
 
 export const envFile = Flag.file("env-file").pipe(
   Flag.optional,
@@ -121,6 +139,24 @@ export const resolveConfig = <
       main: args.config ?? args.configPath ?? "alchemy.run.ts",
     };
   });
+
+export const resolveStackArgs =
+  (kind: "live" | "dev") =>
+  <
+    A extends {
+      readonly config: string | undefined;
+      readonly configPath: string | undefined;
+      readonly stage: string | undefined;
+      readonly envFile: Option.Option<string>;
+    },
+  >(
+    args: A,
+  ) =>
+    Effect.gen(function* () {
+      const resolved = yield* resolveConfig(args);
+      const stage = yield* resolveStage(kind, args.stage, args.envFile);
+      return { ...resolved, stage };
+    });
 
 export const profile = Flag.string("profile").pipe(
   Flag.withDescription(

--- a/packages/alchemy/src/Cli/commands/logs.ts
+++ b/packages/alchemy/src/Cli/commands/logs.ts
@@ -7,7 +7,14 @@ import { Command, Flag } from "effect/unstable/cli";
 import * as Logs from "../../Alchemist/routes/logs.ts";
 import { paint } from "../CliKit/index.ts";
 import { formatLocalTimestamp, TAIL_COLORS } from "../Format.ts";
-import { config, envFile, parseSince, profile, stage } from "./flags.ts";
+import {
+  config,
+  envFile,
+  parseSince,
+  profile,
+  resolveStage,
+  stage,
+} from "./flags.ts";
 import { instrumentCommand } from "./instrument.ts";
 
 const logsLimit = Flag.integer("limit").pipe(
@@ -38,6 +45,91 @@ const logsSince = Flag.string("since").pipe(
   Flag.map(Option.getOrUndefined),
 );
 
+interface LogsArgs {
+  readonly main: string;
+  readonly stage: string;
+  readonly envFile: Option.Option<string>;
+  readonly profile: string | undefined;
+  readonly resources: string | undefined;
+  readonly limit: number;
+  readonly since: string | undefined;
+  readonly tail: boolean;
+}
+
+const runLogs = Effect.fn(function* ({
+  main,
+  stage,
+  envFile,
+  profile,
+  resources,
+  limit,
+  since,
+  tail,
+}: LogsArgs) {
+  const sinceDate = since ? yield* parseSince(since) : undefined;
+  const selected = (resources ?? "")
+    .split(",")
+    .map((resource) => resource.trim())
+    .filter((resource) => resource.length > 0);
+  const target = {
+    entrypoint: main,
+    stage,
+    profile,
+    envFile: Option.getOrUndefined(envFile),
+  };
+  const available = yield* Logs.resources(target);
+  const selectedSet = new Set(selected);
+  const matching = available.filter(
+    (resource) =>
+      selectedSet.size === 0 ||
+      selectedSet.has(resource.fqn) ||
+      selectedSet.has(resource.logicalId),
+  );
+  const colors = new Map(
+    matching.map((resource, index) => [
+      resource.fqn,
+      TAIL_COLORS[index % TAIL_COLORS.length]!,
+    ]),
+  );
+  const format = (entry: {
+    resource: { fqn: string };
+    timestamp: Date;
+    message: string;
+  }) =>
+    `${paint(colors.get(entry.resource.fqn) ?? "gray", `${formatLocalTimestamp(entry.timestamp)} [${entry.resource.fqn}]`)} ${entry.message}`;
+
+  if (tail) {
+    const tailing = matching.filter((resource) => resource.supportsTail);
+    if (tailing.length === 0) {
+      yield* Console.log("No matching resources support live logs.");
+      return;
+    }
+    yield* Console.log(
+      `Tailing: ${tailing.map(({ logicalId }) => logicalId).join(", ")}`,
+    );
+    yield* Logs.tail({ target, resources: selected }).pipe(
+      Stream.runForEach((entry) => Console.log(format(entry))),
+    );
+    return;
+  }
+
+  const entries = yield* Logs.entries({
+    target,
+    resources: selected,
+    limit,
+    since: sinceDate,
+  });
+  if (entries.length === 0) {
+    yield* Console.log(
+      selected.length > 0
+        ? "No resources with logs match --resource (deploy first, or selected resources may not expose logs)."
+        : "No resources with logs found. Deploy first, then run logs.",
+    );
+    return;
+  }
+  for (const entry of entries) yield* Console.log(format(entry));
+});
+
 export const logsCommand = Command.make(
   "logs",
   {
@@ -50,94 +142,16 @@ export const logsCommand = Command.make(
     since: logsSince,
     tail,
   },
-  instrumentCommand(
-    "logs",
-    (a: {
-      main: string;
-      stage: string;
-      profile: string | undefined;
-      limit: number;
-      tail: boolean;
-    }) => ({
-      "alchemy.stage": a.stage,
-      "alchemy.profile": a.profile ?? "",
-      "alchemy.main": a.main,
-      "alchemy.limit": a.limit,
-      "alchemy.tail": a.tail,
-    }),
-  )(
-    Effect.fn(function* ({
-      main,
-      stage,
-      envFile,
-      profile,
-      resources,
-      limit,
-      since,
-      tail,
-    }) {
-      const sinceDate = since ? yield* parseSince(since) : undefined;
-      const selected = (resources ?? "")
-        .split(",")
-        .map((resource) => resource.trim())
-        .filter((resource) => resource.length > 0);
-      const target = {
-        entrypoint: main,
-        stage,
-        profile,
-        envFile: Option.getOrUndefined(envFile),
-      };
-      const available = yield* Logs.resources(target);
-      const selectedSet = new Set(selected);
-      const matching = available.filter(
-        (resource) =>
-          selectedSet.size === 0 ||
-          selectedSet.has(resource.fqn) ||
-          selectedSet.has(resource.logicalId),
-      );
-      const colors = new Map(
-        matching.map((resource, index) => [
-          resource.fqn,
-          TAIL_COLORS[index % TAIL_COLORS.length]!,
-        ]),
-      );
-      const format = (entry: {
-        resource: { fqn: string };
-        timestamp: Date;
-        message: string;
-      }) =>
-        `${paint(colors.get(entry.resource.fqn) ?? "gray", `${formatLocalTimestamp(entry.timestamp)} [${entry.resource.fqn}]`)} ${entry.message}`;
-
-      if (tail) {
-        const tailing = matching.filter((resource) => resource.supportsTail);
-        if (tailing.length === 0) {
-          yield* Console.log("No matching resources support live logs.");
-          return;
-        }
-        yield* Console.log(
-          `Tailing: ${tailing.map(({ logicalId }) => logicalId).join(", ")}`,
-        );
-        yield* Logs.tail({ target, resources: selected }).pipe(
-          Stream.runForEach((entry) => Console.log(format(entry))),
-        );
-        return;
-      }
-
-      const entries = yield* Logs.entries({
-        target,
-        resources: selected,
-        limit,
-        since: sinceDate,
-      });
-      if (entries.length === 0) {
-        yield* Console.log(
-          selected.length > 0
-            ? "No resources with logs match --resource (deploy first, or selected resources may not expose logs)."
-            : "No resources with logs found. Deploy first, then run logs.",
-        );
-        return;
-      }
-      for (const entry of entries) yield* Console.log(format(entry));
-    }),
-  ),
+  (args) =>
+    resolveStage("live", args.stage, args.envFile).pipe(
+      Effect.flatMap((stage) =>
+        instrumentCommand("logs", (a: LogsArgs) => ({
+          "alchemy.stage": a.stage,
+          "alchemy.profile": a.profile ?? "",
+          "alchemy.main": a.main,
+          "alchemy.limit": a.limit,
+          "alchemy.tail": a.tail,
+        }))(runLogs)({ ...args, stage }),
+      ),
+    ),
 ).pipe(Command.withDescription("Fetch or tail logs from stack resources"));

--- a/packages/alchemy/src/Cli/main.ts
+++ b/packages/alchemy/src/Cli/main.ts
@@ -188,7 +188,7 @@ const program = Effect.gen(function* () {
 );
 
 const mainEffect = program.pipe(
-  // $USER and $STAGE are set by the environment
+  // $USER and $ALCHEMY_STAGE are set by the environment
   Effect.provide(services),
   Effect.scoped,
   handleCliErrors,

--- a/packages/alchemy/test/Cli/StageEnvironment.test.ts
+++ b/packages/alchemy/test/Cli/StageEnvironment.test.ts
@@ -1,9 +1,13 @@
-import { devStage, stage } from "@/Cli/commands/flags.ts";
+import { UserInputError } from "@/Cli/commands/errors.ts";
+import { resolveStage, stage } from "@/Cli/commands/flags.ts";
 import { PlatformServices } from "@/Util/PlatformServices.ts";
 import { describe, expect, test } from "alchemy-test";
 import * as ConfigProvider from "effect/ConfigProvider";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+import * as Result from "effect/Result";
 
 const envLayer = (env: Record<string, string>) =>
   Layer.mergeAll(
@@ -11,64 +15,167 @@ const envLayer = (env: Record<string, string>) =>
     ConfigProvider.layer(ConfigProvider.fromEnv({ env })),
   );
 
-const TestEnv = envLayer({ STAGE: "production", USER: "name" });
+const TestEnv = envLayer({ USER: "sam" });
 
-describe("STAGE environment variable", () => {
-  test.effect("takes precedence over the user default", () =>
+const writeEnvFile = (contents: string) =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const file = yield* fs.makeTempFileScoped();
+    yield* fs.writeFileString(file, contents);
+    return file;
+  });
+
+const withoutProcessStage = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+  Effect.suspend(() => {
+    const previous = {
+      ALCHEMY_STAGE: process.env.ALCHEMY_STAGE,
+      STAGE: process.env.STAGE,
+    };
+    delete process.env.ALCHEMY_STAGE;
+    delete process.env.STAGE;
+    return Effect.ensuring(
+      effect,
+      Effect.sync(() => {
+        if (previous.ALCHEMY_STAGE === undefined) {
+          delete process.env.ALCHEMY_STAGE;
+        } else {
+          process.env.ALCHEMY_STAGE = previous.ALCHEMY_STAGE;
+        }
+        if (previous.STAGE === undefined) {
+          delete process.env.STAGE;
+        } else {
+          process.env.STAGE = previous.STAGE;
+        }
+      }),
+    );
+  });
+
+describe("--stage flag", () => {
+  test.effect("yields an omitted flag as undefined", () =>
     Effect.gen(function* () {
       const [, selected] = yield* stage.parse({ arguments: [], flags: {} });
-
-      expect(selected).toBe("production");
+      expect(selected).toBeUndefined();
     }).pipe(Effect.provide(TestEnv)),
   );
 
-  test.effect("yields to an explicit --stage flag", () =>
+  test.effect("parses an explicit --stage flag", () =>
     Effect.gen(function* () {
       const [, selected] = yield* stage.parse({
         arguments: [],
         flags: { stage: ["preview"] },
       });
-
       expect(selected).toBe("preview");
     }).pipe(Effect.provide(TestEnv)),
   );
 });
 
+const provideStageTest = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+  effect.pipe(Effect.scoped, withoutProcessStage, Effect.provide(TestEnv));
+
+describe("ALCHEMY_STAGE", () => {
+  test.effect(
+    "overrides the user default from --env-file / .env",
+    () =>
+      Effect.gen(function* () {
+        const file = yield* writeEnvFile("ALCHEMY_STAGE=production\n");
+        expect(yield* resolveStage("live", undefined, Option.some(file))).toBe(
+          "production",
+        );
+      }).pipe(provideStageTest),
+    { exclusive: true },
+  );
+
+  test.effect(
+    "yields to an explicit --stage flag",
+    () =>
+      Effect.gen(function* () {
+        const file = yield* writeEnvFile("ALCHEMY_STAGE=production\n");
+        expect(yield* resolveStage("live", "preview", Option.some(file))).toBe(
+          "preview",
+        );
+      }).pipe(provideStageTest),
+    { exclusive: true },
+  );
+
+  test.effect(
+    "ignores $STAGE",
+    () =>
+      Effect.gen(function* () {
+        const file = yield* writeEnvFile("STAGE=production\n");
+        expect(yield* resolveStage("live", undefined, Option.some(file))).toBe(
+          "live_sam",
+        );
+      }).pipe(provideStageTest),
+    { exclusive: true },
+  );
+
+  test.effect(
+    "alchemy dev honors $ALCHEMY_STAGE",
+    () =>
+      Effect.gen(function* () {
+        const file = yield* writeEnvFile("ALCHEMY_STAGE=production\n");
+        expect(yield* resolveStage("dev", undefined, Option.some(file))).toBe(
+          "production",
+        );
+      }).pipe(provideStageTest),
+    { exclusive: true },
+  );
+
+  test.effect(
+    "process env $ALCHEMY_STAGE overrides the user default",
+    () =>
+      Effect.gen(function* () {
+        process.env.ALCHEMY_STAGE = "production";
+        const file = yield* writeEnvFile("");
+        expect(yield* resolveStage("live", undefined, Option.some(file))).toBe(
+          "production",
+        );
+      }).pipe(provideStageTest),
+    { exclusive: true },
+  );
+
+  test.effect(
+    "rejects an invalid $ALCHEMY_STAGE",
+    () =>
+      Effect.gen(function* () {
+        const file = yield* writeEnvFile("ALCHEMY_STAGE=not a stage\n");
+        const result = yield* resolveStage(
+          "live",
+          undefined,
+          Option.some(file),
+        ).pipe(Effect.result);
+        expect(Result.isFailure(result)).toBe(true);
+        if (Result.isFailure(result)) {
+          expect(result.failure).toBeInstanceOf(UserInputError);
+          expect(result.failure.message).toContain("$ALCHEMY_STAGE");
+        }
+      }).pipe(provideStageTest),
+    { exclusive: true },
+  );
+});
+
 describe("default stages", () => {
-  test.effect("deploy/destroy default to live_${USER}", () =>
-    Effect.gen(function* () {
-      const [, selected] = yield* stage.parse({ arguments: [], flags: {} });
-      expect(selected).toBe("live_sam");
-    }).pipe(Effect.provide(envLayer({ USER: "sam" }))),
+  test.effect(
+    "deploy/destroy default to live_${USER}",
+    () =>
+      Effect.gen(function* () {
+        const file = yield* writeEnvFile("");
+        expect(yield* resolveStage("live", undefined, Option.some(file))).toBe(
+          "live_sam",
+        );
+      }).pipe(provideStageTest),
+    { exclusive: true },
   );
 
-  test.effect("alchemy dev defaults to dev_${USER}", () =>
-    Effect.gen(function* () {
-      const [, selected] = yield* devStage.parse({
-        arguments: [],
-        flags: {},
-      });
-      expect(selected).toBe("dev_sam");
-    }).pipe(Effect.provide(envLayer({ USER: "sam" }))),
-  );
-
-  test.effect("alchemy dev honors --stage", () =>
-    Effect.gen(function* () {
-      const [, selected] = yield* devStage.parse({
-        arguments: [],
-        flags: { stage: ["prod"] },
-      });
-      expect(selected).toBe("prod");
-    }).pipe(Effect.provide(envLayer({ USER: "sam" }))),
-  );
-
-  test.effect("alchemy dev honors $STAGE", () =>
-    Effect.gen(function* () {
-      const [, selected] = yield* devStage.parse({
-        arguments: [],
-        flags: {},
-      });
-      expect(selected).toBe("production");
-    }).pipe(Effect.provide(TestEnv)),
+  test.effect(
+    "alchemy dev defaults to dev_${USER}",
+    () =>
+      Effect.gen(function* () {
+        const file = yield* writeEnvFile("");
+        expect(yield* resolveStage("dev", undefined, Option.some(file))).toBe(
+          "dev_sam",
+        );
+      }).pipe(provideStageTest),
+    { exclusive: true },
   );
 });

--- a/website/src/content/docs/aws/tutorial/part-4.mdx
+++ b/website/src/content/docs/aws/tutorial/part-4.mdx
@@ -17,23 +17,23 @@ the infrastructure.
 ## The default stage
 
 You've been using stages all along. If you don't pass `--stage`,
-Alchemy deploys to **`dev_$USER`** (e.g. `dev_sam`):
+Alchemy deploys to **`live_$USER`** (e.g. `live_sam`):
 
 ```sh
 $ whoami
 sam
 
 $ bun alchemy deploy
-# deploys to stage `dev_sam`
+# deploys to stage `live_sam`
 ```
 
 Each developer on your team automatically gets a personal sandbox
 without any config. The resolution order is:
 
 1. `--stage <name>` flag
-2. `$STAGE` environment variable
-3. `dev_${USER}` (or `dev_${USERNAME}` on Windows)
-4. `dev_unknown` if no user is set
+2. `$ALCHEMY_STAGE` environment variable
+3. `live_${USER}` (or `live_${USERNAME}` on Windows)
+4. `live_unknown` if no user is set
 
 ## Deploy a second stage
 

--- a/website/src/content/docs/cli/deploy.mdx
+++ b/website/src/content/docs/cli/deploy.mdx
@@ -48,7 +48,7 @@ When the plan contains no changes, the approval prompt is skipped automatically.
 | Option              | Description                                                                                                                |
 | ------------------- | -------------------------------------------------------------------------------------------------------------------------- |
 | `--config, -c <file>`            | Stack file to deploy (defaults to `alchemy.run.ts`)                                                                        |
-| `--stage <name>`    | Stage to deploy to (defaults to `live_$USER`)                                                                              |
+| `--stage <name>`    | Stage to deploy to (defaults to `$ALCHEMY_STAGE` or `live_$USER`)                                                          |
 | `--yes`             | Skip the approval prompt                                                                                                   |
 | `--dry-run`         | Show the plan without applying (same as `alchemy plan`)                                                                    |
 | `--detailed`        | Show declared resource properties as YAML                                                                                  |

--- a/website/src/content/docs/cli/destroy.mdx
+++ b/website/src/content/docs/cli/destroy.mdx
@@ -28,7 +28,7 @@ Proceed?
 | Option              | Description                                                       |
 | ------------------- | ----------------------------------------------------------------- |
 | `--config, -c <file>`            | Stack file to destroy (defaults to `alchemy.run.ts`)              |
-| `--stage <name>`    | Stage to destroy (defaults to `live_$USER`)                       |
+| `--stage <name>`    | Stage to destroy (defaults to `$ALCHEMY_STAGE` or `live_$USER`)   |
 | `--yes`             | Skip the approval prompt                                          |
 | `--dry-run`         | Show what would be deleted without actually deleting              |
 | `--profile <name>`  | Auth profile to use (defaults to `$ALCHEMY_PROFILE` or `default`) |

--- a/website/src/content/docs/cli/dev.mdx
+++ b/website/src/content/docs/cli/dev.mdx
@@ -21,7 +21,7 @@ A failed apply keeps dev alive so healthy resources keep serving — fix the err
 
 | Option              | Description                                                        |
 | ------------------- | ------------------------------------------------------------------ |
-| `--stage <name>`    | Stage to use for dev (defaults to `dev_$USER`)                     |
+| `--stage <name>`    | Stage to use for dev (defaults to `$ALCHEMY_STAGE` or `dev_$USER`) |
 | `--force`           | Force updates for resources that would otherwise no-op             |
 | `--profile <name>`  | Auth profile to use (defaults to `$ALCHEMY_PROFILE` or `default`) |
 | `--env-file <path>` | Load environment variables from a file                             |
@@ -29,7 +29,7 @@ A failed apply keeps dev alive so healthy resources keep serving — fix the err
 
 `alchemy deploy` defaults to `live_$USER`. Using a different default
 here means a bare `alchemy dev` will not replace a stage you deployed.
-Pass `--stage` (or `$STAGE`) to run local emulation against a specific
+Pass `--stage` (or `$ALCHEMY_STAGE`) to run local emulation against a specific
 stage — including one you also deploy.
 
 Tear the default local-dev stage down with

--- a/website/src/content/docs/cli/drift.mdx
+++ b/website/src/content/docs/cli/drift.mdx
@@ -23,7 +23,7 @@ before applying the repair.
 | Option              | Description                                                        |
 | ------------------- | ------------------------------------------------------------------ |
 | `--repair`          | Repair detected drift after showing and confirming the plan        |
-| `--stage <name>`    | Stage to check (defaults to `live_$USER`)                          |
+| `--stage <name>`    | Stage to check (defaults to `$ALCHEMY_STAGE` or `live_$USER`)       |
 | `--yes`             | Skip the repair confirmation prompt                                |
 | `--profile <name>`  | Auth profile to use (defaults to `$ALCHEMY_PROFILE` or `default`) |
 | `--env-file <path>` | Load environment variables from a file                             |

--- a/website/src/content/docs/cli/index.mdx
+++ b/website/src/content/docs/cli/index.mdx
@@ -39,7 +39,7 @@ Each command has its own page: [deploy](/cli/deploy), [plan](/cli/plan), [destro
 
 | Option              | Description                                                                                                                              |
 | ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| `--stage <name>`    | Stage to target. Falls back to `$STAGE`, then `live_$USER` (`dev_$USER` for `alchemy dev`). Must match `[a-z0-9]+([-_a-z0-9]+)*`. |
+| `--stage <name>`    | Stage to target. Falls back to `$ALCHEMY_STAGE`, then `live_$USER` (`dev_$USER` for `alchemy dev`). Must match `[a-z0-9]+([-_a-z0-9]+)*`. |
 | `--profile <name>`  | Auth profile from `~/.alchemy/profiles.json`. Overrides `$ALCHEMY_PROFILE`; defaults to `default`.                                      |
 | `--env-file <path>` | File to load environment variables from. Defaults to `.env`.                                                                             |
 | `--yes`             | Yes to all prompts.                                                                                                                       |

--- a/website/src/content/docs/cli/logs.mdx
+++ b/website/src/content/docs/cli/logs.mdx
@@ -21,7 +21,7 @@ Resources must be deployed and their provider must implement log fetching; if no
 
 | Option              | Description                                                                                    |
 | ------------------- | ---------------------------------------------------------------------------------------------- |
-| `--stage <name>`    | Stage to fetch logs from (defaults to `live_$USER`)                                            |
+| `--stage <name>`    | Stage to fetch logs from (defaults to `$ALCHEMY_STAGE` or `live_$USER`)                        |
 | `--resource, -r <ids>`  | Comma-separated logical resource IDs to include, such as `Worker,Api`                          |
 | `--limit <n>`       | Number of log entries to fetch (default: 100)                                                  |
 | `--since <time>`    | Fetch logs since this time — a duration (`30m`, `1h`, `2d`; units `s`/`m`/`h`/`d`) or ISO date |

--- a/website/src/content/docs/cli/plan.mdx
+++ b/website/src/content/docs/cli/plan.mdx
@@ -56,7 +56,7 @@ redacted. Deletes stay compact.
 | Option              | Description                                                       |
 | ------------------- | ----------------------------------------------------------------- |
 | `--config, -c <file>`            | Stack file to plan (defaults to `alchemy.run.ts`)                 |
-| `--stage <name>`    | Stage to plan against (defaults to `live_$USER`)                  |
+| `--stage <name>`    | Stage to plan against (defaults to `$ALCHEMY_STAGE` or `live_$USER`) |
 | `--profile <name>`  | Auth profile to use (defaults to `$ALCHEMY_PROFILE` or `default`) |
 | `--env-file <path>` | Load environment variables from a file                            |
 | `--detailed`        | Show declared resource properties as YAML                        |

--- a/website/src/content/docs/environments/stages.mdx
+++ b/website/src/content/docs/environments/stages.mdx
@@ -34,14 +34,14 @@ $ alchemy destroy --stage dev_sam
 # tears down the local-dev stage
 ```
 
-`--stage` and `$STAGE` still work on both commands. Pointing `alchemy
-dev` at the same stage as a deploy (`--stage prod`, or a shared
-`$STAGE`) is a live ⇄ local replacement of that stage.
+`--stage` and `$ALCHEMY_STAGE` still work on both commands. Pointing
+`alchemy dev` at the same stage as a deploy (`--stage prod`, or a
+shared `$ALCHEMY_STAGE`) is a live ⇄ local replacement of that stage.
 
 The resolution order is:
 
 1. `--stage <name>` flag
-2. `$STAGE` environment variable
+2. `$ALCHEMY_STAGE` environment variable (process env, `--env-file`, or `.env`)
 3. `live_${USER}` for deploy / destroy / plan / logs / drift
    (`dev_${USER}` for `alchemy dev`)
 4. `live_unknown` / `dev_unknown` if no user is set


### PR DESCRIPTION
When `--stage` is omitted, the CLI now reads `$ALCHEMY_STAGE` — from the process environment, `--env-file`, or `.env` — the same way `$ALCHEMY_PROFILE` works. `$STAGE` is no longer consulted.

```sh
ALCHEMY_STAGE=prod alchemy deploy
```

```
# .env
ALCHEMY_STAGE=prod
```

Resolution order: `--stage` > `$ALCHEMY_STAGE` > `live_$USER` (`dev_$USER` for `alchemy dev`).
