### PR TITLE
fix: expose the Worker resource's ref method in its type

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -23,6 +23,7 @@ import {
 import {
   isResourceOfType,
   Resource,
+  type ResourceClass,
   type ResourceClassLike,
 } from "../../Resource.ts";
 import type { Rpc } from "../../Rpc.ts";
@@ -2295,6 +2296,7 @@ export const isSelf = (value: unknown): value is Self =>
  * @category Workers & Compute
  */
 export const Worker: ResourceClassLike<Worker> &
+  Pick<ResourceClass<Worker>, "ref"> &
   Effect.Effect<
     Worker & WorkerRuntimeContext & RuntimeContext,
     never,


### PR DESCRIPTION
## Problem

I want to use a reference to a Worker as a binding from another Worker — that is, bind a Worker deployed in another stage/stack into `env` as a service binding:

```ts
env: { TARGET: yield* Cloudflare.Worker.ref("OtherWorker", { stage: "staging" }) }
```

`Cloudflare.Worker.ref(id, { stage, stack })` is the documented way to reference a Worker deployed in another stage/stack (the `version.parent` examples use it), and the runtime value does carry it. But the type annotation on the `Worker` const omits it, so the call fails to typecheck with `Property 'ref' does not exist`.

## Cause

`Worker` is typed `ResourceClassLike<Worker>`, which intentionally drops the class-level members — including `ref`. Other resources built through the same `Platform()` path expose `ref` via `ResourceClass` (for example `D1.Database`), so this looks unintentional.

## Fix

Add just the missing member back, without widening to the full `ResourceClass` shape (which would also pull in `ResourceConstructor`'s call signatures):

```ts
export const Worker: ResourceClassLike<Worker> &
  Pick<ResourceClass<Worker>, "ref"> &
  ...
```