### PR TITLE
feat(ui): UIProvider contract + dashboard UI providers for all resources

### DIFF
--- a/packages/alchemy/package.json
+++ b/packages/alchemy/package.json
@@ -60,6 +60,12 @@
       "worker": "./src/*.ts",
       "import": "./lib/*.js"
     },
+    "./UI/UIProvider": {
+      "types": "./lib/UI/UIProvider.d.ts",
+      "bun": "./src/UI/UIProvider.ts",
+      "worker": "./src/UI/UIProvider.ts",
+      "import": "./lib/UI/UIProvider.js"
+    },
     "./AI": {
       "types": "./lib/AI/index.d.ts",
       "bun": "./src/AI/index.ts",
@@ -107,6 +113,12 @@
       "bun": "./src/AWS/Lambda/*.ts",
       "worker": "./src/AWS/Lambda/*.ts",
       "import": "./lib/AWS/Lambda/*.js"
+    },
+    "./AWS/UI": {
+      "types": "./lib/AWS/UI.d.ts",
+      "bun": "./src/AWS/UI.ts",
+      "worker": "./src/AWS/UI.ts",
+      "import": "./lib/AWS/UI.js"
     },
     "./Command": {
       "types": "./lib/Command/index.d.ts",
@@ -174,6 +186,12 @@
       "worker": "./src/Cloudflare/Live.ts",
       "import": "./lib/Cloudflare/Live.js"
     },
+    "./Cloudflare/UI": {
+      "types": "./lib/Cloudflare/UI.d.ts",
+      "bun": "./src/Cloudflare/UI.ts",
+      "worker": "./src/Cloudflare/UI.ts",
+      "import": "./lib/Cloudflare/UI.js"
+    },
     "./Cloudflare/*": {
       "types": "./lib/Cloudflare/*/index.d.ts",
       "bun": "./src/Cloudflare/*/index.ts",
@@ -221,6 +239,12 @@
       "bun": "./src/Neon/*/index.ts",
       "worker": "./src/Neon/*/index.ts",
       "import": "./lib/Neon/*/index.js"
+    },
+    "./Neon/UI": {
+      "types": "./lib/Neon/UI.d.ts",
+      "bun": "./src/Neon/UI.ts",
+      "worker": "./src/Neon/UI.ts",
+      "import": "./lib/Neon/UI.js"
     },
     "./Hetzner": {
       "types": "./lib/Hetzner/index.d.ts",
@@ -307,6 +331,12 @@
       "bun": "./src/Planetscale/*/index.ts",
       "worker": "./src/Planetscale/*/index.ts",
       "import": "./lib/Planetscale/*/index.js"
+    },
+    "./Planetscale/UI": {
+      "types": "./lib/Planetscale/UI.d.ts",
+      "bun": "./src/Planetscale/UI.ts",
+      "worker": "./src/Planetscale/UI.ts",
+      "import": "./lib/Planetscale/UI.js"
     },
     "./Runtime": {
       "types": "./lib/Runtime.d.ts",

--- a/packages/alchemy/src/AWS/ACM/ui.ts
+++ b/packages/alchemy/src/AWS/ACM/ui.ts
@@ -1,0 +1,74 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { AccountConfiguration } from "./AccountConfiguration.ts";
+import type { Certificate } from "./Certificate.ts";
+
+/**
+ * Dashboard UI providers for AWS ACM resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** ACM brand color (AWS Security, Identity & Compliance red). */
+const ACM_COLOR = "#DD344C";
+
+/** Parse the region segment out of a certificate ARN. */
+const arnRegion = (arn: string | undefined) => arn?.split(":")[3];
+
+/** Parse the certificate UUID out of a certificate ARN. */
+const arnCertificateId = (arn: string | undefined) => arn?.split("/")[1];
+
+export const CertificateUI = UIProvider.succeed<Certificate>(
+  "AWS.ACM.Certificate",
+  {
+    displayName: "ACM Certificate",
+    icon: "shield-check",
+    color: ACM_COLOR,
+    category: "security",
+    summary: (ctx) => ctx.attrs?.domainName,
+    consoleUrl: (ctx) => {
+      const region = arnRegion(ctx.attrs?.certificateArn);
+      const id = arnCertificateId(ctx.attrs?.certificateArn);
+      return region === undefined || id === undefined
+        ? undefined
+        : `https://${region}.console.aws.amazon.com/acm/home?region=${region}#/certificates/${id}`;
+    },
+    facts: (ctx) => [
+      { label: "domain", value: ctx.attrs?.domainName, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.certificateArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "status", value: ctx.attrs?.status },
+      { label: "validation", value: ctx.attrs?.validationMethod },
+      { label: "key algorithm", value: ctx.attrs?.keyAlgorithm },
+      {
+        label: "alt names",
+        value: ctx.attrs?.subjectAlternativeNames?.join(", "),
+      },
+      { label: "hosted zone", value: ctx.attrs?.hostedZoneId, mono: true },
+    ],
+  },
+);
+
+export const AccountConfigurationUI = UIProvider.succeed<AccountConfiguration>(
+  "AWS.ACM.AccountConfiguration",
+  {
+    displayName: "ACM Account Configuration",
+    icon: "settings",
+    color: ACM_COLOR,
+    category: "security",
+    summary: (ctx) =>
+      ctx.attrs?.daysBeforeExpiry === undefined
+        ? undefined
+        : `${ctx.attrs.daysBeforeExpiry} days before expiry`,
+    facts: (ctx) => [
+      { label: "days before expiry", value: ctx.attrs?.daysBeforeExpiry },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(CertificateUI, AccountConfigurationUI);

--- a/packages/alchemy/src/AWS/ACMPCA/ui.ts
+++ b/packages/alchemy/src/AWS/ACMPCA/ui.ts
@@ -1,0 +1,92 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { CertificateAuthority } from "./CertificateAuthority.ts";
+import type { CertificateAuthorityPolicy } from "./CertificateAuthorityPolicy.ts";
+import type { Permission } from "./Permission.ts";
+
+/**
+ * Dashboard UI providers for AWS ACMPCA resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+const ACMPCA_COLOR = "#DD344C";
+
+export const CertificateAuthorityUI = UIProvider.succeed<CertificateAuthority>(
+  "AWS.ACMPCA.CertificateAuthority",
+  {
+    displayName: "ACM PCA Certificate Authority",
+    icon: "shield-check",
+    color: ACMPCA_COLOR,
+    category: "security",
+    summary: (ctx) => ctx.attrs?.certificateAuthorityArn,
+    facts: (ctx) => [
+      {
+        label: "arn",
+        value: ctx.attrs?.certificateAuthorityArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "status", value: ctx.attrs?.status },
+      { label: "type", value: ctx.props?.type },
+      { label: "common name", value: ctx.props?.subject?.commonName },
+      { label: "key algorithm", value: ctx.props?.keyAlgorithm },
+      { label: "usage mode", value: ctx.props?.usageMode },
+    ],
+  },
+);
+
+export const CertificateAuthorityPolicyUI =
+  UIProvider.succeed<CertificateAuthorityPolicy>(
+    "AWS.ACMPCA.CertificateAuthorityPolicy",
+    {
+      displayName: "ACM PCA Authority Policy",
+      icon: "file-text",
+      color: ACMPCA_COLOR,
+      category: "security",
+      summary: (ctx) => ctx.attrs?.certificateAuthorityArn,
+      facts: (ctx) => [
+        {
+          label: "authority",
+          value: ctx.attrs?.certificateAuthorityArn,
+          mono: true,
+          copy: true,
+        },
+        { label: "policy", value: ctx.attrs?.policy, mono: true },
+      ],
+    },
+  );
+
+export const PermissionUI = UIProvider.succeed<Permission>(
+  "AWS.ACMPCA.Permission",
+  {
+    displayName: "ACM PCA Permission",
+    icon: "key-round",
+    color: ACMPCA_COLOR,
+    category: "security",
+    summary: (ctx) => ctx.attrs?.principal,
+    facts: (ctx) => [
+      {
+        label: "authority",
+        value: ctx.attrs?.certificateAuthorityArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "principal", value: ctx.attrs?.principal, mono: true },
+      {
+        label: "actions",
+        value: ctx.props?.actions?.join(", "),
+        mono: true,
+      },
+      { label: "source account", value: ctx.props?.sourceAccount, mono: true },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(
+    CertificateAuthorityUI,
+    CertificateAuthorityPolicyUI,
+    PermissionUI,
+  );

--- a/packages/alchemy/src/AWS/AIOps/ui.ts
+++ b/packages/alchemy/src/AWS/AIOps/ui.ts
@@ -1,0 +1,29 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { InvestigationGroup } from "./InvestigationGroup.ts";
+
+/**
+ * Dashboard UI providers for AWS AIOps resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+export const InvestigationGroupUI = UIProvider.succeed<InvestigationGroup>(
+  "AWS.AIOps.InvestigationGroup",
+  {
+    displayName: "CloudWatch Investigation Group",
+    icon: "search",
+    color: "#E7157B",
+    category: "observability",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      { label: "arn", value: ctx.attrs?.arn, mono: true, copy: true },
+      { label: "role", value: ctx.attrs?.roleArn, mono: true, copy: true },
+      { label: "retention (days)", value: ctx.attrs?.retentionInDays },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(InvestigationGroupUI);

--- a/packages/alchemy/src/AWS/AMP/ui.ts
+++ b/packages/alchemy/src/AWS/AMP/ui.ts
@@ -1,0 +1,254 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { AlertManagerDefinition } from "./AlertManagerDefinition.ts";
+import type { AnomalyDetector } from "./AnomalyDetector.ts";
+import type { LoggingConfiguration } from "./LoggingConfiguration.ts";
+import type { QueryLoggingConfiguration } from "./QueryLoggingConfiguration.ts";
+import type { ResourcePolicy } from "./ResourcePolicy.ts";
+import type { RuleGroupsNamespace } from "./RuleGroupsNamespace.ts";
+import type { Scraper } from "./Scraper.ts";
+import type { ScraperLoggingConfiguration } from "./ScraperLoggingConfiguration.ts";
+import type { Workspace } from "./Workspace.ts";
+
+/**
+ * Dashboard UI providers for AWS AMP (Managed Service for Prometheus)
+ * resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** AWS Management & Governance / Observability brand pink. */
+const COLOR = "#E7157B";
+
+const regionOf = (arn: string | undefined): string | undefined =>
+  arn?.split(":")[3] || undefined;
+
+export const WorkspaceUI = UIProvider.succeed<Workspace>("AWS.AMP.Workspace", {
+  displayName: "AMP Workspace",
+  icon: "chart-line",
+  color: COLOR,
+  category: "observability",
+  summary: (ctx) => ctx.attrs?.alias ?? ctx.attrs?.workspaceId,
+  consoleUrl: (ctx) => {
+    const region = regionOf(ctx.attrs?.workspaceArn);
+    return region === undefined || ctx.attrs?.workspaceId === undefined
+      ? undefined
+      : `https://${region}.console.aws.amazon.com/prometheus/home?region=${region}#/workspaces/${ctx.attrs.workspaceId}`;
+  },
+  facts: (ctx) => [
+    {
+      label: "workspace",
+      value: ctx.attrs?.workspaceId,
+      mono: true,
+      copy: true,
+    },
+    { label: "arn", value: ctx.attrs?.workspaceArn, mono: true, copy: true },
+    { label: "alias", value: ctx.attrs?.alias },
+    { label: "status", value: ctx.attrs?.status },
+    {
+      label: "endpoint",
+      value: ctx.attrs?.prometheusEndpoint,
+      mono: true,
+      copy: true,
+    },
+  ],
+});
+
+export const AlertManagerDefinitionUI =
+  UIProvider.succeed<AlertManagerDefinition>("AWS.AMP.AlertManagerDefinition", {
+    displayName: "AMP Alert Manager Definition",
+    icon: "bell",
+    color: COLOR,
+    category: "observability",
+    summary: (ctx) => ctx.attrs?.workspaceId,
+    facts: (ctx) => [
+      {
+        label: "workspace",
+        value: ctx.attrs?.workspaceId,
+        mono: true,
+        copy: true,
+      },
+      { label: "status", value: ctx.attrs?.status },
+    ],
+  });
+
+export const AnomalyDetectorUI = UIProvider.succeed<AnomalyDetector>(
+  "AWS.AMP.AnomalyDetector",
+  {
+    displayName: "AMP Anomaly Detector",
+    icon: "activity",
+    color: COLOR,
+    category: "observability",
+    summary: (ctx) => ctx.attrs?.alias,
+    facts: (ctx) => [
+      { label: "detector", value: ctx.attrs?.alias, copy: true },
+      {
+        label: "id",
+        value: ctx.attrs?.anomalyDetectorId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.anomalyDetectorArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "workspace", value: ctx.attrs?.workspaceId, mono: true },
+      { label: "status", value: ctx.attrs?.status },
+    ],
+  },
+);
+
+export const LoggingConfigurationUI = UIProvider.succeed<LoggingConfiguration>(
+  "AWS.AMP.LoggingConfiguration",
+  {
+    displayName: "AMP Logging Configuration",
+    icon: "scroll-text",
+    color: COLOR,
+    category: "observability",
+    summary: (ctx) => ctx.attrs?.workspaceId,
+    facts: (ctx) => [
+      {
+        label: "workspace",
+        value: ctx.attrs?.workspaceId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "log group",
+        value: ctx.attrs?.logGroupArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "status", value: ctx.attrs?.status },
+    ],
+  },
+);
+
+export const QueryLoggingConfigurationUI =
+  UIProvider.succeed<QueryLoggingConfiguration>(
+    "AWS.AMP.QueryLoggingConfiguration",
+    {
+      displayName: "AMP Query Logging Configuration",
+      icon: "scroll-text",
+      color: COLOR,
+      category: "observability",
+      summary: (ctx) => ctx.attrs?.workspaceId,
+      facts: (ctx) => [
+        {
+          label: "workspace",
+          value: ctx.attrs?.workspaceId,
+          mono: true,
+          copy: true,
+        },
+        {
+          label: "destinations",
+          value: ctx.attrs?.destinations?.length
+            ? ctx.attrs.destinations.map((d) => d.logGroupArn).join(", ")
+            : undefined,
+          mono: true,
+        },
+        { label: "status", value: ctx.attrs?.status },
+      ],
+    },
+  );
+
+export const ResourcePolicyUI = UIProvider.succeed<ResourcePolicy>(
+  "AWS.AMP.ResourcePolicy",
+  {
+    displayName: "AMP Resource Policy",
+    icon: "shield",
+    color: COLOR,
+    category: "observability",
+    summary: (ctx) => ctx.attrs?.workspaceId,
+    facts: (ctx) => [
+      {
+        label: "workspace",
+        value: ctx.attrs?.workspaceId,
+        mono: true,
+        copy: true,
+      },
+      { label: "status", value: ctx.attrs?.policyStatus },
+      { label: "revision", value: ctx.attrs?.revisionId, mono: true },
+    ],
+  },
+);
+
+export const RuleGroupsNamespaceUI = UIProvider.succeed<RuleGroupsNamespace>(
+  "AWS.AMP.RuleGroupsNamespace",
+  {
+    displayName: "AMP Rule Groups Namespace",
+    icon: "list-ordered",
+    color: COLOR,
+    category: "observability",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "namespace", value: ctx.attrs?.name, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.ruleGroupsNamespaceArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "workspace", value: ctx.attrs?.workspaceId, mono: true },
+      { label: "status", value: ctx.attrs?.status },
+    ],
+  },
+);
+
+export const ScraperUI = UIProvider.succeed<Scraper>("AWS.AMP.Scraper", {
+  displayName: "AMP Scraper",
+  icon: "cable",
+  color: COLOR,
+  category: "observability",
+  summary: (ctx) => ctx.attrs?.alias ?? ctx.attrs?.scraperId,
+  facts: (ctx) => [
+    { label: "scraper", value: ctx.attrs?.scraperId, mono: true, copy: true },
+    { label: "arn", value: ctx.attrs?.scraperArn, mono: true, copy: true },
+    { label: "alias", value: ctx.attrs?.alias },
+    { label: "role", value: ctx.attrs?.roleArn, mono: true },
+    { label: "status", value: ctx.attrs?.status },
+  ],
+});
+
+export const ScraperLoggingConfigurationUI =
+  UIProvider.succeed<ScraperLoggingConfiguration>(
+    "AWS.AMP.ScraperLoggingConfiguration",
+    {
+      displayName: "AMP Scraper Logging Configuration",
+      icon: "scroll-text",
+      color: COLOR,
+      category: "observability",
+      summary: (ctx) => ctx.attrs?.scraperId,
+      facts: (ctx) => [
+        {
+          label: "scraper",
+          value: ctx.attrs?.scraperId,
+          mono: true,
+          copy: true,
+        },
+        {
+          label: "log group",
+          value: ctx.attrs?.logGroupArn,
+          mono: true,
+          copy: true,
+        },
+        { label: "status", value: ctx.attrs?.status },
+      ],
+    },
+  );
+
+export const ui = () =>
+  Layer.mergeAll(
+    WorkspaceUI,
+    AlertManagerDefinitionUI,
+    AnomalyDetectorUI,
+    LoggingConfigurationUI,
+    QueryLoggingConfigurationUI,
+    ResourcePolicyUI,
+    RuleGroupsNamespaceUI,
+    ScraperUI,
+    ScraperLoggingConfigurationUI,
+  );

--- a/packages/alchemy/src/AWS/AccessAnalyzer/ui.ts
+++ b/packages/alchemy/src/AWS/AccessAnalyzer/ui.ts
@@ -1,0 +1,59 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Analyzer } from "./Analyzer.ts";
+import type { ArchiveRule } from "./ArchiveRule.ts";
+
+/**
+ * Dashboard UI providers for AWS AccessAnalyzer resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+const regionOf = (arn: string | undefined) => arn?.split(":")[3];
+
+export const AnalyzerUI = UIProvider.succeed<Analyzer>(
+  "AWS.AccessAnalyzer.Analyzer",
+  {
+    displayName: "Access Analyzer",
+    icon: "search",
+    color: "#DD344C",
+    category: "security",
+    summary: (ctx) => ctx.attrs?.analyzerName,
+    consoleUrl: (ctx) => {
+      const region = regionOf(ctx.attrs?.analyzerArn);
+      return ctx.attrs?.analyzerName === undefined || region === undefined
+        ? undefined
+        : `https://${region}.console.aws.amazon.com/access-analyzer/home?region=${region}#/analyzer/${encodeURIComponent(ctx.attrs.analyzerName)}`;
+    },
+    facts: (ctx) => [
+      { label: "analyzer", value: ctx.attrs?.analyzerName, copy: true },
+      { label: "arn", value: ctx.attrs?.analyzerArn, mono: true, copy: true },
+      { label: "type", value: ctx.attrs?.type },
+      { label: "status", value: ctx.attrs?.status },
+    ],
+  },
+);
+
+export const ArchiveRuleUI = UIProvider.succeed<ArchiveRule>(
+  "AWS.AccessAnalyzer.ArchiveRule",
+  {
+    displayName: "Analyzer Archive Rule",
+    icon: "archive",
+    color: "#DD344C",
+    category: "security",
+    summary: (ctx) => ctx.attrs?.ruleName,
+    facts: (ctx) => [
+      { label: "rule", value: ctx.attrs?.ruleName, copy: true },
+      { label: "analyzer", value: ctx.attrs?.analyzerName, copy: true },
+      {
+        label: "filtered attributes",
+        value: ctx.props?.filter
+          ? Object.keys(ctx.props.filter).length
+          : undefined,
+      },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(AnalyzerUI, ArchiveRuleUI);

--- a/packages/alchemy/src/AWS/Account/ui.ts
+++ b/packages/alchemy/src/AWS/Account/ui.ts
@@ -1,0 +1,96 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { AccountName } from "./AccountName.ts";
+import type { AlternateContact } from "./AlternateContact.ts";
+import type { ContactInformation } from "./ContactInformation.ts";
+import type { Region } from "./Region.ts";
+
+/**
+ * Dashboard UI providers for AWS Account resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** AWS Management & Governance brand pink. */
+const COLOR = "#E7157B";
+
+export const AccountNameUI = UIProvider.succeed<AccountName>(
+  "AWS.Account.AccountName",
+  {
+    displayName: "Account Name",
+    icon: "building-2",
+    color: COLOR,
+    category: "config",
+    summary: (ctx) => ctx.attrs?.accountName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.accountName, copy: true },
+      {
+        label: "account id",
+        value: ctx.attrs?.accountId,
+        mono: true,
+        copy: true,
+      },
+      { label: "state", value: ctx.attrs?.accountState },
+      { label: "created", value: ctx.attrs?.accountCreatedDate },
+    ],
+  },
+);
+
+export const AlternateContactUI = UIProvider.succeed<AlternateContact>(
+  "AWS.Account.AlternateContact",
+  {
+    displayName: "Alternate Contact",
+    icon: "phone",
+    color: COLOR,
+    category: "config",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "type", value: ctx.attrs?.alternateContactType },
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      { label: "title", value: ctx.attrs?.title },
+      { label: "email", value: ctx.attrs?.emailAddress, copy: true },
+      { label: "phone", value: ctx.attrs?.phoneNumber, mono: true },
+    ],
+  },
+);
+
+export const ContactInformationUI = UIProvider.succeed<ContactInformation>(
+  "AWS.Account.ContactInformation",
+  {
+    displayName: "Primary Contact Information",
+    icon: "map-pin",
+    color: COLOR,
+    category: "config",
+    summary: (ctx) => ctx.attrs?.fullName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.fullName, copy: true },
+      { label: "company", value: ctx.attrs?.companyName },
+      { label: "address", value: ctx.attrs?.addressLine1 },
+      { label: "city", value: ctx.attrs?.city },
+      { label: "country", value: ctx.attrs?.countryCode },
+      { label: "phone", value: ctx.attrs?.phoneNumber, mono: true },
+    ],
+  },
+);
+
+export const RegionUI = UIProvider.succeed<Region>("AWS.Account.Region", {
+  displayName: "Region Opt-In",
+  icon: "globe",
+  color: COLOR,
+  category: "config",
+  summary: (ctx) => ctx.attrs?.regionName,
+  facts: (ctx) => [
+    { label: "region", value: ctx.attrs?.regionName, mono: true, copy: true },
+    { label: "enabled", value: ctx.attrs?.enabled },
+    { label: "opt status", value: ctx.attrs?.regionOptStatus },
+  ],
+});
+
+export const ui = () =>
+  Layer.mergeAll(
+    AccountNameUI,
+    AlternateContactUI,
+    ContactInformationUI,
+    RegionUI,
+  );

--- a/packages/alchemy/src/AWS/Amplify/ui.ts
+++ b/packages/alchemy/src/AWS/Amplify/ui.ts
@@ -1,0 +1,70 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { App } from "./App.ts";
+import type { Branch } from "./Branch.ts";
+
+/**
+ * Dashboard UI providers for AWS Amplify resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** AWS Front-End Web & Mobile (Amplify) brand pink. */
+const COLOR = "#E7157B";
+
+const regionOf = (arn: string | undefined): string | undefined =>
+  arn?.split(":")[3] || undefined;
+
+export const AppUI = UIProvider.succeed<App>("AWS.Amplify.App", {
+  displayName: "Amplify App",
+  icon: "layers",
+  color: COLOR,
+  category: "compute",
+  summary: (ctx) => ctx.attrs?.name,
+  link: (ctx) =>
+    ctx.attrs?.defaultDomain === undefined
+      ? undefined
+      : `https://${ctx.attrs.defaultDomain}`,
+  consoleUrl: (ctx) => {
+    const region = regionOf(ctx.attrs?.appArn);
+    return ctx.attrs?.appId === undefined || region === undefined
+      ? undefined
+      : `https://${region}.console.aws.amazon.com/amplify/home?region=${region}#/${ctx.attrs.appId}`;
+  },
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.name, copy: true },
+    { label: "app id", value: ctx.attrs?.appId, mono: true, copy: true },
+    { label: "arn", value: ctx.attrs?.appArn, mono: true, copy: true },
+    { label: "platform", value: ctx.attrs?.platform },
+    {
+      label: "default domain",
+      value: ctx.attrs?.defaultDomain,
+      mono: true,
+      copy: true,
+    },
+  ],
+});
+
+export const BranchUI = UIProvider.succeed<Branch>("AWS.Amplify.Branch", {
+  displayName: "Amplify Branch",
+  icon: "git-branch",
+  color: COLOR,
+  category: "compute",
+  summary: (ctx) => ctx.attrs?.branchName,
+  consoleUrl: (ctx) => {
+    const region = regionOf(ctx.attrs?.branchArn);
+    return ctx.attrs?.appId === undefined ||
+      ctx.attrs?.branchName === undefined ||
+      region === undefined
+      ? undefined
+      : `https://${region}.console.aws.amazon.com/amplify/home?region=${region}#/${ctx.attrs.appId}/${ctx.attrs.branchName}`;
+  },
+  facts: (ctx) => [
+    { label: "branch", value: ctx.attrs?.branchName, copy: true },
+    { label: "app id", value: ctx.attrs?.appId, mono: true, copy: true },
+    { label: "arn", value: ctx.attrs?.branchArn, mono: true, copy: true },
+  ],
+});
+
+export const ui = () => Layer.mergeAll(AppUI, BranchUI);

--- a/packages/alchemy/src/AWS/ApiGateway/ui.ts
+++ b/packages/alchemy/src/AWS/ApiGateway/ui.ts
@@ -1,0 +1,395 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Account } from "./Account.ts";
+import type { ApiKey } from "./ApiKey.ts";
+import type { Authorizer } from "./Authorizer.ts";
+import type { BasePathMapping } from "./BasePathMapping.ts";
+import type { DeploymentType } from "./Deployment.ts";
+import type { DomainName } from "./DomainName.ts";
+import type { ApiGatewayResource } from "./GatewayResource.ts";
+import type { GatewayResponse } from "./GatewayResponse.ts";
+import type { MethodType } from "./Method.ts";
+import type { RestApi } from "./RestApi.ts";
+import type { ApiGatewayStage } from "./Stage.ts";
+import type { UsagePlan } from "./UsagePlan.ts";
+import type { UsagePlanKey } from "./UsagePlanKey.ts";
+import type { VpcLink } from "./VpcLink.ts";
+
+/**
+ * Dashboard UI providers for AWS API Gateway resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** AWS App Integration (API Gateway) brand pink. */
+const COLOR = "#E7157B";
+
+export const RestApiUI = UIProvider.succeed<RestApi>("AWS.ApiGateway.RestApi", {
+  displayName: "API Gateway REST API",
+  icon: "network",
+  color: COLOR,
+  category: "network",
+  summary: (ctx) => ctx.attrs?.name ?? ctx.attrs?.restApiId,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.name },
+    { label: "api id", value: ctx.attrs?.restApiId, mono: true, copy: true },
+    {
+      label: "root resource",
+      value: ctx.attrs?.rootResourceId,
+      mono: true,
+      copy: true,
+    },
+    {
+      label: "endpoint types",
+      value: ctx.attrs?.endpointConfiguration?.types?.join(", "),
+    },
+    { label: "api key source", value: ctx.attrs?.apiKeySource },
+    {
+      label: "execute-api endpoint",
+      value:
+        ctx.attrs?.disableExecuteApiEndpoint === undefined
+          ? undefined
+          : ctx.attrs.disableExecuteApiEndpoint
+            ? "disabled"
+            : "enabled",
+    },
+    { label: "description", value: ctx.attrs?.description },
+  ],
+});
+
+/**
+ * GatewayResource.ts imports the resource factory aliased
+ * (`Resource as ResourceFactory`), so its declaration reads
+ * `ResourceFactory<ApiGatewayResource>("AWS.ApiGateway.Resource")` —
+ * equivalent to `Resource<ApiGatewayResource>("AWS.ApiGateway.Resource")`.
+ * The tag below is that exact type string, not a guess.
+ */
+export const GatewayResourceUI = UIProvider.succeed<ApiGatewayResource>(
+  "AWS.ApiGateway.Resource",
+  {
+    displayName: "API Gateway Resource",
+    icon: "route",
+    color: COLOR,
+    category: "network",
+    summary: (ctx) => ctx.attrs?.pathPart,
+    facts: (ctx) => [
+      { label: "path part", value: ctx.attrs?.pathPart, mono: true },
+      {
+        label: "resource id",
+        value: ctx.attrs?.resourceId,
+        mono: true,
+        copy: true,
+      },
+      { label: "parent id", value: ctx.attrs?.parentId, mono: true },
+      { label: "api id", value: ctx.attrs?.restApiId, mono: true, copy: true },
+    ],
+  },
+);
+
+export const MethodUI = UIProvider.succeed<MethodType>(
+  "AWS.ApiGateway.Method",
+  {
+    displayName: "API Gateway Method",
+    icon: "arrow-right-left",
+    color: COLOR,
+    category: "network",
+    summary: (ctx) => ctx.attrs?.httpMethod,
+    facts: (ctx) => [
+      { label: "http method", value: ctx.attrs?.httpMethod, mono: true },
+      {
+        label: "resource id",
+        value: ctx.attrs?.resourceId,
+        mono: true,
+        copy: true,
+      },
+      { label: "api id", value: ctx.attrs?.restApiId, mono: true, copy: true },
+      { label: "authorization", value: ctx.attrs?.authorizationType },
+      { label: "authorizer id", value: ctx.attrs?.authorizerId, mono: true },
+      { label: "api key required", value: ctx.attrs?.apiKeyRequired },
+      { label: "integration", value: ctx.attrs?.integration?.type },
+    ],
+  },
+);
+
+export const DeploymentUI = UIProvider.succeed<DeploymentType>(
+  "AWS.ApiGateway.Deployment",
+  {
+    displayName: "API Gateway Deployment",
+    icon: "rocket",
+    color: COLOR,
+    category: "network",
+    summary: (ctx) => ctx.attrs?.deploymentId,
+    facts: (ctx) => [
+      {
+        label: "deployment id",
+        value: ctx.attrs?.deploymentId,
+        mono: true,
+        copy: true,
+      },
+      { label: "api id", value: ctx.attrs?.restApiId, mono: true, copy: true },
+      { label: "description", value: ctx.attrs?.description },
+    ],
+  },
+);
+
+export const StageUI = UIProvider.succeed<ApiGatewayStage>(
+  "AWS.ApiGateway.Stage",
+  {
+    displayName: "API Gateway Stage",
+    icon: "layers",
+    color: COLOR,
+    category: "network",
+    summary: (ctx) => ctx.attrs?.stageName,
+    facts: (ctx) => [
+      { label: "stage", value: ctx.attrs?.stageName, mono: true },
+      { label: "api id", value: ctx.attrs?.restApiId, mono: true, copy: true },
+      {
+        label: "deployment id",
+        value: ctx.attrs?.deploymentId,
+        mono: true,
+        copy: true,
+      },
+      { label: "tracing", value: ctx.attrs?.tracingEnabled },
+      { label: "cache cluster", value: ctx.attrs?.cacheClusterEnabled },
+      { label: "web acl", value: ctx.attrs?.webAclArn, mono: true },
+      { label: "description", value: ctx.attrs?.description },
+    ],
+  },
+);
+
+export const DomainNameUI = UIProvider.succeed<DomainName>(
+  "AWS.ApiGateway.DomainName",
+  {
+    displayName: "API Gateway Domain Name",
+    icon: "globe",
+    color: COLOR,
+    category: "dns",
+    summary: (ctx) => ctx.attrs?.domainName,
+    link: (ctx) =>
+      ctx.attrs?.domainName === undefined
+        ? undefined
+        : `https://${ctx.attrs.domainName}`,
+    facts: (ctx) => [
+      {
+        label: "domain",
+        value: ctx.attrs?.domainName,
+        copy: true,
+        href:
+          ctx.attrs?.domainName === undefined
+            ? undefined
+            : `https://${ctx.attrs.domainName}`,
+      },
+      {
+        label: "regional domain",
+        value: ctx.attrs?.regionalDomainName,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "regional zone id",
+        value: ctx.attrs?.regionalHostedZoneId,
+        mono: true,
+      },
+      {
+        label: "distribution domain",
+        value: ctx.attrs?.distributionDomainName,
+        mono: true,
+        copy: true,
+      },
+      { label: "arn", value: ctx.attrs?.domainNameArn, mono: true, copy: true },
+    ],
+  },
+);
+
+export const BasePathMappingUI = UIProvider.succeed<BasePathMapping>(
+  "AWS.ApiGateway.BasePathMapping",
+  {
+    displayName: "API Gateway Base Path Mapping",
+    icon: "link-2",
+    color: COLOR,
+    category: "network",
+    summary: (ctx) =>
+      ctx.attrs?.domainName === undefined
+        ? undefined
+        : `${ctx.attrs.domainName}/${ctx.attrs.basePath === "(none)" || ctx.attrs.basePath === undefined ? "" : ctx.attrs.basePath}`,
+    facts: (ctx) => [
+      { label: "domain", value: ctx.attrs?.domainName, copy: true },
+      { label: "base path", value: ctx.attrs?.basePath, mono: true },
+      { label: "api id", value: ctx.attrs?.restApiId, mono: true, copy: true },
+      { label: "stage", value: ctx.attrs?.stage, mono: true },
+    ],
+  },
+);
+
+export const AuthorizerUI = UIProvider.succeed<Authorizer>(
+  "AWS.ApiGateway.Authorizer",
+  {
+    displayName: "API Gateway Authorizer",
+    icon: "shield-check",
+    color: COLOR,
+    category: "auth",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name },
+      {
+        label: "authorizer id",
+        value: ctx.attrs?.authorizerId,
+        mono: true,
+        copy: true,
+      },
+      { label: "type", value: ctx.attrs?.type },
+      { label: "api id", value: ctx.attrs?.restApiId, mono: true, copy: true },
+    ],
+  },
+);
+
+export const ApiKeyUI = UIProvider.succeed<ApiKey>("AWS.ApiGateway.ApiKey", {
+  displayName: "API Gateway API Key",
+  icon: "key-round",
+  color: COLOR,
+  category: "auth",
+  summary: (ctx) => ctx.attrs?.name ?? ctx.attrs?.id,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.name },
+    { label: "key id", value: ctx.attrs?.id, mono: true, copy: true },
+    { label: "enabled", value: ctx.attrs?.enabled },
+  ],
+});
+
+export const UsagePlanUI = UIProvider.succeed<UsagePlan>(
+  "AWS.ApiGateway.UsagePlan",
+  {
+    displayName: "API Gateway Usage Plan",
+    icon: "gauge",
+    color: COLOR,
+    category: "network",
+    summary: (ctx) => ctx.attrs?.name ?? ctx.attrs?.id,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name },
+      { label: "plan id", value: ctx.attrs?.id, mono: true, copy: true },
+      {
+        label: "stages",
+        value: ctx.attrs?.apiStages
+          ?.map((s) => `${s.apiId ?? "?"}:${s.stage ?? "?"}`)
+          .join(", "),
+        mono: true,
+      },
+      {
+        label: "throttle",
+        value:
+          ctx.attrs?.throttle === undefined
+            ? undefined
+            : `${ctx.attrs.throttle.rateLimit ?? "-"} rps / burst ${ctx.attrs.throttle.burstLimit ?? "-"}`,
+      },
+      {
+        label: "quota",
+        value:
+          ctx.attrs?.quota === undefined
+            ? undefined
+            : `${ctx.attrs.quota.limit ?? "-"} per ${ctx.attrs.quota.period ?? "-"}`,
+      },
+      { label: "description", value: ctx.attrs?.description },
+    ],
+  },
+);
+
+export const UsagePlanKeyUI = UIProvider.succeed<UsagePlanKey>(
+  "AWS.ApiGateway.UsagePlanKey",
+  {
+    displayName: "API Gateway Usage Plan Key",
+    icon: "key",
+    color: COLOR,
+    category: "auth",
+    summary: (ctx) => ctx.attrs?.name ?? ctx.attrs?.keyId,
+    facts: (ctx) => [
+      { label: "key id", value: ctx.attrs?.keyId, mono: true, copy: true },
+      { label: "key type", value: ctx.attrs?.keyType },
+      {
+        label: "usage plan id",
+        value: ctx.attrs?.usagePlanId,
+        mono: true,
+        copy: true,
+      },
+      { label: "name", value: ctx.attrs?.name },
+    ],
+  },
+);
+
+export const VpcLinkUI = UIProvider.succeed<VpcLink>("AWS.ApiGateway.VpcLink", {
+  displayName: "API Gateway VPC Link",
+  icon: "cable",
+  color: COLOR,
+  category: "network",
+  summary: (ctx) => ctx.attrs?.name ?? ctx.attrs?.vpcLinkId,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.name },
+    {
+      label: "vpc link id",
+      value: ctx.attrs?.vpcLinkId,
+      mono: true,
+      copy: true,
+    },
+    { label: "status", value: ctx.attrs?.status },
+    {
+      label: "targets",
+      value: ctx.attrs?.targetArns?.join(", "),
+      mono: true,
+    },
+    { label: "description", value: ctx.attrs?.description },
+  ],
+});
+
+export const GatewayResponseUI = UIProvider.succeed<GatewayResponse>(
+  "AWS.ApiGateway.GatewayResponse",
+  {
+    displayName: "API Gateway Response",
+    icon: "reply",
+    color: COLOR,
+    category: "network",
+    summary: (ctx) => ctx.attrs?.responseType,
+    facts: (ctx) => [
+      { label: "response type", value: ctx.attrs?.responseType, mono: true },
+      { label: "status code", value: ctx.attrs?.statusCode, mono: true },
+      { label: "api id", value: ctx.attrs?.restApiId, mono: true, copy: true },
+    ],
+  },
+);
+
+export const AccountUI = UIProvider.succeed<Account>("AWS.ApiGateway.Account", {
+  displayName: "API Gateway Account",
+  icon: "settings",
+  color: COLOR,
+  category: "config",
+  summary: (ctx) => ctx.attrs?.cloudwatchRoleArn,
+  facts: (ctx) => [
+    {
+      label: "cloudwatch role",
+      value: ctx.attrs?.cloudwatchRoleArn,
+      mono: true,
+      copy: true,
+    },
+    {
+      label: "manages role",
+      value: ctx.attrs?.managesCloudwatchRoleArn,
+    },
+  ],
+});
+
+export const ui = () =>
+  Layer.mergeAll(
+    RestApiUI,
+    GatewayResourceUI,
+    MethodUI,
+    DeploymentUI,
+    StageUI,
+    DomainNameUI,
+    BasePathMappingUI,
+    AuthorizerUI,
+    ApiKeyUI,
+    UsagePlanUI,
+    UsagePlanKeyUI,
+    VpcLinkUI,
+    GatewayResponseUI,
+    AccountUI,
+  );

--- a/packages/alchemy/src/AWS/ApiGatewayV2/ui.ts
+++ b/packages/alchemy/src/AWS/ApiGatewayV2/ui.ts
@@ -1,0 +1,241 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Api } from "./Api.ts";
+import type { ApiMapping } from "./ApiMapping.ts";
+import type { AuthorizerType } from "./Authorizer.ts";
+import type { DomainName } from "./DomainName.ts";
+import type { IntegrationType } from "./Integration.ts";
+import type { RouteType } from "./Route.ts";
+import type { ApiGatewayV2Stage } from "./Stage.ts";
+import type { VpcLink } from "./VpcLink.ts";
+
+/**
+ * Dashboard UI providers for AWS ApiGatewayV2 resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** AWS App Integration (API Gateway) brand pink. */
+const COLOR = "#E7157B";
+
+export const ApiUI = UIProvider.succeed<Api>("AWS.ApiGatewayV2.Api", {
+  displayName: "API Gateway V2 API",
+  icon: "network",
+  color: COLOR,
+  category: "network",
+  summary: (ctx) => ctx.attrs?.name ?? ctx.attrs?.apiId,
+  link: (ctx) => ctx.attrs?.apiEndpoint,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.name, copy: true },
+    { label: "api id", value: ctx.attrs?.apiId, mono: true, copy: true },
+    {
+      label: "endpoint",
+      value: ctx.attrs?.apiEndpoint,
+      mono: true,
+      href: ctx.attrs?.apiEndpoint,
+      copy: true,
+    },
+    { label: "protocol", value: ctx.attrs?.protocolType },
+    { label: "description", value: ctx.attrs?.description },
+  ],
+});
+
+export const ApiMappingUI = UIProvider.succeed<ApiMapping>(
+  "AWS.ApiGatewayV2.ApiMapping",
+  {
+    displayName: "API Gateway V2 API Mapping",
+    icon: "link",
+    color: COLOR,
+    category: "network",
+    summary: (ctx) =>
+      ctx.attrs?.domainName === undefined
+        ? undefined
+        : `${ctx.attrs.domainName}/${ctx.attrs.apiMappingKey ?? ""}`,
+    facts: (ctx) => [
+      { label: "domain", value: ctx.attrs?.domainName, copy: true },
+      {
+        label: "mapping id",
+        value: ctx.attrs?.apiMappingId,
+        mono: true,
+        copy: true,
+      },
+      { label: "api id", value: ctx.attrs?.apiId, mono: true, copy: true },
+      { label: "stage", value: ctx.attrs?.stage, mono: true },
+      { label: "base path", value: ctx.attrs?.apiMappingKey, mono: true },
+    ],
+  },
+);
+
+export const AuthorizerUI = UIProvider.succeed<AuthorizerType>(
+  "AWS.ApiGatewayV2.Authorizer",
+  {
+    displayName: "API Gateway V2 Authorizer",
+    icon: "shield-check",
+    color: COLOR,
+    category: "auth",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      {
+        label: "authorizer id",
+        value: ctx.attrs?.authorizerId,
+        mono: true,
+        copy: true,
+      },
+      { label: "type", value: ctx.attrs?.authorizerType },
+      { label: "api id", value: ctx.attrs?.apiId, mono: true, copy: true },
+      { label: "issuer", value: ctx.attrs?.jwtConfiguration?.Issuer },
+    ],
+  },
+);
+
+export const DomainNameUI = UIProvider.succeed<DomainName>(
+  "AWS.ApiGatewayV2.DomainName",
+  {
+    displayName: "API Gateway V2 Domain Name",
+    icon: "globe",
+    color: COLOR,
+    category: "dns",
+    summary: (ctx) => ctx.attrs?.domainName,
+    link: (ctx) =>
+      ctx.attrs?.domainName === undefined
+        ? undefined
+        : `https://${ctx.attrs.domainName}`,
+    facts: (ctx) => [
+      {
+        label: "domain",
+        value: ctx.attrs?.domainName,
+        copy: true,
+        href:
+          ctx.attrs?.domainName === undefined
+            ? undefined
+            : `https://${ctx.attrs.domainName}`,
+      },
+      { label: "arn", value: ctx.attrs?.domainNameArn, mono: true, copy: true },
+      {
+        label: "target domain",
+        value: ctx.attrs?.domainNameConfigurations?.[0]?.ApiGatewayDomainName,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "hosted zone",
+        value: ctx.attrs?.domainNameConfigurations?.[0]?.HostedZoneId,
+        mono: true,
+      },
+    ],
+  },
+);
+
+export const IntegrationUI = UIProvider.succeed<IntegrationType>(
+  "AWS.ApiGatewayV2.Integration",
+  {
+    displayName: "API Gateway V2 Integration",
+    icon: "plug",
+    color: COLOR,
+    category: "network",
+    summary: (ctx) => ctx.attrs?.integrationUri ?? ctx.attrs?.integrationType,
+    facts: (ctx) => [
+      { label: "type", value: ctx.attrs?.integrationType },
+      { label: "uri", value: ctx.attrs?.integrationUri, mono: true },
+      {
+        label: "integration id",
+        value: ctx.attrs?.integrationId,
+        mono: true,
+        copy: true,
+      },
+      { label: "api id", value: ctx.attrs?.apiId, mono: true, copy: true },
+      { label: "method", value: ctx.attrs?.integrationMethod, mono: true },
+      { label: "payload version", value: ctx.attrs?.payloadFormatVersion },
+    ],
+  },
+);
+
+export const RouteUI = UIProvider.succeed<RouteType>("AWS.ApiGatewayV2.Route", {
+  displayName: "API Gateway V2 Route",
+  icon: "route",
+  color: COLOR,
+  category: "network",
+  summary: (ctx) => ctx.attrs?.routeKey,
+  facts: (ctx) => [
+    { label: "route key", value: ctx.attrs?.routeKey, mono: true },
+    { label: "route id", value: ctx.attrs?.routeId, mono: true, copy: true },
+    { label: "api id", value: ctx.attrs?.apiId, mono: true, copy: true },
+    { label: "target", value: ctx.attrs?.target, mono: true },
+    { label: "authorization", value: ctx.attrs?.authorizationType },
+    { label: "authorizer id", value: ctx.attrs?.authorizerId, mono: true },
+  ],
+});
+
+export const StageUI = UIProvider.succeed<ApiGatewayV2Stage>(
+  "AWS.ApiGatewayV2.Stage",
+  {
+    displayName: "API Gateway V2 Stage",
+    icon: "layers",
+    color: COLOR,
+    category: "network",
+    summary: (ctx) => ctx.attrs?.stageName,
+    link: (ctx) => ctx.attrs?.invokeUrl,
+    facts: (ctx) => [
+      { label: "stage", value: ctx.attrs?.stageName, mono: true },
+      {
+        label: "invoke url",
+        value: ctx.attrs?.invokeUrl,
+        mono: true,
+        href: ctx.attrs?.invokeUrl,
+        copy: true,
+      },
+      { label: "api id", value: ctx.attrs?.apiId, mono: true, copy: true },
+      { label: "auto deploy", value: ctx.attrs?.autoDeploy },
+      { label: "deployment id", value: ctx.attrs?.deploymentId, mono: true },
+    ],
+  },
+);
+
+export const VpcLinkUI = UIProvider.succeed<VpcLink>(
+  "AWS.ApiGatewayV2.VpcLink",
+  {
+    displayName: "API Gateway V2 VPC Link",
+    icon: "cable",
+    color: COLOR,
+    category: "network",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      {
+        label: "vpc link id",
+        value: ctx.attrs?.vpcLinkId,
+        mono: true,
+        copy: true,
+      },
+      { label: "status", value: ctx.attrs?.status },
+      {
+        label: "subnets",
+        value: ctx.attrs?.subnetIds?.length
+          ? ctx.attrs.subnetIds.join(", ")
+          : undefined,
+        mono: true,
+      },
+      {
+        label: "security groups",
+        value: ctx.attrs?.securityGroupIds?.length
+          ? ctx.attrs.securityGroupIds.join(", ")
+          : undefined,
+        mono: true,
+      },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(
+    ApiUI,
+    ApiMappingUI,
+    AuthorizerUI,
+    DomainNameUI,
+    IntegrationUI,
+    RouteUI,
+    StageUI,
+    VpcLinkUI,
+  );

--- a/packages/alchemy/src/AWS/AppConfig/ui.ts
+++ b/packages/alchemy/src/AWS/AppConfig/ui.ts
@@ -1,0 +1,228 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Application } from "./Application.ts";
+import type { ConfigurationProfile } from "./ConfigurationProfile.ts";
+import type { Deployment } from "./Deployment.ts";
+import type { DeploymentStrategy } from "./DeploymentStrategy.ts";
+import type { Environment } from "./Environment.ts";
+import type { Extension } from "./Extension.ts";
+import type { ExtensionAssociation } from "./ExtensionAssociation.ts";
+import type { HostedConfigurationVersion } from "./HostedConfigurationVersion.ts";
+
+/**
+ * Dashboard UI providers for AWS AppConfig resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+const APPCONFIG_COLOR = "#E7157B";
+
+export const ApplicationUI = UIProvider.succeed<Application>(
+  "AWS.AppConfig.Application",
+  {
+    displayName: "AppConfig Application",
+    icon: "package",
+    color: APPCONFIG_COLOR,
+    category: "config",
+    summary: (ctx) => ctx.attrs?.applicationName,
+    facts: (ctx) => [
+      { label: "application", value: ctx.attrs?.applicationName, copy: true },
+      { label: "id", value: ctx.attrs?.applicationId, mono: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.applicationArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "description", value: ctx.props?.description },
+    ],
+  },
+);
+
+export const ConfigurationProfileUI = UIProvider.succeed<ConfigurationProfile>(
+  "AWS.AppConfig.ConfigurationProfile",
+  {
+    displayName: "AppConfig Configuration Profile",
+    icon: "file-text",
+    color: APPCONFIG_COLOR,
+    category: "config",
+    summary: (ctx) => ctx.attrs?.configurationProfileName,
+    facts: (ctx) => [
+      {
+        label: "profile",
+        value: ctx.attrs?.configurationProfileName,
+        copy: true,
+      },
+      { label: "id", value: ctx.attrs?.configurationProfileId, mono: true },
+      { label: "application", value: ctx.attrs?.applicationId, mono: true },
+      { label: "location", value: ctx.attrs?.locationUri, mono: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.configurationProfileArn,
+        mono: true,
+        copy: true,
+      },
+    ],
+  },
+);
+
+export const DeploymentUI = UIProvider.succeed<Deployment>(
+  "AWS.AppConfig.Deployment",
+  {
+    displayName: "AppConfig Deployment",
+    icon: "upload",
+    color: APPCONFIG_COLOR,
+    category: "config",
+    summary: (ctx) =>
+      ctx.attrs?.deploymentNumber === undefined
+        ? undefined
+        : `deployment-${ctx.attrs.deploymentNumber}`,
+    facts: (ctx) => [
+      { label: "deployment", value: ctx.attrs?.deploymentNumber },
+      { label: "application", value: ctx.attrs?.applicationId, mono: true },
+      { label: "environment", value: ctx.attrs?.environmentId, mono: true },
+      {
+        label: "profile",
+        value: ctx.attrs?.configurationProfileId,
+        mono: true,
+      },
+      { label: "version", value: ctx.attrs?.configurationVersion },
+      { label: "state", value: ctx.attrs?.state },
+    ],
+  },
+);
+
+export const DeploymentStrategyUI = UIProvider.succeed<DeploymentStrategy>(
+  "AWS.AppConfig.DeploymentStrategy",
+  {
+    displayName: "AppConfig Deployment Strategy",
+    icon: "workflow",
+    color: APPCONFIG_COLOR,
+    category: "config",
+    summary: (ctx) => ctx.attrs?.deploymentStrategyName,
+    facts: (ctx) => [
+      {
+        label: "strategy",
+        value: ctx.attrs?.deploymentStrategyName,
+        copy: true,
+      },
+      { label: "id", value: ctx.attrs?.deploymentStrategyId, mono: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.deploymentStrategyArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "growth factor", value: ctx.props?.growthFactor },
+      { label: "growth type", value: ctx.props?.growthType },
+      { label: "replicate to", value: ctx.props?.replicateTo },
+    ],
+  },
+);
+
+export const EnvironmentUI = UIProvider.succeed<Environment>(
+  "AWS.AppConfig.Environment",
+  {
+    displayName: "AppConfig Environment",
+    icon: "layers",
+    color: APPCONFIG_COLOR,
+    category: "config",
+    summary: (ctx) => ctx.attrs?.environmentName,
+    facts: (ctx) => [
+      { label: "environment", value: ctx.attrs?.environmentName, copy: true },
+      { label: "id", value: ctx.attrs?.environmentId, mono: true },
+      { label: "application", value: ctx.attrs?.applicationId, mono: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.environmentArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "state", value: ctx.attrs?.state },
+    ],
+  },
+);
+
+export const ExtensionUI = UIProvider.succeed<Extension>(
+  "AWS.AppConfig.Extension",
+  {
+    displayName: "AppConfig Extension",
+    icon: "plug",
+    color: APPCONFIG_COLOR,
+    category: "config",
+    summary: (ctx) => ctx.attrs?.extensionName,
+    facts: (ctx) => [
+      { label: "extension", value: ctx.attrs?.extensionName, copy: true },
+      { label: "id", value: ctx.attrs?.extensionId, mono: true },
+      { label: "arn", value: ctx.attrs?.extensionArn, mono: true, copy: true },
+      { label: "version", value: ctx.attrs?.versionNumber },
+      { label: "description", value: ctx.props?.description },
+    ],
+  },
+);
+
+export const ExtensionAssociationUI = UIProvider.succeed<ExtensionAssociation>(
+  "AWS.AppConfig.ExtensionAssociation",
+  {
+    displayName: "AppConfig Extension Association",
+    icon: "link",
+    color: APPCONFIG_COLOR,
+    category: "config",
+    summary: (ctx) => ctx.attrs?.extensionAssociationId,
+    facts: (ctx) => [
+      {
+        label: "association",
+        value: ctx.attrs?.extensionAssociationId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.extensionAssociationArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "extension", value: ctx.attrs?.extensionArn, mono: true },
+      { label: "resource", value: ctx.attrs?.resourceArn, mono: true },
+    ],
+  },
+);
+
+export const HostedConfigurationVersionUI =
+  UIProvider.succeed<HostedConfigurationVersion>(
+    "AWS.AppConfig.HostedConfigurationVersion",
+    {
+      displayName: "AppConfig Hosted Configuration Version",
+      icon: "scroll-text",
+      color: APPCONFIG_COLOR,
+      category: "config",
+      summary: (ctx) =>
+        ctx.attrs?.versionNumber === undefined
+          ? undefined
+          : `version-${ctx.attrs.versionNumber}`,
+      facts: (ctx) => [
+        { label: "application", value: ctx.attrs?.applicationId, mono: true },
+        {
+          label: "profile",
+          value: ctx.attrs?.configurationProfileId,
+          mono: true,
+        },
+        { label: "version", value: ctx.attrs?.versionNumber },
+        { label: "content type", value: ctx.attrs?.contentType },
+        { label: "label", value: ctx.attrs?.versionLabel },
+      ],
+    },
+  );
+
+export const ui = () =>
+  Layer.mergeAll(
+    ApplicationUI,
+    ConfigurationProfileUI,
+    DeploymentUI,
+    DeploymentStrategyUI,
+    EnvironmentUI,
+    ExtensionUI,
+    ExtensionAssociationUI,
+    HostedConfigurationVersionUI,
+  );

--- a/packages/alchemy/src/AWS/AppFlow/ui.ts
+++ b/packages/alchemy/src/AWS/AppFlow/ui.ts
@@ -1,0 +1,56 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { ConnectorProfile } from "./ConnectorProfile.ts";
+import type { Flow } from "./Flow.ts";
+
+/**
+ * Dashboard UI providers for AWS AppFlow resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+export const ConnectorProfileUI = UIProvider.succeed<ConnectorProfile>(
+  "AWS.AppFlow.ConnectorProfile",
+  {
+    displayName: "AppFlow Connector Profile",
+    icon: "plug",
+    color: "#E7157B",
+    category: "eventing",
+    summary: (ctx) => ctx.attrs?.connectorProfileName,
+    facts: (ctx) => [
+      {
+        label: "profile",
+        value: ctx.attrs?.connectorProfileName,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.connectorProfileArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "connector type", value: ctx.attrs?.connectorType },
+      {
+        label: "credentials arn",
+        value: ctx.attrs?.credentialsArn,
+        mono: true,
+      },
+    ],
+  },
+);
+
+export const FlowUI = UIProvider.succeed<Flow>("AWS.AppFlow.Flow", {
+  displayName: "AppFlow Flow",
+  icon: "workflow",
+  color: "#E7157B",
+  category: "eventing",
+  summary: (ctx) => ctx.attrs?.flowName,
+  facts: (ctx) => [
+    { label: "flow", value: ctx.attrs?.flowName, copy: true },
+    { label: "arn", value: ctx.attrs?.flowArn, mono: true, copy: true },
+    { label: "status", value: ctx.attrs?.flowStatus },
+  ],
+});
+
+export const ui = () => Layer.mergeAll(ConnectorProfileUI, FlowUI);

--- a/packages/alchemy/src/AWS/AppIntegrations/ui.ts
+++ b/packages/alchemy/src/AWS/AppIntegrations/ui.ts
@@ -1,0 +1,83 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Application } from "./Application.ts";
+import type { DataIntegration } from "./DataIntegration.ts";
+import type { EventIntegration } from "./EventIntegration.ts";
+
+/**
+ * Dashboard UI providers for AWS AppIntegrations resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+const COLOR = "#E7157B";
+
+export const ApplicationUI = UIProvider.succeed<Application>(
+  "AWS.AppIntegrations.Application",
+  {
+    displayName: "AppIntegrations Application",
+    icon: "app-window",
+    color: COLOR,
+    category: "eventing",
+    summary: (ctx) => ctx.attrs?.applicationName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.applicationName, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.applicationArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "namespace", value: ctx.attrs?.namespace, mono: true },
+      { label: "access url", value: ctx.props?.accessUrl, mono: true },
+    ],
+  },
+);
+
+export const DataIntegrationUI = UIProvider.succeed<DataIntegration>(
+  "AWS.AppIntegrations.DataIntegration",
+  {
+    displayName: "AppIntegrations Data Integration",
+    icon: "download",
+    color: COLOR,
+    category: "eventing",
+    summary: (ctx) => ctx.attrs?.dataIntegrationName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.dataIntegrationName, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.dataIntegrationArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "source uri", value: ctx.attrs?.sourceURI, mono: true },
+      { label: "kms key", value: ctx.attrs?.kmsKey, mono: true },
+    ],
+  },
+);
+
+export const EventIntegrationUI = UIProvider.succeed<EventIntegration>(
+  "AWS.AppIntegrations.EventIntegration",
+  {
+    displayName: "AppIntegrations Event Integration",
+    icon: "webhook",
+    color: COLOR,
+    category: "eventing",
+    summary: (ctx) => ctx.attrs?.eventIntegrationName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.eventIntegrationName, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.eventIntegrationArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "source", value: ctx.attrs?.source, mono: true },
+      { label: "event bus", value: ctx.attrs?.eventBridgeBus },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(ApplicationUI, DataIntegrationUI, EventIntegrationUI);

--- a/packages/alchemy/src/AWS/AppRegistry/ui.ts
+++ b/packages/alchemy/src/AWS/AppRegistry/ui.ts
@@ -1,0 +1,141 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Application } from "./Application.ts";
+import type { AttributeGroup } from "./AttributeGroup.ts";
+import type { AttributeGroupAssociation } from "./AttributeGroupAssociation.ts";
+import type { ResourceAssociation } from "./ResourceAssociation.ts";
+
+/**
+ * Dashboard UI providers for AWS AppRegistry resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** AWS Management & Governance (AppRegistry) brand pink. */
+const COLOR = "#E7157B";
+
+export const ApplicationUI = UIProvider.succeed<Application>(
+  "AWS.AppRegistry.Application",
+  {
+    displayName: "AppRegistry Application",
+    icon: "boxes",
+    color: COLOR,
+    category: "config",
+    summary: (ctx) => ctx.attrs?.applicationName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.applicationName, copy: true },
+      {
+        label: "id",
+        value: ctx.attrs?.applicationId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.applicationArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "description", value: ctx.props?.description },
+    ],
+  },
+);
+
+export const AttributeGroupUI = UIProvider.succeed<AttributeGroup>(
+  "AWS.AppRegistry.AttributeGroup",
+  {
+    displayName: "AppRegistry Attribute Group",
+    icon: "tags",
+    color: COLOR,
+    category: "config",
+    summary: (ctx) => ctx.attrs?.attributeGroupName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.attributeGroupName, copy: true },
+      {
+        label: "id",
+        value: ctx.attrs?.attributeGroupId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.attributeGroupArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "description", value: ctx.props?.description },
+    ],
+  },
+);
+
+export const AttributeGroupAssociationUI =
+  UIProvider.succeed<AttributeGroupAssociation>(
+    "AWS.AppRegistry.AttributeGroupAssociation",
+    {
+      displayName: "AppRegistry Attribute Group Association",
+      icon: "link",
+      color: COLOR,
+      category: "config",
+      summary: (ctx) => ctx.attrs?.attributeGroupId,
+      facts: (ctx) => [
+        {
+          label: "application id",
+          value: ctx.attrs?.applicationId,
+          mono: true,
+          copy: true,
+        },
+        {
+          label: "application arn",
+          value: ctx.attrs?.applicationArn,
+          mono: true,
+        },
+        {
+          label: "attribute group id",
+          value: ctx.attrs?.attributeGroupId,
+          mono: true,
+          copy: true,
+        },
+        {
+          label: "attribute group arn",
+          value: ctx.attrs?.attributeGroupArn,
+          mono: true,
+        },
+      ],
+    },
+  );
+
+export const ResourceAssociationUI = UIProvider.succeed<ResourceAssociation>(
+  "AWS.AppRegistry.ResourceAssociation",
+  {
+    displayName: "AppRegistry Resource Association",
+    icon: "share-2",
+    color: COLOR,
+    category: "config",
+    summary: (ctx) => ctx.attrs?.resourceName,
+    facts: (ctx) => [
+      { label: "resource", value: ctx.attrs?.resourceName, copy: true },
+      {
+        label: "resource arn",
+        value: ctx.attrs?.resourceArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "resource type", value: ctx.attrs?.resourceType },
+      {
+        label: "application id",
+        value: ctx.attrs?.applicationId,
+        mono: true,
+        copy: true,
+      },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(
+    ApplicationUI,
+    AttributeGroupUI,
+    AttributeGroupAssociationUI,
+    ResourceAssociationUI,
+  );

--- a/packages/alchemy/src/AWS/AppRunner/ui.ts
+++ b/packages/alchemy/src/AWS/AppRunner/ui.ts
@@ -1,0 +1,117 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { AutoScalingConfiguration } from "./AutoScalingConfiguration.ts";
+import type { ObservabilityConfiguration } from "./ObservabilityConfiguration.ts";
+import type { VpcConnector } from "./VpcConnector.ts";
+
+/**
+ * Dashboard UI providers for AWS AppRunner resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+export const AutoScalingConfigurationUI =
+  UIProvider.succeed<AutoScalingConfiguration>(
+    "AWS.AppRunner.AutoScalingConfiguration",
+    {
+      displayName: "App Runner Auto Scaling Configuration",
+      icon: "gauge",
+      color: "#ED7100",
+      category: "compute",
+      summary: (ctx) => ctx.attrs?.autoScalingConfigurationName,
+      facts: (ctx) => [
+        {
+          label: "name",
+          value: ctx.attrs?.autoScalingConfigurationName,
+          copy: true,
+        },
+        {
+          label: "arn",
+          value: ctx.attrs?.autoScalingConfigurationArn,
+          mono: true,
+          copy: true,
+        },
+        {
+          label: "revision",
+          value: ctx.attrs?.autoScalingConfigurationRevision,
+        },
+        { label: "max concurrency", value: ctx.attrs?.maxConcurrency },
+        { label: "min size", value: ctx.attrs?.minSize },
+        { label: "max size", value: ctx.attrs?.maxSize },
+      ],
+    },
+  );
+
+export const ObservabilityConfigurationUI =
+  UIProvider.succeed<ObservabilityConfiguration>(
+    "AWS.AppRunner.ObservabilityConfiguration",
+    {
+      displayName: "App Runner Observability Configuration",
+      icon: "eye",
+      color: "#ED7100",
+      category: "observability",
+      summary: (ctx) => ctx.attrs?.observabilityConfigurationName,
+      facts: (ctx) => [
+        {
+          label: "name",
+          value: ctx.attrs?.observabilityConfigurationName,
+          copy: true,
+        },
+        {
+          label: "arn",
+          value: ctx.attrs?.observabilityConfigurationArn,
+          mono: true,
+          copy: true,
+        },
+        {
+          label: "revision",
+          value: ctx.attrs?.observabilityConfigurationRevision,
+        },
+        { label: "trace vendor", value: ctx.attrs?.traceVendor },
+      ],
+    },
+  );
+
+export const VpcConnectorUI = UIProvider.succeed<VpcConnector>(
+  "AWS.AppRunner.VpcConnector",
+  {
+    displayName: "App Runner VPC Connector",
+    icon: "network",
+    color: "#ED7100",
+    category: "network",
+    summary: (ctx) => ctx.attrs?.vpcConnectorName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.vpcConnectorName, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.vpcConnectorArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "revision", value: ctx.attrs?.vpcConnectorRevision },
+      { label: "status", value: ctx.attrs?.status },
+      {
+        label: "subnets",
+        value: ctx.attrs?.subnets?.length
+          ? ctx.attrs.subnets.join(", ")
+          : undefined,
+        mono: true,
+      },
+      {
+        label: "security groups",
+        value: ctx.attrs?.securityGroups?.length
+          ? ctx.attrs.securityGroups.join(", ")
+          : undefined,
+        mono: true,
+      },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(
+    AutoScalingConfigurationUI,
+    ObservabilityConfigurationUI,
+    VpcConnectorUI,
+  );

--- a/packages/alchemy/src/AWS/AppSync/ui.ts
+++ b/packages/alchemy/src/AWS/AppSync/ui.ts
@@ -1,0 +1,189 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { AppSyncApiAssociation } from "./ApiAssociation.ts";
+import type { AppSyncApiKey } from "./ApiKey.ts";
+import type { AppSyncDataSource } from "./DataSource.ts";
+import type { AppSyncDomainName } from "./DomainName.ts";
+import type { AppSyncFunction } from "./Function.ts";
+import type { GraphqlApi } from "./GraphqlApi.ts";
+import type { AppSyncResolver } from "./Resolver.ts";
+
+/**
+ * Dashboard UI providers for AWS AppSync resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** AWS App Integration (AppSync) brand pink. */
+const COLOR = "#E7157B";
+
+export const GraphqlApiUI = UIProvider.succeed<GraphqlApi>(
+  "AWS.AppSync.GraphqlApi",
+  {
+    displayName: "AppSync GraphQL API",
+    icon: "share-2",
+    color: COLOR,
+    category: "network",
+    summary: (ctx) => ctx.attrs?.name ?? ctx.attrs?.apiId,
+    link: (ctx) => ctx.attrs?.graphqlUrl,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      { label: "api id", value: ctx.attrs?.apiId, mono: true, copy: true },
+      { label: "arn", value: ctx.attrs?.apiArn, mono: true, copy: true },
+      {
+        label: "graphql url",
+        value: ctx.attrs?.graphqlUrl,
+        href: ctx.attrs?.graphqlUrl,
+        mono: true,
+        copy: true,
+      },
+      { label: "realtime url", value: ctx.attrs?.realtimeUrl, mono: true },
+      { label: "auth", value: ctx.attrs?.authenticationType },
+    ],
+  },
+);
+
+export const ApiKeyUI = UIProvider.succeed<AppSyncApiKey>(
+  "AWS.AppSync.ApiKey",
+  {
+    displayName: "AppSync API Key",
+    icon: "key-round",
+    color: COLOR,
+    category: "auth",
+    summary: (ctx) => ctx.attrs?.apiId,
+    facts: (ctx) => [
+      { label: "api id", value: ctx.attrs?.apiId, mono: true, copy: true },
+      { label: "description", value: ctx.attrs?.description },
+      { label: "expires", value: ctx.attrs?.expires },
+    ],
+  },
+);
+
+export const DataSourceUI = UIProvider.succeed<AppSyncDataSource>(
+  "AWS.AppSync.DataSource",
+  {
+    displayName: "AppSync Data Source",
+    icon: "cable",
+    color: COLOR,
+    category: "network",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      { label: "api id", value: ctx.attrs?.apiId, mono: true, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.dataSourceArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "type", value: ctx.attrs?.type },
+      { label: "service role", value: ctx.attrs?.serviceRoleArn, mono: true },
+    ],
+  },
+);
+
+export const DomainNameUI = UIProvider.succeed<AppSyncDomainName>(
+  "AWS.AppSync.DomainName",
+  {
+    displayName: "AppSync Domain Name",
+    icon: "globe",
+    color: COLOR,
+    category: "dns",
+    summary: (ctx) => ctx.attrs?.domainName,
+    link: (ctx) =>
+      ctx.attrs?.domainName === undefined
+        ? undefined
+        : `https://${ctx.attrs.domainName}`,
+    facts: (ctx) => [
+      {
+        label: "domain",
+        value: ctx.attrs?.domainName,
+        copy: true,
+        href:
+          ctx.attrs?.domainName === undefined
+            ? undefined
+            : `https://${ctx.attrs.domainName}`,
+      },
+      { label: "arn", value: ctx.attrs?.domainNameArn, mono: true, copy: true },
+      { label: "certificate", value: ctx.attrs?.certificateArn, mono: true },
+      {
+        label: "cloudfront target",
+        value: ctx.attrs?.appsyncDomainName,
+        mono: true,
+        copy: true,
+      },
+      { label: "hosted zone", value: ctx.attrs?.hostedZoneId, mono: true },
+    ],
+  },
+);
+
+export const ApiAssociationUI = UIProvider.succeed<AppSyncApiAssociation>(
+  "AWS.AppSync.ApiAssociation",
+  {
+    displayName: "AppSync API Association",
+    icon: "link",
+    color: COLOR,
+    category: "network",
+    summary: (ctx) => ctx.attrs?.domainName,
+    facts: (ctx) => [
+      { label: "domain", value: ctx.attrs?.domainName, mono: true, copy: true },
+      { label: "api id", value: ctx.attrs?.apiId, mono: true, copy: true },
+    ],
+  },
+);
+
+export const FunctionUI = UIProvider.succeed<AppSyncFunction>(
+  "AWS.AppSync.Function",
+  {
+    displayName: "AppSync Function",
+    icon: "code",
+    color: COLOR,
+    category: "compute",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      {
+        label: "function id",
+        value: ctx.attrs?.functionId,
+        mono: true,
+        copy: true,
+      },
+      { label: "arn", value: ctx.attrs?.functionArn, mono: true, copy: true },
+      { label: "api id", value: ctx.attrs?.apiId, mono: true, copy: true },
+      { label: "data source", value: ctx.attrs?.dataSourceName, mono: true },
+    ],
+  },
+);
+
+export const ResolverUI = UIProvider.succeed<AppSyncResolver>(
+  "AWS.AppSync.Resolver",
+  {
+    displayName: "AppSync Resolver",
+    icon: "route",
+    color: COLOR,
+    category: "compute",
+    summary: (ctx) =>
+      ctx.attrs?.typeName === undefined || ctx.attrs?.fieldName === undefined
+        ? undefined
+        : `${ctx.attrs.typeName}.${ctx.attrs.fieldName}`,
+    facts: (ctx) => [
+      { label: "type", value: ctx.attrs?.typeName, mono: true },
+      { label: "field", value: ctx.attrs?.fieldName, mono: true },
+      { label: "arn", value: ctx.attrs?.resolverArn, mono: true, copy: true },
+      { label: "kind", value: ctx.attrs?.kind },
+      { label: "data source", value: ctx.attrs?.dataSourceName, mono: true },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(
+    GraphqlApiUI,
+    ApiKeyUI,
+    DataSourceUI,
+    DomainNameUI,
+    ApiAssociationUI,
+    FunctionUI,
+    ResolverUI,
+  );

--- a/packages/alchemy/src/AWS/ApplicationAutoScaling/ui.ts
+++ b/packages/alchemy/src/AWS/ApplicationAutoScaling/ui.ts
@@ -1,0 +1,86 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { ScalableTarget } from "./ScalableTarget.ts";
+import type { ScalingPolicy } from "./ScalingPolicy.ts";
+import type { ScheduledAction } from "./ScheduledAction.ts";
+
+/**
+ * Dashboard UI providers for AWS ApplicationAutoScaling resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+export const ScalableTargetUI = UIProvider.succeed<ScalableTarget>(
+  "AWS.ApplicationAutoScaling.ScalableTarget",
+  {
+    displayName: "Scalable Target",
+    icon: "gauge",
+    color: "#E7157B",
+    category: "config",
+    summary: (ctx) => ctx.attrs?.resourceId,
+    facts: (ctx) => [
+      { label: "namespace", value: ctx.attrs?.serviceNamespace },
+      { label: "resource", value: ctx.attrs?.resourceId, copy: true },
+      { label: "dimension", value: ctx.attrs?.scalableDimension },
+      { label: "min capacity", value: ctx.attrs?.minCapacity },
+      { label: "max capacity", value: ctx.attrs?.maxCapacity },
+      { label: "role", value: ctx.attrs?.roleArn, mono: true },
+      {
+        label: "suspended",
+        value: ctx.attrs?.suspendedState !== undefined,
+      },
+    ],
+  },
+);
+
+export const ScalingPolicyUI = UIProvider.succeed<ScalingPolicy>(
+  "AWS.ApplicationAutoScaling.ScalingPolicy",
+  {
+    displayName: "Auto Scaling Policy",
+    icon: "chart-line",
+    color: "#E7157B",
+    category: "config",
+    summary: (ctx) => ctx.attrs?.policyName,
+    facts: (ctx) => [
+      { label: "policy", value: ctx.attrs?.policyName, copy: true },
+      { label: "arn", value: ctx.attrs?.policyArn, mono: true, copy: true },
+      { label: "namespace", value: ctx.attrs?.serviceNamespace },
+      { label: "resource", value: ctx.attrs?.resourceId },
+      { label: "type", value: ctx.attrs?.policyType },
+      { label: "alarms", value: ctx.attrs?.alarms?.length },
+    ],
+  },
+);
+
+export const ScheduledActionUI = UIProvider.succeed<ScheduledAction>(
+  "AWS.ApplicationAutoScaling.ScheduledAction",
+  {
+    displayName: "Auto Scaling Scheduled Action",
+    icon: "calendar",
+    color: "#E7157B",
+    category: "config",
+    summary: (ctx) => ctx.attrs?.scheduledActionName,
+    facts: (ctx) => [
+      {
+        label: "action",
+        value: ctx.attrs?.scheduledActionName,
+        copy: true,
+      },
+      { label: "resource", value: ctx.attrs?.resourceId },
+      { label: "schedule", value: ctx.attrs?.schedule, mono: true },
+      { label: "timezone", value: ctx.attrs?.timezone },
+      {
+        label: "min capacity",
+        value: ctx.attrs?.scalableTargetAction?.MinCapacity,
+      },
+      {
+        label: "max capacity",
+        value: ctx.attrs?.scalableTargetAction?.MaxCapacity,
+      },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(ScalableTargetUI, ScalingPolicyUI, ScheduledActionUI);

--- a/packages/alchemy/src/AWS/ApplicationSignals/ui.ts
+++ b/packages/alchemy/src/AWS/ApplicationSignals/ui.ts
@@ -1,0 +1,104 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Discovery } from "./Discovery.ts";
+import type { GroupingConfiguration } from "./GroupingConfiguration.ts";
+import type { InstrumentationConfiguration } from "./InstrumentationConfiguration.ts";
+import type { ServiceLevelObjective } from "./ServiceLevelObjective.ts";
+
+/**
+ * Dashboard UI providers for AWS ApplicationSignals resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+const APPLICATION_SIGNALS_COLOR = "#E7157B";
+
+export const DiscoveryUI = UIProvider.succeed<Discovery>(
+  "AWS.ApplicationSignals.Discovery",
+  {
+    displayName: "Application Signals Discovery",
+    icon: "search",
+    color: APPLICATION_SIGNALS_COLOR,
+    category: "observability",
+    summary: (ctx) => ctx.attrs?.accountId,
+    facts: (ctx) => [
+      { label: "account", value: ctx.attrs?.accountId, mono: true },
+      { label: "region", value: ctx.attrs?.region },
+    ],
+  },
+);
+
+export const GroupingConfigurationUI =
+  UIProvider.succeed<GroupingConfiguration>(
+    "AWS.ApplicationSignals.GroupingConfiguration",
+    {
+      displayName: "Application Signals Grouping Configuration",
+      icon: "layers",
+      color: APPLICATION_SIGNALS_COLOR,
+      category: "observability",
+      summary: (ctx) =>
+        ctx.attrs?.groupingAttributeDefinitions?.length === undefined
+          ? undefined
+          : `${ctx.attrs.groupingAttributeDefinitions.length} grouping(s)`,
+      facts: (ctx) => [
+        {
+          label: "groupings",
+          value: ctx.attrs?.groupingAttributeDefinitions?.length,
+        },
+        {
+          label: "names",
+          value: ctx.attrs?.groupingAttributeDefinitions
+            ?.map((d) => d.GroupingName)
+            .join(", "),
+        },
+        { label: "updated", value: ctx.attrs?.updatedAt },
+      ],
+    },
+  );
+
+export const InstrumentationConfigurationUI =
+  UIProvider.succeed<InstrumentationConfiguration>(
+    "AWS.ApplicationSignals.InstrumentationConfiguration",
+    {
+      displayName: "Application Signals Instrumentation Configuration",
+      icon: "activity",
+      color: APPLICATION_SIGNALS_COLOR,
+      category: "observability",
+      summary: (ctx) => ctx.attrs?.service,
+      facts: (ctx) => [
+        { label: "arn", value: ctx.attrs?.arn, mono: true, copy: true },
+        { label: "type", value: ctx.attrs?.instrumentationType },
+        { label: "service", value: ctx.attrs?.service, copy: true },
+        { label: "environment", value: ctx.attrs?.environment },
+        { label: "signal", value: ctx.attrs?.signalType },
+        { label: "created", value: ctx.attrs?.createdAt },
+      ],
+    },
+  );
+
+export const ServiceLevelObjectiveUI =
+  UIProvider.succeed<ServiceLevelObjective>(
+    "AWS.ApplicationSignals.ServiceLevelObjective",
+    {
+      displayName: "Application Signals SLO",
+      icon: "gauge",
+      color: APPLICATION_SIGNALS_COLOR,
+      category: "observability",
+      summary: (ctx) => ctx.attrs?.sloName,
+      facts: (ctx) => [
+        { label: "slo", value: ctx.attrs?.sloName, copy: true },
+        { label: "arn", value: ctx.attrs?.sloArn, mono: true, copy: true },
+        { label: "evaluation", value: ctx.attrs?.evaluationType },
+        { label: "description", value: ctx.props?.description },
+      ],
+    },
+  );
+
+export const ui = () =>
+  Layer.mergeAll(
+    DiscoveryUI,
+    GroupingConfigurationUI,
+    InstrumentationConfigurationUI,
+    ServiceLevelObjectiveUI,
+  );

--- a/packages/alchemy/src/AWS/Athena/ui.ts
+++ b/packages/alchemy/src/AWS/Athena/ui.ts
@@ -1,0 +1,95 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { DataCatalog } from "./DataCatalog.ts";
+import type { NamedQuery } from "./NamedQuery.ts";
+import type { PreparedStatement } from "./PreparedStatement.ts";
+import type { WorkGroup } from "./WorkGroup.ts";
+
+/**
+ * Dashboard UI providers for AWS Athena resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+const COLOR = "#8C4FFF";
+
+export const DataCatalogUI = UIProvider.succeed<DataCatalog>(
+  "AWS.Athena.DataCatalog",
+  {
+    displayName: "Athena Data Catalog",
+    icon: "database",
+    color: COLOR,
+    category: "database",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.dataCatalogArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "type", value: ctx.attrs?.type },
+      { label: "description", value: ctx.attrs?.description },
+    ],
+  },
+);
+
+export const NamedQueryUI = UIProvider.succeed<NamedQuery>(
+  "AWS.Athena.NamedQuery",
+  {
+    displayName: "Athena Named Query",
+    icon: "scroll-text",
+    color: COLOR,
+    category: "database",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      { label: "id", value: ctx.attrs?.namedQueryId, mono: true, copy: true },
+      { label: "database", value: ctx.attrs?.database, mono: true },
+      { label: "work group", value: ctx.attrs?.workGroup },
+      { label: "description", value: ctx.attrs?.description },
+    ],
+  },
+);
+
+export const PreparedStatementUI = UIProvider.succeed<PreparedStatement>(
+  "AWS.Athena.PreparedStatement",
+  {
+    displayName: "Athena Prepared Statement",
+    icon: "file-text",
+    color: COLOR,
+    category: "database",
+    summary: (ctx) => ctx.attrs?.statementName,
+    facts: (ctx) => [
+      { label: "statement", value: ctx.attrs?.statementName, copy: true },
+      { label: "work group", value: ctx.attrs?.workGroup },
+      { label: "description", value: ctx.attrs?.description },
+    ],
+  },
+);
+
+export const WorkGroupUI = UIProvider.succeed<WorkGroup>(
+  "AWS.Athena.WorkGroup",
+  {
+    displayName: "Athena Work Group",
+    icon: "layers",
+    color: COLOR,
+    category: "database",
+    summary: (ctx) => ctx.attrs?.workGroupName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.workGroupName, copy: true },
+      { label: "arn", value: ctx.attrs?.workGroupArn, mono: true, copy: true },
+      { label: "state", value: ctx.attrs?.state },
+      {
+        label: "output location",
+        value: ctx.attrs?.outputLocation,
+        mono: true,
+      },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(DataCatalogUI, NamedQueryUI, PreparedStatementUI, WorkGroupUI);

--- a/packages/alchemy/src/AWS/AuditManager/ui.ts
+++ b/packages/alchemy/src/AWS/AuditManager/ui.ts
@@ -1,0 +1,85 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Assessment } from "./Assessment.ts";
+import type { Control } from "./Control.ts";
+import type { Framework } from "./Framework.ts";
+
+/**
+ * Dashboard UI providers for AWS AuditManager resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** AWS Security, Identity & Compliance (Audit Manager) brand red. */
+const COLOR = "#DD344C";
+
+export const AssessmentUI = UIProvider.succeed<Assessment>(
+  "AWS.AuditManager.Assessment",
+  {
+    displayName: "Audit Manager Assessment",
+    icon: "scroll-text",
+    color: COLOR,
+    category: "security",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      {
+        label: "assessment id",
+        value: ctx.attrs?.assessmentId,
+        mono: true,
+        copy: true,
+      },
+      { label: "arn", value: ctx.attrs?.arn, mono: true, copy: true },
+      { label: "status", value: ctx.attrs?.status },
+      { label: "framework", value: ctx.attrs?.frameworkId, mono: true },
+    ],
+  },
+);
+
+export const ControlUI = UIProvider.succeed<Control>(
+  "AWS.AuditManager.Control",
+  {
+    displayName: "Audit Manager Control",
+    icon: "shield-check",
+    color: COLOR,
+    category: "security",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      {
+        label: "control id",
+        value: ctx.attrs?.controlId,
+        mono: true,
+        copy: true,
+      },
+      { label: "arn", value: ctx.attrs?.arn, mono: true, copy: true },
+      { label: "type", value: ctx.attrs?.type },
+      { label: "state", value: ctx.attrs?.state },
+    ],
+  },
+);
+
+export const FrameworkUI = UIProvider.succeed<Framework>(
+  "AWS.AuditManager.Framework",
+  {
+    displayName: "Audit Manager Framework",
+    icon: "book-open",
+    color: COLOR,
+    category: "security",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      {
+        label: "framework id",
+        value: ctx.attrs?.frameworkId,
+        mono: true,
+        copy: true,
+      },
+      { label: "arn", value: ctx.attrs?.arn, mono: true, copy: true },
+      { label: "type", value: ctx.attrs?.type },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(AssessmentUI, ControlUI, FrameworkUI);

--- a/packages/alchemy/src/AWS/AutoScaling/ui.ts
+++ b/packages/alchemy/src/AWS/AutoScaling/ui.ts
@@ -1,0 +1,181 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { AutoScalingGroup } from "./AutoScalingGroup.ts";
+import type { LaunchTemplate } from "./LaunchTemplate.ts";
+import type { LifecycleHook } from "./LifecycleHook.ts";
+import type { ScalingPolicy } from "./ScalingPolicy.ts";
+import type { ScheduledAction } from "./ScheduledAction.ts";
+
+/**
+ * Dashboard UI providers for AWS AutoScaling resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** AWS compute brand orange. */
+const COMPUTE_ORANGE = "#ED7100";
+
+/** Extract the region segment from an AWS ARN (arn:aws:svc:REGION:...). */
+const regionOfArn = (arn: string | undefined): string | undefined =>
+  arn?.split(":")[3] || undefined;
+
+export const AutoScalingGroupUI = UIProvider.succeed<AutoScalingGroup>(
+  "AWS.AutoScaling.AutoScalingGroup",
+  {
+    displayName: "Auto Scaling Group",
+    icon: "scaling",
+    color: COMPUTE_ORANGE,
+    category: "compute",
+    summary: (ctx) => ctx.attrs?.autoScalingGroupName,
+    consoleUrl: (ctx) => {
+      const region = regionOfArn(ctx.attrs?.autoScalingGroupArn);
+      return ctx.attrs?.autoScalingGroupName === undefined ||
+        region === undefined
+        ? undefined
+        : `https://${region}.console.aws.amazon.com/ec2/home?region=${region}#AutoScalingGroupDetails:id=${encodeURIComponent(ctx.attrs.autoScalingGroupName)};view=details`;
+    },
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.autoScalingGroupName, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.autoScalingGroupArn,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "capacity",
+        value:
+          ctx.attrs?.desiredCapacity === undefined
+            ? undefined
+            : `${ctx.attrs.minSize} / ${ctx.attrs.desiredCapacity} / ${ctx.attrs.maxSize} (min/desired/max)`,
+      },
+      {
+        label: "launch template",
+        value: ctx.attrs?.launchTemplateName ?? ctx.attrs?.launchTemplateId,
+        mono: true,
+      },
+      { label: "health check", value: ctx.attrs?.healthCheckType },
+      { label: "subnets", value: ctx.attrs?.subnetIds?.length },
+      { label: "target groups", value: ctx.attrs?.targetGroupArns?.length },
+    ],
+  },
+);
+
+export const LaunchTemplateUI = UIProvider.succeed<LaunchTemplate>(
+  "AWS.AutoScaling.LaunchTemplate",
+  {
+    displayName: "Launch Template",
+    icon: "rocket",
+    color: COMPUTE_ORANGE,
+    category: "compute",
+    summary: (ctx) => ctx.attrs?.launchTemplateName,
+    consoleUrl: (ctx) => {
+      const region = regionOfArn(ctx.attrs?.launchTemplateArn);
+      return ctx.attrs?.launchTemplateId === undefined || region === undefined
+        ? undefined
+        : `https://${region}.console.aws.amazon.com/ec2/home?region=${region}#LaunchTemplateDetails:launchTemplateId=${ctx.attrs.launchTemplateId}`;
+    },
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.launchTemplateName, copy: true },
+      {
+        label: "template id",
+        value: ctx.attrs?.launchTemplateId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.launchTemplateArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "latest version", value: ctx.attrs?.latestVersionNumber },
+      { label: "default version", value: ctx.attrs?.defaultVersionNumber },
+      { label: "instance type", value: ctx.props?.instanceType },
+      { label: "ami", value: ctx.props?.imageId, mono: true },
+    ],
+  },
+);
+
+export const ScalingPolicyUI = UIProvider.succeed<ScalingPolicy>(
+  "AWS.AutoScaling.ScalingPolicy",
+  {
+    displayName: "Scaling Policy",
+    icon: "gauge",
+    color: COMPUTE_ORANGE,
+    category: "compute",
+    summary: (ctx) => ctx.attrs?.policyName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.policyName, copy: true },
+      { label: "arn", value: ctx.attrs?.policyArn, mono: true, copy: true },
+      { label: "auto scaling group", value: ctx.attrs?.autoScalingGroupName },
+      { label: "type", value: ctx.attrs?.policyType },
+      { label: "metric", value: ctx.attrs?.predefinedMetricType },
+      { label: "target value", value: ctx.attrs?.targetValue },
+      { label: "alarms", value: ctx.attrs?.alarms?.length },
+    ],
+  },
+);
+
+export const LifecycleHookUI = UIProvider.succeed<LifecycleHook>(
+  "AWS.AutoScaling.LifecycleHook",
+  {
+    displayName: "Lifecycle Hook",
+    icon: "timer",
+    color: COMPUTE_ORANGE,
+    category: "compute",
+    summary: (ctx) => ctx.attrs?.lifecycleHookName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.lifecycleHookName, copy: true },
+      { label: "auto scaling group", value: ctx.attrs?.autoScalingGroupName },
+      { label: "transition", value: ctx.attrs?.lifecycleTransition },
+      { label: "heartbeat timeout (s)", value: ctx.attrs?.heartbeatTimeout },
+      { label: "default result", value: ctx.attrs?.defaultResult },
+      {
+        label: "notification target",
+        value: ctx.attrs?.notificationTargetARN,
+        mono: true,
+      },
+    ],
+  },
+);
+
+export const ScheduledActionUI = UIProvider.succeed<ScheduledAction>(
+  "AWS.AutoScaling.ScheduledAction",
+  {
+    displayName: "Scheduled Action",
+    icon: "calendar",
+    color: COMPUTE_ORANGE,
+    category: "compute",
+    summary: (ctx) => ctx.attrs?.scheduledActionName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.scheduledActionName, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.scheduledActionARN,
+        mono: true,
+        copy: true,
+      },
+      { label: "auto scaling group", value: ctx.attrs?.autoScalingGroupName },
+      { label: "recurrence", value: ctx.attrs?.recurrence, mono: true },
+      { label: "start time", value: ctx.attrs?.startTime },
+      {
+        label: "capacity",
+        value:
+          ctx.attrs?.desiredCapacity === undefined
+            ? undefined
+            : `${ctx.attrs.minSize ?? ""} / ${ctx.attrs.desiredCapacity} / ${ctx.attrs.maxSize ?? ""} (min/desired/max)`,
+      },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(
+    AutoScalingGroupUI,
+    LaunchTemplateUI,
+    ScalingPolicyUI,
+    LifecycleHookUI,
+    ScheduledActionUI,
+  );

--- a/packages/alchemy/src/AWS/B2BI/ui.ts
+++ b/packages/alchemy/src/AWS/B2BI/ui.ts
@@ -1,0 +1,102 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Capability } from "./Capability.ts";
+import type { Partnership } from "./Partnership.ts";
+import type { Profile } from "./Profile.ts";
+import type { Transformer } from "./Transformer.ts";
+
+/**
+ * Dashboard UI providers for AWS B2BI resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+export const CapabilityUI = UIProvider.succeed<Capability>(
+  "AWS.B2BI.Capability",
+  {
+    displayName: "B2BI Capability",
+    icon: "workflow",
+    color: "#E7157B",
+    category: "eventing",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.capabilityArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "id", value: ctx.attrs?.capabilityId, mono: true },
+      { label: "type", value: ctx.attrs?.type },
+    ],
+  },
+);
+
+export const PartnershipUI = UIProvider.succeed<Partnership>(
+  "AWS.B2BI.Partnership",
+  {
+    displayName: "B2BI Partnership",
+    icon: "share-2",
+    color: "#E7157B",
+    category: "eventing",
+    summary: (ctx) => ctx.props?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.props?.name, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.partnershipArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "id", value: ctx.attrs?.partnershipId, mono: true },
+      { label: "profile", value: ctx.attrs?.profileId, mono: true },
+      {
+        label: "trading partner",
+        value: ctx.attrs?.tradingPartnerId,
+        mono: true,
+      },
+    ],
+  },
+);
+
+export const ProfileUI = UIProvider.succeed<Profile>("AWS.B2BI.Profile", {
+  displayName: "B2BI Profile",
+  icon: "briefcase",
+  color: "#E7157B",
+  category: "eventing",
+  summary: (ctx) => ctx.attrs?.name,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.name, copy: true },
+    { label: "arn", value: ctx.attrs?.profileArn, mono: true, copy: true },
+    { label: "id", value: ctx.attrs?.profileId, mono: true },
+    { label: "business", value: ctx.attrs?.businessName },
+    { label: "log group", value: ctx.attrs?.logGroupName, mono: true },
+  ],
+});
+
+export const TransformerUI = UIProvider.succeed<Transformer>(
+  "AWS.B2BI.Transformer",
+  {
+    displayName: "B2BI Transformer",
+    icon: "repeat",
+    color: "#E7157B",
+    category: "eventing",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.transformerArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "id", value: ctx.attrs?.transformerId, mono: true },
+      { label: "status", value: ctx.attrs?.status },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(CapabilityUI, PartnershipUI, ProfileUI, TransformerUI);

--- a/packages/alchemy/src/AWS/BCMDataExports/ui.ts
+++ b/packages/alchemy/src/AWS/BCMDataExports/ui.ts
@@ -1,0 +1,39 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Export } from "./Export.ts";
+
+/**
+ * Dashboard UI providers for AWS BCMDataExports resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+export const ExportUI = UIProvider.succeed<Export>(
+  "AWS.BCMDataExports.Export",
+  {
+    displayName: "Data Export",
+    icon: "download",
+    color: "#E7157B",
+    category: "billing",
+    summary: (ctx) => ctx.attrs?.exportName,
+    facts: (ctx) => [
+      { label: "export", value: ctx.attrs?.exportName, copy: true },
+      { label: "arn", value: ctx.attrs?.exportArn, mono: true, copy: true },
+      {
+        label: "bucket",
+        value: ctx.props?.s3Destination?.s3Bucket,
+        mono: true,
+      },
+      {
+        label: "prefix",
+        value: ctx.props?.s3Destination?.s3Prefix,
+        mono: true,
+      },
+      { label: "refresh", value: ctx.props?.refreshCadence?.frequency },
+      { label: "description", value: ctx.props?.description },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(ExportUI);

--- a/packages/alchemy/src/AWS/Backup/ui.ts
+++ b/packages/alchemy/src/AWS/Backup/ui.ts
@@ -1,0 +1,88 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { BackupPlan } from "./BackupPlan.ts";
+import type { BackupSelection } from "./BackupSelection.ts";
+import type { BackupVault } from "./BackupVault.ts";
+
+/**
+ * Dashboard UI providers for AWS Backup resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** AWS Storage (Backup) brand green. */
+const COLOR = "#7AA116";
+
+export const BackupPlanUI = UIProvider.succeed<BackupPlan>(
+  "AWS.Backup.BackupPlan",
+  {
+    displayName: "Backup Plan",
+    icon: "calendar",
+    color: COLOR,
+    category: "storage",
+    summary: (ctx) => ctx.attrs?.backupPlanName,
+    facts: (ctx) => [
+      { label: "plan", value: ctx.attrs?.backupPlanName, copy: true },
+      { label: "id", value: ctx.attrs?.backupPlanId, mono: true, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.backupPlanArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "version", value: ctx.attrs?.versionId, mono: true },
+      { label: "rules", value: ctx.props?.rules?.length },
+    ],
+  },
+);
+
+export const BackupSelectionUI = UIProvider.succeed<BackupSelection>(
+  "AWS.Backup.BackupSelection",
+  {
+    displayName: "Backup Selection",
+    icon: "filter",
+    color: COLOR,
+    category: "storage",
+    summary: (ctx) => ctx.attrs?.selectionName,
+    facts: (ctx) => [
+      { label: "selection", value: ctx.attrs?.selectionName, copy: true },
+      { label: "id", value: ctx.attrs?.selectionId, mono: true, copy: true },
+      {
+        label: "backup plan",
+        value: ctx.attrs?.backupPlanId,
+        mono: true,
+        copy: true,
+      },
+      { label: "role", value: ctx.props?.iamRoleArn, mono: true },
+    ],
+  },
+);
+
+export const BackupVaultUI = UIProvider.succeed<BackupVault>(
+  "AWS.Backup.BackupVault",
+  {
+    displayName: "Backup Vault",
+    icon: "archive",
+    color: COLOR,
+    category: "storage",
+    summary: (ctx) => ctx.attrs?.backupVaultName,
+    facts: (ctx) => [
+      { label: "vault", value: ctx.attrs?.backupVaultName, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.backupVaultArn,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "encryption key",
+        value: ctx.props?.encryptionKeyArn,
+        mono: true,
+      },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(BackupPlanUI, BackupSelectionUI, BackupVaultUI);

--- a/packages/alchemy/src/AWS/BackupSearch/ui.ts
+++ b/packages/alchemy/src/AWS/BackupSearch/ui.ts
@@ -1,0 +1,66 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { ExportJob } from "./ExportJob.ts";
+import type { SearchJob } from "./SearchJob.ts";
+
+/**
+ * Dashboard UI providers for AWS BackupSearch resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+export const SearchJobUI = UIProvider.succeed<SearchJob>(
+  "AWS.BackupSearch.SearchJob",
+  {
+    displayName: "Backup Search Job",
+    icon: "search",
+    color: "#7AA116",
+    category: "storage",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      {
+        label: "id",
+        value: ctx.attrs?.searchJobIdentifier,
+        mono: true,
+        copy: true,
+      },
+      { label: "arn", value: ctx.attrs?.searchJobArn, mono: true, copy: true },
+      { label: "status", value: ctx.attrs?.status },
+    ],
+  },
+);
+
+export const ExportJobUI = UIProvider.succeed<ExportJob>(
+  "AWS.BackupSearch.ExportJob",
+  {
+    displayName: "Backup Search Export Job",
+    icon: "download",
+    color: "#7AA116",
+    category: "storage",
+    summary: (ctx) => ctx.attrs?.exportJobIdentifier,
+    facts: (ctx) => [
+      {
+        label: "id",
+        value: ctx.attrs?.exportJobIdentifier,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.exportJobArn,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "search job",
+        value: ctx.attrs?.searchJobArn,
+        mono: true,
+      },
+      { label: "status", value: ctx.attrs?.status },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(SearchJobUI, ExportJobUI);

--- a/packages/alchemy/src/AWS/Batch/ui.ts
+++ b/packages/alchemy/src/AWS/Batch/ui.ts
@@ -1,0 +1,80 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { ComputeEnvironment } from "./ComputeEnvironment.ts";
+import type { JobQueue } from "./JobQueue.ts";
+
+/**
+ * Dashboard UI providers for AWS Batch resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+const regionOf = (arn: string | undefined): string | undefined =>
+  arn?.split(":")[3] || undefined;
+
+export const ComputeEnvironmentUI = UIProvider.succeed<ComputeEnvironment>(
+  "AWS.Batch.ComputeEnvironment",
+  {
+    displayName: "Batch Compute Environment",
+    icon: "cpu",
+    color: "#ED7100",
+    category: "compute",
+    summary: (ctx) => ctx.attrs?.computeEnvironmentName,
+    consoleUrl: (ctx) => {
+      const region = regionOf(ctx.attrs?.computeEnvironmentArn);
+      return region === undefined ||
+        ctx.attrs?.computeEnvironmentName === undefined
+        ? undefined
+        : `https://${region}.console.aws.amazon.com/batch/home?region=${region}#compute-environments/detail/${ctx.attrs.computeEnvironmentName}`;
+    },
+    facts: (ctx) => [
+      {
+        label: "environment",
+        value: ctx.attrs?.computeEnvironmentName,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.computeEnvironmentArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "type", value: ctx.attrs?.type },
+      { label: "management", value: ctx.attrs?.managementType },
+      { label: "state", value: ctx.attrs?.state },
+      { label: "status", value: ctx.attrs?.status },
+      { label: "max vcpus", value: ctx.attrs?.maxvCpus },
+    ],
+  },
+);
+
+export const JobQueueUI = UIProvider.succeed<JobQueue>("AWS.Batch.JobQueue", {
+  displayName: "Batch Job Queue",
+  icon: "list-ordered",
+  color: "#ED7100",
+  category: "queue",
+  summary: (ctx) => ctx.attrs?.jobQueueName,
+  consoleUrl: (ctx) => {
+    const region = regionOf(ctx.attrs?.jobQueueArn);
+    return region === undefined || ctx.attrs?.jobQueueName === undefined
+      ? undefined
+      : `https://${region}.console.aws.amazon.com/batch/home?region=${region}#queues/detail/${ctx.attrs.jobQueueName}`;
+  },
+  facts: (ctx) => [
+    { label: "queue", value: ctx.attrs?.jobQueueName, copy: true },
+    { label: "arn", value: ctx.attrs?.jobQueueArn, mono: true, copy: true },
+    { label: "state", value: ctx.attrs?.state },
+    { label: "status", value: ctx.attrs?.status },
+    { label: "priority", value: ctx.attrs?.priority },
+    {
+      label: "compute environments",
+      value: ctx.attrs?.computeEnvironments?.length
+        ? ctx.attrs.computeEnvironments.join(", ")
+        : undefined,
+      mono: true,
+    },
+  ],
+});
+
+export const ui = () => Layer.mergeAll(ComputeEnvironmentUI, JobQueueUI);

--- a/packages/alchemy/src/AWS/Bedrock/ui.ts
+++ b/packages/alchemy/src/AWS/Bedrock/ui.ts
@@ -1,0 +1,114 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Agent } from "./Agent.ts";
+import type { AgentAlias } from "./AgentAlias.ts";
+import type { DataSource } from "./DataSource.ts";
+import type { KnowledgeBase } from "./KnowledgeBase.ts";
+
+/**
+ * Dashboard UI providers for AWS Bedrock resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+const regionOf = (arn: string | undefined) => arn?.split(":")[3];
+
+export const AgentUI = UIProvider.succeed<Agent>("AWS.Bedrock.Agent", {
+  displayName: "Bedrock Agent",
+  icon: "bot",
+  color: "#01A88D",
+  category: "ai",
+  summary: (ctx) => ctx.attrs?.agentName,
+  consoleUrl: (ctx) => {
+    const region = regionOf(ctx.attrs?.agentArn);
+    return ctx.attrs?.agentId === undefined || region === undefined
+      ? undefined
+      : `https://${region}.console.aws.amazon.com/bedrock/home?region=${region}#/agents/${ctx.attrs.agentId}`;
+  },
+  facts: (ctx) => [
+    { label: "agent", value: ctx.attrs?.agentName, copy: true },
+    { label: "id", value: ctx.attrs?.agentId, mono: true, copy: true },
+    { label: "arn", value: ctx.attrs?.agentArn, mono: true, copy: true },
+    { label: "version", value: ctx.attrs?.agentVersion },
+    { label: "role", value: ctx.attrs?.agentResourceRoleArn, mono: true },
+    { label: "model", value: ctx.props?.foundationModel },
+  ],
+});
+
+export const AgentAliasUI = UIProvider.succeed<AgentAlias>(
+  "AWS.Bedrock.AgentAlias",
+  {
+    displayName: "Bedrock Agent Alias",
+    icon: "tag",
+    color: "#01A88D",
+    category: "ai",
+    summary: (ctx) => ctx.attrs?.agentAliasName,
+    facts: (ctx) => [
+      { label: "alias", value: ctx.attrs?.agentAliasName, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.agentAliasArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "agent", value: ctx.attrs?.agentId, mono: true },
+    ],
+  },
+);
+
+export const DataSourceUI = UIProvider.succeed<DataSource>(
+  "AWS.Bedrock.DataSource",
+  {
+    displayName: "Bedrock Data Source",
+    icon: "folder",
+    color: "#01A88D",
+    category: "ai",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "source", value: ctx.attrs?.name, copy: true },
+      { label: "id", value: ctx.attrs?.dataSourceId, mono: true, copy: true },
+      {
+        label: "knowledge base",
+        value: ctx.attrs?.knowledgeBaseId,
+        mono: true,
+      },
+    ],
+  },
+);
+
+export const KnowledgeBaseUI = UIProvider.succeed<KnowledgeBase>(
+  "AWS.Bedrock.KnowledgeBase",
+  {
+    displayName: "Bedrock Knowledge Base",
+    icon: "brain",
+    color: "#01A88D",
+    category: "ai",
+    summary: (ctx) => ctx.attrs?.name,
+    consoleUrl: (ctx) => {
+      const region = regionOf(ctx.attrs?.knowledgeBaseArn);
+      return ctx.attrs?.knowledgeBaseId === undefined || region === undefined
+        ? undefined
+        : `https://${region}.console.aws.amazon.com/bedrock/home?region=${region}#/knowledge-bases/${ctx.attrs.knowledgeBaseId}`;
+    },
+    facts: (ctx) => [
+      { label: "knowledge base", value: ctx.attrs?.name, copy: true },
+      {
+        label: "id",
+        value: ctx.attrs?.knowledgeBaseId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.knowledgeBaseArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "role", value: ctx.attrs?.roleArn, mono: true },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(AgentUI, AgentAliasUI, DataSourceUI, KnowledgeBaseUI);

--- a/packages/alchemy/src/AWS/BedrockAgentCore/ui.ts
+++ b/packages/alchemy/src/AWS/BedrockAgentCore/ui.ts
@@ -1,0 +1,145 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { BrowserCustom } from "./BrowserCustom.ts";
+import type { CodeInterpreter } from "./CodeInterpreter.ts";
+import type { Gateway } from "./Gateway.ts";
+import type { Memory } from "./Memory.ts";
+import type { Runtime } from "./Runtime.ts";
+
+/**
+ * Dashboard UI providers for AWS BedrockAgentCore resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** AWS Machine Learning & AI brand teal. */
+const COLOR = "#01A88D";
+
+export const BrowserCustomUI = UIProvider.succeed<BrowserCustom>(
+  "AWS.BedrockAgentCore.BrowserCustom",
+  {
+    displayName: "AgentCore Browser",
+    icon: "globe",
+    color: COLOR,
+    category: "ai",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      { label: "id", value: ctx.attrs?.browserId, mono: true, copy: true },
+      { label: "arn", value: ctx.attrs?.browserArn, mono: true, copy: true },
+      { label: "status", value: ctx.attrs?.status },
+    ],
+  },
+);
+
+export const CodeInterpreterUI = UIProvider.succeed<CodeInterpreter>(
+  "AWS.BedrockAgentCore.CodeInterpreter",
+  {
+    displayName: "AgentCore Code Interpreter",
+    icon: "terminal",
+    color: COLOR,
+    category: "ai",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      {
+        label: "id",
+        value: ctx.attrs?.codeInterpreterId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.codeInterpreterArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "status", value: ctx.attrs?.status },
+    ],
+  },
+);
+
+export const GatewayUI = UIProvider.succeed<Gateway>(
+  "AWS.BedrockAgentCore.Gateway",
+  {
+    displayName: "AgentCore Gateway",
+    icon: "waypoints",
+    color: COLOR,
+    category: "ai",
+    summary: (ctx) => ctx.attrs?.name,
+    link: (ctx) => ctx.attrs?.gatewayUrl,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      { label: "id", value: ctx.attrs?.gatewayId, mono: true, copy: true },
+      { label: "arn", value: ctx.attrs?.gatewayArn, mono: true, copy: true },
+      {
+        label: "url",
+        value: ctx.attrs?.gatewayUrl,
+        href: ctx.attrs?.gatewayUrl,
+        copy: true,
+      },
+      { label: "status", value: ctx.attrs?.status },
+      { label: "protocol", value: ctx.props?.protocolType },
+    ],
+  },
+);
+
+export const MemoryUI = UIProvider.succeed<Memory>(
+  "AWS.BedrockAgentCore.Memory",
+  {
+    displayName: "AgentCore Memory",
+    icon: "brain",
+    color: COLOR,
+    category: "ai",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      { label: "id", value: ctx.attrs?.memoryId, mono: true, copy: true },
+      { label: "arn", value: ctx.attrs?.memoryArn, mono: true, copy: true },
+      { label: "status", value: ctx.attrs?.status },
+      {
+        label: "execution role",
+        value: ctx.props?.memoryExecutionRoleArn,
+        mono: true,
+      },
+    ],
+  },
+);
+
+export const RuntimeUI = UIProvider.succeed<Runtime>(
+  "AWS.BedrockAgentCore.Runtime",
+  {
+    displayName: "AgentCore Runtime",
+    icon: "bot",
+    color: COLOR,
+    category: "ai",
+    summary: (ctx) => ctx.attrs?.agentRuntimeName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.agentRuntimeName, copy: true },
+      {
+        label: "id",
+        value: ctx.attrs?.agentRuntimeId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.agentRuntimeArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "version", value: ctx.attrs?.agentRuntimeVersion },
+      { label: "status", value: ctx.attrs?.status },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(
+    BrowserCustomUI,
+    CodeInterpreterUI,
+    GatewayUI,
+    MemoryUI,
+    RuntimeUI,
+  );

--- a/packages/alchemy/src/AWS/BedrockDataAutomation/ui.ts
+++ b/packages/alchemy/src/AWS/BedrockDataAutomation/ui.ts
@@ -1,0 +1,70 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Blueprint } from "./Blueprint.ts";
+import type { DataAutomationLibrary } from "./DataAutomationLibrary.ts";
+import type { DataAutomationProject } from "./DataAutomationProject.ts";
+
+/**
+ * Dashboard UI providers for AWS BedrockDataAutomation resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** AWS machine learning & AI brand teal. */
+const COLOR = "#01A88D";
+
+export const BlueprintUI = UIProvider.succeed<Blueprint>(
+  "AWS.BedrockDataAutomation.Blueprint",
+  {
+    displayName: "Bedrock Data Automation Blueprint",
+    icon: "file-text",
+    color: COLOR,
+    category: "ai",
+    summary: (ctx) => ctx.attrs?.blueprintName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.blueprintName, copy: true },
+      { label: "arn", value: ctx.attrs?.blueprintArn, mono: true, copy: true },
+      { label: "type", value: ctx.attrs?.type },
+      { label: "stage", value: ctx.attrs?.blueprintStage },
+    ],
+  },
+);
+
+export const DataAutomationLibraryUI =
+  UIProvider.succeed<DataAutomationLibrary>(
+    "AWS.BedrockDataAutomation.DataAutomationLibrary",
+    {
+      displayName: "Data Automation Library",
+      icon: "book-open",
+      color: COLOR,
+      category: "ai",
+      summary: (ctx) => ctx.attrs?.libraryName,
+      facts: (ctx) => [
+        { label: "name", value: ctx.attrs?.libraryName, copy: true },
+        { label: "arn", value: ctx.attrs?.libraryArn, mono: true, copy: true },
+        { label: "status", value: ctx.attrs?.status },
+      ],
+    },
+  );
+
+export const DataAutomationProjectUI =
+  UIProvider.succeed<DataAutomationProject>(
+    "AWS.BedrockDataAutomation.DataAutomationProject",
+    {
+      displayName: "Data Automation Project",
+      icon: "sparkles",
+      color: COLOR,
+      category: "ai",
+      summary: (ctx) => ctx.attrs?.projectName,
+      facts: (ctx) => [
+        { label: "name", value: ctx.attrs?.projectName, copy: true },
+        { label: "arn", value: ctx.attrs?.projectArn, mono: true, copy: true },
+        { label: "stage", value: ctx.attrs?.projectStage },
+        { label: "status", value: ctx.attrs?.status },
+      ],
+    },
+  );
+
+export const ui = () =>
+  Layer.mergeAll(BlueprintUI, DataAutomationLibraryUI, DataAutomationProjectUI);

--- a/packages/alchemy/src/AWS/Budgets/ui.ts
+++ b/packages/alchemy/src/AWS/Budgets/ui.ts
@@ -1,0 +1,58 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Budget } from "./Budget.ts";
+import type { BudgetAction } from "./BudgetAction.ts";
+
+/**
+ * Dashboard UI providers for AWS Budgets resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+export const BudgetUI = UIProvider.succeed<Budget>("AWS.Budgets.Budget", {
+  displayName: "Budget",
+  icon: "dollar-sign",
+  color: "#E7157B",
+  category: "billing",
+  summary: (ctx) => ctx.attrs?.budgetName,
+  facts: (ctx) => [
+    { label: "budget", value: ctx.attrs?.budgetName, copy: true },
+    { label: "arn", value: ctx.attrs?.budgetArn, mono: true, copy: true },
+    { label: "account", value: ctx.attrs?.accountId, mono: true },
+    { label: "type", value: ctx.props?.budgetType },
+    { label: "time unit", value: ctx.props?.timeUnit },
+    {
+      label: "limit",
+      value: ctx.props?.budgetLimit
+        ? `${ctx.props.budgetLimit.amount} ${ctx.props.budgetLimit.unit}`
+        : undefined,
+    },
+  ],
+});
+
+export const BudgetActionUI = UIProvider.succeed<BudgetAction>(
+  "AWS.Budgets.BudgetAction",
+  {
+    displayName: "Budget Action",
+    icon: "zap",
+    color: "#E7157B",
+    category: "billing",
+    summary: (ctx) => ctx.attrs?.actionId,
+    facts: (ctx) => [
+      {
+        label: "action id",
+        value: ctx.attrs?.actionId,
+        mono: true,
+        copy: true,
+      },
+      { label: "arn", value: ctx.attrs?.actionArn, mono: true, copy: true },
+      { label: "budget", value: ctx.attrs?.budgetName, copy: true },
+      { label: "account", value: ctx.attrs?.accountId, mono: true },
+      { label: "action type", value: ctx.props?.actionType },
+      { label: "approval", value: ctx.props?.approvalModel },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(BudgetUI, BudgetActionUI);

--- a/packages/alchemy/src/AWS/Chatbot/ui.ts
+++ b/packages/alchemy/src/AWS/Chatbot/ui.ts
@@ -1,0 +1,119 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Association } from "./Association.ts";
+import type { CustomAction } from "./CustomAction.ts";
+import type { MicrosoftTeamsChannelConfiguration } from "./MicrosoftTeamsChannelConfiguration.ts";
+import type { SlackChannelConfiguration } from "./SlackChannelConfiguration.ts";
+
+/**
+ * Dashboard UI providers for AWS Chatbot resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** AWS Management & Governance (Chatbot) brand pink. */
+const COLOR = "#E7157B";
+
+export const SlackChannelConfigurationUI =
+  UIProvider.succeed<SlackChannelConfiguration>(
+    "AWS.Chatbot.SlackChannelConfiguration",
+    {
+      displayName: "Chatbot Slack Channel Configuration",
+      icon: "message-square",
+      color: COLOR,
+      category: "config",
+      summary: (ctx) => ctx.attrs?.configurationName,
+      facts: (ctx) => [
+        { label: "name", value: ctx.attrs?.configurationName, copy: true },
+        {
+          label: "arn",
+          value: ctx.attrs?.chatConfigurationArn,
+          mono: true,
+          copy: true,
+        },
+        { label: "slack team", value: ctx.attrs?.slackTeamName },
+        { label: "team id", value: ctx.attrs?.slackTeamId, mono: true },
+        { label: "channel id", value: ctx.attrs?.slackChannelId, mono: true },
+        { label: "state", value: ctx.attrs?.state },
+      ],
+    },
+  );
+
+export const MicrosoftTeamsChannelConfigurationUI =
+  UIProvider.succeed<MicrosoftTeamsChannelConfiguration>(
+    "AWS.Chatbot.MicrosoftTeamsChannelConfiguration",
+    {
+      displayName: "Chatbot Microsoft Teams Channel Configuration",
+      icon: "message-square",
+      color: COLOR,
+      category: "config",
+      summary: (ctx) => ctx.attrs?.configurationName,
+      facts: (ctx) => [
+        { label: "name", value: ctx.attrs?.configurationName, copy: true },
+        {
+          label: "arn",
+          value: ctx.attrs?.chatConfigurationArn,
+          mono: true,
+          copy: true,
+        },
+        { label: "team id", value: ctx.attrs?.teamId, mono: true },
+        { label: "tenant id", value: ctx.attrs?.tenantId, mono: true },
+        { label: "channel id", value: ctx.attrs?.teamsChannelId, mono: true },
+        { label: "state", value: ctx.attrs?.state },
+      ],
+    },
+  );
+
+export const CustomActionUI = UIProvider.succeed<CustomAction>(
+  "AWS.Chatbot.CustomAction",
+  {
+    displayName: "Chatbot Custom Action",
+    icon: "terminal",
+    color: COLOR,
+    category: "config",
+    summary: (ctx) => ctx.attrs?.actionName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.actionName, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.customActionArn,
+        mono: true,
+        copy: true,
+      },
+    ],
+  },
+);
+
+export const AssociationUI = UIProvider.succeed<Association>(
+  "AWS.Chatbot.Association",
+  {
+    displayName: "Chatbot Association",
+    icon: "link",
+    color: COLOR,
+    category: "config",
+    summary: (ctx) => ctx.attrs?.resourceArn,
+    facts: (ctx) => [
+      {
+        label: "chat configuration",
+        value: ctx.attrs?.chatConfigurationArn,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "resource",
+        value: ctx.attrs?.resourceArn,
+        mono: true,
+        copy: true,
+      },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(
+    SlackChannelConfigurationUI,
+    MicrosoftTeamsChannelConfigurationUI,
+    CustomActionUI,
+    AssociationUI,
+  );

--- a/packages/alchemy/src/AWS/CloudFormation/ui.ts
+++ b/packages/alchemy/src/AWS/CloudFormation/ui.ts
@@ -1,0 +1,40 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Stack } from "./Stack.ts";
+
+/**
+ * Dashboard UI providers for AWS CloudFormation resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+const regionOf = (arn: string | undefined): string | undefined =>
+  arn?.split(":")[3] || undefined;
+
+export const StackUI = UIProvider.succeed<Stack>("AWS.CloudFormation.Stack", {
+  displayName: "CloudFormation Stack",
+  icon: "layers",
+  color: "#E7157B",
+  category: "config",
+  summary: (ctx) => ctx.attrs?.stackName,
+  consoleUrl: (ctx) => {
+    const region = regionOf(ctx.attrs?.stackId);
+    return region === undefined || ctx.attrs?.stackId === undefined
+      ? undefined
+      : `https://${region}.console.aws.amazon.com/cloudformation/home?region=${region}#/stacks/stackinfo?stackId=${encodeURIComponent(ctx.attrs.stackId)}`;
+  },
+  facts: (ctx) => [
+    { label: "stack", value: ctx.attrs?.stackName, copy: true },
+    { label: "stack id", value: ctx.attrs?.stackId, mono: true, copy: true },
+    { label: "status", value: ctx.attrs?.stackStatus },
+    {
+      label: "outputs",
+      value: ctx.attrs?.outputs
+        ? Object.keys(ctx.attrs.outputs).length
+        : undefined,
+    },
+  ],
+});
+
+export const ui = () => Layer.mergeAll(StackUI);

--- a/packages/alchemy/src/AWS/CloudFront/ui.ts
+++ b/packages/alchemy/src/AWS/CloudFront/ui.ts
@@ -1,0 +1,381 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { CachePolicy } from "./CachePolicy.ts";
+import type { Distribution } from "./Distribution.ts";
+import type { Function } from "./Function.ts";
+import type { Invalidation } from "./Invalidation.ts";
+import type { KeyGroup } from "./KeyGroup.ts";
+import type { KeyValueStore } from "./KeyValueStore.ts";
+import type { KvEntries } from "./KvEntries.ts";
+import type { KvRoutesUpdate } from "./KvRoutesUpdate.ts";
+import type { OriginAccessControl } from "./OriginAccessControl.ts";
+import type { OriginRequestPolicy } from "./OriginRequestPolicy.ts";
+import type { PublicKey } from "./PublicKey.ts";
+import type { RealtimeLogConfig } from "./RealtimeLogConfig.ts";
+import type { ResponseHeadersPolicy } from "./ResponseHeadersPolicy.ts";
+import type { VpcOrigin } from "./VpcOrigin.ts";
+
+/**
+ * Dashboard UI providers for AWS CloudFront resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** CloudFront brand color (AWS Networking & Content Delivery purple). */
+const CLOUDFRONT_COLOR = "#8C4FFF";
+
+export const DistributionUI = UIProvider.succeed<Distribution>(
+  "AWS.CloudFront.Distribution",
+  {
+    displayName: "CloudFront Distribution",
+    icon: "globe",
+    color: CLOUDFRONT_COLOR,
+    category: "cdn",
+    summary: (ctx) => ctx.attrs?.domainName ?? ctx.attrs?.distributionId,
+    link: (ctx) =>
+      ctx.attrs?.domainName === undefined
+        ? undefined
+        : `https://${ctx.attrs.domainName}`,
+    consoleUrl: (ctx) =>
+      ctx.attrs?.distributionId === undefined
+        ? undefined
+        : `https://console.aws.amazon.com/cloudfront/v4/home#/distributions/${ctx.attrs.distributionId}`,
+    facts: (ctx) => [
+      { label: "id", value: ctx.attrs?.distributionId, mono: true, copy: true },
+      {
+        label: "domain",
+        value: ctx.attrs?.domainName,
+        href:
+          ctx.attrs?.domainName === undefined
+            ? undefined
+            : `https://${ctx.attrs.domainName}`,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.distributionArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "status", value: ctx.attrs?.status },
+      { label: "enabled", value: ctx.attrs?.enabled },
+      { label: "aliases", value: ctx.attrs?.aliases?.join(", ") },
+      { label: "hosted zone", value: ctx.attrs?.hostedZoneId, mono: true },
+    ],
+  },
+);
+
+export const FunctionUI = UIProvider.succeed<Function>(
+  "AWS.CloudFront.Function",
+  {
+    displayName: "CloudFront Function",
+    icon: "code",
+    color: CLOUDFRONT_COLOR,
+    category: "compute",
+    summary: (ctx) => ctx.attrs?.functionName,
+    consoleUrl: (ctx) =>
+      ctx.attrs?.functionName === undefined
+        ? undefined
+        : `https://console.aws.amazon.com/cloudfront/v4/home#/functions/${ctx.attrs.functionName}`,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.functionName, copy: true },
+      { label: "arn", value: ctx.attrs?.functionArn, mono: true, copy: true },
+      { label: "runtime", value: ctx.attrs?.runtime },
+      { label: "stage", value: ctx.attrs?.stage },
+      { label: "status", value: ctx.attrs?.status },
+      { label: "kv stores", value: ctx.attrs?.keyValueStoreArns?.length },
+    ],
+  },
+);
+
+export const CachePolicyUI = UIProvider.succeed<CachePolicy>(
+  "AWS.CloudFront.CachePolicy",
+  {
+    displayName: "CloudFront Cache Policy",
+    icon: "timer",
+    color: CLOUDFRONT_COLOR,
+    category: "cdn",
+    summary: (ctx) => ctx.attrs?.name ?? ctx.attrs?.cachePolicyId,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      { label: "id", value: ctx.attrs?.cachePolicyId, mono: true, copy: true },
+      { label: "min TTL", value: ctx.attrs?.minTTL },
+      { label: "default TTL", value: ctx.attrs?.defaultTTL },
+      { label: "max TTL", value: ctx.attrs?.maxTTL },
+      { label: "comment", value: ctx.attrs?.comment },
+    ],
+  },
+);
+
+export const OriginRequestPolicyUI = UIProvider.succeed<OriginRequestPolicy>(
+  "AWS.CloudFront.OriginRequestPolicy",
+  {
+    displayName: "CloudFront Origin Request Policy",
+    icon: "arrow-right-left",
+    color: CLOUDFRONT_COLOR,
+    category: "cdn",
+    summary: (ctx) => ctx.attrs?.name ?? ctx.attrs?.originRequestPolicyId,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      {
+        label: "id",
+        value: ctx.attrs?.originRequestPolicyId,
+        mono: true,
+        copy: true,
+      },
+      { label: "headers", value: ctx.attrs?.headersConfig?.HeaderBehavior },
+      { label: "cookies", value: ctx.attrs?.cookiesConfig?.CookieBehavior },
+      {
+        label: "query strings",
+        value: ctx.attrs?.queryStringsConfig?.QueryStringBehavior,
+      },
+      { label: "comment", value: ctx.attrs?.comment },
+    ],
+  },
+);
+
+export const ResponseHeadersPolicyUI =
+  UIProvider.succeed<ResponseHeadersPolicy>(
+    "AWS.CloudFront.ResponseHeadersPolicy",
+    {
+      displayName: "CloudFront Response Headers Policy",
+      icon: "shield",
+      color: CLOUDFRONT_COLOR,
+      category: "cdn",
+      summary: (ctx) => ctx.attrs?.name ?? ctx.attrs?.responseHeadersPolicyId,
+      facts: (ctx) => [
+        { label: "name", value: ctx.attrs?.name, copy: true },
+        {
+          label: "id",
+          value: ctx.attrs?.responseHeadersPolicyId,
+          mono: true,
+          copy: true,
+        },
+        { label: "cors", value: ctx.attrs?.corsConfig !== undefined },
+        {
+          label: "security headers",
+          value: ctx.attrs?.securityHeadersConfig !== undefined,
+        },
+        {
+          label: "server timing",
+          value: ctx.attrs?.serverTimingHeadersConfig !== undefined,
+        },
+        { label: "comment", value: ctx.attrs?.comment },
+      ],
+    },
+  );
+
+export const OriginAccessControlUI = UIProvider.succeed<OriginAccessControl>(
+  "AWS.CloudFront.OriginAccessControl",
+  {
+    displayName: "CloudFront Origin Access Control",
+    icon: "lock",
+    color: CLOUDFRONT_COLOR,
+    category: "security",
+    summary: (ctx) => ctx.attrs?.name ?? ctx.attrs?.originAccessControlId,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      {
+        label: "id",
+        value: ctx.attrs?.originAccessControlId,
+        mono: true,
+        copy: true,
+      },
+      { label: "origin type", value: ctx.attrs?.originType },
+      { label: "signing behavior", value: ctx.attrs?.signingBehavior },
+      { label: "signing protocol", value: ctx.attrs?.signingProtocol },
+      { label: "description", value: ctx.attrs?.description },
+    ],
+  },
+);
+
+export const PublicKeyUI = UIProvider.succeed<PublicKey>(
+  "AWS.CloudFront.PublicKey",
+  {
+    displayName: "CloudFront Public Key",
+    icon: "key-round",
+    color: CLOUDFRONT_COLOR,
+    category: "security",
+    summary: (ctx) => ctx.attrs?.name ?? ctx.attrs?.publicKeyId,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      { label: "id", value: ctx.attrs?.publicKeyId, mono: true, copy: true },
+      {
+        label: "caller reference",
+        value: ctx.attrs?.callerReference,
+        mono: true,
+      },
+      { label: "comment", value: ctx.attrs?.comment },
+    ],
+  },
+);
+
+export const KeyGroupUI = UIProvider.succeed<KeyGroup>(
+  "AWS.CloudFront.KeyGroup",
+  {
+    displayName: "CloudFront Key Group",
+    icon: "key",
+    color: CLOUDFRONT_COLOR,
+    category: "security",
+    summary: (ctx) => ctx.attrs?.name ?? ctx.attrs?.keyGroupId,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      { label: "id", value: ctx.attrs?.keyGroupId, mono: true, copy: true },
+      { label: "public keys", value: ctx.attrs?.items?.length },
+      { label: "comment", value: ctx.attrs?.comment },
+    ],
+  },
+);
+
+export const KeyValueStoreUI = UIProvider.succeed<KeyValueStore>(
+  "AWS.CloudFront.KeyValueStore",
+  {
+    displayName: "CloudFront KeyValueStore",
+    icon: "database",
+    color: CLOUDFRONT_COLOR,
+    category: "storage",
+    summary: (ctx) =>
+      ctx.attrs?.keyValueStoreName ?? ctx.attrs?.keyValueStoreId,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.keyValueStoreName, copy: true },
+      {
+        label: "id",
+        value: ctx.attrs?.keyValueStoreId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.keyValueStoreArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "status", value: ctx.attrs?.status },
+      { label: "comment", value: ctx.attrs?.comment },
+    ],
+  },
+);
+
+export const KvEntriesUI = UIProvider.succeed<KvEntries>(
+  "AWS.CloudFront.KvEntries",
+  {
+    displayName: "CloudFront KV Entries",
+    icon: "list",
+    color: CLOUDFRONT_COLOR,
+    category: "storage",
+    summary: (ctx) => ctx.attrs?.namespace,
+    facts: (ctx) => [
+      { label: "namespace", value: ctx.attrs?.namespace, mono: true },
+      { label: "store", value: ctx.attrs?.store, mono: true, copy: true },
+      {
+        label: "entries",
+        value:
+          ctx.attrs?.entries === undefined
+            ? undefined
+            : Object.keys(ctx.attrs.entries).length,
+      },
+    ],
+  },
+);
+
+export const KvRoutesUpdateUI = UIProvider.succeed<KvRoutesUpdate>(
+  "AWS.CloudFront.KvRoutesUpdate",
+  {
+    displayName: "CloudFront KV Route",
+    icon: "route",
+    color: CLOUDFRONT_COLOR,
+    category: "cdn",
+    summary: (ctx) =>
+      ctx.attrs?.namespace === undefined || ctx.attrs?.key === undefined
+        ? undefined
+        : `${ctx.attrs.namespace}:${ctx.attrs.key}`,
+    facts: (ctx) => [
+      { label: "namespace", value: ctx.attrs?.namespace, mono: true },
+      { label: "key", value: ctx.attrs?.key, mono: true },
+      { label: "entry", value: ctx.attrs?.entry, mono: true, copy: true },
+      { label: "store", value: ctx.attrs?.store, mono: true, copy: true },
+    ],
+  },
+);
+
+export const InvalidationUI = UIProvider.succeed<Invalidation>(
+  "AWS.CloudFront.Invalidation",
+  {
+    displayName: "CloudFront Invalidation",
+    icon: "refresh-cw",
+    color: CLOUDFRONT_COLOR,
+    category: "cdn",
+    summary: (ctx) => ctx.attrs?.invalidationId,
+    consoleUrl: (ctx) =>
+      ctx.attrs?.distributionId === undefined
+        ? undefined
+        : `https://console.aws.amazon.com/cloudfront/v4/home#/distributions/${ctx.attrs.distributionId}`,
+    facts: (ctx) => [
+      { label: "id", value: ctx.attrs?.invalidationId, mono: true, copy: true },
+      {
+        label: "distribution",
+        value: ctx.attrs?.distributionId,
+        mono: true,
+        copy: true,
+      },
+      { label: "status", value: ctx.attrs?.status },
+      { label: "version", value: ctx.attrs?.version, mono: true },
+      { label: "paths", value: ctx.attrs?.paths?.join(", "), mono: true },
+    ],
+  },
+);
+
+export const VpcOriginUI = UIProvider.succeed<VpcOrigin>(
+  "AWS.CloudFront.VpcOrigin",
+  {
+    displayName: "CloudFront VPC Origin",
+    icon: "network",
+    color: CLOUDFRONT_COLOR,
+    category: "network",
+    summary: (ctx) => ctx.attrs?.name ?? ctx.attrs?.vpcOriginId,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      { label: "id", value: ctx.attrs?.vpcOriginId, mono: true, copy: true },
+      { label: "arn", value: ctx.attrs?.vpcOriginArn, mono: true, copy: true },
+      { label: "origin arn", value: ctx.attrs?.arn, mono: true, copy: true },
+      { label: "status", value: ctx.attrs?.status },
+    ],
+  },
+);
+
+export const RealtimeLogConfigUI = UIProvider.succeed<RealtimeLogConfig>(
+  "AWS.CloudFront.RealtimeLogConfig",
+  {
+    displayName: "CloudFront Real-Time Log Config",
+    icon: "scroll-text",
+    color: CLOUDFRONT_COLOR,
+    category: "cdn",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      { label: "arn", value: ctx.attrs?.arn, mono: true, copy: true },
+      { label: "sampling rate", value: ctx.attrs?.samplingRate },
+      { label: "fields", value: ctx.attrs?.fields?.join(", "), mono: true },
+      { label: "endpoints", value: ctx.attrs?.endpoints?.length },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(
+    DistributionUI,
+    FunctionUI,
+    CachePolicyUI,
+    OriginRequestPolicyUI,
+    ResponseHeadersPolicyUI,
+    OriginAccessControlUI,
+    PublicKeyUI,
+    KeyGroupUI,
+    KeyValueStoreUI,
+    KvEntriesUI,
+    KvRoutesUpdateUI,
+    InvalidationUI,
+    VpcOriginUI,
+    RealtimeLogConfigUI,
+  );

--- a/packages/alchemy/src/AWS/CloudHSMV2/ui.ts
+++ b/packages/alchemy/src/AWS/CloudHSMV2/ui.ts
@@ -1,0 +1,54 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Cluster } from "./Cluster.ts";
+import type { Hsm } from "./Hsm.ts";
+
+/**
+ * Dashboard UI providers for AWS CloudHSMV2 resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** AWS Security, Identity & Compliance brand red. */
+const COLOR = "#DD344C";
+
+export const ClusterUI = UIProvider.succeed<Cluster>("AWS.CloudHSMV2.Cluster", {
+  displayName: "CloudHSM Cluster",
+  icon: "shield-check",
+  color: COLOR,
+  category: "security",
+  summary: (ctx) => ctx.attrs?.clusterId,
+  facts: (ctx) => [
+    {
+      label: "cluster id",
+      value: ctx.attrs?.clusterId,
+      mono: true,
+      copy: true,
+    },
+    { label: "state", value: ctx.attrs?.state },
+    { label: "hsm type", value: ctx.attrs?.hsmType },
+    { label: "mode", value: ctx.attrs?.mode },
+    { label: "network type", value: ctx.attrs?.networkType },
+    { label: "vpc", value: ctx.attrs?.vpcId, mono: true },
+    { label: "backup retention (days)", value: ctx.attrs?.backupRetentionDays },
+  ],
+});
+
+export const HsmUI = UIProvider.succeed<Hsm>("AWS.CloudHSMV2.Hsm", {
+  displayName: "CloudHSM HSM",
+  icon: "cpu",
+  color: COLOR,
+  category: "security",
+  summary: (ctx) => ctx.attrs?.hsmId,
+  facts: (ctx) => [
+    { label: "hsm id", value: ctx.attrs?.hsmId, mono: true, copy: true },
+    { label: "cluster", value: ctx.attrs?.clusterId, mono: true, copy: true },
+    { label: "state", value: ctx.attrs?.state },
+    { label: "az", value: ctx.attrs?.availabilityZone },
+    { label: "eni", value: ctx.attrs?.eniId, mono: true },
+    { label: "eni ip", value: ctx.attrs?.eniIp, mono: true },
+  ],
+});
+
+export const ui = () => Layer.mergeAll(ClusterUI, HsmUI);

--- a/packages/alchemy/src/AWS/CloudMap/ui.ts
+++ b/packages/alchemy/src/AWS/CloudMap/ui.ts
@@ -1,0 +1,156 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { HttpNamespace } from "./HttpNamespace.ts";
+import type { InstanceRegistration } from "./InstanceRegistration.ts";
+import type { PrivateDnsNamespace } from "./PrivateDnsNamespace.ts";
+import type { PublicDnsNamespace } from "./PublicDnsNamespace.ts";
+import type { Service } from "./Service.ts";
+
+/**
+ * Dashboard UI providers for AWS CloudMap resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+const COLOR = "#8C4FFF";
+
+export const HttpNamespaceUI = UIProvider.succeed<HttpNamespace>(
+  "AWS.CloudMap.HttpNamespace",
+  {
+    displayName: "Cloud Map HTTP Namespace",
+    icon: "waypoints",
+    color: COLOR,
+    category: "network",
+    summary: (ctx) => ctx.attrs?.namespaceName,
+    facts: (ctx) => [
+      { label: "namespace", value: ctx.attrs?.namespaceName, copy: true },
+      {
+        label: "id",
+        value: ctx.attrs?.namespaceId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.namespaceArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "http name", value: ctx.attrs?.httpName, mono: true },
+      { label: "description", value: ctx.props?.description },
+    ],
+  },
+);
+
+export const PrivateDnsNamespaceUI = UIProvider.succeed<PrivateDnsNamespace>(
+  "AWS.CloudMap.PrivateDnsNamespace",
+  {
+    displayName: "Cloud Map Private DNS Namespace",
+    icon: "globe",
+    color: COLOR,
+    category: "dns",
+    summary: (ctx) => ctx.attrs?.namespaceName,
+    facts: (ctx) => [
+      { label: "namespace", value: ctx.attrs?.namespaceName, copy: true },
+      {
+        label: "id",
+        value: ctx.attrs?.namespaceId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.namespaceArn,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "hosted zone",
+        value: ctx.attrs?.hostedZoneId,
+        mono: true,
+        copy: true,
+      },
+      { label: "vpc", value: ctx.props?.vpc, mono: true },
+    ],
+  },
+);
+
+export const PublicDnsNamespaceUI = UIProvider.succeed<PublicDnsNamespace>(
+  "AWS.CloudMap.PublicDnsNamespace",
+  {
+    displayName: "Cloud Map Public DNS Namespace",
+    icon: "globe",
+    color: COLOR,
+    category: "dns",
+    summary: (ctx) => ctx.attrs?.namespaceName,
+    facts: (ctx) => [
+      { label: "namespace", value: ctx.attrs?.namespaceName, copy: true },
+      {
+        label: "id",
+        value: ctx.attrs?.namespaceId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.namespaceArn,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "hosted zone",
+        value: ctx.attrs?.hostedZoneId,
+        mono: true,
+        copy: true,
+      },
+    ],
+  },
+);
+
+export const ServiceUI = UIProvider.succeed<Service>("AWS.CloudMap.Service", {
+  displayName: "Cloud Map Service",
+  icon: "share-2",
+  color: COLOR,
+  category: "network",
+  summary: (ctx) => ctx.attrs?.serviceName,
+  facts: (ctx) => [
+    { label: "service", value: ctx.attrs?.serviceName, copy: true },
+    { label: "id", value: ctx.attrs?.serviceId, mono: true, copy: true },
+    { label: "arn", value: ctx.attrs?.serviceArn, mono: true, copy: true },
+    {
+      label: "namespace",
+      value: ctx.attrs?.namespaceName,
+      mono: true,
+    },
+  ],
+});
+
+export const InstanceRegistrationUI = UIProvider.succeed<InstanceRegistration>(
+  "AWS.CloudMap.InstanceRegistration",
+  {
+    displayName: "Cloud Map Instance Registration",
+    icon: "plug",
+    color: COLOR,
+    category: "network",
+    summary: (ctx) => ctx.attrs?.instanceId,
+    facts: (ctx) => [
+      { label: "instance", value: ctx.attrs?.instanceId, copy: true },
+      {
+        label: "service",
+        value: ctx.attrs?.serviceId,
+        mono: true,
+        copy: true,
+      },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(
+    HttpNamespaceUI,
+    PrivateDnsNamespaceUI,
+    PublicDnsNamespaceUI,
+    ServiceUI,
+    InstanceRegistrationUI,
+  );

--- a/packages/alchemy/src/AWS/CloudTrail/ui.ts
+++ b/packages/alchemy/src/AWS/CloudTrail/ui.ts
@@ -1,0 +1,55 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { EventDataStore } from "./EventDataStore.ts";
+import type { Trail } from "./Trail.ts";
+
+/**
+ * Dashboard UI providers for AWS CloudTrail resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** AWS Management & Governance / Observability (CloudTrail) brand pink. */
+const COLOR = "#E7157B";
+
+export const EventDataStoreUI = UIProvider.succeed<EventDataStore>(
+  "AWS.CloudTrail.EventDataStore",
+  {
+    displayName: "CloudTrail Event Data Store",
+    icon: "database",
+    color: COLOR,
+    category: "observability",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.eventDataStoreArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "status", value: ctx.attrs?.status },
+      { label: "multi-region", value: ctx.props?.multiRegionEnabled },
+      { label: "organization", value: ctx.props?.organizationEnabled },
+    ],
+  },
+);
+
+export const TrailUI = UIProvider.succeed<Trail>("AWS.CloudTrail.Trail", {
+  displayName: "CloudTrail Trail",
+  icon: "scroll-text",
+  color: COLOR,
+  category: "observability",
+  summary: (ctx) => ctx.attrs?.trailName,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.trailName, copy: true },
+    { label: "arn", value: ctx.attrs?.trailArn, mono: true, copy: true },
+    { label: "region", value: ctx.attrs?.homeRegion },
+    { label: "bucket", value: ctx.attrs?.s3BucketName, mono: true, copy: true },
+    { label: "logging", value: ctx.attrs?.isLogging },
+    { label: "multi-region", value: ctx.props?.isMultiRegionTrail },
+  ],
+});
+
+export const ui = () => Layer.mergeAll(EventDataStoreUI, TrailUI);

--- a/packages/alchemy/src/AWS/CloudWatch/ui.ts
+++ b/packages/alchemy/src/AWS/CloudWatch/ui.ts
@@ -1,0 +1,188 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Alarm } from "./Alarm.ts";
+import type { AlarmMuteRule } from "./AlarmMuteRule.ts";
+import type { AnomalyDetector } from "./AnomalyDetector.ts";
+import type { CompositeAlarm } from "./CompositeAlarm.ts";
+import type { Dashboard } from "./Dashboard.ts";
+import type { InsightRule } from "./InsightRule.ts";
+import type { MetricStream } from "./MetricStream.ts";
+
+/**
+ * Dashboard UI providers for AWS CloudWatch resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+const regionOf = (arn: string | undefined) => arn?.split(":")[3];
+
+export const AlarmUI = UIProvider.succeed<Alarm>("AWS.CloudWatch.Alarm", {
+  displayName: "CloudWatch Alarm",
+  icon: "bell",
+  color: "#E7157B",
+  category: "observability",
+  summary: (ctx) => ctx.attrs?.alarmName,
+  consoleUrl: (ctx) => {
+    const region = regionOf(ctx.attrs?.alarmArn);
+    return ctx.attrs?.alarmName === undefined || region === undefined
+      ? undefined
+      : `https://${region}.console.aws.amazon.com/cloudwatch/home?region=${region}#alarmsV2:alarm/${encodeURIComponent(ctx.attrs.alarmName)}`;
+  },
+  facts: (ctx) => [
+    { label: "alarm", value: ctx.attrs?.alarmName, copy: true },
+    { label: "arn", value: ctx.attrs?.alarmArn, mono: true, copy: true },
+    { label: "state", value: ctx.attrs?.stateValue },
+    { label: "namespace", value: ctx.props?.Namespace },
+    { label: "metric", value: ctx.props?.MetricName },
+    { label: "reason", value: ctx.attrs?.stateReason },
+  ],
+});
+
+export const CompositeAlarmUI = UIProvider.succeed<CompositeAlarm>(
+  "AWS.CloudWatch.CompositeAlarm",
+  {
+    displayName: "CloudWatch Composite Alarm",
+    icon: "bell-plus",
+    color: "#E7157B",
+    category: "observability",
+    summary: (ctx) => ctx.attrs?.alarmName,
+    consoleUrl: (ctx) => {
+      const region = regionOf(ctx.attrs?.alarmArn);
+      return ctx.attrs?.alarmName === undefined || region === undefined
+        ? undefined
+        : `https://${region}.console.aws.amazon.com/cloudwatch/home?region=${region}#alarmsV2:alarm/${encodeURIComponent(ctx.attrs.alarmName)}`;
+    },
+    facts: (ctx) => [
+      { label: "alarm", value: ctx.attrs?.alarmName, copy: true },
+      { label: "arn", value: ctx.attrs?.alarmArn, mono: true, copy: true },
+      { label: "state", value: ctx.attrs?.stateValue },
+      { label: "rule", value: ctx.props?.AlarmRule, mono: true },
+      { label: "reason", value: ctx.attrs?.stateReason },
+    ],
+  },
+);
+
+export const AlarmMuteRuleUI = UIProvider.succeed<AlarmMuteRule>(
+  "AWS.CloudWatch.AlarmMuteRule",
+  {
+    displayName: "CloudWatch Alarm Mute Rule",
+    icon: "bell-off",
+    color: "#E7157B",
+    category: "observability",
+    summary: (ctx) => ctx.attrs?.alarmMuteRuleName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.alarmMuteRuleName, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.alarmMuteRuleArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "status", value: ctx.attrs?.status },
+      { label: "mute type", value: ctx.attrs?.muteType },
+    ],
+  },
+);
+
+export const AnomalyDetectorUI = UIProvider.succeed<AnomalyDetector>(
+  "AWS.CloudWatch.AnomalyDetector",
+  {
+    displayName: "CloudWatch Anomaly Detector",
+    icon: "activity",
+    color: "#E7157B",
+    category: "observability",
+    summary: (ctx) =>
+      ctx.props?.MetricName
+        ? `${ctx.props?.Namespace ? `${ctx.props.Namespace}/` : ""}${ctx.props.MetricName}`
+        : ctx.attrs?.detectorId,
+    facts: (ctx) => [
+      { label: "detector id", value: ctx.attrs?.detectorId, mono: true },
+      { label: "namespace", value: ctx.props?.Namespace },
+      { label: "metric", value: ctx.props?.MetricName },
+      { label: "stat", value: ctx.props?.Stat },
+    ],
+  },
+);
+
+export const DashboardUI = UIProvider.succeed<Dashboard>(
+  "AWS.CloudWatch.Dashboard",
+  {
+    displayName: "CloudWatch Dashboard",
+    icon: "layout-dashboard",
+    color: "#E7157B",
+    category: "observability",
+    summary: (ctx) => ctx.attrs?.dashboardName,
+    consoleUrl: (ctx) => {
+      const region = regionOf(ctx.attrs?.dashboardArn);
+      return ctx.attrs?.dashboardName === undefined || region === undefined
+        ? undefined
+        : `https://${region}.console.aws.amazon.com/cloudwatch/home?region=${region}#dashboards:name=${encodeURIComponent(ctx.attrs.dashboardName)}`;
+    },
+    facts: (ctx) => [
+      { label: "dashboard", value: ctx.attrs?.dashboardName, copy: true },
+      { label: "arn", value: ctx.attrs?.dashboardArn, mono: true, copy: true },
+      {
+        label: "widgets",
+        value: Array.isArray((ctx.attrs?.dashboardBody as any)?.widgets)
+          ? (ctx.attrs?.dashboardBody as any).widgets.length
+          : undefined,
+      },
+    ],
+  },
+);
+
+export const InsightRuleUI = UIProvider.succeed<InsightRule>(
+  "AWS.CloudWatch.InsightRule",
+  {
+    displayName: "CloudWatch Insight Rule",
+    icon: "trending-up",
+    color: "#E7157B",
+    category: "observability",
+    summary: (ctx) => ctx.attrs?.ruleName,
+    facts: (ctx) => [
+      { label: "rule", value: ctx.attrs?.ruleName, copy: true },
+      { label: "arn", value: ctx.attrs?.ruleArn, mono: true, copy: true },
+      { label: "state", value: ctx.attrs?.state },
+    ],
+  },
+);
+
+export const MetricStreamUI = UIProvider.succeed<MetricStream>(
+  "AWS.CloudWatch.MetricStream",
+  {
+    displayName: "CloudWatch Metric Stream",
+    icon: "waves",
+    color: "#E7157B",
+    category: "observability",
+    summary: (ctx) => ctx.attrs?.metricStreamName,
+    facts: (ctx) => [
+      { label: "stream", value: ctx.attrs?.metricStreamName, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.metricStreamArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "state", value: ctx.attrs?.state },
+      { label: "output format", value: ctx.props?.OutputFormat },
+      {
+        label: "firehose",
+        value: ctx.props?.FirehoseArn,
+        mono: true,
+        copy: true,
+      },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(
+    AlarmUI,
+    CompositeAlarmUI,
+    AlarmMuteRuleUI,
+    AnomalyDetectorUI,
+    DashboardUI,
+    InsightRuleUI,
+    MetricStreamUI,
+  );

--- a/packages/alchemy/src/AWS/CodeArtifact/ui.ts
+++ b/packages/alchemy/src/AWS/CodeArtifact/ui.ts
@@ -1,0 +1,54 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Domain } from "./Domain.ts";
+import type { Repository } from "./Repository.ts";
+
+/**
+ * Dashboard UI providers for AWS CodeArtifact resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+export const DomainUI = UIProvider.succeed<Domain>("AWS.CodeArtifact.Domain", {
+  displayName: "CodeArtifact Domain",
+  icon: "package",
+  color: "#7AA116",
+  category: "storage",
+  summary: (ctx) => ctx.attrs?.domainName,
+  facts: (ctx) => [
+    { label: "domain", value: ctx.attrs?.domainName, copy: true },
+    { label: "arn", value: ctx.attrs?.domainArn, mono: true, copy: true },
+    { label: "owner", value: ctx.attrs?.owner, mono: true },
+    { label: "status", value: ctx.attrs?.status },
+    { label: "encryption key", value: ctx.attrs?.encryptionKey, mono: true },
+  ],
+});
+
+export const RepositoryUI = UIProvider.succeed<Repository>(
+  "AWS.CodeArtifact.Repository",
+  {
+    displayName: "CodeArtifact Repository",
+    icon: "boxes",
+    color: "#7AA116",
+    category: "storage",
+    summary: (ctx) => ctx.attrs?.repositoryName,
+    facts: (ctx) => [
+      { label: "repository", value: ctx.attrs?.repositoryName, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.repositoryArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "domain", value: ctx.attrs?.domainName, copy: true },
+      { label: "domain owner", value: ctx.attrs?.domainOwner, mono: true },
+      {
+        label: "external connection",
+        value: ctx.props?.externalConnection,
+      },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(DomainUI, RepositoryUI);

--- a/packages/alchemy/src/AWS/CodeBuild/ui.ts
+++ b/packages/alchemy/src/AWS/CodeBuild/ui.ts
@@ -1,0 +1,57 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Project } from "./Project.ts";
+import type { ReportGroup } from "./ReportGroup.ts";
+
+/**
+ * Dashboard UI providers for AWS CodeBuild resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** AWS Compute (CodeBuild) brand orange. */
+const COLOR = "#ED7100";
+
+const regionOf = (arn: string | undefined): string | undefined =>
+  arn?.split(":")[3] || undefined;
+
+export const ProjectUI = UIProvider.succeed<Project>("AWS.CodeBuild.Project", {
+  displayName: "CodeBuild Project",
+  icon: "wrench",
+  color: COLOR,
+  category: "compute",
+  summary: (ctx) => ctx.attrs?.projectName,
+  consoleUrl: (ctx) => {
+    const region = regionOf(ctx.attrs?.projectArn);
+    return ctx.attrs?.projectName === undefined || region === undefined
+      ? undefined
+      : `https://${region}.console.aws.amazon.com/codesuite/codebuild/projects/${ctx.attrs.projectName}`;
+  },
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.projectName, copy: true },
+    { label: "arn", value: ctx.attrs?.projectArn, mono: true, copy: true },
+  ],
+});
+
+export const ReportGroupUI = UIProvider.succeed<ReportGroup>(
+  "AWS.CodeBuild.ReportGroup",
+  {
+    displayName: "CodeBuild Report Group",
+    icon: "table",
+    color: COLOR,
+    category: "observability",
+    summary: (ctx) => ctx.attrs?.reportGroupName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.reportGroupName, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.reportGroupArn,
+        mono: true,
+        copy: true,
+      },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(ProjectUI, ReportGroupUI);

--- a/packages/alchemy/src/AWS/CodeConnections/ui.ts
+++ b/packages/alchemy/src/AWS/CodeConnections/ui.ts
@@ -1,0 +1,116 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Connection } from "./Connection.ts";
+import type { Host } from "./Host.ts";
+import type { RepositoryLink } from "./RepositoryLink.ts";
+import type { SyncConfiguration } from "./SyncConfiguration.ts";
+
+/**
+ * Dashboard UI providers for AWS CodeConnections resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** AWS Management & Governance (CodeConnections) brand pink. */
+const COLOR = "#E7157B";
+
+export const ConnectionUI = UIProvider.succeed<Connection>(
+  "AWS.CodeConnections.Connection",
+  {
+    displayName: "CodeConnections Connection",
+    icon: "link",
+    color: COLOR,
+    category: "config",
+    summary: (ctx) => ctx.attrs?.connectionName,
+    facts: (ctx) => [
+      { label: "connection", value: ctx.attrs?.connectionName, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.connectionArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "provider", value: ctx.attrs?.providerType },
+      { label: "status", value: ctx.attrs?.connectionStatus },
+    ],
+  },
+);
+
+export const HostUI = UIProvider.succeed<Host>("AWS.CodeConnections.Host", {
+  displayName: "CodeConnections Host",
+  icon: "server",
+  color: COLOR,
+  category: "config",
+  summary: (ctx) => ctx.attrs?.hostName,
+  facts: (ctx) => [
+    { label: "host", value: ctx.attrs?.hostName, copy: true },
+    { label: "arn", value: ctx.attrs?.hostArn, mono: true, copy: true },
+    { label: "provider", value: ctx.attrs?.providerType },
+    { label: "endpoint", value: ctx.attrs?.providerEndpoint, mono: true },
+    { label: "status", value: ctx.attrs?.hostStatus },
+  ],
+});
+
+export const RepositoryLinkUI = UIProvider.succeed<RepositoryLink>(
+  "AWS.CodeConnections.RepositoryLink",
+  {
+    displayName: "CodeConnections Repository Link",
+    icon: "git-branch",
+    color: COLOR,
+    category: "config",
+    summary: (ctx) =>
+      ctx.attrs?.ownerId && ctx.attrs?.repositoryName
+        ? `${ctx.attrs.ownerId}/${ctx.attrs.repositoryName}`
+        : ctx.attrs?.repositoryLinkId,
+    facts: (ctx) => [
+      {
+        label: "id",
+        value: ctx.attrs?.repositoryLinkId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.repositoryLinkArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "owner", value: ctx.attrs?.ownerId, copy: true },
+      { label: "repository", value: ctx.attrs?.repositoryName, copy: true },
+      { label: "provider", value: ctx.attrs?.providerType },
+      {
+        label: "connection",
+        value: ctx.attrs?.connectionArn,
+        mono: true,
+      },
+    ],
+  },
+);
+
+export const SyncConfigurationUI = UIProvider.succeed<SyncConfiguration>(
+  "AWS.CodeConnections.SyncConfiguration",
+  {
+    displayName: "CodeConnections Sync Configuration",
+    icon: "repeat",
+    color: COLOR,
+    category: "config",
+    summary: (ctx) => ctx.attrs?.resourceName,
+    facts: (ctx) => [
+      { label: "resource", value: ctx.attrs?.resourceName, copy: true },
+      { label: "sync type", value: ctx.attrs?.syncType },
+      { label: "branch", value: ctx.attrs?.branch },
+      { label: "config file", value: ctx.attrs?.configFile, mono: true },
+      {
+        label: "repository link",
+        value: ctx.attrs?.repositoryLinkId,
+        mono: true,
+        copy: true,
+      },
+      { label: "role", value: ctx.attrs?.roleArn, mono: true },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(ConnectionUI, HostUI, RepositoryLinkUI, SyncConfigurationUI);

--- a/packages/alchemy/src/AWS/CodeDeploy/ui.ts
+++ b/packages/alchemy/src/AWS/CodeDeploy/ui.ts
@@ -1,0 +1,119 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Application } from "./Application.ts";
+import type { DeploymentConfig } from "./DeploymentConfig.ts";
+import type { DeploymentGroup } from "./DeploymentGroup.ts";
+
+/**
+ * Dashboard UI providers for AWS CodeDeploy resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+const COLOR = "#E7157B";
+
+export const ApplicationUI = UIProvider.succeed<Application>(
+  "AWS.CodeDeploy.Application",
+  {
+    displayName: "CodeDeploy Application",
+    icon: "box",
+    color: COLOR,
+    category: "config",
+    summary: (ctx) => ctx.attrs?.applicationName,
+    facts: (ctx) => [
+      {
+        label: "application",
+        value: ctx.attrs?.applicationName,
+        copy: true,
+      },
+      {
+        label: "id",
+        value: ctx.attrs?.applicationId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.applicationArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "compute platform", value: ctx.attrs?.computePlatform },
+    ],
+  },
+);
+
+export const DeploymentConfigUI = UIProvider.succeed<DeploymentConfig>(
+  "AWS.CodeDeploy.DeploymentConfig",
+  {
+    displayName: "CodeDeploy Deployment Config",
+    icon: "settings",
+    color: COLOR,
+    category: "config",
+    summary: (ctx) => ctx.attrs?.deploymentConfigName,
+    facts: (ctx) => [
+      {
+        label: "config",
+        value: ctx.attrs?.deploymentConfigName,
+        copy: true,
+      },
+      {
+        label: "id",
+        value: ctx.attrs?.deploymentConfigId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.deploymentConfigArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "compute platform", value: ctx.attrs?.computePlatform },
+    ],
+  },
+);
+
+export const DeploymentGroupUI = UIProvider.succeed<DeploymentGroup>(
+  "AWS.CodeDeploy.DeploymentGroup",
+  {
+    displayName: "CodeDeploy Deployment Group",
+    icon: "workflow",
+    color: COLOR,
+    category: "config",
+    summary: (ctx) => ctx.attrs?.deploymentGroupName,
+    facts: (ctx) => [
+      {
+        label: "group",
+        value: ctx.attrs?.deploymentGroupName,
+        copy: true,
+      },
+      {
+        label: "id",
+        value: ctx.attrs?.deploymentGroupId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.deploymentGroupArn,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "application",
+        value: ctx.attrs?.applicationName,
+        mono: true,
+      },
+      {
+        label: "service role",
+        value: ctx.attrs?.serviceRoleArn,
+        mono: true,
+      },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(ApplicationUI, DeploymentConfigUI, DeploymentGroupUI);

--- a/packages/alchemy/src/AWS/CodePipeline/ui.ts
+++ b/packages/alchemy/src/AWS/CodePipeline/ui.ts
@@ -1,0 +1,40 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Pipeline } from "./Pipeline.ts";
+
+/**
+ * Dashboard UI providers for AWS CodePipeline resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+const regionOf = (arn: string | undefined): string | undefined =>
+  arn?.split(":")[3] || undefined;
+
+export const PipelineUI = UIProvider.succeed<Pipeline>(
+  "AWS.CodePipeline.Pipeline",
+  {
+    displayName: "CodePipeline Pipeline",
+    icon: "workflow",
+    color: "#E7157B",
+    category: "eventing",
+    summary: (ctx) => ctx.attrs?.pipelineName,
+    consoleUrl: (ctx) => {
+      const region = regionOf(ctx.attrs?.pipelineArn);
+      return ctx.attrs?.pipelineName === undefined || region === undefined
+        ? undefined
+        : `https://${region}.console.aws.amazon.com/codesuite/codepipeline/pipelines/${ctx.attrs.pipelineName}/view?region=${region}`;
+    },
+    facts: (ctx) => [
+      { label: "pipeline", value: ctx.attrs?.pipelineName, copy: true },
+      { label: "arn", value: ctx.attrs?.pipelineArn, mono: true, copy: true },
+      { label: "version", value: ctx.attrs?.pipelineVersion },
+      { label: "role", value: ctx.props?.roleArn, mono: true },
+      { label: "stages", value: ctx.props?.stages?.length },
+      { label: "type", value: ctx.props?.pipelineType },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(PipelineUI);

--- a/packages/alchemy/src/AWS/Cognito/ui.ts
+++ b/packages/alchemy/src/AWS/Cognito/ui.ts
@@ -1,0 +1,256 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Group } from "./Group.ts";
+import type { IdentityPool } from "./IdentityPool.ts";
+import type { IdentityPoolRoleAttachment } from "./IdentityPoolRoleAttachment.ts";
+import type { IdentityProvider } from "./IdentityProvider.ts";
+import type { ManagedLoginBranding } from "./ManagedLoginBranding.ts";
+import type { ResourceServer } from "./ResourceServer.ts";
+import type { User } from "./User.ts";
+import type { UserPool } from "./UserPool.ts";
+import type { UserPoolClient } from "./UserPoolClient.ts";
+import type { UserPoolDomain } from "./UserPoolDomain.ts";
+
+/**
+ * Dashboard UI providers for AWS Cognito resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** Cognito brand color (AWS Security, Identity & Compliance red). */
+const COGNITO_COLOR = "#DD344C";
+
+const regionOf = (arn: string | undefined) => arn?.split(":")[3];
+
+export const UserPoolUI = UIProvider.succeed<UserPool>("AWS.Cognito.UserPool", {
+  displayName: "Cognito User Pool",
+  icon: "users",
+  color: COGNITO_COLOR,
+  category: "auth",
+  summary: (ctx) => ctx.attrs?.userPoolName,
+  consoleUrl: (ctx) => {
+    const region = regionOf(ctx.attrs?.userPoolArn);
+    return ctx.attrs?.userPoolId === undefined || region === undefined
+      ? undefined
+      : `https://${region}.console.aws.amazon.com/cognito/v2/idp/user-pools/${ctx.attrs.userPoolId}/user-pool-overview?region=${region}`;
+  },
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.userPoolName, copy: true },
+    { label: "id", value: ctx.attrs?.userPoolId, mono: true, copy: true },
+    { label: "arn", value: ctx.attrs?.userPoolArn, mono: true, copy: true },
+    { label: "mfa", value: ctx.props?.mfaConfiguration },
+    { label: "tier", value: ctx.props?.tier },
+  ],
+});
+
+export const UserPoolClientUI = UIProvider.succeed<UserPoolClient>(
+  "AWS.Cognito.UserPoolClient",
+  {
+    displayName: "Cognito User Pool Client",
+    icon: "key-round",
+    color: COGNITO_COLOR,
+    category: "auth",
+    summary: (ctx) => ctx.attrs?.clientName,
+    facts: (ctx) => [
+      { label: "client", value: ctx.attrs?.clientName, copy: true },
+      {
+        label: "client id",
+        value: ctx.attrs?.clientId,
+        mono: true,
+        copy: true,
+      },
+      { label: "user pool", value: ctx.attrs?.userPoolId, mono: true },
+      { label: "has secret", value: ctx.attrs?.clientSecret !== undefined },
+      {
+        label: "auth flows",
+        value: ctx.props?.explicitAuthFlows?.join(", "),
+      },
+    ],
+  },
+);
+
+export const UserPoolDomainUI = UIProvider.succeed<UserPoolDomain>(
+  "AWS.Cognito.UserPoolDomain",
+  {
+    displayName: "Cognito User Pool Domain",
+    icon: "globe",
+    color: COGNITO_COLOR,
+    category: "auth",
+    summary: (ctx) => ctx.attrs?.domain,
+    facts: (ctx) => [
+      { label: "domain", value: ctx.attrs?.domain, copy: true },
+      { label: "user pool", value: ctx.attrs?.userPoolId, mono: true },
+      {
+        label: "cloudfront domain",
+        value: ctx.attrs?.cloudFrontDomain,
+        mono: true,
+        copy: true,
+      },
+      { label: "managed login version", value: ctx.props?.managedLoginVersion },
+    ],
+  },
+);
+
+export const GroupUI = UIProvider.succeed<Group>("AWS.Cognito.Group", {
+  displayName: "Cognito Group",
+  icon: "list-ordered",
+  color: COGNITO_COLOR,
+  category: "auth",
+  summary: (ctx) => ctx.attrs?.groupName,
+  facts: (ctx) => [
+    { label: "group", value: ctx.attrs?.groupName, copy: true },
+    { label: "user pool", value: ctx.attrs?.userPoolId, mono: true },
+    { label: "role", value: ctx.props?.roleArn, mono: true },
+    { label: "precedence", value: ctx.props?.precedence },
+    { label: "description", value: ctx.props?.description },
+  ],
+});
+
+export const UserUI = UIProvider.succeed<User>("AWS.Cognito.User", {
+  displayName: "Cognito User",
+  icon: "user",
+  color: COGNITO_COLOR,
+  category: "auth",
+  summary: (ctx) => ctx.attrs?.username,
+  facts: (ctx) => [
+    { label: "username", value: ctx.attrs?.username, copy: true },
+    { label: "user pool", value: ctx.attrs?.userPoolId, mono: true },
+    { label: "sub", value: ctx.attrs?.sub, mono: true, copy: true },
+    { label: "status", value: ctx.attrs?.userStatus },
+    { label: "enabled", value: ctx.props?.enabled },
+  ],
+});
+
+export const IdentityPoolUI = UIProvider.succeed<IdentityPool>(
+  "AWS.Cognito.IdentityPool",
+  {
+    displayName: "Cognito Identity Pool",
+    icon: "fingerprint",
+    color: COGNITO_COLOR,
+    category: "auth",
+    summary: (ctx) => ctx.attrs?.identityPoolName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.identityPoolName, copy: true },
+      {
+        label: "id",
+        value: ctx.attrs?.identityPoolId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.identityPoolArn,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "unauthenticated",
+        value: ctx.props?.allowUnauthenticatedIdentities,
+      },
+    ],
+  },
+);
+
+export const IdentityPoolRoleAttachmentUI =
+  UIProvider.succeed<IdentityPoolRoleAttachment>(
+    "AWS.Cognito.IdentityPoolRoleAttachment",
+    {
+      displayName: "Cognito Identity Pool Role Attachment",
+      icon: "link",
+      color: COGNITO_COLOR,
+      category: "auth",
+      summary: (ctx) => ctx.attrs?.identityPoolId,
+      facts: (ctx) => [
+        {
+          label: "identity pool",
+          value: ctx.attrs?.identityPoolId,
+          mono: true,
+          copy: true,
+        },
+        {
+          label: "authenticated role",
+          value: ctx.attrs?.roles?.authenticated,
+          mono: true,
+        },
+        {
+          label: "unauthenticated role",
+          value: ctx.attrs?.roles?.unauthenticated,
+          mono: true,
+        },
+      ],
+    },
+  );
+
+export const IdentityProviderUI = UIProvider.succeed<IdentityProvider>(
+  "AWS.Cognito.IdentityProvider",
+  {
+    displayName: "Cognito Identity Provider",
+    icon: "share-2",
+    color: COGNITO_COLOR,
+    category: "auth",
+    summary: (ctx) => ctx.attrs?.providerName,
+    facts: (ctx) => [
+      { label: "provider", value: ctx.attrs?.providerName, copy: true },
+      { label: "user pool", value: ctx.attrs?.userPoolId, mono: true },
+      { label: "type", value: ctx.attrs?.providerType },
+    ],
+  },
+);
+
+export const ResourceServerUI = UIProvider.succeed<ResourceServer>(
+  "AWS.Cognito.ResourceServer",
+  {
+    displayName: "Cognito Resource Server",
+    icon: "server",
+    color: COGNITO_COLOR,
+    category: "auth",
+    summary: (ctx) => ctx.attrs?.name ?? ctx.attrs?.identifier,
+    facts: (ctx) => [
+      { label: "identifier", value: ctx.attrs?.identifier, copy: true },
+      { label: "name", value: ctx.attrs?.name },
+      { label: "user pool", value: ctx.attrs?.userPoolId, mono: true },
+      { label: "scopes", value: ctx.props?.scopes?.length },
+    ],
+  },
+);
+
+export const ManagedLoginBrandingUI = UIProvider.succeed<ManagedLoginBranding>(
+  "AWS.Cognito.ManagedLoginBranding",
+  {
+    displayName: "Cognito Managed Login Branding",
+    icon: "palette",
+    color: COGNITO_COLOR,
+    category: "auth",
+    summary: (ctx) => ctx.attrs?.clientId,
+    consoleUrl: (ctx) =>
+      ctx.attrs?.userPoolId === undefined
+        ? undefined
+        : `https://console.aws.amazon.com/cognito/v2/idp/user-pools/${ctx.attrs.userPoolId}/branding`,
+    facts: (ctx) => [
+      {
+        label: "branding id",
+        value: ctx.attrs?.managedLoginBrandingId,
+        mono: true,
+        copy: true,
+      },
+      { label: "user pool", value: ctx.attrs?.userPoolId, mono: true },
+      { label: "client", value: ctx.attrs?.clientId, mono: true },
+      { label: "use defaults", value: ctx.props?.useCognitoProvidedValues },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(
+    UserPoolUI,
+    UserPoolClientUI,
+    UserPoolDomainUI,
+    GroupUI,
+    UserUI,
+    IdentityPoolUI,
+    IdentityPoolRoleAttachmentUI,
+    IdentityProviderUI,
+    ResourceServerUI,
+    ManagedLoginBrandingUI,
+  );

--- a/packages/alchemy/src/AWS/Config/ui.ts
+++ b/packages/alchemy/src/AWS/Config/ui.ts
@@ -1,0 +1,143 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { AggregationAuthorization } from "./AggregationAuthorization.ts";
+import type { ConfigRule } from "./ConfigRule.ts";
+import type { ConfigurationRecorder } from "./ConfigurationRecorder.ts";
+import type { DeliveryChannel } from "./DeliveryChannel.ts";
+import type { RetentionConfiguration } from "./RetentionConfiguration.ts";
+
+/**
+ * Dashboard UI providers for AWS Config resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** AWS Management & Governance brand pink. */
+const COLOR = "#E7157B";
+
+export const AggregationAuthorizationUI =
+  UIProvider.succeed<AggregationAuthorization>(
+    "AWS.Config.AggregationAuthorization",
+    {
+      displayName: "Config Aggregation Authorization",
+      icon: "share-2",
+      color: COLOR,
+      category: "config",
+      summary: (ctx) =>
+        ctx.attrs?.authorizedAccountId === undefined
+          ? undefined
+          : `${ctx.attrs.authorizedAccountId} (${ctx.attrs.authorizedAwsRegion ?? ""})`,
+      facts: (ctx) => [
+        {
+          label: "arn",
+          value: ctx.attrs?.aggregationAuthorizationArn,
+          mono: true,
+          copy: true,
+        },
+        {
+          label: "account",
+          value: ctx.attrs?.authorizedAccountId,
+          mono: true,
+          copy: true,
+        },
+        { label: "region", value: ctx.attrs?.authorizedAwsRegion },
+      ],
+    },
+  );
+
+export const ConfigRuleUI = UIProvider.succeed<ConfigRule>(
+  "AWS.Config.ConfigRule",
+  {
+    displayName: "Config Rule",
+    icon: "list-checks",
+    color: COLOR,
+    category: "config",
+    summary: (ctx) => ctx.attrs?.configRuleName,
+    facts: (ctx) => [
+      { label: "rule", value: ctx.attrs?.configRuleName, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.configRuleArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "rule id", value: ctx.attrs?.configRuleId, mono: true },
+      { label: "owner", value: ctx.props?.source?.owner },
+      { label: "source", value: ctx.props?.source?.sourceIdentifier },
+      { label: "description", value: ctx.props?.description },
+    ],
+  },
+);
+
+export const ConfigurationRecorderUI =
+  UIProvider.succeed<ConfigurationRecorder>(
+    "AWS.Config.ConfigurationRecorder",
+    {
+      displayName: "Configuration Recorder",
+      icon: "scroll-text",
+      color: COLOR,
+      category: "config",
+      summary: (ctx) => ctx.attrs?.recorderName,
+      facts: (ctx) => [
+        { label: "recorder", value: ctx.attrs?.recorderName, copy: true },
+        { label: "arn", value: ctx.attrs?.recorderArn, mono: true, copy: true },
+        { label: "role", value: ctx.props?.roleArn, mono: true },
+        { label: "recording", value: ctx.props?.recording },
+      ],
+    },
+  );
+
+export const DeliveryChannelUI = UIProvider.succeed<DeliveryChannel>(
+  "AWS.Config.DeliveryChannel",
+  {
+    displayName: "Config Delivery Channel",
+    icon: "send",
+    color: COLOR,
+    category: "config",
+    summary: (ctx) => ctx.attrs?.deliveryChannelName,
+    facts: (ctx) => [
+      { label: "channel", value: ctx.attrs?.deliveryChannelName, copy: true },
+      {
+        label: "bucket",
+        value: ctx.attrs?.s3BucketName,
+        mono: true,
+        copy: true,
+      },
+      { label: "key prefix", value: ctx.props?.s3KeyPrefix, mono: true },
+      { label: "sns topic", value: ctx.props?.snsTopicArn, mono: true },
+    ],
+  },
+);
+
+export const RetentionConfigurationUI =
+  UIProvider.succeed<RetentionConfiguration>(
+    "AWS.Config.RetentionConfiguration",
+    {
+      displayName: "Config Retention Configuration",
+      icon: "clock",
+      color: COLOR,
+      category: "config",
+      summary: (ctx) => ctx.attrs?.retentionConfigurationName,
+      facts: (ctx) => [
+        {
+          label: "name",
+          value: ctx.attrs?.retentionConfigurationName,
+          copy: true,
+        },
+        {
+          label: "retention (days)",
+          value: ctx.attrs?.retentionPeriodInDays,
+        },
+      ],
+    },
+  );
+
+export const ui = () =>
+  Layer.mergeAll(
+    AggregationAuthorizationUI,
+    ConfigRuleUI,
+    ConfigurationRecorderUI,
+    DeliveryChannelUI,
+    RetentionConfigurationUI,
+  );

--- a/packages/alchemy/src/AWS/ControlTower/ui.ts
+++ b/packages/alchemy/src/AWS/ControlTower/ui.ts
@@ -1,0 +1,94 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { EnabledBaseline } from "./EnabledBaseline.ts";
+import type { EnabledControl } from "./EnabledControl.ts";
+import type { LandingZone } from "./LandingZone.ts";
+
+/**
+ * Dashboard UI providers for AWS Control Tower resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** AWS Management & Governance brand pink. */
+const COLOR = "#E7157B";
+
+export const EnabledBaselineUI = UIProvider.succeed<EnabledBaseline>(
+  "AWS.ControlTower.EnabledBaseline",
+  {
+    displayName: "Control Tower Enabled Baseline",
+    icon: "shield-check",
+    color: COLOR,
+    category: "config",
+    summary: (ctx) => ctx.attrs?.baselineIdentifier,
+    facts: (ctx) => [
+      {
+        label: "arn",
+        value: ctx.attrs?.enabledBaselineArn,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "baseline",
+        value: ctx.attrs?.baselineIdentifier,
+        mono: true,
+        copy: true,
+      },
+      { label: "target", value: ctx.attrs?.targetIdentifier, mono: true },
+      { label: "version", value: ctx.attrs?.baselineVersion },
+    ],
+  },
+);
+
+export const EnabledControlUI = UIProvider.succeed<EnabledControl>(
+  "AWS.ControlTower.EnabledControl",
+  {
+    displayName: "Control Tower Enabled Control",
+    icon: "shield",
+    color: COLOR,
+    category: "config",
+    summary: (ctx) => ctx.attrs?.controlIdentifier,
+    facts: (ctx) => [
+      {
+        label: "arn",
+        value: ctx.attrs?.enabledControlArn,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "control",
+        value: ctx.attrs?.controlIdentifier,
+        mono: true,
+        copy: true,
+      },
+      { label: "target", value: ctx.attrs?.targetIdentifier, mono: true },
+    ],
+  },
+);
+
+export const LandingZoneUI = UIProvider.succeed<LandingZone>(
+  "AWS.ControlTower.LandingZone",
+  {
+    displayName: "Control Tower Landing Zone",
+    icon: "map",
+    color: COLOR,
+    category: "config",
+    summary: (ctx) => ctx.attrs?.version,
+    facts: (ctx) => [
+      {
+        label: "arn",
+        value: ctx.attrs?.landingZoneArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "version", value: ctx.attrs?.version },
+      { label: "status", value: ctx.attrs?.status },
+      { label: "latest version", value: ctx.attrs?.latestAvailableVersion },
+      { label: "drift", value: ctx.attrs?.driftStatus },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(EnabledBaselineUI, EnabledControlUI, LandingZoneUI);

--- a/packages/alchemy/src/AWS/CostAndUsageReport/ui.ts
+++ b/packages/alchemy/src/AWS/CostAndUsageReport/ui.ts
@@ -1,0 +1,32 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { ReportDefinition } from "./ReportDefinition.ts";
+
+/**
+ * Dashboard UI providers for AWS CostAndUsageReport resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+export const ReportDefinitionUI = UIProvider.succeed<ReportDefinition>(
+  "AWS.CostAndUsageReport.ReportDefinition",
+  {
+    displayName: "Cost and Usage Report",
+    icon: "dollar-sign",
+    color: "#E7157B",
+    category: "billing",
+    summary: (ctx) => ctx.attrs?.reportName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.reportName, copy: true },
+      { label: "arn", value: ctx.attrs?.reportArn, mono: true, copy: true },
+      { label: "time unit", value: ctx.attrs?.timeUnit },
+      { label: "format", value: ctx.attrs?.format },
+      { label: "compression", value: ctx.attrs?.compression },
+      { label: "bucket", value: ctx.attrs?.s3Bucket, mono: true, copy: true },
+      { label: "prefix", value: ctx.attrs?.s3Prefix, mono: true },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(ReportDefinitionUI);

--- a/packages/alchemy/src/AWS/CostExplorer/ui.ts
+++ b/packages/alchemy/src/AWS/CostExplorer/ui.ts
@@ -1,0 +1,78 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { AnomalyMonitor } from "./AnomalyMonitor.ts";
+import type { AnomalySubscription } from "./AnomalySubscription.ts";
+import type { CostCategory } from "./CostCategory.ts";
+
+/**
+ * Dashboard UI providers for AWS Cost Explorer resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+export const AnomalyMonitorUI = UIProvider.succeed<AnomalyMonitor>(
+  "AWS.CostExplorer.AnomalyMonitor",
+  {
+    displayName: "Cost Anomaly Monitor",
+    icon: "eye",
+    color: "#E7157B",
+    category: "billing",
+    summary: (ctx) => ctx.attrs?.monitorName,
+    facts: (ctx) => [
+      { label: "monitor", value: ctx.attrs?.monitorName, copy: true },
+      { label: "arn", value: ctx.attrs?.monitorArn, mono: true, copy: true },
+      { label: "type", value: ctx.attrs?.monitorType },
+      { label: "dimension", value: ctx.props?.monitorDimension },
+    ],
+  },
+);
+
+export const AnomalySubscriptionUI = UIProvider.succeed<AnomalySubscription>(
+  "AWS.CostExplorer.AnomalySubscription",
+  {
+    displayName: "Cost Anomaly Subscription",
+    icon: "bell",
+    color: "#E7157B",
+    category: "billing",
+    summary: (ctx) => ctx.attrs?.subscriptionName,
+    facts: (ctx) => [
+      { label: "subscription", value: ctx.attrs?.subscriptionName, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.subscriptionArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "account", value: ctx.attrs?.accountId, mono: true },
+      { label: "frequency", value: ctx.props?.frequency },
+      { label: "monitors", value: ctx.props?.monitorArnList?.length },
+    ],
+  },
+);
+
+export const CostCategoryUI = UIProvider.succeed<CostCategory>(
+  "AWS.CostExplorer.CostCategory",
+  {
+    displayName: "Cost Category",
+    icon: "tags",
+    color: "#E7157B",
+    category: "billing",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.costCategoryArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "effective start", value: ctx.attrs?.effectiveStart },
+      { label: "rules", value: ctx.props?.rules?.length },
+      { label: "default value", value: ctx.props?.defaultValue },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(AnomalyMonitorUI, AnomalySubscriptionUI, CostCategoryUI);

--- a/packages/alchemy/src/AWS/DAX/ui.ts
+++ b/packages/alchemy/src/AWS/DAX/ui.ts
@@ -1,0 +1,81 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Cluster } from "./Cluster.ts";
+import type { ParameterGroup } from "./ParameterGroup.ts";
+import type { SubnetGroup } from "./SubnetGroup.ts";
+
+/**
+ * Dashboard UI providers for AWS DAX resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+const DAX_COLOR = "#C925D1";
+
+export const ClusterUI = UIProvider.succeed<Cluster>("AWS.DAX.Cluster", {
+  displayName: "DAX Cluster",
+  icon: "database",
+  color: DAX_COLOR,
+  category: "database",
+  summary: (ctx) => ctx.attrs?.clusterName,
+  facts: (ctx) => [
+    { label: "cluster", value: ctx.attrs?.clusterName, copy: true },
+    { label: "arn", value: ctx.attrs?.clusterArn, mono: true, copy: true },
+    { label: "status", value: ctx.attrs?.status },
+    { label: "node type", value: ctx.attrs?.nodeType },
+    { label: "nodes", value: ctx.attrs?.totalNodes },
+    {
+      label: "endpoint",
+      value: ctx.attrs?.discoveryEndpointUrl,
+      mono: true,
+      copy: true,
+    },
+    { label: "encryption", value: ctx.attrs?.clusterEndpointEncryptionType },
+  ],
+});
+
+export const ParameterGroupUI = UIProvider.succeed<ParameterGroup>(
+  "AWS.DAX.ParameterGroup",
+  {
+    displayName: "DAX Parameter Group",
+    icon: "settings",
+    color: DAX_COLOR,
+    category: "database",
+    summary: (ctx) => ctx.attrs?.parameterGroupName,
+    facts: (ctx) => [
+      {
+        label: "parameter group",
+        value: ctx.attrs?.parameterGroupName,
+        copy: true,
+      },
+      { label: "description", value: ctx.attrs?.description },
+    ],
+  },
+);
+
+export const SubnetGroupUI = UIProvider.succeed<SubnetGroup>(
+  "AWS.DAX.SubnetGroup",
+  {
+    displayName: "DAX Subnet Group",
+    icon: "network",
+    color: DAX_COLOR,
+    category: "database",
+    summary: (ctx) => ctx.attrs?.subnetGroupName,
+    facts: (ctx) => [
+      { label: "subnet group", value: ctx.attrs?.subnetGroupName, copy: true },
+      { label: "vpc", value: ctx.attrs?.vpcId, mono: true },
+      {
+        label: "subnets",
+        value: ctx.attrs?.subnetIds?.length
+          ? ctx.attrs.subnetIds.join(", ")
+          : undefined,
+        mono: true,
+      },
+      { label: "description", value: ctx.attrs?.description },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(ClusterUI, ParameterGroupUI, SubnetGroupUI);

--- a/packages/alchemy/src/AWS/DLM/ui.ts
+++ b/packages/alchemy/src/AWS/DLM/ui.ts
@@ -1,0 +1,31 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { LifecyclePolicy } from "./LifecyclePolicy.ts";
+
+/**
+ * Dashboard UI providers for AWS DLM resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+export const LifecyclePolicyUI = UIProvider.succeed<LifecyclePolicy>(
+  "AWS.DLM.LifecyclePolicy",
+  {
+    displayName: "DLM Lifecycle Policy",
+    icon: "repeat",
+    color: "#7AA116",
+    category: "storage",
+    summary: (ctx) => ctx.attrs?.policyId,
+    facts: (ctx) => [
+      { label: "policy", value: ctx.attrs?.policyId, mono: true, copy: true },
+      { label: "arn", value: ctx.attrs?.policyArn, mono: true, copy: true },
+      { label: "state", value: ctx.attrs?.state },
+      { label: "type", value: ctx.props?.policyDetails?.policyType },
+      { label: "role", value: ctx.attrs?.executionRoleArn, mono: true },
+      { label: "description", value: ctx.props?.description },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(LifecyclePolicyUI);

--- a/packages/alchemy/src/AWS/DMS/ui.ts
+++ b/packages/alchemy/src/AWS/DMS/ui.ts
@@ -1,0 +1,97 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Endpoint } from "./Endpoint.ts";
+import type { ReplicationInstance } from "./ReplicationInstance.ts";
+import type { ReplicationSubnetGroup } from "./ReplicationSubnetGroup.ts";
+
+/**
+ * Dashboard UI providers for AWS DMS (Database Migration Service) resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+const COLOR = "#C925D1";
+
+export const EndpointUI = UIProvider.succeed<Endpoint>("AWS.DMS.Endpoint", {
+  displayName: "DMS Endpoint",
+  icon: "plug-zap",
+  color: COLOR,
+  category: "database",
+  summary: (ctx) => ctx.attrs?.endpointIdentifier,
+  facts: (ctx) => [
+    { label: "identifier", value: ctx.attrs?.endpointIdentifier, copy: true },
+    { label: "arn", value: ctx.attrs?.endpointArn, mono: true, copy: true },
+    { label: "type", value: ctx.attrs?.endpointType },
+    { label: "engine", value: ctx.attrs?.engineName },
+    { label: "status", value: ctx.attrs?.status },
+  ],
+});
+
+export const ReplicationInstanceUI = UIProvider.succeed<ReplicationInstance>(
+  "AWS.DMS.ReplicationInstance",
+  {
+    displayName: "DMS Replication Instance",
+    icon: "server",
+    color: COLOR,
+    category: "database",
+    summary: (ctx) => ctx.attrs?.replicationInstanceIdentifier,
+    facts: (ctx) => [
+      {
+        label: "identifier",
+        value: ctx.attrs?.replicationInstanceIdentifier,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.replicationInstanceArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "class", value: ctx.attrs?.replicationInstanceClass },
+      { label: "status", value: ctx.attrs?.status },
+      { label: "engine version", value: ctx.attrs?.engineVersion },
+      {
+        label: "private ips",
+        value: ctx.attrs?.privateIpAddresses?.length
+          ? ctx.attrs.privateIpAddresses.join(", ")
+          : undefined,
+        mono: true,
+      },
+    ],
+  },
+);
+
+export const ReplicationSubnetGroupUI =
+  UIProvider.succeed<ReplicationSubnetGroup>("AWS.DMS.ReplicationSubnetGroup", {
+    displayName: "DMS Replication Subnet Group",
+    icon: "network",
+    color: COLOR,
+    category: "database",
+    summary: (ctx) => ctx.attrs?.replicationSubnetGroupIdentifier,
+    facts: (ctx) => [
+      {
+        label: "identifier",
+        value: ctx.attrs?.replicationSubnetGroupIdentifier,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.replicationSubnetGroupArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "vpc", value: ctx.attrs?.vpcId, mono: true },
+      {
+        label: "subnets",
+        value: ctx.attrs?.subnetIds?.length
+          ? ctx.attrs.subnetIds.join(", ")
+          : undefined,
+        mono: true,
+      },
+      { label: "status", value: ctx.attrs?.status },
+    ],
+  });
+
+export const ui = () =>
+  Layer.mergeAll(EndpointUI, ReplicationInstanceUI, ReplicationSubnetGroupUI);

--- a/packages/alchemy/src/AWS/DSQL/ui.ts
+++ b/packages/alchemy/src/AWS/DSQL/ui.ts
@@ -1,0 +1,69 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Cluster } from "./Cluster.ts";
+import type { ClusterPolicy } from "./ClusterPolicy.ts";
+import type { Stream } from "./Stream.ts";
+
+/**
+ * Dashboard UI providers for AWS DSQL resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+export const ClusterUI = UIProvider.succeed<Cluster>("AWS.DSQL.Cluster", {
+  displayName: "Aurora DSQL Cluster",
+  icon: "database",
+  color: "#C925D1",
+  category: "database",
+  summary: (ctx) => ctx.attrs?.clusterId,
+  facts: (ctx) => [
+    { label: "cluster", value: ctx.attrs?.clusterId, mono: true, copy: true },
+    { label: "arn", value: ctx.attrs?.clusterArn, mono: true, copy: true },
+    { label: "endpoint", value: ctx.attrs?.endpoint, mono: true, copy: true },
+    { label: "status", value: ctx.attrs?.status },
+    {
+      label: "deletion protection",
+      value: ctx.attrs?.deletionProtectionEnabled,
+    },
+  ],
+});
+
+export const ClusterPolicyUI = UIProvider.succeed<ClusterPolicy>(
+  "AWS.DSQL.ClusterPolicy",
+  {
+    displayName: "DSQL Cluster Policy",
+    icon: "lock",
+    color: "#C925D1",
+    category: "security",
+    summary: (ctx) => ctx.attrs?.clusterId,
+    facts: (ctx) => [
+      { label: "cluster", value: ctx.attrs?.clusterId, mono: true },
+      { label: "version", value: ctx.attrs?.policyVersion, mono: true },
+      { label: "policy", value: ctx.attrs?.policy, mono: true },
+    ],
+  },
+);
+
+export const StreamUI = UIProvider.succeed<Stream>("AWS.DSQL.Stream", {
+  displayName: "DSQL Stream",
+  icon: "waypoints",
+  color: "#C925D1",
+  category: "eventing",
+  summary: (ctx) => ctx.attrs?.streamId,
+  facts: (ctx) => [
+    { label: "stream", value: ctx.attrs?.streamId, mono: true, copy: true },
+    { label: "arn", value: ctx.attrs?.streamArn, mono: true, copy: true },
+    { label: "cluster", value: ctx.attrs?.clusterId, mono: true },
+    { label: "status", value: ctx.attrs?.status },
+    { label: "ordering", value: ctx.attrs?.ordering },
+    { label: "format", value: ctx.attrs?.format },
+    {
+      label: "kinesis stream",
+      value: ctx.attrs?.kinesisStreamArn,
+      mono: true,
+    },
+  ],
+});
+
+export const ui = () => Layer.mergeAll(ClusterUI, ClusterPolicyUI, StreamUI);

--- a/packages/alchemy/src/AWS/DataBrew/ui.ts
+++ b/packages/alchemy/src/AWS/DataBrew/ui.ts
@@ -1,0 +1,114 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Dataset } from "./Dataset.ts";
+import type { Job } from "./Job.ts";
+import type { Project } from "./Project.ts";
+import type { Recipe } from "./Recipe.ts";
+import type { Ruleset } from "./Ruleset.ts";
+import type { Schedule } from "./Schedule.ts";
+
+/**
+ * Dashboard UI providers for AWS DataBrew resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** AWS Analytics (DataBrew) brand purple. */
+const COLOR = "#8C4FFF";
+
+export const DatasetUI = UIProvider.succeed<Dataset>("AWS.DataBrew.Dataset", {
+  displayName: "DataBrew Dataset",
+  icon: "table",
+  color: COLOR,
+  category: "database",
+  summary: (ctx) => ctx.attrs?.datasetName,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.datasetName, copy: true },
+    { label: "arn", value: ctx.attrs?.datasetArn, mono: true, copy: true },
+    { label: "format", value: ctx.props?.format },
+    {
+      label: "bucket",
+      value: ctx.props?.input?.s3InputDefinition?.bucket,
+      mono: true,
+    },
+  ],
+});
+
+export const JobUI = UIProvider.succeed<Job>("AWS.DataBrew.Job", {
+  displayName: "DataBrew Job",
+  icon: "play",
+  color: COLOR,
+  category: "other",
+  summary: (ctx) => ctx.attrs?.jobName,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.jobName, copy: true },
+    { label: "arn", value: ctx.attrs?.jobArn, mono: true, copy: true },
+    { label: "type", value: ctx.attrs?.type },
+    { label: "dataset", value: ctx.props?.datasetName, mono: true },
+    { label: "role", value: ctx.props?.role, mono: true },
+  ],
+});
+
+export const ProjectUI = UIProvider.succeed<Project>("AWS.DataBrew.Project", {
+  displayName: "DataBrew Project",
+  icon: "pencil-ruler",
+  color: COLOR,
+  category: "other",
+  summary: (ctx) => ctx.attrs?.projectName,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.projectName, copy: true },
+    { label: "arn", value: ctx.attrs?.projectArn, mono: true, copy: true },
+    { label: "dataset", value: ctx.props?.datasetName, mono: true },
+    { label: "recipe", value: ctx.props?.recipeName, mono: true },
+  ],
+});
+
+export const RecipeUI = UIProvider.succeed<Recipe>("AWS.DataBrew.Recipe", {
+  displayName: "DataBrew Recipe",
+  icon: "book-open",
+  color: COLOR,
+  category: "other",
+  summary: (ctx) => ctx.attrs?.recipeName,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.recipeName, copy: true },
+    { label: "arn", value: ctx.attrs?.recipeArn, mono: true, copy: true },
+    { label: "version", value: ctx.attrs?.recipeVersion, mono: true },
+    { label: "steps", value: ctx.props?.steps?.length },
+    { label: "published", value: ctx.props?.publish },
+  ],
+});
+
+export const RulesetUI = UIProvider.succeed<Ruleset>("AWS.DataBrew.Ruleset", {
+  displayName: "DataBrew Ruleset",
+  icon: "test-tube",
+  color: COLOR,
+  category: "other",
+  summary: (ctx) => ctx.attrs?.rulesetName,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.rulesetName, copy: true },
+    { label: "arn", value: ctx.attrs?.rulesetArn, mono: true, copy: true },
+    { label: "target", value: ctx.attrs?.targetArn, mono: true, copy: true },
+    { label: "rules", value: ctx.props?.rules?.length },
+  ],
+});
+
+export const ScheduleUI = UIProvider.succeed<Schedule>(
+  "AWS.DataBrew.Schedule",
+  {
+    displayName: "DataBrew Schedule",
+    icon: "calendar",
+    color: COLOR,
+    category: "other",
+    summary: (ctx) => ctx.attrs?.scheduleName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.scheduleName, copy: true },
+      { label: "arn", value: ctx.attrs?.scheduleArn, mono: true, copy: true },
+      { label: "cron", value: ctx.props?.cronExpression, mono: true },
+      { label: "jobs", value: ctx.props?.jobNames?.join(", ") },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(DatasetUI, JobUI, ProjectUI, RecipeUI, RulesetUI, ScheduleUI);

--- a/packages/alchemy/src/AWS/DataExchange/ui.ts
+++ b/packages/alchemy/src/AWS/DataExchange/ui.ts
@@ -1,0 +1,82 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { DataSet } from "./DataSet.ts";
+import type { EventAction } from "./EventAction.ts";
+import type { Revision } from "./Revision.ts";
+
+/**
+ * Dashboard UI providers for AWS DataExchange resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+export const DataSetUI = UIProvider.succeed<DataSet>(
+  "AWS.DataExchange.DataSet",
+  {
+    displayName: "Data Exchange Data Set",
+    icon: "database",
+    color: "#8C4FFF",
+    category: "other",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "data set", value: ctx.attrs?.name, copy: true },
+      { label: "id", value: ctx.attrs?.dataSetId, mono: true, copy: true },
+      { label: "arn", value: ctx.attrs?.dataSetArn, mono: true, copy: true },
+      { label: "asset type", value: ctx.attrs?.assetType },
+      { label: "origin", value: ctx.attrs?.origin },
+    ],
+  },
+);
+
+export const EventActionUI = UIProvider.succeed<EventAction>(
+  "AWS.DataExchange.EventAction",
+  {
+    displayName: "Data Exchange Event Action",
+    icon: "zap",
+    color: "#8C4FFF",
+    category: "eventing",
+    summary: (ctx) => ctx.attrs?.eventActionId,
+    facts: (ctx) => [
+      {
+        label: "action",
+        value: ctx.attrs?.eventActionId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.eventActionArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "data set", value: ctx.attrs?.dataSetId, mono: true },
+      { label: "bucket", value: ctx.props?.exportRevisionToS3?.bucket },
+    ],
+  },
+);
+
+export const RevisionUI = UIProvider.succeed<Revision>(
+  "AWS.DataExchange.Revision",
+  {
+    displayName: "Data Exchange Revision",
+    icon: "git-branch",
+    color: "#8C4FFF",
+    category: "other",
+    summary: (ctx) => ctx.attrs?.revisionId,
+    facts: (ctx) => [
+      {
+        label: "revision",
+        value: ctx.attrs?.revisionId,
+        mono: true,
+        copy: true,
+      },
+      { label: "arn", value: ctx.attrs?.revisionArn, mono: true, copy: true },
+      { label: "data set", value: ctx.attrs?.dataSetId, mono: true },
+      { label: "finalized", value: ctx.attrs?.finalized },
+      { label: "comment", value: ctx.props?.comment },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(DataSetUI, EventActionUI, RevisionUI);

--- a/packages/alchemy/src/AWS/DataSync/ui.ts
+++ b/packages/alchemy/src/AWS/DataSync/ui.ts
@@ -1,0 +1,81 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { LocationEfs } from "./LocationEfs.ts";
+import type { LocationS3 } from "./LocationS3.ts";
+import type { Task } from "./Task.ts";
+
+/**
+ * Dashboard UI providers for AWS DataSync resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** AWS Storage (DataSync) brand green. */
+const COLOR = "#7AA116";
+
+export const LocationEfsUI = UIProvider.succeed<LocationEfs>(
+  "AWS.DataSync.LocationEfs",
+  {
+    displayName: "DataSync EFS Location",
+    icon: "hard-drive",
+    color: COLOR,
+    category: "storage",
+    summary: (ctx) => ctx.attrs?.locationUri,
+    facts: (ctx) => [
+      {
+        label: "uri",
+        value: ctx.attrs?.locationUri,
+        mono: true,
+        copy: true,
+      },
+      { label: "arn", value: ctx.attrs?.locationArn, mono: true, copy: true },
+    ],
+  },
+);
+
+export const LocationS3UI = UIProvider.succeed<LocationS3>(
+  "AWS.DataSync.LocationS3",
+  {
+    displayName: "DataSync S3 Location",
+    icon: "cylinder",
+    color: COLOR,
+    category: "storage",
+    summary: (ctx) => ctx.attrs?.locationUri,
+    facts: (ctx) => [
+      {
+        label: "uri",
+        value: ctx.attrs?.locationUri,
+        mono: true,
+        copy: true,
+      },
+      { label: "arn", value: ctx.attrs?.locationArn, mono: true, copy: true },
+    ],
+  },
+);
+
+export const TaskUI = UIProvider.succeed<Task>("AWS.DataSync.Task", {
+  displayName: "DataSync Task",
+  icon: "repeat",
+  color: COLOR,
+  category: "storage",
+  summary: (ctx) => ctx.attrs?.taskArn,
+  facts: (ctx) => [
+    { label: "arn", value: ctx.attrs?.taskArn, mono: true, copy: true },
+    { label: "status", value: ctx.attrs?.taskStatus },
+    {
+      label: "source",
+      value: ctx.attrs?.sourceLocationArn,
+      mono: true,
+      copy: true,
+    },
+    {
+      label: "destination",
+      value: ctx.attrs?.destinationLocationArn,
+      mono: true,
+      copy: true,
+    },
+  ],
+});
+
+export const ui = () => Layer.mergeAll(LocationEfsUI, LocationS3UI, TaskUI);

--- a/packages/alchemy/src/AWS/DataZone/ui.ts
+++ b/packages/alchemy/src/AWS/DataZone/ui.ts
@@ -1,0 +1,119 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Domain } from "./Domain.ts";
+import type { Environment } from "./Environment.ts";
+import type { EnvironmentBlueprintConfiguration } from "./EnvironmentBlueprintConfiguration.ts";
+import type { Project } from "./Project.ts";
+
+/**
+ * Dashboard UI providers for AWS DataZone resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** AWS analytics brand purple (DataZone). */
+const COLOR = "#8C4FFF";
+
+export const DomainUI = UIProvider.succeed<Domain>("AWS.DataZone.Domain", {
+  displayName: "DataZone Domain",
+  icon: "building-2",
+  color: COLOR,
+  category: "other",
+  summary: (ctx) => ctx.attrs?.name,
+  link: (ctx) => ctx.attrs?.portalUrl,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.name, copy: true },
+    { label: "id", value: ctx.attrs?.domainId, mono: true, copy: true },
+    { label: "arn", value: ctx.attrs?.domainArn, mono: true, copy: true },
+    { label: "status", value: ctx.attrs?.status },
+    {
+      label: "portal",
+      value: ctx.attrs?.portalUrl,
+      href: ctx.attrs?.portalUrl,
+      copy: true,
+    },
+    {
+      label: "execution role",
+      value: ctx.attrs?.domainExecutionRole,
+      mono: true,
+    },
+  ],
+});
+
+export const EnvironmentUI = UIProvider.succeed<Environment>(
+  "AWS.DataZone.Environment",
+  {
+    displayName: "DataZone Environment",
+    icon: "server",
+    color: COLOR,
+    category: "other",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      { label: "id", value: ctx.attrs?.environmentId, mono: true, copy: true },
+      { label: "domain", value: ctx.attrs?.domainId, mono: true },
+      { label: "project", value: ctx.attrs?.projectId, mono: true },
+      { label: "status", value: ctx.attrs?.status },
+      { label: "aws account", value: ctx.attrs?.awsAccountId, mono: true },
+      { label: "region", value: ctx.attrs?.awsAccountRegion },
+    ],
+  },
+);
+
+export const EnvironmentBlueprintConfigurationUI =
+  UIProvider.succeed<EnvironmentBlueprintConfiguration>(
+    "AWS.DataZone.EnvironmentBlueprintConfiguration",
+    {
+      displayName: "Environment Blueprint Configuration",
+      icon: "settings",
+      color: COLOR,
+      category: "config",
+      summary: (ctx) => ctx.attrs?.environmentBlueprintName,
+      facts: (ctx) => [
+        {
+          label: "blueprint",
+          value: ctx.attrs?.environmentBlueprintName,
+          copy: true,
+        },
+        { label: "domain", value: ctx.attrs?.domainId, mono: true },
+        {
+          label: "blueprint id",
+          value: ctx.attrs?.environmentBlueprintId,
+          mono: true,
+        },
+        {
+          label: "enabled regions",
+          value: ctx.attrs?.enabledRegions?.join(", "),
+        },
+        {
+          label: "provisioning role",
+          value: ctx.attrs?.provisioningRoleArn,
+          mono: true,
+        },
+      ],
+    },
+  );
+
+export const ProjectUI = UIProvider.succeed<Project>("AWS.DataZone.Project", {
+  displayName: "DataZone Project",
+  icon: "folder",
+  color: COLOR,
+  category: "other",
+  summary: (ctx) => ctx.attrs?.name,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.name, copy: true },
+    { label: "id", value: ctx.attrs?.projectId, mono: true, copy: true },
+    { label: "domain", value: ctx.attrs?.domainId, mono: true },
+    { label: "status", value: ctx.attrs?.projectStatus },
+    { label: "created by", value: ctx.attrs?.createdBy, mono: true },
+  ],
+});
+
+export const ui = () =>
+  Layer.mergeAll(
+    DomainUI,
+    EnvironmentUI,
+    EnvironmentBlueprintConfigurationUI,
+    ProjectUI,
+  );

--- a/packages/alchemy/src/AWS/Deadline/ui.ts
+++ b/packages/alchemy/src/AWS/Deadline/ui.ts
@@ -1,0 +1,132 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Budget } from "./Budget.ts";
+import type { Farm } from "./Farm.ts";
+import type { Fleet } from "./Fleet.ts";
+import type { Monitor } from "./Monitor.ts";
+import type { Queue } from "./Queue.ts";
+import type { StorageProfile } from "./StorageProfile.ts";
+
+/**
+ * Dashboard UI providers for AWS Deadline resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+const DEADLINE_COLOR = "#ED7100";
+
+export const BudgetUI = UIProvider.succeed<Budget>("AWS.Deadline.Budget", {
+  displayName: "Deadline Budget",
+  icon: "dollar-sign",
+  color: DEADLINE_COLOR,
+  category: "billing",
+  summary: (ctx) => ctx.attrs?.displayName,
+  facts: (ctx) => [
+    { label: "budget", value: ctx.attrs?.displayName, copy: true },
+    { label: "id", value: ctx.attrs?.budgetId, mono: true },
+    { label: "arn", value: ctx.attrs?.budgetArn, mono: true, copy: true },
+    { label: "farm", value: ctx.attrs?.farmId, mono: true },
+    { label: "queue", value: ctx.attrs?.queueId, mono: true },
+    { label: "status", value: ctx.attrs?.status },
+    { label: "limit", value: ctx.attrs?.approximateDollarLimit },
+  ],
+});
+
+export const FarmUI = UIProvider.succeed<Farm>("AWS.Deadline.Farm", {
+  displayName: "Deadline Farm",
+  icon: "server",
+  color: DEADLINE_COLOR,
+  category: "compute",
+  summary: (ctx) => ctx.attrs?.displayName,
+  facts: (ctx) => [
+    { label: "farm", value: ctx.attrs?.displayName, copy: true },
+    { label: "id", value: ctx.attrs?.farmId, mono: true },
+    { label: "arn", value: ctx.attrs?.farmArn, mono: true, copy: true },
+    { label: "cost scale factor", value: ctx.attrs?.costScaleFactor },
+    { label: "kms key", value: ctx.attrs?.kmsKeyArn, mono: true },
+  ],
+});
+
+export const FleetUI = UIProvider.succeed<Fleet>("AWS.Deadline.Fleet", {
+  displayName: "Deadline Fleet",
+  icon: "boxes",
+  color: DEADLINE_COLOR,
+  category: "compute",
+  summary: (ctx) => ctx.attrs?.displayName,
+  facts: (ctx) => [
+    { label: "fleet", value: ctx.attrs?.displayName, copy: true },
+    { label: "id", value: ctx.attrs?.fleetId, mono: true },
+    { label: "arn", value: ctx.attrs?.fleetArn, mono: true, copy: true },
+    { label: "farm", value: ctx.attrs?.farmId, mono: true },
+    { label: "status", value: ctx.attrs?.status },
+    { label: "workers", value: ctx.attrs?.workerCount },
+    { label: "max workers", value: ctx.attrs?.maxWorkerCount },
+    { label: "role", value: ctx.attrs?.roleArn, mono: true },
+  ],
+});
+
+export const MonitorUI = UIProvider.succeed<Monitor>("AWS.Deadline.Monitor", {
+  displayName: "Deadline Monitor",
+  icon: "eye",
+  color: DEADLINE_COLOR,
+  category: "config",
+  summary: (ctx) => ctx.attrs?.displayName,
+  link: (ctx) => ctx.attrs?.url,
+  facts: (ctx) => [
+    { label: "monitor", value: ctx.attrs?.displayName, copy: true },
+    { label: "id", value: ctx.attrs?.monitorId, mono: true },
+    { label: "arn", value: ctx.attrs?.monitorArn, mono: true, copy: true },
+    { label: "subdomain", value: ctx.attrs?.subdomain },
+    { label: "url", value: ctx.attrs?.url, href: ctx.attrs?.url, copy: true },
+    { label: "role", value: ctx.attrs?.roleArn, mono: true },
+  ],
+});
+
+export const QueueUI = UIProvider.succeed<Queue>("AWS.Deadline.Queue", {
+  displayName: "Deadline Queue",
+  icon: "list-ordered",
+  color: DEADLINE_COLOR,
+  category: "queue",
+  summary: (ctx) => ctx.attrs?.displayName,
+  facts: (ctx) => [
+    { label: "queue", value: ctx.attrs?.displayName, copy: true },
+    { label: "id", value: ctx.attrs?.queueId, mono: true },
+    { label: "arn", value: ctx.attrs?.queueArn, mono: true, copy: true },
+    { label: "farm", value: ctx.attrs?.farmId, mono: true },
+    { label: "status", value: ctx.attrs?.status },
+    { label: "budget action", value: ctx.attrs?.defaultBudgetAction },
+    { label: "role", value: ctx.attrs?.roleArn, mono: true },
+  ],
+});
+
+export const StorageProfileUI = UIProvider.succeed<StorageProfile>(
+  "AWS.Deadline.StorageProfile",
+  {
+    displayName: "Deadline Storage Profile",
+    icon: "hard-drive",
+    color: DEADLINE_COLOR,
+    category: "storage",
+    summary: (ctx) => ctx.attrs?.displayName,
+    facts: (ctx) => [
+      { label: "profile", value: ctx.attrs?.displayName, copy: true },
+      { label: "id", value: ctx.attrs?.storageProfileId, mono: true },
+      { label: "farm", value: ctx.attrs?.farmId, mono: true },
+      { label: "os", value: ctx.attrs?.osFamily },
+      {
+        label: "locations",
+        value: ctx.attrs?.fileSystemLocations?.length,
+      },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(
+    BudgetUI,
+    FarmUI,
+    FleetUI,
+    MonitorUI,
+    QueueUI,
+    StorageProfileUI,
+  );

--- a/packages/alchemy/src/AWS/Detective/ui.ts
+++ b/packages/alchemy/src/AWS/Detective/ui.ts
@@ -1,0 +1,24 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Graph } from "./Graph.ts";
+
+/**
+ * Dashboard UI providers for AWS Detective resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+export const GraphUI = UIProvider.succeed<Graph>("AWS.Detective.Graph", {
+  displayName: "Detective Graph",
+  icon: "eye",
+  color: "#DD344C",
+  category: "security",
+  summary: (ctx) => ctx.attrs?.graphArn?.split("/").pop(),
+  facts: (ctx) => [
+    { label: "arn", value: ctx.attrs?.graphArn, mono: true, copy: true },
+    { label: "created", value: ctx.attrs?.createdTime },
+  ],
+});
+
+export const ui = () => Layer.mergeAll(GraphUI);

--- a/packages/alchemy/src/AWS/DevOpsGuru/ui.ts
+++ b/packages/alchemy/src/AWS/DevOpsGuru/ui.ts
@@ -1,0 +1,115 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { EventSourcesConfig } from "./EventSourcesConfig.ts";
+import type { NotificationChannel } from "./NotificationChannel.ts";
+import type { ResourceCollection } from "./ResourceCollection.ts";
+import type { ServiceIntegration } from "./ServiceIntegration.ts";
+
+/**
+ * Dashboard UI providers for AWS DevOpsGuru resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+const COLOR = "#E7157B";
+
+export const EventSourcesConfigUI = UIProvider.succeed<EventSourcesConfig>(
+  "AWS.DevOpsGuru.EventSourcesConfig",
+  {
+    displayName: "DevOps Guru Event Sources",
+    icon: "plug-zap",
+    color: COLOR,
+    category: "observability",
+    summary: (ctx) =>
+      ctx.attrs?.amazonCodeGuruProfiler ? "CodeGuru Profiler" : undefined,
+    facts: (ctx) => [
+      {
+        label: "codeguru profiler",
+        value: ctx.attrs?.amazonCodeGuruProfiler,
+      },
+    ],
+  },
+);
+
+export const NotificationChannelUI = UIProvider.succeed<NotificationChannel>(
+  "AWS.DevOpsGuru.NotificationChannel",
+  {
+    displayName: "DevOps Guru Notification Channel",
+    icon: "bell",
+    color: COLOR,
+    category: "observability",
+    summary: (ctx) => ctx.attrs?.topicArn,
+    facts: (ctx) => [
+      { label: "id", value: ctx.attrs?.id, mono: true, copy: true },
+      {
+        label: "topic",
+        value: ctx.attrs?.topicArn,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "severities",
+        value: ctx.props?.severities?.length
+          ? ctx.props.severities.join(", ")
+          : undefined,
+      },
+    ],
+  },
+);
+
+export const ResourceCollectionUI = UIProvider.succeed<ResourceCollection>(
+  "AWS.DevOpsGuru.ResourceCollection",
+  {
+    displayName: "DevOps Guru Resource Collection",
+    icon: "boxes",
+    color: COLOR,
+    category: "observability",
+    summary: (ctx) =>
+      ctx.attrs?.cloudFormationStackNames?.length
+        ? ctx.attrs.cloudFormationStackNames.join(", ")
+        : ctx.attrs?.tags?.map((t) => t.appBoundaryKey).join(", "),
+    facts: (ctx) => [
+      {
+        label: "stacks",
+        value: ctx.attrs?.cloudFormationStackNames?.length
+          ? ctx.attrs.cloudFormationStackNames.join(", ")
+          : undefined,
+      },
+      {
+        label: "tag keys",
+        value: ctx.attrs?.tags?.length
+          ? ctx.attrs.tags.map((t) => t.appBoundaryKey).join(", ")
+          : undefined,
+      },
+    ],
+  },
+);
+
+export const ServiceIntegrationUI = UIProvider.succeed<ServiceIntegration>(
+  "AWS.DevOpsGuru.ServiceIntegration",
+  {
+    displayName: "DevOps Guru Service Integration",
+    icon: "plug",
+    color: COLOR,
+    category: "observability",
+    summary: (ctx) => ctx.attrs?.encryptionType,
+    facts: (ctx) => [
+      { label: "ops center", value: ctx.attrs?.opsCenter },
+      {
+        label: "logs anomaly detection",
+        value: ctx.attrs?.logsAnomalyDetection,
+      },
+      { label: "encryption", value: ctx.attrs?.encryptionType },
+      { label: "kms key", value: ctx.attrs?.kmsKeyId, mono: true },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(
+    EventSourcesConfigUI,
+    NotificationChannelUI,
+    ResourceCollectionUI,
+    ServiceIntegrationUI,
+  );

--- a/packages/alchemy/src/AWS/DirectoryService/ui.ts
+++ b/packages/alchemy/src/AWS/DirectoryService/ui.ts
@@ -1,0 +1,105 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { ConditionalForwarder } from "./ConditionalForwarder.ts";
+import type { Directory } from "./Directory.ts";
+import type { EventTopic } from "./EventTopic.ts";
+
+/**
+ * Dashboard UI providers for AWS Directory Service resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** AWS Security, Identity & Compliance (Directory Service) brand red. */
+const COLOR = "#DD344C";
+
+export const DirectoryUI = UIProvider.succeed<Directory>(
+  "AWS.DirectoryService.Directory",
+  {
+    displayName: "Directory",
+    icon: "users",
+    color: COLOR,
+    category: "auth",
+    summary: (ctx) => ctx.attrs?.directoryName,
+    facts: (ctx) => [
+      { label: "directory", value: ctx.attrs?.directoryName, copy: true },
+      { label: "id", value: ctx.attrs?.directoryId, mono: true, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.directoryArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "type", value: ctx.attrs?.type },
+      { label: "stage", value: ctx.attrs?.stage },
+      { label: "access url", value: ctx.attrs?.accessUrl, mono: true },
+      { label: "vpc", value: ctx.attrs?.vpcId, mono: true },
+      {
+        label: "dns addresses",
+        value: ctx.attrs?.dnsIpAddrs?.length
+          ? ctx.attrs.dnsIpAddrs.join(", ")
+          : undefined,
+        mono: true,
+      },
+    ],
+  },
+);
+
+export const ConditionalForwarderUI = UIProvider.succeed<ConditionalForwarder>(
+  "AWS.DirectoryService.ConditionalForwarder",
+  {
+    displayName: "Directory Conditional Forwarder",
+    icon: "route",
+    color: COLOR,
+    category: "dns",
+    summary: (ctx) => ctx.attrs?.remoteDomainName,
+    facts: (ctx) => [
+      { label: "domain", value: ctx.attrs?.remoteDomainName, copy: true },
+      {
+        label: "directory",
+        value: ctx.attrs?.directoryId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "dns addresses",
+        value: ctx.attrs?.dnsIpAddrs?.length
+          ? ctx.attrs.dnsIpAddrs.join(", ")
+          : undefined,
+        mono: true,
+      },
+      { label: "replication scope", value: ctx.attrs?.replicationScope },
+    ],
+  },
+);
+
+export const EventTopicUI = UIProvider.succeed<EventTopic>(
+  "AWS.DirectoryService.EventTopic",
+  {
+    displayName: "Directory Event Topic",
+    icon: "bell",
+    color: COLOR,
+    category: "eventing",
+    summary: (ctx) => ctx.attrs?.topicName,
+    facts: (ctx) => [
+      { label: "topic", value: ctx.attrs?.topicName, copy: true },
+      {
+        label: "topic arn",
+        value: ctx.attrs?.topicArn,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "directory",
+        value: ctx.attrs?.directoryId,
+        mono: true,
+        copy: true,
+      },
+      { label: "status", value: ctx.attrs?.status },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(DirectoryUI, ConditionalForwarderUI, EventTopicUI);

--- a/packages/alchemy/src/AWS/DocDB/ui.ts
+++ b/packages/alchemy/src/AWS/DocDB/ui.ts
@@ -1,0 +1,125 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { DBCluster } from "./DBCluster.ts";
+import type { DBInstance } from "./DBInstance.ts";
+import type { DBSubnetGroup } from "./DBSubnetGroup.ts";
+
+/**
+ * Dashboard UI providers for AWS DocDB resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** AWS purple/magenta database brand color. */
+const COLOR = "#C925D1";
+
+/** Extract the region segment from an AWS ARN (`arn:aws:docdb:REGION:...`). */
+const regionOfArn = (arn: string | undefined): string | undefined =>
+  arn?.split(":")[3] || undefined;
+
+export const DBClusterUI = UIProvider.succeed<DBCluster>(
+  "AWS.DocDB.DBCluster",
+  {
+    displayName: "DocumentDB Cluster",
+    icon: "database",
+    color: COLOR,
+    category: "database",
+    summary: (ctx) => ctx.attrs?.dbClusterIdentifier,
+    consoleUrl: (ctx) => {
+      const region = regionOfArn(ctx.attrs?.dbClusterArn);
+      return region === undefined ||
+        ctx.attrs?.dbClusterIdentifier === undefined
+        ? undefined
+        : `https://${region}.console.aws.amazon.com/docdb/home?region=${region}#database:id=${ctx.attrs.dbClusterIdentifier};is-cluster=true`;
+    },
+    facts: (ctx) => [
+      {
+        label: "identifier",
+        value: ctx.attrs?.dbClusterIdentifier,
+        copy: true,
+      },
+      { label: "arn", value: ctx.attrs?.dbClusterArn, mono: true, copy: true },
+      { label: "endpoint", value: ctx.attrs?.endpoint, mono: true, copy: true },
+      {
+        label: "reader endpoint",
+        value: ctx.attrs?.readerEndpoint,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "engine",
+        value:
+          ctx.attrs?.engineVersion === undefined
+            ? ctx.attrs?.engine
+            : `${ctx.attrs.engine} ${ctx.attrs.engineVersion}`,
+      },
+      { label: "status", value: ctx.attrs?.status },
+      { label: "members", value: ctx.attrs?.dbClusterMembers?.length },
+    ],
+  },
+);
+
+export const DBInstanceUI = UIProvider.succeed<DBInstance>(
+  "AWS.DocDB.DBInstance",
+  {
+    displayName: "DocumentDB Instance",
+    icon: "server",
+    color: COLOR,
+    category: "database",
+    summary: (ctx) => ctx.attrs?.dbInstanceIdentifier,
+    consoleUrl: (ctx) => {
+      const region = regionOfArn(ctx.attrs?.dbInstanceArn);
+      return region === undefined ||
+        ctx.attrs?.dbInstanceIdentifier === undefined
+        ? undefined
+        : `https://${region}.console.aws.amazon.com/docdb/home?region=${region}#database:id=${ctx.attrs.dbInstanceIdentifier};is-cluster=false`;
+    },
+    facts: (ctx) => [
+      {
+        label: "identifier",
+        value: ctx.attrs?.dbInstanceIdentifier,
+        copy: true,
+      },
+      { label: "arn", value: ctx.attrs?.dbInstanceArn, mono: true, copy: true },
+      {
+        label: "endpoint",
+        value:
+          ctx.attrs?.endpointAddress === undefined
+            ? undefined
+            : `${ctx.attrs.endpointAddress}:${ctx.attrs.endpointPort ?? ""}`,
+        mono: true,
+        copy: true,
+      },
+      { label: "cluster", value: ctx.attrs?.dbClusterIdentifier },
+      { label: "class", value: ctx.attrs?.dbInstanceClass },
+      { label: "status", value: ctx.attrs?.status },
+    ],
+  },
+);
+
+export const DBSubnetGroupUI = UIProvider.succeed<DBSubnetGroup>(
+  "AWS.DocDB.DBSubnetGroup",
+  {
+    displayName: "DocumentDB Subnet Group",
+    icon: "network",
+    color: COLOR,
+    category: "network",
+    summary: (ctx) => ctx.attrs?.dbSubnetGroupName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.dbSubnetGroupName, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.dbSubnetGroupArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "vpc", value: ctx.attrs?.vpcId, mono: true },
+      { label: "subnets", value: ctx.attrs?.subnetIds?.join(", "), mono: true },
+      { label: "status", value: ctx.attrs?.status },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(DBClusterUI, DBInstanceUI, DBSubnetGroupUI);

--- a/packages/alchemy/src/AWS/DocDBElastic/ui.ts
+++ b/packages/alchemy/src/AWS/DocDBElastic/ui.ts
@@ -1,0 +1,37 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Cluster } from "./Cluster.ts";
+
+/**
+ * Dashboard UI providers for AWS DocDBElastic resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+export const ClusterUI = UIProvider.succeed<Cluster>(
+  "AWS.DocDBElastic.Cluster",
+  {
+    displayName: "DocumentDB Elastic Cluster",
+    icon: "database",
+    color: "#C925D1",
+    category: "database",
+    summary: (ctx) => ctx.attrs?.clusterName,
+    facts: (ctx) => [
+      { label: "cluster", value: ctx.attrs?.clusterName, copy: true },
+      { label: "arn", value: ctx.attrs?.clusterArn, mono: true, copy: true },
+      {
+        label: "endpoint",
+        value: ctx.attrs?.clusterEndpoint,
+        mono: true,
+        copy: true,
+      },
+      { label: "status", value: ctx.attrs?.status },
+      { label: "admin user", value: ctx.attrs?.adminUserName, mono: true },
+      { label: "shard capacity", value: ctx.attrs?.shardCapacity },
+      { label: "shard count", value: ctx.attrs?.shardCount },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(ClusterUI);

--- a/packages/alchemy/src/AWS/DynamoDB/ui.ts
+++ b/packages/alchemy/src/AWS/DynamoDB/ui.ts
@@ -1,0 +1,56 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Table } from "./Table.ts";
+
+/**
+ * Dashboard UI providers for AWS DynamoDB resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** Extract the region segment from an AWS ARN (`arn:aws:dynamodb:REGION:...`). */
+const regionOfArn = (arn: string | undefined): string | undefined =>
+  arn?.split(":")[3] || undefined;
+
+export const TableUI = UIProvider.succeed<Table>("AWS.DynamoDB.Table", {
+  displayName: "DynamoDB Table",
+  icon: "table",
+  color: "#C925D1",
+  category: "database",
+  summary: (ctx) => ctx.attrs?.tableName,
+  consoleUrl: (ctx) => {
+    const region = regionOfArn(ctx.attrs?.tableArn);
+    return region === undefined || ctx.attrs?.tableName === undefined
+      ? undefined
+      : `https://${region}.console.aws.amazon.com/dynamodbv2/home?region=${region}#table?name=${ctx.attrs.tableName}`;
+  },
+  facts: (ctx) => [
+    { label: "table", value: ctx.attrs?.tableName, copy: true },
+    { label: "arn", value: ctx.attrs?.tableArn, mono: true, copy: true },
+    {
+      label: "key",
+      value:
+        ctx.attrs?.partitionKey === undefined
+          ? undefined
+          : `${ctx.attrs.partitionKey}${ctx.attrs.sortKey ? ` / ${ctx.attrs.sortKey}` : ""}`,
+      mono: true,
+    },
+    { label: "billing", value: ctx.props?.billingMode },
+    {
+      label: "stream",
+      value: ctx.attrs?.latestStreamArn,
+      mono: true,
+      copy: true,
+    },
+    { label: "gsis", value: ctx.attrs?.globalSecondaryIndexes?.length },
+    { label: "lsis", value: ctx.attrs?.localSecondaryIndexes?.length },
+    {
+      label: "pitr",
+      value:
+        ctx.attrs?.pointInTimeRecoveryDescription?.PointInTimeRecoveryStatus,
+    },
+  ],
+});
+
+export const ui = () => Layer.mergeAll(TableUI);

--- a/packages/alchemy/src/AWS/EC2/ui.ts
+++ b/packages/alchemy/src/AWS/EC2/ui.ts
@@ -1,0 +1,835 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { DhcpOptions } from "./DhcpOptions.ts";
+import type { EIP } from "./EIP.ts";
+import type { EgressOnlyInternetGateway } from "./EgressOnlyInternetGateway.ts";
+import type { FlowLog } from "./FlowLog.ts";
+import type { Instance } from "./Instance.ts";
+import type { InternetGateway } from "./InternetGateway.ts";
+import type { KeyPair } from "./KeyPair.ts";
+import type { NatGateway } from "./NatGateway.ts";
+import type { NetworkAcl } from "./NetworkAcl.ts";
+import type { NetworkAclAssociation } from "./NetworkAclAssociation.ts";
+import type { NetworkAclEntry } from "./NetworkAclEntry.ts";
+import type { NetworkInterface } from "./NetworkInterface.ts";
+import type { NetworkInterfaceAttachment } from "./NetworkInterfaceAttachment.ts";
+import type { PrefixList } from "./PrefixList.ts";
+import type { Route } from "./Route.ts";
+import type { RouteTable } from "./RouteTable.ts";
+import type { RouteTableAssociation } from "./RouteTableAssociation.ts";
+import type { SecurityGroup } from "./SecurityGroup.ts";
+import type { SecurityGroupRule } from "./SecurityGroupRule.ts";
+import type { Snapshot } from "./Snapshot.ts";
+import type { Subnet } from "./Subnet.ts";
+import type { Volume } from "./Volume.ts";
+import type { VolumeAttachment } from "./VolumeAttachment.ts";
+import type { Vpc } from "./Vpc.ts";
+import type { VpcEndpoint } from "./VpcEndpoint.ts";
+import type { VpcPeeringConnection } from "./VpcPeeringConnection.ts";
+
+/**
+ * Dashboard UI providers for AWS EC2 resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** AWS networking (VPC) brand purple. */
+const NETWORK_PURPLE = "#8C4FFF";
+/** AWS compute brand orange. */
+const COMPUTE_ORANGE = "#ED7100";
+/** AWS storage (EBS) brand green. */
+const STORAGE_GREEN = "#7AA116";
+
+/** Extract the region segment from an AWS ARN (arn:aws:svc:REGION:...). */
+const regionOfArn = (arn: string | undefined): string | undefined =>
+  arn?.split(":")[3] || undefined;
+
+const vpcConsole = (
+  region: string | undefined,
+  hash: string,
+): string | undefined =>
+  region === undefined
+    ? undefined
+    : `https://${region}.console.aws.amazon.com/vpcconsole/home?region=${region}#${hash}`;
+
+const ec2Console = (
+  region: string | undefined,
+  hash: string,
+): string | undefined =>
+  region === undefined
+    ? undefined
+    : `https://${region}.console.aws.amazon.com/ec2/home?region=${region}#${hash}`;
+
+export const VpcUI = UIProvider.succeed<Vpc>("AWS.EC2.VPC", {
+  displayName: "VPC",
+  icon: "network",
+  color: NETWORK_PURPLE,
+  category: "network",
+  summary: (ctx) => ctx.attrs?.vpcId,
+  consoleUrl: (ctx) =>
+    ctx.attrs?.vpcId === undefined
+      ? undefined
+      : vpcConsole(
+          regionOfArn(ctx.attrs?.vpcArn),
+          `VpcDetails:VpcId=${ctx.attrs.vpcId}`,
+        ),
+  facts: (ctx) => [
+    { label: "vpc id", value: ctx.attrs?.vpcId, mono: true, copy: true },
+    { label: "arn", value: ctx.attrs?.vpcArn, mono: true, copy: true },
+    { label: "cidr", value: ctx.attrs?.cidrBlock, mono: true },
+    { label: "state", value: ctx.attrs?.state },
+    { label: "default", value: ctx.attrs?.isDefault },
+    { label: "dhcp options", value: ctx.attrs?.dhcpOptionsId, mono: true },
+  ],
+});
+
+export const SubnetUI = UIProvider.succeed<Subnet>("AWS.EC2.Subnet", {
+  displayName: "Subnet",
+  icon: "grid-2x2",
+  color: NETWORK_PURPLE,
+  category: "network",
+  summary: (ctx) => ctx.attrs?.subnetId,
+  consoleUrl: (ctx) =>
+    ctx.attrs?.subnetId === undefined
+      ? undefined
+      : vpcConsole(
+          regionOfArn(ctx.attrs?.subnetArn),
+          `SubnetDetails:SubnetId=${ctx.attrs.subnetId}`,
+        ),
+  facts: (ctx) => [
+    { label: "subnet id", value: ctx.attrs?.subnetId, mono: true, copy: true },
+    { label: "arn", value: ctx.attrs?.subnetArn, mono: true, copy: true },
+    { label: "vpc", value: ctx.attrs?.vpcId, mono: true },
+    { label: "cidr", value: ctx.attrs?.cidrBlock, mono: true },
+    { label: "az", value: ctx.attrs?.availabilityZone },
+    { label: "public ip on launch", value: ctx.attrs?.mapPublicIpOnLaunch },
+    { label: "available ips", value: ctx.attrs?.availableIpAddressCount },
+  ],
+});
+
+export const InstanceUI = UIProvider.succeed<Instance>("AWS.EC2.Instance", {
+  displayName: "EC2 Instance",
+  icon: "server",
+  color: COMPUTE_ORANGE,
+  category: "compute",
+  summary: (ctx) => ctx.attrs?.instanceId,
+  link: (ctx) =>
+    ctx.attrs?.publicDnsName ? `http://${ctx.attrs.publicDnsName}` : undefined,
+  consoleUrl: (ctx) =>
+    ctx.attrs?.instanceId === undefined
+      ? undefined
+      : ec2Console(
+          regionOfArn(ctx.attrs?.instanceArn),
+          `InstanceDetails:instanceId=${ctx.attrs.instanceId}`,
+        ),
+  facts: (ctx) => [
+    {
+      label: "instance id",
+      value: ctx.attrs?.instanceId,
+      mono: true,
+      copy: true,
+    },
+    { label: "type", value: ctx.attrs?.instanceType },
+    { label: "state", value: ctx.attrs?.state },
+    { label: "ami", value: ctx.attrs?.imageId, mono: true },
+    { label: "az", value: ctx.attrs?.availabilityZone },
+    { label: "public ip", value: ctx.attrs?.publicIpAddress, mono: true },
+    { label: "private ip", value: ctx.attrs?.privateIpAddress, mono: true },
+    { label: "subnet", value: ctx.attrs?.subnetId, mono: true },
+  ],
+});
+
+export const SecurityGroupUI = UIProvider.succeed<SecurityGroup>(
+  "AWS.EC2.SecurityGroup",
+  {
+    displayName: "Security Group",
+    icon: "shield",
+    color: COMPUTE_ORANGE,
+    category: "security",
+    summary: (ctx) => ctx.attrs?.groupName ?? ctx.attrs?.groupId,
+    consoleUrl: (ctx) =>
+      ctx.attrs?.groupId === undefined
+        ? undefined
+        : ec2Console(
+            regionOfArn(ctx.attrs?.groupArn),
+            `SecurityGroup:groupId=${ctx.attrs.groupId}`,
+          ),
+    facts: (ctx) => [
+      { label: "group id", value: ctx.attrs?.groupId, mono: true, copy: true },
+      { label: "name", value: ctx.attrs?.groupName },
+      { label: "arn", value: ctx.attrs?.groupArn, mono: true, copy: true },
+      { label: "vpc", value: ctx.attrs?.vpcId, mono: true },
+      { label: "description", value: ctx.attrs?.description },
+      { label: "ingress rules", value: ctx.attrs?.ingressRules?.length },
+      { label: "egress rules", value: ctx.attrs?.egressRules?.length },
+    ],
+  },
+);
+
+export const SecurityGroupRuleUI = UIProvider.succeed<SecurityGroupRule>(
+  "AWS.EC2.SecurityGroupRule",
+  {
+    displayName: "Security Group Rule",
+    icon: "shield-check",
+    color: COMPUTE_ORANGE,
+    category: "security",
+    summary: (ctx) => ctx.attrs?.securityGroupRuleId,
+    facts: (ctx) => [
+      {
+        label: "rule id",
+        value: ctx.attrs?.securityGroupRuleId,
+        mono: true,
+        copy: true,
+      },
+      { label: "group", value: ctx.attrs?.groupId, mono: true },
+      {
+        label: "direction",
+        value:
+          ctx.attrs?.isEgress === undefined
+            ? undefined
+            : ctx.attrs.isEgress
+              ? "egress"
+              : "ingress",
+      },
+      { label: "protocol", value: ctx.attrs?.ipProtocol },
+      {
+        label: "ports",
+        value:
+          ctx.attrs?.fromPort === undefined
+            ? undefined
+            : ctx.attrs.fromPort === ctx.attrs.toPort
+              ? ctx.attrs.fromPort
+              : `${ctx.attrs.fromPort}-${ctx.attrs.toPort}`,
+      },
+      {
+        label: "source",
+        value:
+          ctx.attrs?.cidrIpv4 ??
+          ctx.attrs?.cidrIpv6 ??
+          ctx.attrs?.referencedGroupId ??
+          ctx.attrs?.prefixListId,
+        mono: true,
+      },
+    ],
+  },
+);
+
+export const KeyPairUI = UIProvider.succeed<KeyPair>("AWS.EC2.KeyPair", {
+  displayName: "EC2 Key Pair",
+  icon: "key-round",
+  color: COMPUTE_ORANGE,
+  category: "security",
+  summary: (ctx) => ctx.attrs?.keyName,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.keyName, copy: true },
+    { label: "key id", value: ctx.attrs?.keyPairId, mono: true, copy: true },
+    { label: "type", value: ctx.attrs?.keyType },
+    { label: "fingerprint", value: ctx.attrs?.keyFingerprint, mono: true },
+  ],
+});
+
+export const EIPUI = UIProvider.succeed<EIP>("AWS.EC2.EIP", {
+  displayName: "Elastic IP",
+  icon: "map-pin",
+  color: NETWORK_PURPLE,
+  category: "network",
+  summary: (ctx) => ctx.attrs?.publicIp,
+  consoleUrl: (ctx) =>
+    ctx.attrs?.allocationId === undefined
+      ? undefined
+      : ec2Console(
+          regionOfArn(ctx.attrs?.eipArn),
+          `ElasticIpDetails:AllocationId=${ctx.attrs.allocationId}`,
+        ),
+  facts: (ctx) => [
+    { label: "public ip", value: ctx.attrs?.publicIp, mono: true, copy: true },
+    {
+      label: "allocation id",
+      value: ctx.attrs?.allocationId,
+      mono: true,
+      copy: true,
+    },
+    { label: "arn", value: ctx.attrs?.eipArn, mono: true, copy: true },
+    { label: "domain", value: ctx.attrs?.domain },
+    { label: "network border group", value: ctx.attrs?.networkBorderGroup },
+  ],
+});
+
+export const InternetGatewayUI = UIProvider.succeed<InternetGateway>(
+  "AWS.EC2.InternetGateway",
+  {
+    displayName: "Internet Gateway",
+    icon: "globe",
+    color: NETWORK_PURPLE,
+    category: "network",
+    summary: (ctx) => ctx.attrs?.internetGatewayId,
+    consoleUrl: (ctx) =>
+      ctx.attrs?.internetGatewayId === undefined
+        ? undefined
+        : vpcConsole(
+            regionOfArn(ctx.attrs?.internetGatewayArn),
+            `InternetGatewayDetails:internetGatewayId=${ctx.attrs.internetGatewayId}`,
+          ),
+    facts: (ctx) => [
+      {
+        label: "gateway id",
+        value: ctx.attrs?.internetGatewayId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.internetGatewayArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "vpc", value: ctx.attrs?.vpcId, mono: true },
+      {
+        label: "attachment",
+        value: ctx.attrs?.attachments?.[0]?.state,
+      },
+    ],
+  },
+);
+
+export const EgressOnlyInternetGatewayUI =
+  UIProvider.succeed<EgressOnlyInternetGateway>(
+    "AWS.EC2.EgressOnlyInternetGateway",
+    {
+      displayName: "Egress-Only Internet Gateway",
+      icon: "arrow-up-right",
+      color: NETWORK_PURPLE,
+      category: "network",
+      summary: (ctx) => ctx.attrs?.egressOnlyInternetGatewayId,
+      facts: (ctx) => [
+        {
+          label: "gateway id",
+          value: ctx.attrs?.egressOnlyInternetGatewayId,
+          mono: true,
+          copy: true,
+        },
+        {
+          label: "arn",
+          value: ctx.attrs?.egressOnlyInternetGatewayArn,
+          mono: true,
+          copy: true,
+        },
+        {
+          label: "vpc",
+          value: ctx.attrs?.attachments?.[0]?.vpcId,
+          mono: true,
+        },
+        {
+          label: "attachment",
+          value: ctx.attrs?.attachments?.[0]?.state,
+        },
+      ],
+    },
+  );
+
+export const NatGatewayUI = UIProvider.succeed<NatGateway>(
+  "AWS.EC2.NatGateway",
+  {
+    displayName: "NAT Gateway",
+    icon: "arrow-right-left",
+    color: NETWORK_PURPLE,
+    category: "network",
+    summary: (ctx) => ctx.attrs?.natGatewayId,
+    consoleUrl: (ctx) =>
+      ctx.attrs?.natGatewayId === undefined
+        ? undefined
+        : vpcConsole(
+            regionOfArn(ctx.attrs?.natGatewayArn),
+            `NatGatewayDetails:natGatewayId=${ctx.attrs.natGatewayId}`,
+          ),
+    facts: (ctx) => [
+      {
+        label: "gateway id",
+        value: ctx.attrs?.natGatewayId,
+        mono: true,
+        copy: true,
+      },
+      { label: "state", value: ctx.attrs?.state },
+      { label: "connectivity", value: ctx.attrs?.connectivityType },
+      { label: "public ip", value: ctx.attrs?.publicIp, mono: true },
+      { label: "private ip", value: ctx.attrs?.privateIp, mono: true },
+      { label: "subnet", value: ctx.attrs?.subnetId, mono: true },
+      { label: "vpc", value: ctx.attrs?.vpcId, mono: true },
+    ],
+  },
+);
+
+export const RouteTableUI = UIProvider.succeed<RouteTable>(
+  "AWS.EC2.RouteTable",
+  {
+    displayName: "Route Table",
+    icon: "table",
+    color: NETWORK_PURPLE,
+    category: "network",
+    summary: (ctx) => ctx.attrs?.routeTableId,
+    consoleUrl: (ctx) =>
+      ctx.attrs?.routeTableId === undefined
+        ? undefined
+        : vpcConsole(
+            regionOfArn(ctx.attrs?.routeTableArn),
+            `RouteTableDetails:RouteTableId=${ctx.attrs.routeTableId}`,
+          ),
+    facts: (ctx) => [
+      {
+        label: "route table id",
+        value: ctx.attrs?.routeTableId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.routeTableArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "vpc", value: ctx.attrs?.vpcId, mono: true },
+      { label: "associations", value: ctx.attrs?.associations?.length },
+    ],
+  },
+);
+
+export const RouteUI = UIProvider.succeed<Route>("AWS.EC2.Route", {
+  displayName: "Route",
+  icon: "route",
+  color: NETWORK_PURPLE,
+  category: "network",
+  summary: (ctx) =>
+    ctx.attrs?.destinationCidrBlock ??
+    ctx.attrs?.destinationIpv6CidrBlock ??
+    ctx.attrs?.destinationPrefixListId,
+  facts: (ctx) => [
+    {
+      label: "destination",
+      value:
+        ctx.attrs?.destinationCidrBlock ??
+        ctx.attrs?.destinationIpv6CidrBlock ??
+        ctx.attrs?.destinationPrefixListId,
+      mono: true,
+    },
+    {
+      label: "target",
+      value:
+        ctx.attrs?.gatewayId ??
+        ctx.attrs?.natGatewayId ??
+        ctx.attrs?.instanceId ??
+        ctx.attrs?.networkInterfaceId ??
+        ctx.attrs?.vpcPeeringConnectionId ??
+        ctx.attrs?.transitGatewayId ??
+        ctx.attrs?.localGatewayId ??
+        ctx.attrs?.carrierGatewayId,
+      mono: true,
+    },
+    { label: "route table", value: ctx.attrs?.routeTableId, mono: true },
+    { label: "state", value: ctx.attrs?.state },
+    { label: "origin", value: ctx.attrs?.origin },
+  ],
+});
+
+export const RouteTableAssociationUI =
+  UIProvider.succeed<RouteTableAssociation>("AWS.EC2.RouteTableAssociation", {
+    displayName: "Route Table Association",
+    icon: "link",
+    color: NETWORK_PURPLE,
+    category: "network",
+    summary: (ctx) => ctx.attrs?.associationId,
+    facts: (ctx) => [
+      {
+        label: "association id",
+        value: ctx.attrs?.associationId,
+        mono: true,
+        copy: true,
+      },
+      { label: "route table", value: ctx.attrs?.routeTableId, mono: true },
+      { label: "subnet", value: ctx.attrs?.subnetId, mono: true },
+      { label: "gateway", value: ctx.attrs?.gatewayId, mono: true },
+      { label: "state", value: ctx.attrs?.associationState?.state },
+    ],
+  });
+
+export const NetworkAclUI = UIProvider.succeed<NetworkAcl>(
+  "AWS.EC2.NetworkAcl",
+  {
+    displayName: "Network ACL",
+    icon: "list-checks",
+    color: NETWORK_PURPLE,
+    category: "security",
+    summary: (ctx) => ctx.attrs?.networkAclId,
+    consoleUrl: (ctx) =>
+      ctx.attrs?.networkAclId === undefined
+        ? undefined
+        : vpcConsole(
+            regionOfArn(ctx.attrs?.networkAclArn),
+            `NetworkAclDetails:networkAclId=${ctx.attrs.networkAclId}`,
+          ),
+    facts: (ctx) => [
+      {
+        label: "acl id",
+        value: ctx.attrs?.networkAclId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.networkAclArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "vpc", value: ctx.attrs?.vpcId, mono: true },
+      { label: "default", value: ctx.attrs?.isDefault },
+      { label: "entries", value: ctx.attrs?.entries?.length },
+      { label: "associations", value: ctx.attrs?.associations?.length },
+    ],
+  },
+);
+
+export const NetworkAclEntryUI = UIProvider.succeed<NetworkAclEntry>(
+  "AWS.EC2.NetworkAclEntry",
+  {
+    displayName: "Network ACL Entry",
+    icon: "list-plus",
+    color: NETWORK_PURPLE,
+    category: "security",
+    summary: (ctx) =>
+      ctx.attrs?.ruleNumber === undefined
+        ? undefined
+        : `rule ${ctx.attrs.ruleNumber} (${ctx.attrs.egress ? "egress" : "ingress"})`,
+    facts: (ctx) => [
+      { label: "acl", value: ctx.attrs?.networkAclId, mono: true },
+      { label: "rule number", value: ctx.attrs?.ruleNumber },
+      { label: "action", value: ctx.attrs?.ruleAction },
+      {
+        label: "direction",
+        value:
+          ctx.attrs?.egress === undefined
+            ? undefined
+            : ctx.attrs.egress
+              ? "egress"
+              : "ingress",
+      },
+      { label: "protocol", value: ctx.attrs?.protocol },
+      {
+        label: "cidr",
+        value: ctx.attrs?.cidrBlock ?? ctx.attrs?.ipv6CidrBlock,
+        mono: true,
+      },
+      {
+        label: "ports",
+        value:
+          ctx.attrs?.portRange?.from === undefined
+            ? undefined
+            : ctx.attrs.portRange.from === ctx.attrs.portRange.to
+              ? ctx.attrs.portRange.from
+              : `${ctx.attrs.portRange.from}-${ctx.attrs.portRange.to}`,
+      },
+    ],
+  },
+);
+
+export const NetworkAclAssociationUI =
+  UIProvider.succeed<NetworkAclAssociation>("AWS.EC2.NetworkAclAssociation", {
+    displayName: "Network ACL Association",
+    icon: "link-2",
+    color: NETWORK_PURPLE,
+    category: "security",
+    summary: (ctx) => ctx.attrs?.associationId,
+    facts: (ctx) => [
+      {
+        label: "association id",
+        value: ctx.attrs?.associationId,
+        mono: true,
+        copy: true,
+      },
+      { label: "acl", value: ctx.attrs?.networkAclId, mono: true },
+      { label: "subnet", value: ctx.attrs?.subnetId, mono: true },
+    ],
+  });
+
+export const VpcEndpointUI = UIProvider.succeed<VpcEndpoint>(
+  "AWS.EC2.VpcEndpoint",
+  {
+    displayName: "VPC Endpoint",
+    icon: "plug",
+    color: NETWORK_PURPLE,
+    category: "network",
+    summary: (ctx) => ctx.attrs?.serviceName ?? ctx.attrs?.vpcEndpointId,
+    consoleUrl: (ctx) =>
+      ctx.attrs?.vpcEndpointId === undefined
+        ? undefined
+        : vpcConsole(
+            regionOfArn(ctx.attrs?.vpcEndpointArn),
+            `EndpointDetails:vpcEndpointId=${ctx.attrs.vpcEndpointId}`,
+          ),
+    facts: (ctx) => [
+      {
+        label: "endpoint id",
+        value: ctx.attrs?.vpcEndpointId,
+        mono: true,
+        copy: true,
+      },
+      { label: "service", value: ctx.attrs?.serviceName, mono: true },
+      { label: "type", value: ctx.attrs?.vpcEndpointType },
+      { label: "vpc", value: ctx.attrs?.vpcId, mono: true },
+      { label: "state", value: ctx.attrs?.state },
+      { label: "private dns", value: ctx.attrs?.privateDnsEnabled },
+    ],
+  },
+);
+
+export const DhcpOptionsUI = UIProvider.succeed<DhcpOptions>(
+  "AWS.EC2.DhcpOptions",
+  {
+    displayName: "DHCP Options Set",
+    icon: "settings",
+    color: NETWORK_PURPLE,
+    category: "network",
+    summary: (ctx) => ctx.attrs?.dhcpOptionsId,
+    consoleUrl: (ctx) =>
+      ctx.attrs?.dhcpOptionsId === undefined
+        ? undefined
+        : vpcConsole(
+            regionOfArn(ctx.attrs?.dhcpOptionsArn),
+            `DhcpOptionsDetails:DhcpOptionsId=${ctx.attrs.dhcpOptionsId}`,
+          ),
+    facts: (ctx) => [
+      {
+        label: "dhcp options id",
+        value: ctx.attrs?.dhcpOptionsId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.dhcpOptionsArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "vpc", value: ctx.attrs?.vpcId, mono: true },
+      { label: "owner", value: ctx.attrs?.ownerId, mono: true },
+      { label: "domain name", value: ctx.props?.domainName },
+    ],
+  },
+);
+
+export const FlowLogUI = UIProvider.succeed<FlowLog>("AWS.EC2.FlowLog", {
+  displayName: "VPC Flow Log",
+  icon: "activity",
+  color: NETWORK_PURPLE,
+  category: "observability",
+  summary: (ctx) => ctx.attrs?.resourceId,
+  facts: (ctx) => [
+    {
+      label: "flow log id",
+      value: ctx.attrs?.flowLogId,
+      mono: true,
+      copy: true,
+    },
+    { label: "arn", value: ctx.attrs?.flowLogArn, mono: true, copy: true },
+    { label: "resource", value: ctx.attrs?.resourceId, mono: true },
+    { label: "traffic type", value: ctx.attrs?.trafficType },
+    { label: "destination", value: ctx.attrs?.logDestinationType },
+    { label: "log group", value: ctx.props?.logGroupName, mono: true },
+  ],
+});
+
+export const NetworkInterfaceUI = UIProvider.succeed<NetworkInterface>(
+  "AWS.EC2.NetworkInterface",
+  {
+    displayName: "Network Interface",
+    icon: "cable",
+    color: NETWORK_PURPLE,
+    category: "network",
+    summary: (ctx) =>
+      ctx.attrs?.privateIpAddress ?? ctx.attrs?.networkInterfaceId,
+    facts: (ctx) => [
+      {
+        label: "interface id",
+        value: ctx.attrs?.networkInterfaceId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.networkInterfaceArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "subnet", value: ctx.attrs?.subnetId, mono: true },
+      { label: "vpc", value: ctx.attrs?.vpcId, mono: true },
+      { label: "status", value: ctx.attrs?.status },
+      { label: "private ip", value: ctx.attrs?.privateIpAddress, mono: true },
+      { label: "mac address", value: ctx.attrs?.macAddress, mono: true },
+    ],
+  },
+);
+
+export const NetworkInterfaceAttachmentUI =
+  UIProvider.succeed<NetworkInterfaceAttachment>(
+    "AWS.EC2.NetworkInterfaceAttachment",
+    {
+      displayName: "Network Interface Attachment",
+      icon: "link",
+      color: NETWORK_PURPLE,
+      category: "network",
+      summary: (ctx) => ctx.attrs?.attachmentId,
+      facts: (ctx) => [
+        {
+          label: "attachment id",
+          value: ctx.attrs?.attachmentId,
+          mono: true,
+          copy: true,
+        },
+        {
+          label: "interface",
+          value: ctx.attrs?.networkInterfaceId,
+          mono: true,
+        },
+        { label: "instance", value: ctx.attrs?.instanceId, mono: true },
+        { label: "device index", value: ctx.attrs?.deviceIndex },
+        { label: "status", value: ctx.attrs?.status },
+      ],
+    },
+  );
+
+export const PrefixListUI = UIProvider.succeed<PrefixList>(
+  "AWS.EC2.PrefixList",
+  {
+    displayName: "Managed Prefix List",
+    icon: "list-ordered",
+    color: NETWORK_PURPLE,
+    category: "network",
+    summary: (ctx) => ctx.attrs?.prefixListName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.prefixListName, copy: true },
+      {
+        label: "prefix list id",
+        value: ctx.attrs?.prefixListId,
+        mono: true,
+        copy: true,
+      },
+      { label: "arn", value: ctx.attrs?.prefixListArn, mono: true, copy: true },
+      { label: "address family", value: ctx.attrs?.addressFamily },
+      { label: "max entries", value: ctx.attrs?.maxEntries },
+      { label: "version", value: ctx.attrs?.version },
+    ],
+  },
+);
+
+export const SnapshotUI = UIProvider.succeed<Snapshot>("AWS.EC2.Snapshot", {
+  displayName: "EBS Snapshot",
+  icon: "archive",
+  color: STORAGE_GREEN,
+  category: "storage",
+  summary: (ctx) => ctx.attrs?.snapshotId,
+  facts: (ctx) => [
+    {
+      label: "snapshot id",
+      value: ctx.attrs?.snapshotId,
+      mono: true,
+      copy: true,
+    },
+    { label: "arn", value: ctx.attrs?.snapshotArn, mono: true, copy: true },
+    { label: "volume", value: ctx.attrs?.volumeId, mono: true },
+    { label: "size (gib)", value: ctx.attrs?.volumeSize },
+    { label: "state", value: ctx.attrs?.state },
+    { label: "progress", value: ctx.attrs?.progress },
+    { label: "encrypted", value: ctx.attrs?.encrypted },
+  ],
+});
+
+export const VolumeUI = UIProvider.succeed<Volume>("AWS.EC2.Volume", {
+  displayName: "EBS Volume",
+  icon: "hard-drive",
+  color: STORAGE_GREEN,
+  category: "storage",
+  summary: (ctx) => ctx.attrs?.volumeId,
+  facts: (ctx) => [
+    { label: "volume id", value: ctx.attrs?.volumeId, mono: true, copy: true },
+    { label: "arn", value: ctx.attrs?.volumeArn, mono: true, copy: true },
+    { label: "az", value: ctx.attrs?.availabilityZone },
+    { label: "size (gib)", value: ctx.attrs?.size },
+    { label: "type", value: ctx.attrs?.volumeType },
+    { label: "state", value: ctx.attrs?.state },
+    { label: "iops", value: ctx.attrs?.iops },
+    { label: "encrypted", value: ctx.attrs?.encrypted },
+  ],
+});
+
+export const VolumeAttachmentUI = UIProvider.succeed<VolumeAttachment>(
+  "AWS.EC2.VolumeAttachment",
+  {
+    displayName: "EBS Volume Attachment",
+    icon: "link",
+    color: STORAGE_GREEN,
+    category: "storage",
+    summary: (ctx) => ctx.attrs?.device,
+    facts: (ctx) => [
+      { label: "volume", value: ctx.attrs?.volumeId, mono: true, copy: true },
+      { label: "instance", value: ctx.attrs?.instanceId, mono: true },
+      { label: "device", value: ctx.attrs?.device, mono: true },
+      { label: "state", value: ctx.attrs?.state },
+    ],
+  },
+);
+
+export const VpcPeeringConnectionUI = UIProvider.succeed<VpcPeeringConnection>(
+  "AWS.EC2.VpcPeeringConnection",
+  {
+    displayName: "VPC Peering Connection",
+    icon: "share-2",
+    color: NETWORK_PURPLE,
+    category: "network",
+    summary: (ctx) => ctx.attrs?.vpcPeeringConnectionId,
+    facts: (ctx) => [
+      {
+        label: "connection id",
+        value: ctx.attrs?.vpcPeeringConnectionId,
+        mono: true,
+        copy: true,
+      },
+      { label: "status", value: ctx.attrs?.status },
+      { label: "requester vpc", value: ctx.attrs?.requesterVpcId, mono: true },
+      { label: "accepter vpc", value: ctx.attrs?.accepterVpcId, mono: true },
+      {
+        label: "accepter owner",
+        value: ctx.attrs?.accepterOwnerId,
+        mono: true,
+      },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(
+    VpcUI,
+    SubnetUI,
+    InstanceUI,
+    SecurityGroupUI,
+    SecurityGroupRuleUI,
+    KeyPairUI,
+    EIPUI,
+    InternetGatewayUI,
+    EgressOnlyInternetGatewayUI,
+    NatGatewayUI,
+    RouteTableUI,
+    RouteUI,
+    RouteTableAssociationUI,
+    NetworkAclUI,
+    NetworkAclEntryUI,
+    NetworkAclAssociationUI,
+    VpcEndpointUI,
+    DhcpOptionsUI,
+    FlowLogUI,
+    NetworkInterfaceUI,
+    NetworkInterfaceAttachmentUI,
+    PrefixListUI,
+    SnapshotUI,
+    VolumeUI,
+    VolumeAttachmentUI,
+    VpcPeeringConnectionUI,
+  );

--- a/packages/alchemy/src/AWS/ECR/ui.ts
+++ b/packages/alchemy/src/AWS/ECR/ui.ts
@@ -1,0 +1,93 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Image } from "./Image.ts";
+import type { RegistryPolicy } from "./RegistryPolicy.ts";
+import type { Repository } from "./Repository.ts";
+
+/**
+ * Dashboard UI providers for AWS ECR resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+const regionOf = (arn: string | undefined): string | undefined =>
+  arn?.split(":")[3] || undefined;
+
+export const RepositoryUI = UIProvider.succeed<Repository>(
+  "AWS.ECR.Repository",
+  {
+    displayName: "ECR Repository",
+    icon: "package",
+    color: "#ED7100",
+    category: "storage",
+    summary: (ctx) => ctx.attrs?.repositoryName,
+    consoleUrl: (ctx) => {
+      const region = regionOf(ctx.attrs?.repositoryArn);
+      return region === undefined ||
+        ctx.attrs?.registryId === undefined ||
+        ctx.attrs?.repositoryName === undefined
+        ? undefined
+        : `https://${region}.console.aws.amazon.com/ecr/repositories/private/${ctx.attrs.registryId}/${ctx.attrs.repositoryName}?region=${region}`;
+    },
+    facts: (ctx) => [
+      { label: "repository", value: ctx.attrs?.repositoryName, copy: true },
+      {
+        label: "uri",
+        value: ctx.attrs?.repositoryUri,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.repositoryArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "registry", value: ctx.attrs?.registryId, mono: true },
+      { label: "tag mutability", value: ctx.attrs?.imageTagMutability },
+      { label: "scan on push", value: ctx.props?.scanOnPush },
+    ],
+  },
+);
+
+export const ImageUI = UIProvider.succeed<Image>("AWS.ECR.Image", {
+  displayName: "ECR Image",
+  icon: "layers",
+  color: "#ED7100",
+  category: "storage",
+  summary: (ctx) => ctx.attrs?.imageTag,
+  facts: (ctx) => [
+    { label: "image", value: ctx.attrs?.imageUri, mono: true, copy: true },
+    { label: "digest", value: ctx.attrs?.digest, mono: true, copy: true },
+    {
+      label: "repository",
+      value: ctx.attrs?.repositoryName,
+      mono: true,
+    },
+    { label: "tag", value: ctx.attrs?.imageTag, mono: true },
+    { label: "owns repository", value: ctx.attrs?.ownsRepository },
+  ],
+});
+
+export const RegistryPolicyUI = UIProvider.succeed<RegistryPolicy>(
+  "AWS.ECR.RegistryPolicy",
+  {
+    displayName: "ECR Registry Policy",
+    icon: "lock",
+    color: "#ED7100",
+    category: "security",
+    summary: (ctx) => ctx.attrs?.registryId,
+    facts: (ctx) => [
+      {
+        label: "registry",
+        value: ctx.attrs?.registryId,
+        mono: true,
+        copy: true,
+      },
+      { label: "policy", value: ctx.attrs?.policy, mono: true },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(RepositoryUI, ImageUI, RegistryPolicyUI);

--- a/packages/alchemy/src/AWS/ECRPublic/ui.ts
+++ b/packages/alchemy/src/AWS/ECRPublic/ui.ts
@@ -1,0 +1,44 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { PublicRepository } from "./Repository.ts";
+
+/**
+ * Dashboard UI providers for AWS ECRPublic resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+export const PublicRepositoryUI = UIProvider.succeed<PublicRepository>(
+  "AWS.ECRPublic.Repository",
+  {
+    displayName: "ECR Public Repository",
+    icon: "package",
+    color: "#ED7100",
+    category: "storage",
+    summary: (ctx) => ctx.attrs?.repositoryName,
+    link: (ctx) =>
+      ctx.attrs?.repositoryUri === undefined
+        ? undefined
+        : `https://${ctx.attrs.repositoryUri}`,
+    facts: (ctx) => [
+      { label: "repository", value: ctx.attrs?.repositoryName, copy: true },
+      {
+        label: "uri",
+        value: ctx.attrs?.repositoryUri,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.repositoryArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "registry", value: ctx.attrs?.registryId, mono: true },
+      { label: "policy", value: ctx.attrs?.policyText, mono: true },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(PublicRepositoryUI);

--- a/packages/alchemy/src/AWS/ECS/ui.ts
+++ b/packages/alchemy/src/AWS/ECS/ui.ts
@@ -1,0 +1,185 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { CapacityProvider } from "./CapacityProvider.ts";
+import type { Cluster } from "./Cluster.ts";
+import type { Service } from "./Service.ts";
+import type { Task } from "./Task.ts";
+import type { TaskDefinition } from "./TaskDefinition.ts";
+
+/**
+ * Dashboard UI providers for AWS ECS resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+const regionOf = (arn: string | undefined): string | undefined =>
+  arn?.split(":")[3] || undefined;
+
+export const ClusterUI = UIProvider.succeed<Cluster>("AWS.ECS.Cluster", {
+  displayName: "ECS Cluster",
+  icon: "boxes",
+  color: "#ED7100",
+  category: "compute",
+  summary: (ctx) => ctx.attrs?.clusterName,
+  consoleUrl: (ctx) => {
+    const region = regionOf(ctx.attrs?.clusterArn);
+    return region === undefined || ctx.attrs?.clusterName === undefined
+      ? undefined
+      : `https://${region}.console.aws.amazon.com/ecs/v2/clusters/${ctx.attrs.clusterName}?region=${region}`;
+  },
+  facts: (ctx) => [
+    { label: "cluster", value: ctx.attrs?.clusterName, copy: true },
+    { label: "arn", value: ctx.attrs?.clusterArn, mono: true, copy: true },
+    { label: "status", value: ctx.attrs?.status },
+    {
+      label: "capacity providers",
+      value: ctx.attrs?.capacityProviders?.length
+        ? ctx.attrs.capacityProviders.join(", ")
+        : undefined,
+    },
+  ],
+});
+
+export const TaskUI = UIProvider.succeed<Task>("AWS.ECS.Task", {
+  displayName: "ECS Task",
+  icon: "container",
+  color: "#ED7100",
+  category: "compute",
+  summary: (ctx) => ctx.attrs?.taskFamily,
+  facts: (ctx) => [
+    { label: "family", value: ctx.attrs?.taskFamily, copy: true },
+    {
+      label: "task definition",
+      value: ctx.attrs?.taskDefinitionArn,
+      mono: true,
+      copy: true,
+    },
+    { label: "container", value: ctx.attrs?.containerName },
+    { label: "image", value: ctx.attrs?.imageUri, mono: true, copy: true },
+    { label: "port", value: ctx.attrs?.port },
+    { label: "log group", value: ctx.attrs?.logGroupName, mono: true },
+    { label: "task role", value: ctx.attrs?.taskRoleArn, mono: true },
+    { label: "code hash", value: ctx.attrs?.code?.hash, mono: true },
+  ],
+});
+
+export const ServiceUI = UIProvider.succeed<Service>("AWS.ECS.Service", {
+  displayName: "ECS Service",
+  icon: "server",
+  color: "#ED7100",
+  category: "compute",
+  summary: (ctx) => ctx.attrs?.serviceName,
+  link: (ctx) => ctx.attrs?.url,
+  consoleUrl: (ctx) => {
+    const region = regionOf(ctx.attrs?.serviceArn);
+    const clusterName = ctx.attrs?.clusterArn?.split("/")[1];
+    return region === undefined ||
+      clusterName === undefined ||
+      ctx.attrs?.serviceName === undefined
+      ? undefined
+      : `https://${region}.console.aws.amazon.com/ecs/v2/clusters/${clusterName}/services/${ctx.attrs.serviceName}?region=${region}`;
+  },
+  facts: (ctx) => [
+    { label: "service", value: ctx.attrs?.serviceName, copy: true },
+    { label: "arn", value: ctx.attrs?.serviceArn, mono: true, copy: true },
+    { label: "cluster", value: ctx.attrs?.clusterArn, mono: true },
+    {
+      label: "task definition",
+      value: ctx.attrs?.taskDefinitionArn,
+      mono: true,
+    },
+    { label: "status", value: ctx.attrs?.status },
+    { label: "desired count", value: ctx.props?.desiredCount },
+    {
+      label: "url",
+      value: ctx.attrs?.url,
+      href: ctx.attrs?.url,
+      copy: true,
+    },
+  ],
+});
+
+export const CapacityProviderUI = UIProvider.succeed<CapacityProvider>(
+  "AWS.ECS.CapacityProvider",
+  {
+    displayName: "ECS Capacity Provider",
+    icon: "layers",
+    color: "#ED7100",
+    category: "compute",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.capacityProviderArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "status", value: ctx.attrs?.status },
+      {
+        label: "auto scaling group",
+        value: ctx.attrs?.autoScalingGroupArn,
+        mono: true,
+      },
+      {
+        label: "managed scaling",
+        value: ctx.attrs?.managedScaling?.status,
+      },
+      {
+        label: "termination protection",
+        value: ctx.attrs?.managedTerminationProtection,
+      },
+    ],
+  },
+);
+
+export const TaskDefinitionUI = UIProvider.succeed<TaskDefinition>(
+  "AWS.ECS.TaskDefinition",
+  {
+    displayName: "ECS Task Definition",
+    icon: "scroll-text",
+    color: "#ED7100",
+    category: "compute",
+    summary: (ctx) =>
+      ctx.attrs?.family === undefined
+        ? undefined
+        : `${ctx.attrs.family}:${ctx.attrs.revision}`,
+    consoleUrl: (ctx) => {
+      const region = regionOf(ctx.attrs?.taskDefinitionArn);
+      return region === undefined ||
+        ctx.attrs?.family === undefined ||
+        ctx.attrs?.revision === undefined
+        ? undefined
+        : `https://${region}.console.aws.amazon.com/ecs/v2/task-definitions/${ctx.attrs.family}/${ctx.attrs.revision}?region=${region}`;
+    },
+    facts: (ctx) => [
+      { label: "family", value: ctx.attrs?.family, copy: true },
+      { label: "revision", value: ctx.attrs?.revision },
+      {
+        label: "arn",
+        value: ctx.attrs?.taskDefinitionArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "container", value: ctx.attrs?.containerName },
+      { label: "port", value: ctx.attrs?.port },
+      { label: "task role", value: ctx.attrs?.taskRoleArn, mono: true },
+      {
+        label: "execution role",
+        value: ctx.attrs?.executionRoleArn,
+        mono: true,
+      },
+      { label: "log group", value: ctx.attrs?.logGroupName, mono: true },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(
+    ClusterUI,
+    TaskUI,
+    ServiceUI,
+    CapacityProviderUI,
+    TaskDefinitionUI,
+  );

--- a/packages/alchemy/src/AWS/EFS/ui.ts
+++ b/packages/alchemy/src/AWS/EFS/ui.ts
@@ -1,0 +1,106 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { AccessPoint } from "./AccessPoint.ts";
+import type { FileSystem } from "./FileSystem.ts";
+import type { MountTarget } from "./MountTarget.ts";
+
+/**
+ * Dashboard UI providers for AWS EFS resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+const COLOR = "#7AA116";
+
+export const FileSystemUI = UIProvider.succeed<FileSystem>(
+  "AWS.EFS.FileSystem",
+  {
+    displayName: "EFS File System",
+    icon: "hard-drive",
+    color: COLOR,
+    category: "storage",
+    summary: (ctx) => ctx.attrs?.fileSystemId,
+    facts: (ctx) => [
+      {
+        label: "file system",
+        value: ctx.attrs?.fileSystemId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.fileSystemArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "performance mode", value: ctx.props?.performanceMode },
+      { label: "throughput mode", value: ctx.props?.throughputMode },
+      { label: "encrypted", value: ctx.props?.encrypted },
+    ],
+  },
+);
+
+export const AccessPointUI = UIProvider.succeed<AccessPoint>(
+  "AWS.EFS.AccessPoint",
+  {
+    displayName: "EFS Access Point",
+    icon: "key-round",
+    color: COLOR,
+    category: "storage",
+    summary: (ctx) => ctx.attrs?.accessPointId,
+    facts: (ctx) => [
+      {
+        label: "access point",
+        value: ctx.attrs?.accessPointId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.accessPointArn,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "file system",
+        value: ctx.attrs?.fileSystemId,
+        mono: true,
+      },
+      { label: "path", value: ctx.props?.rootDirectory?.path, mono: true },
+    ],
+  },
+);
+
+export const MountTargetUI = UIProvider.succeed<MountTarget>(
+  "AWS.EFS.MountTarget",
+  {
+    displayName: "EFS Mount Target",
+    icon: "network",
+    color: COLOR,
+    category: "network",
+    summary: (ctx) => ctx.attrs?.ipAddress ?? ctx.attrs?.mountTargetId,
+    facts: (ctx) => [
+      {
+        label: "mount target",
+        value: ctx.attrs?.mountTargetId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "file system",
+        value: ctx.attrs?.fileSystemId,
+        mono: true,
+      },
+      { label: "subnet", value: ctx.attrs?.subnetId, mono: true },
+      { label: "ip address", value: ctx.attrs?.ipAddress, mono: true },
+      {
+        label: "availability zone",
+        value: ctx.attrs?.availabilityZoneName,
+      },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(FileSystemUI, AccessPointUI, MountTargetUI);

--- a/packages/alchemy/src/AWS/EKS/ui.ts
+++ b/packages/alchemy/src/AWS/EKS/ui.ts
@@ -1,0 +1,192 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { AccessEntry } from "./AccessEntry.ts";
+import type { Addon } from "./Addon.ts";
+import type { Cluster } from "./Cluster.ts";
+import type { FargateProfile } from "./FargateProfile.ts";
+import type { Nodegroup } from "./Nodegroup.ts";
+import type { PodIdentityAssociation } from "./PodIdentityAssociation.ts";
+
+/**
+ * Dashboard UI providers for AWS EKS resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+const regionOf = (arn: string | undefined): string | undefined =>
+  arn?.split(":")[3] || undefined;
+
+export const ClusterUI = UIProvider.succeed<Cluster>("AWS.EKS.Cluster", {
+  displayName: "EKS Cluster",
+  icon: "ship",
+  color: "#ED7100",
+  category: "compute",
+  summary: (ctx) => ctx.attrs?.clusterName,
+  consoleUrl: (ctx) => {
+    const region = regionOf(ctx.attrs?.clusterArn);
+    return region === undefined || ctx.attrs?.clusterName === undefined
+      ? undefined
+      : `https://${region}.console.aws.amazon.com/eks/home?region=${region}#/clusters/${ctx.attrs.clusterName}`;
+  },
+  facts: (ctx) => [
+    { label: "cluster", value: ctx.attrs?.clusterName, copy: true },
+    { label: "arn", value: ctx.attrs?.clusterArn, mono: true, copy: true },
+    { label: "status", value: ctx.attrs?.status },
+    { label: "version", value: ctx.attrs?.version },
+    {
+      label: "endpoint",
+      value: ctx.attrs?.endpoint,
+      mono: true,
+      copy: true,
+    },
+    { label: "role", value: ctx.attrs?.roleArn, mono: true },
+    { label: "oidc issuer", value: ctx.attrs?.oidcIssuer, mono: true },
+  ],
+});
+
+export const AddonUI = UIProvider.succeed<Addon>("AWS.EKS.Addon", {
+  displayName: "EKS Add-on",
+  icon: "puzzle",
+  color: "#ED7100",
+  category: "config",
+  summary: (ctx) => ctx.attrs?.addonName,
+  facts: (ctx) => [
+    { label: "add-on", value: ctx.attrs?.addonName, copy: true },
+    { label: "arn", value: ctx.attrs?.addonArn, mono: true, copy: true },
+    { label: "cluster", value: ctx.attrs?.clusterName },
+    { label: "version", value: ctx.attrs?.addonVersion, mono: true },
+    { label: "status", value: ctx.attrs?.status },
+    { label: "namespace", value: ctx.attrs?.namespace },
+  ],
+});
+
+export const PodIdentityAssociationUI =
+  UIProvider.succeed<PodIdentityAssociation>("AWS.EKS.PodIdentityAssociation", {
+    displayName: "EKS Pod Identity",
+    icon: "key-round",
+    color: "#ED7100",
+    category: "auth",
+    summary: (ctx) =>
+      ctx.attrs?.namespace === undefined ||
+      ctx.attrs?.serviceAccount === undefined
+        ? undefined
+        : `${ctx.attrs.namespace}/${ctx.attrs.serviceAccount}`,
+    facts: (ctx) => [
+      {
+        label: "arn",
+        value: ctx.attrs?.associationArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "id", value: ctx.attrs?.associationId, mono: true },
+      { label: "cluster", value: ctx.attrs?.clusterName },
+      { label: "namespace", value: ctx.attrs?.namespace },
+      { label: "service account", value: ctx.attrs?.serviceAccount },
+      { label: "role", value: ctx.attrs?.roleArn, mono: true, copy: true },
+    ],
+  });
+
+export const AccessEntryUI = UIProvider.succeed<AccessEntry>(
+  "AWS.EKS.AccessEntry",
+  {
+    displayName: "EKS Access Entry",
+    icon: "user-check",
+    color: "#ED7100",
+    category: "auth",
+    summary: (ctx) => ctx.attrs?.principalArn,
+    facts: (ctx) => [
+      {
+        label: "principal",
+        value: ctx.attrs?.principalArn,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.accessEntryArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "cluster", value: ctx.attrs?.clusterName },
+      { label: "username", value: ctx.attrs?.username },
+      { label: "type", value: ctx.attrs?.type },
+      {
+        label: "kubernetes groups",
+        value: ctx.attrs?.kubernetesGroups?.length
+          ? ctx.attrs.kubernetesGroups.join(", ")
+          : undefined,
+      },
+    ],
+  },
+);
+
+export const FargateProfileUI = UIProvider.succeed<FargateProfile>(
+  "AWS.EKS.FargateProfile",
+  {
+    displayName: "EKS Fargate Profile",
+    icon: "cloud",
+    color: "#ED7100",
+    category: "compute",
+    summary: (ctx) => ctx.attrs?.fargateProfileName,
+    facts: (ctx) => [
+      {
+        label: "profile",
+        value: ctx.attrs?.fargateProfileName,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.fargateProfileArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "cluster", value: ctx.attrs?.clusterName },
+      { label: "status", value: ctx.attrs?.status },
+      {
+        label: "subnets",
+        value: ctx.attrs?.subnets?.length
+          ? ctx.attrs.subnets.join(", ")
+          : undefined,
+        mono: true,
+      },
+    ],
+  },
+);
+
+export const NodegroupUI = UIProvider.succeed<Nodegroup>("AWS.EKS.Nodegroup", {
+  displayName: "EKS Node Group",
+  icon: "cpu",
+  color: "#ED7100",
+  category: "compute",
+  summary: (ctx) => ctx.attrs?.nodegroupName,
+  facts: (ctx) => [
+    { label: "node group", value: ctx.attrs?.nodegroupName, copy: true },
+    {
+      label: "arn",
+      value: ctx.attrs?.nodegroupArn,
+      mono: true,
+      copy: true,
+    },
+    { label: "cluster", value: ctx.attrs?.clusterName },
+    { label: "status", value: ctx.attrs?.status },
+    { label: "capacity type", value: ctx.attrs?.capacityType },
+    {
+      label: "instance types",
+      value: ctx.attrs?.instanceTypes?.length
+        ? ctx.attrs.instanceTypes.join(", ")
+        : undefined,
+      mono: true,
+    },
+  ],
+});
+
+export const ui = () =>
+  Layer.mergeAll(
+    ClusterUI,
+    AddonUI,
+    PodIdentityAssociationUI,
+    AccessEntryUI,
+    FargateProfileUI,
+    NodegroupUI,
+  );

--- a/packages/alchemy/src/AWS/ELBv2/ui.ts
+++ b/packages/alchemy/src/AWS/ELBv2/ui.ts
@@ -1,0 +1,211 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Listener } from "./Listener.ts";
+import type { ListenerCertificate } from "./ListenerCertificate.ts";
+import type { ListenerRule } from "./ListenerRule.ts";
+import type { LoadBalancer } from "./LoadBalancer.ts";
+import type { TargetGroup } from "./TargetGroup.ts";
+import type { TargetGroupAttachment } from "./TargetGroupAttachment.ts";
+import type { TrustStore } from "./TrustStore.ts";
+
+/**
+ * Dashboard UI providers for AWS ELBv2 resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+const regionOf = (arn: string | undefined): string | undefined =>
+  arn?.split(":")[3] || undefined;
+
+export const LoadBalancerUI = UIProvider.succeed<LoadBalancer>(
+  "AWS.ELBv2.LoadBalancer",
+  {
+    displayName: "Load Balancer",
+    icon: "network",
+    color: "#ED7100",
+    category: "network",
+    summary: (ctx) => ctx.attrs?.loadBalancerName,
+    consoleUrl: (ctx) => {
+      const region = regionOf(ctx.attrs?.loadBalancerArn);
+      return region === undefined
+        ? undefined
+        : `https://${region}.console.aws.amazon.com/ec2/home?region=${region}#LoadBalancers:`;
+    },
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.loadBalancerName, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.loadBalancerArn,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "dns",
+        value: ctx.attrs?.dnsName,
+        mono: true,
+        copy: true,
+        href:
+          ctx.attrs?.dnsName === undefined
+            ? undefined
+            : `http://${ctx.attrs.dnsName}`,
+      },
+      { label: "type", value: ctx.attrs?.type },
+      { label: "scheme", value: ctx.attrs?.scheme },
+      { label: "vpc", value: ctx.attrs?.vpcId, mono: true },
+      {
+        label: "subnets",
+        value: ctx.attrs?.subnets?.length
+          ? ctx.attrs.subnets.join(", ")
+          : undefined,
+        mono: true,
+      },
+    ],
+  },
+);
+
+export const TargetGroupUI = UIProvider.succeed<TargetGroup>(
+  "AWS.ELBv2.TargetGroup",
+  {
+    displayName: "Target Group",
+    icon: "target",
+    color: "#ED7100",
+    category: "network",
+    summary: (ctx) => ctx.attrs?.targetGroupName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.targetGroupName, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.targetGroupArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "protocol", value: ctx.attrs?.protocol },
+      { label: "port", value: ctx.attrs?.port },
+      { label: "target type", value: ctx.attrs?.targetType },
+      { label: "vpc", value: ctx.attrs?.vpcId, mono: true },
+    ],
+  },
+);
+
+export const ListenerUI = UIProvider.succeed<Listener>("AWS.ELBv2.Listener", {
+  displayName: "Listener",
+  icon: "antenna",
+  color: "#ED7100",
+  category: "network",
+  summary: (ctx) =>
+    ctx.attrs?.protocol === undefined || ctx.attrs?.port === undefined
+      ? undefined
+      : `${ctx.attrs.protocol}:${ctx.attrs.port}`,
+  facts: (ctx) => [
+    { label: "arn", value: ctx.attrs?.listenerArn, mono: true, copy: true },
+    { label: "protocol", value: ctx.attrs?.protocol },
+    { label: "port", value: ctx.attrs?.port },
+    {
+      label: "load balancer",
+      value: ctx.attrs?.loadBalancerArn,
+      mono: true,
+    },
+    {
+      label: "target group",
+      value: ctx.attrs?.targetGroupArn,
+      mono: true,
+    },
+  ],
+});
+
+export const ListenerRuleUI = UIProvider.succeed<ListenerRule>(
+  "AWS.ELBv2.ListenerRule",
+  {
+    displayName: "Listener Rule",
+    icon: "route",
+    color: "#ED7100",
+    category: "network",
+    summary: (ctx) =>
+      ctx.attrs?.priority === undefined
+        ? undefined
+        : `priority ${ctx.attrs.priority}`,
+    facts: (ctx) => [
+      { label: "arn", value: ctx.attrs?.ruleArn, mono: true, copy: true },
+      { label: "listener", value: ctx.attrs?.listenerArn, mono: true },
+      { label: "priority", value: ctx.attrs?.priority },
+      { label: "default", value: ctx.attrs?.isDefault },
+    ],
+  },
+);
+
+export const TrustStoreUI = UIProvider.succeed<TrustStore>(
+  "AWS.ELBv2.TrustStore",
+  {
+    displayName: "Trust Store",
+    icon: "shield-check",
+    color: "#ED7100",
+    category: "security",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.trustStoreArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "status", value: ctx.attrs?.status },
+      {
+        label: "ca certificates",
+        value: ctx.attrs?.numberOfCaCertificates,
+      },
+    ],
+  },
+);
+
+export const ListenerCertificateUI = UIProvider.succeed<ListenerCertificate>(
+  "AWS.ELBv2.ListenerCertificate",
+  {
+    displayName: "Listener Certificate",
+    icon: "shield-check",
+    color: "#ED7100",
+    category: "security",
+    summary: (ctx) => ctx.attrs?.certificateArn,
+    facts: (ctx) => [
+      {
+        label: "certificate",
+        value: ctx.attrs?.certificateArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "listener", value: ctx.attrs?.listenerArn, mono: true },
+    ],
+  },
+);
+
+export const TargetGroupAttachmentUI =
+  UIProvider.succeed<TargetGroupAttachment>("AWS.ELBv2.TargetGroupAttachment", {
+    displayName: "Target Group Attachment",
+    icon: "link",
+    color: "#ED7100",
+    category: "network",
+    summary: (ctx) => ctx.attrs?.targetId,
+    facts: (ctx) => [
+      { label: "target", value: ctx.attrs?.targetId, mono: true, copy: true },
+      {
+        label: "target group",
+        value: ctx.attrs?.targetGroupArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "port", value: ctx.attrs?.port },
+      { label: "availability zone", value: ctx.attrs?.availabilityZone },
+    ],
+  });
+
+export const ui = () =>
+  Layer.mergeAll(
+    LoadBalancerUI,
+    TargetGroupUI,
+    ListenerUI,
+    ListenerRuleUI,
+    TrustStoreUI,
+    ListenerCertificateUI,
+    TargetGroupAttachmentUI,
+  );

--- a/packages/alchemy/src/AWS/EMR/ui.ts
+++ b/packages/alchemy/src/AWS/EMR/ui.ts
@@ -1,0 +1,82 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Cluster } from "./Cluster.ts";
+import type { SecurityConfiguration } from "./SecurityConfiguration.ts";
+import type { Studio } from "./Studio.ts";
+
+/**
+ * Dashboard UI providers for AWS EMR resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** AWS Analytics brand purple. */
+const COLOR = "#8C4FFF";
+
+const regionOf = (arn: string | undefined): string | undefined =>
+  arn?.split(":")[3] || undefined;
+
+export const ClusterUI = UIProvider.succeed<Cluster>("AWS.EMR.Cluster", {
+  displayName: "EMR Cluster",
+  icon: "server",
+  color: COLOR,
+  category: "compute",
+  summary: (ctx) => ctx.attrs?.clusterName,
+  consoleUrl: (ctx) => {
+    const region = regionOf(ctx.attrs?.clusterArn);
+    return region === undefined || ctx.attrs?.clusterId === undefined
+      ? undefined
+      : `https://${region}.console.aws.amazon.com/emr/home?region=${region}#/clusterDetails/${ctx.attrs.clusterId}`;
+  },
+  facts: (ctx) => [
+    { label: "cluster", value: ctx.attrs?.clusterName, copy: true },
+    { label: "id", value: ctx.attrs?.clusterId, mono: true, copy: true },
+    { label: "arn", value: ctx.attrs?.clusterArn, mono: true, copy: true },
+    { label: "state", value: ctx.attrs?.state },
+    {
+      label: "master dns",
+      value: ctx.attrs?.masterPublicDnsName,
+      mono: true,
+    },
+  ],
+});
+
+export const SecurityConfigurationUI =
+  UIProvider.succeed<SecurityConfiguration>("AWS.EMR.SecurityConfiguration", {
+    displayName: "EMR Security Configuration",
+    icon: "shield",
+    color: COLOR,
+    category: "config",
+    summary: (ctx) => ctx.attrs?.securityConfigurationName,
+    facts: (ctx) => [
+      {
+        label: "configuration",
+        value: ctx.attrs?.securityConfigurationName,
+        copy: true,
+      },
+    ],
+  });
+
+export const StudioUI = UIProvider.succeed<Studio>("AWS.EMR.Studio", {
+  displayName: "EMR Studio",
+  icon: "notebook",
+  color: COLOR,
+  category: "other",
+  summary: (ctx) => ctx.attrs?.studioName,
+  link: (ctx) => ctx.attrs?.url,
+  facts: (ctx) => [
+    { label: "studio", value: ctx.attrs?.studioName, copy: true },
+    { label: "id", value: ctx.attrs?.studioId, mono: true, copy: true },
+    { label: "arn", value: ctx.attrs?.studioArn, mono: true, copy: true },
+    {
+      label: "url",
+      value: ctx.attrs?.url,
+      href: ctx.attrs?.url,
+      copy: true,
+    },
+  ],
+});
+
+export const ui = () =>
+  Layer.mergeAll(ClusterUI, SecurityConfigurationUI, StudioUI);

--- a/packages/alchemy/src/AWS/EMRContainers/ui.ts
+++ b/packages/alchemy/src/AWS/EMRContainers/ui.ts
@@ -1,0 +1,81 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { JobTemplate } from "./JobTemplate.ts";
+import type { VirtualCluster } from "./VirtualCluster.ts";
+
+/**
+ * Dashboard UI providers for AWS EMRContainers resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+const COLOR = "#8C4FFF";
+
+export const VirtualClusterUI = UIProvider.succeed<VirtualCluster>(
+  "AWS.EMRContainers.VirtualCluster",
+  {
+    displayName: "EMR Virtual Cluster",
+    icon: "boxes",
+    color: COLOR,
+    category: "other",
+    summary: (ctx) => ctx.attrs?.virtualClusterName,
+    facts: (ctx) => [
+      {
+        label: "cluster",
+        value: ctx.attrs?.virtualClusterName,
+        copy: true,
+      },
+      {
+        label: "id",
+        value: ctx.attrs?.virtualClusterId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.virtualClusterArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "eks cluster", value: ctx.attrs?.eksClusterName, mono: true },
+      { label: "state", value: ctx.attrs?.state },
+    ],
+  },
+);
+
+export const JobTemplateUI = UIProvider.succeed<JobTemplate>(
+  "AWS.EMRContainers.JobTemplate",
+  {
+    displayName: "EMR Job Template",
+    icon: "scroll-text",
+    color: COLOR,
+    category: "other",
+    summary: (ctx) => ctx.attrs?.jobTemplateName,
+    facts: (ctx) => [
+      {
+        label: "template",
+        value: ctx.attrs?.jobTemplateName,
+        copy: true,
+      },
+      {
+        label: "id",
+        value: ctx.attrs?.jobTemplateId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.jobTemplateArn,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "release label",
+        value: ctx.props?.jobTemplateData?.releaseLabel,
+      },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(VirtualClusterUI, JobTemplateUI);

--- a/packages/alchemy/src/AWS/EMRServerless/ui.ts
+++ b/packages/alchemy/src/AWS/EMRServerless/ui.ts
@@ -1,0 +1,45 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Application } from "./Application.ts";
+
+/**
+ * Dashboard UI providers for AWS EMRServerless resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+export const ApplicationUI = UIProvider.succeed<Application>(
+  "AWS.EMRServerless.Application",
+  {
+    displayName: "EMR Serverless Application",
+    icon: "cpu",
+    color: "#8C4FFF",
+    category: "other",
+    summary: (ctx) => ctx.attrs?.applicationName,
+    facts: (ctx) => [
+      {
+        label: "application",
+        value: ctx.attrs?.applicationName,
+        copy: true,
+      },
+      {
+        label: "id",
+        value: ctx.attrs?.applicationId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.applicationArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "type", value: ctx.attrs?.type },
+      { label: "release label", value: ctx.attrs?.releaseLabel },
+      { label: "state", value: ctx.attrs?.state },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(ApplicationUI);

--- a/packages/alchemy/src/AWS/ElastiCache/ui.ts
+++ b/packages/alchemy/src/AWS/ElastiCache/ui.ts
@@ -1,0 +1,47 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { ServerlessCache } from "./ServerlessCache.ts";
+
+/**
+ * Dashboard UI providers for AWS ElastiCache resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+export const ServerlessCacheUI = UIProvider.succeed<ServerlessCache>(
+  "AWS.ElastiCache.ServerlessCache",
+  {
+    displayName: "ElastiCache Serverless Cache",
+    icon: "database",
+    color: "#C925D1",
+    category: "database",
+    summary: (ctx) => ctx.attrs?.serverlessCacheName,
+    facts: (ctx) => [
+      {
+        label: "cache",
+        value: ctx.attrs?.serverlessCacheName,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.serverlessCacheArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "engine", value: ctx.attrs?.engine },
+      { label: "status", value: ctx.attrs?.status },
+      {
+        label: "endpoint",
+        value: ctx.attrs?.endpointAddress
+          ? `${ctx.attrs.endpointAddress}:${ctx.attrs.endpointPort ?? ""}`
+          : undefined,
+        mono: true,
+        copy: true,
+      },
+      { label: "version", value: ctx.attrs?.fullEngineVersion },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(ServerlessCacheUI);

--- a/packages/alchemy/src/AWS/ElastiCache/ui.ts
+++ b/packages/alchemy/src/AWS/ElastiCache/ui.ts
@@ -1,6 +1,9 @@
 import * as Layer from "effect/Layer";
 import * as UIProvider from "../../UI/UIProvider.ts";
+import type { CacheCluster } from "./CacheCluster.ts";
+import type { ReplicationGroup } from "./ReplicationGroup.ts";
 import type { ServerlessCache } from "./ServerlessCache.ts";
+import type { SubnetGroup } from "./SubnetGroup.ts";
 
 /**
  * Dashboard UI providers for AWS ElastiCache resources.
@@ -9,12 +12,19 @@ import type { ServerlessCache } from "./ServerlessCache.ts";
  * type-only so no AWS SDK code reaches the dashboard bundle.
  */
 
+const ELASTICACHE_COLOR = "#C925D1";
+
+const endpoint = (
+  address: string | undefined,
+  port: number | undefined,
+): string | undefined => (address ? `${address}:${port ?? ""}` : undefined);
+
 export const ServerlessCacheUI = UIProvider.succeed<ServerlessCache>(
   "AWS.ElastiCache.ServerlessCache",
   {
     displayName: "ElastiCache Serverless Cache",
     icon: "database",
-    color: "#C925D1",
+    color: ELASTICACHE_COLOR,
     category: "database",
     summary: (ctx) => ctx.attrs?.serverlessCacheName,
     facts: (ctx) => [
@@ -33,9 +43,7 @@ export const ServerlessCacheUI = UIProvider.succeed<ServerlessCache>(
       { label: "status", value: ctx.attrs?.status },
       {
         label: "endpoint",
-        value: ctx.attrs?.endpointAddress
-          ? `${ctx.attrs.endpointAddress}:${ctx.attrs.endpointPort ?? ""}`
-          : undefined,
+        value: endpoint(ctx.attrs?.endpointAddress, ctx.attrs?.endpointPort),
         mono: true,
         copy: true,
       },
@@ -44,4 +52,136 @@ export const ServerlessCacheUI = UIProvider.succeed<ServerlessCache>(
   },
 );
 
-export const ui = () => Layer.mergeAll(ServerlessCacheUI);
+export const CacheClusterUI = UIProvider.succeed<CacheCluster>(
+  "AWS.ElastiCache.CacheCluster",
+  {
+    displayName: "ElastiCache Cluster",
+    icon: "database",
+    color: ELASTICACHE_COLOR,
+    category: "database",
+    summary: (ctx) => ctx.attrs?.cacheClusterId,
+    facts: (ctx) => [
+      { label: "cluster", value: ctx.attrs?.cacheClusterId, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.cacheClusterArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "status", value: ctx.attrs?.status },
+      { label: "engine", value: ctx.attrs?.engine },
+      { label: "version", value: ctx.attrs?.engineVersion },
+      { label: "node type", value: ctx.attrs?.nodeType },
+      { label: "nodes", value: ctx.attrs?.endpoints?.length },
+      {
+        label: "endpoints",
+        value: ctx.attrs?.endpoints?.length
+          ? ctx.attrs.endpoints.map((e) => `${e.address}:${e.port}`).join(", ")
+          : undefined,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "in-transit encryption",
+        value: ctx.attrs?.transitEncryptionEnabled,
+      },
+    ],
+  },
+);
+
+export const ReplicationGroupUI = UIProvider.succeed<ReplicationGroup>(
+  "AWS.ElastiCache.ReplicationGroup",
+  {
+    displayName: "ElastiCache Replication Group",
+    icon: "database",
+    color: ELASTICACHE_COLOR,
+    category: "database",
+    summary: (ctx) => ctx.attrs?.replicationGroupId,
+    facts: (ctx) => [
+      {
+        label: "replication group",
+        value: ctx.attrs?.replicationGroupId,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.replicationGroupArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "status", value: ctx.attrs?.status },
+      { label: "engine", value: ctx.attrs?.engine },
+      { label: "version", value: ctx.attrs?.engineVersion },
+      { label: "node type", value: ctx.attrs?.nodeType },
+      { label: "shards", value: ctx.attrs?.nodeGroupIds?.length },
+      {
+        label: "primary endpoint",
+        value: endpoint(
+          ctx.attrs?.primaryEndpointAddress,
+          ctx.attrs?.primaryEndpointPort,
+        ),
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "reader endpoint",
+        value: endpoint(
+          ctx.attrs?.readerEndpointAddress,
+          ctx.attrs?.readerEndpointPort,
+        ),
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "configuration endpoint",
+        value: endpoint(
+          ctx.attrs?.configurationEndpointAddress,
+          ctx.attrs?.configurationEndpointPort,
+        ),
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "in-transit encryption",
+        value: ctx.attrs?.transitEncryptionEnabled,
+      },
+    ],
+  },
+);
+
+export const SubnetGroupUI = UIProvider.succeed<SubnetGroup>(
+  "AWS.ElastiCache.SubnetGroup",
+  {
+    displayName: "ElastiCache Subnet Group",
+    icon: "network",
+    color: ELASTICACHE_COLOR,
+    category: "database",
+    summary: (ctx) => ctx.attrs?.subnetGroupName,
+    facts: (ctx) => [
+      { label: "subnet group", value: ctx.attrs?.subnetGroupName, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.subnetGroupArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "vpc", value: ctx.attrs?.vpcId, mono: true },
+      {
+        label: "subnets",
+        value: ctx.attrs?.subnetIds?.length
+          ? ctx.attrs.subnetIds.join(", ")
+          : undefined,
+        mono: true,
+      },
+      { label: "description", value: ctx.attrs?.description },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(
+    ServerlessCacheUI,
+    CacheClusterUI,
+    ReplicationGroupUI,
+    SubnetGroupUI,
+  );

--- a/packages/alchemy/src/AWS/EntityResolution/ui.ts
+++ b/packages/alchemy/src/AWS/EntityResolution/ui.ts
@@ -1,0 +1,100 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { IdMappingWorkflow } from "./IdMappingWorkflow.ts";
+import type { IdNamespace } from "./IdNamespace.ts";
+import type { MatchingWorkflow } from "./MatchingWorkflow.ts";
+import type { SchemaMapping } from "./SchemaMapping.ts";
+
+/**
+ * Dashboard UI providers for AWS Entity Resolution resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** Entity Resolution brand color (AWS Machine Learning teal). */
+const ENTITY_RESOLUTION_COLOR = "#01A88D";
+
+export const IdMappingWorkflowUI = UIProvider.succeed<IdMappingWorkflow>(
+  "AWS.EntityResolution.IdMappingWorkflow",
+  {
+    displayName: "Entity Resolution ID Mapping Workflow",
+    icon: "workflow",
+    color: ENTITY_RESOLUTION_COLOR,
+    category: "ai",
+    summary: (ctx) => ctx.attrs?.workflowName,
+    facts: (ctx) => [
+      { label: "workflow", value: ctx.attrs?.workflowName, copy: true },
+      { label: "arn", value: ctx.attrs?.workflowArn, mono: true, copy: true },
+      { label: "description", value: ctx.props?.description },
+      { label: "role", value: ctx.props?.roleArn, mono: true },
+    ],
+  },
+);
+
+export const IdNamespaceUI = UIProvider.succeed<IdNamespace>(
+  "AWS.EntityResolution.IdNamespace",
+  {
+    displayName: "Entity Resolution ID Namespace",
+    icon: "layers",
+    color: ENTITY_RESOLUTION_COLOR,
+    category: "ai",
+    summary: (ctx) => ctx.attrs?.idNamespaceName,
+    facts: (ctx) => [
+      { label: "namespace", value: ctx.attrs?.idNamespaceName, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.idNamespaceArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "type", value: ctx.props?.type },
+      { label: "role", value: ctx.props?.roleArn, mono: true },
+    ],
+  },
+);
+
+export const MatchingWorkflowUI = UIProvider.succeed<MatchingWorkflow>(
+  "AWS.EntityResolution.MatchingWorkflow",
+  {
+    displayName: "Entity Resolution Matching Workflow",
+    icon: "merge",
+    color: ENTITY_RESOLUTION_COLOR,
+    category: "ai",
+    summary: (ctx) => ctx.attrs?.workflowName,
+    facts: (ctx) => [
+      { label: "workflow", value: ctx.attrs?.workflowName, copy: true },
+      { label: "arn", value: ctx.attrs?.workflowArn, mono: true, copy: true },
+      {
+        label: "resolution type",
+        value: ctx.props?.resolutionTechniques?.resolutionType,
+      },
+      { label: "role", value: ctx.props?.roleArn, mono: true },
+    ],
+  },
+);
+
+export const SchemaMappingUI = UIProvider.succeed<SchemaMapping>(
+  "AWS.EntityResolution.SchemaMapping",
+  {
+    displayName: "Entity Resolution Schema Mapping",
+    icon: "table",
+    color: ENTITY_RESOLUTION_COLOR,
+    category: "ai",
+    summary: (ctx) => ctx.attrs?.schemaName,
+    facts: (ctx) => [
+      { label: "schema", value: ctx.attrs?.schemaName, copy: true },
+      { label: "arn", value: ctx.attrs?.schemaArn, mono: true, copy: true },
+      { label: "fields", value: ctx.props?.mappedInputFields?.length },
+      { label: "description", value: ctx.props?.description },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(
+    IdMappingWorkflowUI,
+    IdNamespaceUI,
+    MatchingWorkflowUI,
+    SchemaMappingUI,
+  );

--- a/packages/alchemy/src/AWS/EventBridge/ui.ts
+++ b/packages/alchemy/src/AWS/EventBridge/ui.ts
@@ -1,0 +1,186 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { ApiDestination } from "./ApiDestination.ts";
+import type { Archive } from "./Archive.ts";
+import type { Connection } from "./Connection.ts";
+import type { EventBus } from "./EventBus.ts";
+import type { Permission } from "./Permission.ts";
+import type { Rule } from "./Rule.ts";
+
+/**
+ * Dashboard UI providers for AWS EventBridge resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+const regionOf = (arn: string | undefined) => arn?.split(":")[3];
+
+export const EventBusUI = UIProvider.succeed<EventBus>(
+  "AWS.EventBridge.EventBus",
+  {
+    displayName: "EventBridge Bus",
+    icon: "network",
+    color: "#E7157B",
+    category: "eventing",
+    summary: (ctx) => ctx.attrs?.eventBusName,
+    consoleUrl: (ctx) => {
+      const region = regionOf(ctx.attrs?.eventBusArn);
+      return ctx.attrs?.eventBusName === undefined || region === undefined
+        ? undefined
+        : `https://${region}.console.aws.amazon.com/events/home?region=${region}#/eventbus/${encodeURIComponent(ctx.attrs.eventBusName)}`;
+    },
+    facts: (ctx) => [
+      { label: "event bus", value: ctx.attrs?.eventBusName, copy: true },
+      { label: "arn", value: ctx.attrs?.eventBusArn, mono: true, copy: true },
+      { label: "description", value: ctx.attrs?.description },
+    ],
+  },
+);
+
+export const RuleUI = UIProvider.succeed<Rule>("AWS.EventBridge.Rule", {
+  displayName: "EventBridge Rule",
+  icon: "route",
+  color: "#E7157B",
+  category: "eventing",
+  summary: (ctx) => ctx.attrs?.ruleName,
+  consoleUrl: (ctx) => {
+    const region = regionOf(ctx.attrs?.ruleArn);
+    return ctx.attrs?.ruleName === undefined ||
+      ctx.attrs?.eventBusName === undefined ||
+      region === undefined
+      ? undefined
+      : `https://${region}.console.aws.amazon.com/events/home?region=${region}#/eventbus/${encodeURIComponent(ctx.attrs.eventBusName)}/rules/${encodeURIComponent(ctx.attrs.ruleName)}`;
+  },
+  facts: (ctx) => [
+    { label: "rule", value: ctx.attrs?.ruleName, copy: true },
+    { label: "arn", value: ctx.attrs?.ruleArn, mono: true, copy: true },
+    { label: "event bus", value: ctx.attrs?.eventBusName },
+    { label: "schedule", value: ctx.props?.scheduleExpression, mono: true },
+    { label: "state", value: ctx.props?.state },
+    {
+      label: "targets",
+      value: Array.isArray(ctx.props?.targets)
+        ? ctx.props.targets.length
+        : undefined,
+    },
+  ],
+});
+
+export const PermissionUI = UIProvider.succeed<Permission>(
+  "AWS.EventBridge.Permission",
+  {
+    displayName: "EventBridge Permission",
+    icon: "shield-check",
+    color: "#E7157B",
+    category: "eventing",
+    summary: (ctx) => ctx.attrs?.statementId,
+    facts: (ctx) => [
+      {
+        label: "statement id",
+        value: ctx.attrs?.statementId,
+        mono: true,
+        copy: true,
+      },
+      { label: "event bus", value: ctx.attrs?.eventBusName },
+      { label: "principal", value: ctx.props?.principal, mono: true },
+      { label: "action", value: ctx.props?.action, mono: true },
+    ],
+  },
+);
+
+export const ApiDestinationUI = UIProvider.succeed<ApiDestination>(
+  "AWS.EventBridge.ApiDestination",
+  {
+    displayName: "EventBridge API Destination",
+    icon: "webhook",
+    color: "#E7157B",
+    category: "eventing",
+    summary: (ctx) => ctx.attrs?.apiDestinationName,
+    consoleUrl: (ctx) => {
+      const region = regionOf(ctx.attrs?.apiDestinationArn);
+      return ctx.attrs?.apiDestinationName === undefined || region === undefined
+        ? undefined
+        : `https://${region}.console.aws.amazon.com/events/home?region=${region}#/apidestinations/${encodeURIComponent(ctx.attrs.apiDestinationName)}`;
+    },
+    facts: (ctx) => [
+      {
+        label: "destination",
+        value: ctx.attrs?.apiDestinationName,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.apiDestinationArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "state", value: ctx.attrs?.apiDestinationState },
+      { label: "endpoint", value: ctx.props?.invocationEndpoint, mono: true },
+      { label: "method", value: ctx.props?.httpMethod },
+      { label: "connection", value: ctx.props?.connectionArn, mono: true },
+    ],
+  },
+);
+
+export const ArchiveUI = UIProvider.succeed<Archive>(
+  "AWS.EventBridge.Archive",
+  {
+    displayName: "EventBridge Archive",
+    icon: "archive",
+    color: "#E7157B",
+    category: "eventing",
+    summary: (ctx) => ctx.attrs?.archiveName,
+    consoleUrl: (ctx) => {
+      const region = regionOf(ctx.attrs?.archiveArn);
+      return ctx.attrs?.archiveName === undefined || region === undefined
+        ? undefined
+        : `https://${region}.console.aws.amazon.com/events/home?region=${region}#/archives/${encodeURIComponent(ctx.attrs.archiveName)}`;
+    },
+    facts: (ctx) => [
+      { label: "archive", value: ctx.attrs?.archiveName, copy: true },
+      { label: "arn", value: ctx.attrs?.archiveArn, mono: true, copy: true },
+      { label: "event source", value: ctx.attrs?.eventSourceArn, mono: true },
+      { label: "retention", value: ctx.props?.retention?.toString() },
+    ],
+  },
+);
+
+export const ConnectionUI = UIProvider.succeed<Connection>(
+  "AWS.EventBridge.Connection",
+  {
+    displayName: "EventBridge Connection",
+    icon: "plug",
+    color: "#E7157B",
+    category: "eventing",
+    summary: (ctx) => ctx.attrs?.connectionName,
+    consoleUrl: (ctx) => {
+      const region = regionOf(ctx.attrs?.connectionArn);
+      return ctx.attrs?.connectionName === undefined || region === undefined
+        ? undefined
+        : `https://${region}.console.aws.amazon.com/events/home?region=${region}#/connections/${encodeURIComponent(ctx.attrs.connectionName)}`;
+    },
+    facts: (ctx) => [
+      { label: "connection", value: ctx.attrs?.connectionName, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.connectionArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "state", value: ctx.attrs?.connectionState },
+      { label: "auth type", value: ctx.props?.authorizationType },
+      { label: "secret", value: ctx.attrs?.secretArn, mono: true, copy: true },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(
+    EventBusUI,
+    RuleUI,
+    PermissionUI,
+    ApiDestinationUI,
+    ArchiveUI,
+    ConnectionUI,
+  );

--- a/packages/alchemy/src/AWS/FIS/ui.ts
+++ b/packages/alchemy/src/AWS/FIS/ui.ts
@@ -1,0 +1,68 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { ExperimentTemplate } from "./ExperimentTemplate.ts";
+import type { TargetAccountConfiguration } from "./TargetAccountConfiguration.ts";
+
+/**
+ * Dashboard UI providers for AWS FIS (Fault Injection Service) resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** AWS Management & Governance brand pink. */
+const COLOR = "#E7157B";
+
+const regionOf = (arn: string | undefined): string | undefined =>
+  arn?.split(":")[3] || undefined;
+
+export const ExperimentTemplateUI = UIProvider.succeed<ExperimentTemplate>(
+  "AWS.FIS.ExperimentTemplate",
+  {
+    displayName: "FIS Experiment Template",
+    icon: "test-tube",
+    color: COLOR,
+    category: "config",
+    summary: (ctx) => ctx.attrs?.id,
+    consoleUrl: (ctx) => {
+      const region = regionOf(ctx.attrs?.arn);
+      return region === undefined || ctx.attrs?.id === undefined
+        ? undefined
+        : `https://${region}.console.aws.amazon.com/fis/home?region=${region}#/experimentTemplates/${ctx.attrs.id}`;
+    },
+    facts: (ctx) => [
+      { label: "id", value: ctx.attrs?.id, mono: true, copy: true },
+      { label: "arn", value: ctx.attrs?.arn, mono: true, copy: true },
+      { label: "role", value: ctx.attrs?.roleArn, mono: true },
+    ],
+  },
+);
+
+export const TargetAccountConfigurationUI =
+  UIProvider.succeed<TargetAccountConfiguration>(
+    "AWS.FIS.TargetAccountConfiguration",
+    {
+      displayName: "FIS Target Account Configuration",
+      icon: "link",
+      color: COLOR,
+      category: "config",
+      summary: (ctx) => ctx.attrs?.accountId,
+      facts: (ctx) => [
+        {
+          label: "template",
+          value: ctx.attrs?.experimentTemplateId,
+          mono: true,
+        },
+        {
+          label: "account",
+          value: ctx.attrs?.accountId,
+          mono: true,
+          copy: true,
+        },
+        { label: "role", value: ctx.attrs?.roleArn, mono: true },
+      ],
+    },
+  );
+
+export const ui = () =>
+  Layer.mergeAll(ExperimentTemplateUI, TargetAccountConfigurationUI);

--- a/packages/alchemy/src/AWS/FMS/ui.ts
+++ b/packages/alchemy/src/AWS/FMS/ui.ts
@@ -1,0 +1,32 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { AdminAccount } from "./AdminAccount.ts";
+
+/**
+ * Dashboard UI providers for AWS FMS resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+export const AdminAccountUI = UIProvider.succeed<AdminAccount>(
+  "AWS.FMS.AdminAccount",
+  {
+    displayName: "Firewall Manager Admin Account",
+    icon: "shield",
+    color: "#DD344C",
+    category: "security",
+    summary: (ctx) => ctx.attrs?.adminAccount,
+    facts: (ctx) => [
+      {
+        label: "account",
+        value: ctx.attrs?.adminAccount,
+        mono: true,
+        copy: true,
+      },
+      { label: "role status", value: ctx.attrs?.roleStatus },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(AdminAccountUI);

--- a/packages/alchemy/src/AWS/FSx/ui.ts
+++ b/packages/alchemy/src/AWS/FSx/ui.ts
@@ -1,0 +1,41 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { FileSystem } from "./FileSystem.ts";
+
+/**
+ * Dashboard UI providers for AWS FSx resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+export const FileSystemUI = UIProvider.succeed<FileSystem>(
+  "AWS.FSx.FileSystem",
+  {
+    displayName: "FSx File System",
+    icon: "hard-drive",
+    color: "#7AA116",
+    category: "storage",
+    summary: (ctx) => ctx.attrs?.dnsName ?? ctx.attrs?.fileSystemId,
+    facts: (ctx) => [
+      {
+        label: "file system id",
+        value: ctx.attrs?.fileSystemId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.fileSystemArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "type", value: ctx.attrs?.fileSystemType },
+      { label: "dns name", value: ctx.attrs?.dnsName, mono: true },
+      { label: "vpc", value: ctx.attrs?.vpcId, mono: true },
+      { label: "storage capacity (gib)", value: ctx.props?.storageCapacity },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(FileSystemUI);

--- a/packages/alchemy/src/AWS/FinSpace/ui.ts
+++ b/packages/alchemy/src/AWS/FinSpace/ui.ts
@@ -1,0 +1,121 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Environment } from "./Environment.ts";
+import type { KxCluster } from "./KxCluster.ts";
+import type { KxDatabase } from "./KxDatabase.ts";
+import type { KxEnvironment } from "./KxEnvironment.ts";
+
+/**
+ * Dashboard UI providers for AWS FinSpace resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** AWS Database brand purple. */
+const COLOR = "#C925D1";
+
+export const EnvironmentUI = UIProvider.succeed<Environment>(
+  "AWS.FinSpace.Environment",
+  {
+    displayName: "FinSpace Environment",
+    icon: "building-2",
+    color: COLOR,
+    category: "database",
+    summary: (ctx) => ctx.attrs?.name,
+    link: (ctx) => ctx.attrs?.environmentUrl,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      {
+        label: "id",
+        value: ctx.attrs?.environmentId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.environmentArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "status", value: ctx.attrs?.status },
+      {
+        label: "url",
+        value: ctx.attrs?.environmentUrl,
+        href: ctx.attrs?.environmentUrl,
+      },
+    ],
+  },
+);
+
+export const KxClusterUI = UIProvider.succeed<KxCluster>(
+  "AWS.FinSpace.KxCluster",
+  {
+    displayName: "FinSpace kdb Cluster",
+    icon: "server",
+    color: COLOR,
+    category: "database",
+    summary: (ctx) => ctx.attrs?.clusterName,
+    facts: (ctx) => [
+      { label: "cluster", value: ctx.attrs?.clusterName, copy: true },
+      { label: "environment", value: ctx.attrs?.environmentId, mono: true },
+      { label: "type", value: ctx.attrs?.clusterType },
+      { label: "status", value: ctx.attrs?.status },
+      { label: "release", value: ctx.attrs?.releaseLabel },
+      { label: "az mode", value: ctx.attrs?.azMode },
+    ],
+  },
+);
+
+export const KxDatabaseUI = UIProvider.succeed<KxDatabase>(
+  "AWS.FinSpace.KxDatabase",
+  {
+    displayName: "FinSpace kdb Database",
+    icon: "database",
+    color: COLOR,
+    category: "database",
+    summary: (ctx) => ctx.attrs?.databaseName,
+    facts: (ctx) => [
+      { label: "database", value: ctx.attrs?.databaseName, copy: true },
+      { label: "environment", value: ctx.attrs?.environmentId, mono: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.databaseArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "description", value: ctx.attrs?.description },
+    ],
+  },
+);
+
+export const KxEnvironmentUI = UIProvider.succeed<KxEnvironment>(
+  "AWS.FinSpace.KxEnvironment",
+  {
+    displayName: "FinSpace kdb Environment",
+    icon: "boxes",
+    color: COLOR,
+    category: "database",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      {
+        label: "id",
+        value: ctx.attrs?.environmentId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.environmentArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "status", value: ctx.attrs?.status },
+      { label: "kms key", value: ctx.attrs?.kmsKeyId, mono: true },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(EnvironmentUI, KxClusterUI, KxDatabaseUI, KxEnvironmentUI);

--- a/packages/alchemy/src/AWS/Firehose/ui.ts
+++ b/packages/alchemy/src/AWS/Firehose/ui.ts
@@ -1,0 +1,45 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { DeliveryStream } from "./DeliveryStream.ts";
+
+/**
+ * Dashboard UI providers for AWS Firehose resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+const regionOf = (arn: string | undefined) => arn?.split(":")[3];
+
+export const DeliveryStreamUI = UIProvider.succeed<DeliveryStream>(
+  "AWS.Firehose.DeliveryStream",
+  {
+    displayName: "Firehose Delivery Stream",
+    icon: "send",
+    color: "#8C4FFF",
+    category: "queue",
+    summary: (ctx) => ctx.attrs?.deliveryStreamName,
+    consoleUrl: (ctx) => {
+      const region = regionOf(ctx.attrs?.deliveryStreamArn);
+      return ctx.attrs?.deliveryStreamName === undefined || region === undefined
+        ? undefined
+        : `https://${region}.console.aws.amazon.com/firehose/home?region=${region}#/details/${encodeURIComponent(ctx.attrs.deliveryStreamName)}`;
+    },
+    facts: (ctx) => [
+      { label: "stream", value: ctx.attrs?.deliveryStreamName, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.deliveryStreamArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "status", value: ctx.attrs?.deliveryStreamStatus },
+      { label: "source", value: ctx.attrs?.deliveryStreamType },
+      { label: "bucket", value: ctx.attrs?.bucketArn, mono: true, copy: true },
+      { label: "compression", value: ctx.attrs?.compressionFormat },
+      { label: "encryption", value: ctx.attrs?.encryptionStatus },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(DeliveryStreamUI);

--- a/packages/alchemy/src/AWS/Forecast/ui.ts
+++ b/packages/alchemy/src/AWS/Forecast/ui.ts
@@ -1,0 +1,54 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Dataset } from "./Dataset.ts";
+import type { DatasetGroup } from "./DatasetGroup.ts";
+
+/**
+ * Dashboard UI providers for AWS Forecast resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** Forecast brand color (AWS Machine Learning teal). */
+const FORECAST_COLOR = "#01A88D";
+
+export const DatasetUI = UIProvider.succeed<Dataset>("AWS.Forecast.Dataset", {
+  displayName: "Forecast Dataset",
+  icon: "table",
+  color: FORECAST_COLOR,
+  category: "ai",
+  summary: (ctx) => ctx.attrs?.datasetName,
+  facts: (ctx) => [
+    { label: "dataset", value: ctx.attrs?.datasetName, copy: true },
+    { label: "arn", value: ctx.attrs?.datasetArn, mono: true, copy: true },
+    { label: "domain", value: ctx.attrs?.domain },
+    { label: "type", value: ctx.attrs?.datasetType },
+    { label: "status", value: ctx.attrs?.status },
+  ],
+});
+
+export const DatasetGroupUI = UIProvider.succeed<DatasetGroup>(
+  "AWS.Forecast.DatasetGroup",
+  {
+    displayName: "Forecast Dataset Group",
+    icon: "boxes",
+    color: FORECAST_COLOR,
+    category: "ai",
+    summary: (ctx) => ctx.attrs?.datasetGroupName,
+    facts: (ctx) => [
+      { label: "group", value: ctx.attrs?.datasetGroupName, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.datasetGroupArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "domain", value: ctx.attrs?.domain },
+      { label: "status", value: ctx.attrs?.status },
+      { label: "datasets", value: ctx.props?.datasetArns?.length },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(DatasetUI, DatasetGroupUI);

--- a/packages/alchemy/src/AWS/FraudDetector/ui.ts
+++ b/packages/alchemy/src/AWS/FraudDetector/ui.ts
@@ -1,0 +1,171 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Detector } from "./Detector.ts";
+import type { DetectorVersion } from "./DetectorVersion.ts";
+import type { EntityType } from "./EntityType.ts";
+import type { EventType } from "./EventType.ts";
+import type { Label } from "./Label.ts";
+import type { List } from "./List.ts";
+import type { Outcome } from "./Outcome.ts";
+import type { Variable } from "./Variable.ts";
+
+/**
+ * Dashboard UI providers for AWS Fraud Detector resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+const COLOR = "#01A88D";
+
+export const DetectorUI = UIProvider.succeed<Detector>(
+  "AWS.FraudDetector.Detector",
+  {
+    displayName: "Fraud Detector",
+    icon: "shield-check",
+    color: COLOR,
+    category: "ai",
+    summary: (ctx) => ctx.attrs?.detectorId,
+    facts: (ctx) => [
+      { label: "id", value: ctx.attrs?.detectorId, copy: true },
+      { label: "arn", value: ctx.attrs?.arn, mono: true, copy: true },
+      { label: "event type", value: ctx.attrs?.eventTypeName },
+    ],
+  },
+);
+
+export const DetectorVersionUI = UIProvider.succeed<DetectorVersion>(
+  "AWS.FraudDetector.DetectorVersion",
+  {
+    displayName: "Fraud Detector Version",
+    icon: "git-branch",
+    color: COLOR,
+    category: "ai",
+    summary: (ctx) =>
+      ctx.attrs?.detectorVersionId
+        ? `${ctx.attrs?.detectorId ?? ""}/${ctx.attrs.detectorVersionId}`
+        : ctx.attrs?.detectorId,
+    facts: (ctx) => [
+      { label: "detector", value: ctx.attrs?.detectorId, copy: true },
+      { label: "version", value: ctx.attrs?.detectorVersionId },
+      { label: "arn", value: ctx.attrs?.arn, mono: true, copy: true },
+      { label: "status", value: ctx.attrs?.status },
+    ],
+  },
+);
+
+export const EntityTypeUI = UIProvider.succeed<EntityType>(
+  "AWS.FraudDetector.EntityType",
+  {
+    displayName: "Fraud Detector Entity Type",
+    icon: "user",
+    color: COLOR,
+    category: "ai",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      { label: "arn", value: ctx.attrs?.arn, mono: true, copy: true },
+    ],
+  },
+);
+
+export const EventTypeUI = UIProvider.succeed<EventType>(
+  "AWS.FraudDetector.EventType",
+  {
+    displayName: "Fraud Detector Event Type",
+    icon: "zap",
+    color: COLOR,
+    category: "ai",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      { label: "arn", value: ctx.attrs?.arn, mono: true, copy: true },
+      {
+        label: "variables",
+        value: ctx.props?.eventVariables?.length
+          ? ctx.props.eventVariables.join(", ")
+          : undefined,
+        mono: true,
+      },
+      {
+        label: "entity types",
+        value: ctx.props?.entityTypes?.length
+          ? ctx.props.entityTypes.join(", ")
+          : undefined,
+      },
+    ],
+  },
+);
+
+export const LabelUI = UIProvider.succeed<Label>("AWS.FraudDetector.Label", {
+  displayName: "Fraud Detector Label",
+  icon: "tag",
+  color: COLOR,
+  category: "ai",
+  summary: (ctx) => ctx.attrs?.name,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.name, copy: true },
+    { label: "arn", value: ctx.attrs?.arn, mono: true, copy: true },
+  ],
+});
+
+export const ListUI = UIProvider.succeed<List>("AWS.FraudDetector.List", {
+  displayName: "Fraud Detector List",
+  icon: "list-ordered",
+  color: COLOR,
+  category: "ai",
+  summary: (ctx) => ctx.attrs?.name,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.name, copy: true },
+    { label: "arn", value: ctx.attrs?.arn, mono: true, copy: true },
+    { label: "variable type", value: ctx.props?.variableType },
+    {
+      label: "elements",
+      value: ctx.props?.elements?.length,
+    },
+  ],
+});
+
+export const OutcomeUI = UIProvider.succeed<Outcome>(
+  "AWS.FraudDetector.Outcome",
+  {
+    displayName: "Fraud Detector Outcome",
+    icon: "flag",
+    color: COLOR,
+    category: "ai",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      { label: "arn", value: ctx.attrs?.arn, mono: true, copy: true },
+    ],
+  },
+);
+
+export const VariableUI = UIProvider.succeed<Variable>(
+  "AWS.FraudDetector.Variable",
+  {
+    displayName: "Fraud Detector Variable",
+    icon: "table",
+    color: COLOR,
+    category: "ai",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      { label: "arn", value: ctx.attrs?.arn, mono: true, copy: true },
+      { label: "data type", value: ctx.attrs?.dataType },
+      { label: "data source", value: ctx.attrs?.dataSource },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(
+    DetectorUI,
+    DetectorVersionUI,
+    EntityTypeUI,
+    EventTypeUI,
+    LabelUI,
+    ListUI,
+    OutcomeUI,
+    VariableUI,
+  );

--- a/packages/alchemy/src/AWS/Glacier/ui.ts
+++ b/packages/alchemy/src/AWS/Glacier/ui.ts
@@ -1,0 +1,25 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Vault } from "./Vault.ts";
+
+/**
+ * Dashboard UI providers for AWS Glacier resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+export const VaultUI = UIProvider.succeed<Vault>("AWS.Glacier.Vault", {
+  displayName: "Glacier Vault",
+  icon: "archive",
+  color: "#7AA116",
+  category: "storage",
+  summary: (ctx) => ctx.attrs?.vaultName,
+  facts: (ctx) => [
+    { label: "vault", value: ctx.attrs?.vaultName, copy: true },
+    { label: "arn", value: ctx.attrs?.vaultArn, mono: true, copy: true },
+    { label: "created", value: ctx.attrs?.creationDate },
+  ],
+});
+
+export const ui = () => Layer.mergeAll(VaultUI);

--- a/packages/alchemy/src/AWS/GlobalAccelerator/ui.ts
+++ b/packages/alchemy/src/AWS/GlobalAccelerator/ui.ts
@@ -1,0 +1,98 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Accelerator } from "./Accelerator.ts";
+import type { EndpointGroup } from "./EndpointGroup.ts";
+import type { Listener } from "./Listener.ts";
+
+/**
+ * Dashboard UI providers for AWS GlobalAccelerator resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** AWS Networking & Content Delivery brand purple. */
+const COLOR = "#8C4FFF";
+
+export const AcceleratorUI = UIProvider.succeed<Accelerator>(
+  "AWS.GlobalAccelerator.Accelerator",
+  {
+    displayName: "Global Accelerator",
+    icon: "zap",
+    color: COLOR,
+    category: "network",
+    summary: (ctx) => ctx.attrs?.name ?? ctx.attrs?.dnsName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.acceleratorArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "dns name", value: ctx.attrs?.dnsName, mono: true },
+      {
+        label: "ip addresses",
+        value: ctx.attrs?.ipAddresses?.join(", "),
+        mono: true,
+      },
+      { label: "status", value: ctx.attrs?.status },
+      { label: "enabled", value: ctx.attrs?.enabled },
+    ],
+  },
+);
+
+export const EndpointGroupUI = UIProvider.succeed<EndpointGroup>(
+  "AWS.GlobalAccelerator.EndpointGroup",
+  {
+    displayName: "Global Accelerator Endpoint Group",
+    icon: "waypoints",
+    color: COLOR,
+    category: "network",
+    summary: (ctx) => ctx.attrs?.endpointGroupRegion,
+    facts: (ctx) => [
+      {
+        label: "arn",
+        value: ctx.attrs?.endpointGroupArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "listener", value: ctx.attrs?.listenerArn, mono: true },
+      { label: "region", value: ctx.attrs?.endpointGroupRegion },
+      {
+        label: "traffic dial %",
+        value: ctx.attrs?.trafficDialPercentage,
+      },
+      { label: "health check", value: ctx.attrs?.healthCheckProtocol },
+      { label: "endpoints", value: ctx.attrs?.endpoints?.length },
+    ],
+  },
+);
+
+export const ListenerUI = UIProvider.succeed<Listener>(
+  "AWS.GlobalAccelerator.Listener",
+  {
+    displayName: "Global Accelerator Listener",
+    icon: "radio",
+    color: COLOR,
+    category: "network",
+    summary: (ctx) =>
+      ctx.attrs?.portRanges?.map((r) => `${r.fromPort}-${r.toPort}`).join(", "),
+    facts: (ctx) => [
+      { label: "arn", value: ctx.attrs?.listenerArn, mono: true, copy: true },
+      { label: "accelerator", value: ctx.attrs?.acceleratorArn, mono: true },
+      { label: "protocol", value: ctx.attrs?.protocol },
+      {
+        label: "port ranges",
+        value: ctx.attrs?.portRanges
+          ?.map((r) => `${r.fromPort}-${r.toPort}`)
+          .join(", "),
+        mono: true,
+      },
+      { label: "client affinity", value: ctx.attrs?.clientAffinity },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(AcceleratorUI, EndpointGroupUI, ListenerUI);

--- a/packages/alchemy/src/AWS/Glue/ui.ts
+++ b/packages/alchemy/src/AWS/Glue/ui.ts
@@ -1,0 +1,110 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Connection } from "./Connection.ts";
+import type { Crawler } from "./Crawler.ts";
+import type { Database } from "./Database.ts";
+import type { Job } from "./Job.ts";
+import type { Table } from "./Table.ts";
+
+/**
+ * Dashboard UI providers for AWS Glue resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** AWS Analytics (Glue) brand purple. */
+const COLOR = "#8C4FFF";
+
+export const ConnectionUI = UIProvider.succeed<Connection>(
+  "AWS.Glue.Connection",
+  {
+    displayName: "Glue Connection",
+    icon: "plug",
+    color: COLOR,
+    category: "other",
+    summary: (ctx) => ctx.attrs?.connectionName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.connectionName, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.connectionArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "type", value: ctx.attrs?.connectionType },
+      { label: "catalog id", value: ctx.attrs?.catalogId, mono: true },
+    ],
+  },
+);
+
+export const CrawlerUI = UIProvider.succeed<Crawler>("AWS.Glue.Crawler", {
+  displayName: "Glue Crawler",
+  icon: "search",
+  color: COLOR,
+  category: "other",
+  summary: (ctx) => ctx.attrs?.crawlerName,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.crawlerName, copy: true },
+    { label: "arn", value: ctx.attrs?.crawlerArn, mono: true, copy: true },
+    { label: "state", value: ctx.attrs?.state },
+    { label: "database", value: ctx.attrs?.databaseName, mono: true },
+    { label: "role", value: ctx.attrs?.role, mono: true },
+  ],
+});
+
+export const DatabaseUI = UIProvider.succeed<Database>("AWS.Glue.Database", {
+  displayName: "Glue Database",
+  icon: "database",
+  color: COLOR,
+  category: "database",
+  summary: (ctx) => ctx.attrs?.databaseName,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.databaseName, copy: true },
+    { label: "arn", value: ctx.attrs?.databaseArn, mono: true, copy: true },
+    { label: "catalog id", value: ctx.attrs?.catalogId, mono: true },
+    { label: "location", value: ctx.props?.locationUri, mono: true },
+  ],
+});
+
+export const JobUI = UIProvider.succeed<Job>("AWS.Glue.Job", {
+  displayName: "Glue Job",
+  icon: "play",
+  color: COLOR,
+  category: "other",
+  summary: (ctx) => ctx.attrs?.jobName,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.jobName, copy: true },
+    { label: "arn", value: ctx.attrs?.jobArn, mono: true, copy: true },
+    { label: "role", value: ctx.attrs?.role, mono: true },
+    { label: "command", value: ctx.props?.command?.name },
+    { label: "glue version", value: ctx.props?.glueVersion },
+  ],
+});
+
+export const TableUI = UIProvider.succeed<Table>("AWS.Glue.Table", {
+  displayName: "Glue Table",
+  icon: "table",
+  color: COLOR,
+  category: "database",
+  summary: (ctx) => ctx.attrs?.tableName,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.tableName, copy: true },
+    {
+      label: "database",
+      value: ctx.attrs?.databaseName,
+      mono: true,
+      copy: true,
+    },
+    { label: "arn", value: ctx.attrs?.tableArn, mono: true, copy: true },
+    { label: "catalog id", value: ctx.attrs?.catalogId, mono: true },
+    {
+      label: "location",
+      value: ctx.props?.storageDescriptor?.location,
+      mono: true,
+    },
+  ],
+});
+
+export const ui = () =>
+  Layer.mergeAll(ConnectionUI, CrawlerUI, DatabaseUI, JobUI, TableUI);

--- a/packages/alchemy/src/AWS/Grafana/ui.ts
+++ b/packages/alchemy/src/AWS/Grafana/ui.ts
@@ -1,0 +1,45 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Workspace } from "./Workspace.ts";
+
+/**
+ * Dashboard UI providers for AWS Grafana resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+const regionOf = (arn: string | undefined): string | undefined =>
+  arn?.split(":")[3] || undefined;
+
+export const WorkspaceUI = UIProvider.succeed<Workspace>(
+  "AWS.Grafana.Workspace",
+  {
+    displayName: "Grafana Workspace",
+    icon: "gauge",
+    color: "#E7157B",
+    category: "observability",
+    summary: (ctx) => ctx.attrs?.workspaceId,
+    link: (ctx) =>
+      ctx.attrs?.endpoint === undefined
+        ? undefined
+        : ctx.attrs.endpoint.startsWith("http")
+          ? ctx.attrs.endpoint
+          : `https://${ctx.attrs.endpoint}`,
+    consoleUrl: (ctx) => {
+      const region = regionOf(ctx.attrs?.workspaceArn);
+      return ctx.attrs?.workspaceId === undefined || region === undefined
+        ? undefined
+        : `https://${region}.console.aws.amazon.com/grafana/home?region=${region}#/workspaces/${ctx.attrs.workspaceId}`;
+    },
+    facts: (ctx) => [
+      { label: "id", value: ctx.attrs?.workspaceId, mono: true, copy: true },
+      { label: "arn", value: ctx.attrs?.workspaceArn, mono: true, copy: true },
+      { label: "status", value: ctx.attrs?.status },
+      { label: "version", value: ctx.attrs?.grafanaVersion },
+      { label: "endpoint", value: ctx.attrs?.endpoint, mono: true },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(WorkspaceUI);

--- a/packages/alchemy/src/AWS/GreengrassV2/ui.ts
+++ b/packages/alchemy/src/AWS/GreengrassV2/ui.ts
@@ -1,0 +1,64 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { ComponentVersion } from "./ComponentVersion.ts";
+import type { Deployment } from "./Deployment.ts";
+
+/**
+ * Dashboard UI providers for AWS GreengrassV2 resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** AWS Management & Governance brand pink. */
+const COLOR = "#E7157B";
+
+export const ComponentVersionUI = UIProvider.succeed<ComponentVersion>(
+  "AWS.GreengrassV2.ComponentVersion",
+  {
+    displayName: "Greengrass Component Version",
+    icon: "package",
+    color: COLOR,
+    category: "config",
+    summary: (ctx) =>
+      ctx.attrs?.componentName === undefined
+        ? undefined
+        : `${ctx.attrs.componentName}@${ctx.attrs.componentVersion ?? ""}`,
+    facts: (ctx) => [
+      { label: "component", value: ctx.attrs?.componentName, copy: true },
+      { label: "version", value: ctx.attrs?.componentVersion },
+      { label: "arn", value: ctx.attrs?.arn, mono: true, copy: true },
+    ],
+  },
+);
+
+export const DeploymentUI = UIProvider.succeed<Deployment>(
+  "AWS.GreengrassV2.Deployment",
+  {
+    displayName: "Greengrass Deployment",
+    icon: "upload",
+    color: COLOR,
+    category: "config",
+    summary: (ctx) => ctx.props?.deploymentName ?? ctx.attrs?.deploymentId,
+    facts: (ctx) => [
+      {
+        label: "deployment id",
+        value: ctx.attrs?.deploymentId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.deploymentArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "target", value: ctx.attrs?.targetArn, mono: true },
+      { label: "status", value: ctx.attrs?.deploymentStatus },
+      { label: "revision", value: ctx.attrs?.revisionId },
+      { label: "iot job", value: ctx.attrs?.iotJobId, mono: true },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(ComponentVersionUI, DeploymentUI);

--- a/packages/alchemy/src/AWS/GuardDuty/ui.ts
+++ b/packages/alchemy/src/AWS/GuardDuty/ui.ts
@@ -1,0 +1,94 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Detector } from "./Detector.ts";
+import type { Filter } from "./Filter.ts";
+import type { IPSet } from "./IPSet.ts";
+import type { ThreatIntelSet } from "./ThreatIntelSet.ts";
+
+/**
+ * Dashboard UI providers for AWS GuardDuty resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** AWS Security, Identity & Compliance (GuardDuty) brand red. */
+const COLOR = "#DD344C";
+
+export const DetectorUI = UIProvider.succeed<Detector>(
+  "AWS.GuardDuty.Detector",
+  {
+    displayName: "GuardDuty Detector",
+    icon: "shield",
+    color: COLOR,
+    category: "security",
+    summary: (ctx) => ctx.attrs?.detectorId,
+    facts: (ctx) => [
+      { label: "id", value: ctx.attrs?.detectorId, mono: true, copy: true },
+      { label: "arn", value: ctx.attrs?.detectorArn, mono: true, copy: true },
+      { label: "status", value: ctx.attrs?.status },
+      {
+        label: "publishing frequency",
+        value: ctx.attrs?.findingPublishingFrequency,
+      },
+    ],
+  },
+);
+
+export const FilterUI = UIProvider.succeed<Filter>("AWS.GuardDuty.Filter", {
+  displayName: "GuardDuty Filter",
+  icon: "filter",
+  color: COLOR,
+  category: "security",
+  summary: (ctx) => ctx.attrs?.name,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.name, copy: true },
+    { label: "arn", value: ctx.attrs?.filterArn, mono: true, copy: true },
+    { label: "detector", value: ctx.attrs?.detectorId, mono: true },
+    { label: "action", value: ctx.attrs?.action },
+    { label: "rank", value: ctx.attrs?.rank },
+  ],
+});
+
+export const IPSetUI = UIProvider.succeed<IPSet>("AWS.GuardDuty.IPSet", {
+  displayName: "GuardDuty Trusted IP Set",
+  icon: "shield-check",
+  color: COLOR,
+  category: "security",
+  summary: (ctx) => ctx.attrs?.name,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.name, copy: true },
+    { label: "id", value: ctx.attrs?.ipSetId, mono: true, copy: true },
+    { label: "detector", value: ctx.attrs?.detectorId, mono: true },
+    { label: "status", value: ctx.attrs?.status },
+    { label: "format", value: ctx.attrs?.format },
+    { label: "location", value: ctx.attrs?.location, mono: true, copy: true },
+  ],
+});
+
+export const ThreatIntelSetUI = UIProvider.succeed<ThreatIntelSet>(
+  "AWS.GuardDuty.ThreatIntelSet",
+  {
+    displayName: "GuardDuty Threat Intel Set",
+    icon: "alert-triangle",
+    color: COLOR,
+    category: "security",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      {
+        label: "id",
+        value: ctx.attrs?.threatIntelSetId,
+        mono: true,
+        copy: true,
+      },
+      { label: "detector", value: ctx.attrs?.detectorId, mono: true },
+      { label: "status", value: ctx.attrs?.status },
+      { label: "format", value: ctx.attrs?.format },
+      { label: "location", value: ctx.attrs?.location, mono: true, copy: true },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(DetectorUI, FilterUI, IPSetUI, ThreatIntelSetUI);

--- a/packages/alchemy/src/AWS/HealthLake/ui.ts
+++ b/packages/alchemy/src/AWS/HealthLake/ui.ts
@@ -1,0 +1,41 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { FHIRDatastore } from "./FHIRDatastore.ts";
+
+/**
+ * Dashboard UI providers for AWS HealthLake resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+export const FHIRDatastoreUI = UIProvider.succeed<FHIRDatastore>(
+  "AWS.HealthLake.FHIRDatastore",
+  {
+    displayName: "HealthLake FHIR Datastore",
+    icon: "heart-pulse",
+    color: "#01A88D",
+    category: "ai",
+    summary: (ctx) => ctx.attrs?.datastoreName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.datastoreName, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.datastoreArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "id", value: ctx.attrs?.datastoreId, mono: true },
+      { label: "status", value: ctx.attrs?.datastoreStatus },
+      {
+        label: "endpoint",
+        value: ctx.attrs?.datastoreEndpoint,
+        mono: true,
+        copy: true,
+      },
+      { label: "fhir version", value: ctx.attrs?.datastoreTypeVersion },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(FHIRDatastoreUI);

--- a/packages/alchemy/src/AWS/IAM/ui.ts
+++ b/packages/alchemy/src/AWS/IAM/ui.ts
@@ -1,0 +1,557 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { AccessKey } from "./AccessKey.ts";
+import type { AccountAlias } from "./AccountAlias.ts";
+import type { AccountPasswordPolicy } from "./AccountPasswordPolicy.ts";
+import type { Group } from "./Group.ts";
+import type { GroupMembership } from "./GroupMembership.ts";
+import type { InstanceProfile } from "./InstanceProfile.ts";
+import type { LoginProfile } from "./LoginProfile.ts";
+import type { OpenIDConnectProvider } from "./OpenIDConnectProvider.ts";
+import type { Policy } from "./Policy.ts";
+import type { Role } from "./Role.ts";
+import type { SAMLProvider } from "./SAMLProvider.ts";
+import type { SSHPublicKey } from "./SSHPublicKey.ts";
+import type { ServerCertificate } from "./ServerCertificate.ts";
+import type { ServiceLinkedRole } from "./ServiceLinkedRole.ts";
+import type { ServiceSpecificCredential } from "./ServiceSpecificCredential.ts";
+import type { SigningCertificate } from "./SigningCertificate.ts";
+import type { User } from "./User.ts";
+import type { VirtualMFADevice } from "./VirtualMFADevice.ts";
+
+/**
+ * Dashboard UI providers for AWS IAM resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+const IAM_RED = "#DD344C";
+
+export const RoleUI = UIProvider.succeed<Role>("AWS.IAM.Role", {
+  displayName: "IAM Role",
+  icon: "user-cog",
+  color: IAM_RED,
+  category: "auth",
+  summary: (ctx) => ctx.attrs?.roleName,
+  consoleUrl: (ctx) =>
+    ctx.attrs?.roleName === undefined
+      ? undefined
+      : `https://console.aws.amazon.com/iam/home#/roles/details/${ctx.attrs.roleName}`,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.roleName, copy: true },
+    { label: "arn", value: ctx.attrs?.roleArn, mono: true, copy: true },
+    { label: "id", value: ctx.attrs?.roleId, mono: true },
+    { label: "path", value: ctx.attrs?.path },
+    {
+      label: "managed policies",
+      value: ctx.attrs?.managedPolicyArns?.length,
+    },
+    {
+      label: "inline policies",
+      value:
+        ctx.attrs?.inlinePolicies === undefined
+          ? undefined
+          : Object.keys(ctx.attrs.inlinePolicies).length,
+    },
+    { label: "max session", value: ctx.attrs?.maxSessionDuration },
+    {
+      label: "permissions boundary",
+      value: ctx.attrs?.permissionsBoundary,
+      mono: true,
+    },
+  ],
+});
+
+export const UserUI = UIProvider.succeed<User>("AWS.IAM.User", {
+  displayName: "IAM User",
+  icon: "user",
+  color: IAM_RED,
+  category: "auth",
+  summary: (ctx) => ctx.attrs?.userName,
+  consoleUrl: (ctx) =>
+    ctx.attrs?.userName === undefined
+      ? undefined
+      : `https://console.aws.amazon.com/iam/home#/users/details/${ctx.attrs.userName}`,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.userName, copy: true },
+    { label: "arn", value: ctx.attrs?.userArn, mono: true, copy: true },
+    { label: "id", value: ctx.attrs?.userId, mono: true },
+    { label: "path", value: ctx.attrs?.path },
+    {
+      label: "managed policies",
+      value: ctx.attrs?.managedPolicyArns?.length,
+    },
+    {
+      label: "permissions boundary",
+      value: ctx.attrs?.permissionsBoundary,
+      mono: true,
+    },
+  ],
+});
+
+export const GroupUI = UIProvider.succeed<Group>("AWS.IAM.Group", {
+  displayName: "IAM Group",
+  icon: "users",
+  color: IAM_RED,
+  category: "auth",
+  summary: (ctx) => ctx.attrs?.groupName,
+  consoleUrl: (ctx) =>
+    ctx.attrs?.groupName === undefined
+      ? undefined
+      : `https://console.aws.amazon.com/iam/home#/groups/details/${ctx.attrs.groupName}`,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.groupName, copy: true },
+    { label: "arn", value: ctx.attrs?.groupArn, mono: true, copy: true },
+    { label: "id", value: ctx.attrs?.groupId, mono: true },
+    { label: "path", value: ctx.attrs?.path },
+    {
+      label: "managed policies",
+      value: ctx.attrs?.managedPolicyArns?.length,
+    },
+    {
+      label: "inline policies",
+      value:
+        ctx.attrs?.inlinePolicies === undefined
+          ? undefined
+          : Object.keys(ctx.attrs.inlinePolicies).length,
+    },
+  ],
+});
+
+export const GroupMembershipUI = UIProvider.succeed<GroupMembership>(
+  "AWS.IAM.GroupMembership",
+  {
+    displayName: "IAM Group Membership",
+    icon: "user-plus",
+    color: IAM_RED,
+    category: "auth",
+    summary: (ctx) => ctx.attrs?.groupName,
+    facts: (ctx) => [
+      { label: "group", value: ctx.attrs?.groupName, copy: true },
+      { label: "members", value: ctx.attrs?.userNames?.length },
+      { label: "users", value: ctx.attrs?.userNames?.join(", ") },
+    ],
+  },
+);
+
+export const PolicyUI = UIProvider.succeed<Policy>("AWS.IAM.Policy", {
+  displayName: "IAM Policy",
+  icon: "file-lock-2",
+  color: IAM_RED,
+  category: "security",
+  summary: (ctx) => ctx.attrs?.policyName,
+  consoleUrl: (ctx) =>
+    ctx.attrs?.policyArn === undefined
+      ? undefined
+      : `https://console.aws.amazon.com/iam/home#/policies/details/${encodeURIComponent(ctx.attrs.policyArn)}`,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.policyName, copy: true },
+    { label: "arn", value: ctx.attrs?.policyArn, mono: true, copy: true },
+    { label: "id", value: ctx.attrs?.policyId, mono: true },
+    { label: "path", value: ctx.attrs?.path },
+    {
+      label: "default version",
+      value: ctx.attrs?.defaultVersionId,
+      mono: true,
+    },
+    { label: "attachments", value: ctx.attrs?.attachmentCount },
+    { label: "description", value: ctx.attrs?.description },
+  ],
+});
+
+export const InstanceProfileUI = UIProvider.succeed<InstanceProfile>(
+  "AWS.IAM.InstanceProfile",
+  {
+    displayName: "IAM Instance Profile",
+    icon: "id-card",
+    color: IAM_RED,
+    category: "auth",
+    summary: (ctx) => ctx.attrs?.instanceProfileName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.instanceProfileName, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.instanceProfileArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "id", value: ctx.attrs?.instanceProfileId, mono: true },
+      { label: "role", value: ctx.attrs?.roleName, copy: true },
+      { label: "path", value: ctx.attrs?.path },
+    ],
+  },
+);
+
+export const AccessKeyUI = UIProvider.succeed<AccessKey>("AWS.IAM.AccessKey", {
+  displayName: "IAM Access Key",
+  icon: "key-round",
+  color: IAM_RED,
+  category: "auth",
+  summary: (ctx) => ctx.attrs?.accessKeyId,
+  facts: (ctx) => [
+    {
+      label: "access key id",
+      value: ctx.attrs?.accessKeyId,
+      mono: true,
+      copy: true,
+    },
+    { label: "user", value: ctx.attrs?.userName, copy: true },
+    { label: "status", value: ctx.attrs?.status },
+    {
+      label: "created",
+      value:
+        ctx.attrs?.createDate === undefined
+          ? undefined
+          : String(ctx.attrs.createDate),
+    },
+    { label: "last used service", value: ctx.attrs?.lastUsedServiceName },
+    { label: "last used region", value: ctx.attrs?.lastUsedRegion },
+  ],
+});
+
+export const LoginProfileUI = UIProvider.succeed<LoginProfile>(
+  "AWS.IAM.LoginProfile",
+  {
+    displayName: "IAM Login Profile",
+    icon: "log-in",
+    color: IAM_RED,
+    category: "auth",
+    summary: (ctx) => ctx.attrs?.userName,
+    facts: (ctx) => [
+      { label: "user", value: ctx.attrs?.userName, copy: true },
+      {
+        label: "password reset required",
+        value: ctx.attrs?.passwordResetRequired,
+      },
+      {
+        label: "created",
+        value:
+          ctx.attrs?.createDate === undefined
+            ? undefined
+            : String(ctx.attrs.createDate),
+      },
+    ],
+  },
+);
+
+export const OpenIDConnectProviderUI =
+  UIProvider.succeed<OpenIDConnectProvider>("AWS.IAM.OpenIDConnectProvider", {
+    displayName: "IAM OIDC Provider",
+    icon: "fingerprint",
+    color: IAM_RED,
+    category: "auth",
+    summary: (ctx) => ctx.attrs?.url,
+    consoleUrl: (ctx) =>
+      ctx.attrs?.openIDConnectProviderArn === undefined
+        ? undefined
+        : `https://console.aws.amazon.com/iam/home#/identity_providers/details/OPENID/${encodeURIComponent(ctx.attrs.openIDConnectProviderArn)}`,
+    facts: (ctx) => [
+      {
+        label: "url",
+        value: ctx.attrs?.url,
+        href:
+          ctx.attrs?.url === undefined
+            ? undefined
+            : ctx.attrs.url.startsWith("http")
+              ? ctx.attrs.url
+              : `https://${ctx.attrs.url}`,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.openIDConnectProviderArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "client ids", value: ctx.attrs?.clientIDList?.join(", ") },
+      { label: "thumbprints", value: ctx.attrs?.thumbprintList?.length },
+    ],
+  });
+
+export const SAMLProviderUI = UIProvider.succeed<SAMLProvider>(
+  "AWS.IAM.SAMLProvider",
+  {
+    displayName: "IAM SAML Provider",
+    icon: "shield-check",
+    color: IAM_RED,
+    category: "auth",
+    summary: (ctx) => ctx.attrs?.name,
+    consoleUrl: (ctx) =>
+      ctx.attrs?.samlProviderArn === undefined
+        ? undefined
+        : `https://console.aws.amazon.com/iam/home#/identity_providers/details/SAML/${encodeURIComponent(ctx.attrs.samlProviderArn)}`,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.samlProviderArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "uuid", value: ctx.attrs?.samlProviderUUID, mono: true },
+      {
+        label: "assertion encryption",
+        value: ctx.attrs?.assertionEncryptionMode,
+      },
+    ],
+  },
+);
+
+export const ServerCertificateUI = UIProvider.succeed<ServerCertificate>(
+  "AWS.IAM.ServerCertificate",
+  {
+    displayName: "IAM Server Certificate",
+    icon: "file-badge",
+    color: IAM_RED,
+    category: "security",
+    summary: (ctx) => ctx.attrs?.serverCertificateName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.serverCertificateName, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.serverCertificateArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "id", value: ctx.attrs?.serverCertificateId, mono: true },
+      { label: "path", value: ctx.attrs?.path },
+      {
+        label: "expires",
+        value:
+          ctx.attrs?.expiration === undefined
+            ? undefined
+            : String(ctx.attrs.expiration),
+      },
+      {
+        label: "uploaded",
+        value:
+          ctx.attrs?.uploadDate === undefined
+            ? undefined
+            : String(ctx.attrs.uploadDate),
+      },
+    ],
+  },
+);
+
+export const SigningCertificateUI = UIProvider.succeed<SigningCertificate>(
+  "AWS.IAM.SigningCertificate",
+  {
+    displayName: "IAM Signing Certificate",
+    icon: "file-key-2",
+    color: IAM_RED,
+    category: "security",
+    summary: (ctx) => ctx.attrs?.certificateId,
+    facts: (ctx) => [
+      {
+        label: "certificate id",
+        value: ctx.attrs?.certificateId,
+        mono: true,
+        copy: true,
+      },
+      { label: "user", value: ctx.attrs?.userName, copy: true },
+      { label: "status", value: ctx.attrs?.status },
+      {
+        label: "uploaded",
+        value:
+          ctx.attrs?.uploadDate === undefined
+            ? undefined
+            : String(ctx.attrs.uploadDate),
+      },
+    ],
+  },
+);
+
+export const SSHPublicKeyUI = UIProvider.succeed<SSHPublicKey>(
+  "AWS.IAM.SSHPublicKey",
+  {
+    displayName: "IAM SSH Public Key",
+    icon: "key-square",
+    color: IAM_RED,
+    category: "auth",
+    summary: (ctx) => ctx.attrs?.sshPublicKeyId,
+    facts: (ctx) => [
+      {
+        label: "key id",
+        value: ctx.attrs?.sshPublicKeyId,
+        mono: true,
+        copy: true,
+      },
+      { label: "user", value: ctx.attrs?.userName, copy: true },
+      { label: "fingerprint", value: ctx.attrs?.fingerprint, mono: true },
+      { label: "status", value: ctx.attrs?.status },
+      {
+        label: "uploaded",
+        value:
+          ctx.attrs?.uploadDate === undefined
+            ? undefined
+            : String(ctx.attrs.uploadDate),
+      },
+    ],
+  },
+);
+
+export const ServiceSpecificCredentialUI =
+  UIProvider.succeed<ServiceSpecificCredential>(
+    "AWS.IAM.ServiceSpecificCredential",
+    {
+      displayName: "IAM Service Credential",
+      icon: "key",
+      color: IAM_RED,
+      category: "auth",
+      summary: (ctx) => ctx.attrs?.serviceSpecificCredentialId,
+      facts: (ctx) => [
+        {
+          label: "credential id",
+          value: ctx.attrs?.serviceSpecificCredentialId,
+          mono: true,
+          copy: true,
+        },
+        { label: "user", value: ctx.attrs?.userName, copy: true },
+        { label: "service", value: ctx.attrs?.serviceName },
+        {
+          label: "service user",
+          value: ctx.attrs?.serviceUserName,
+          mono: true,
+        },
+        { label: "status", value: ctx.attrs?.status },
+        {
+          label: "expires",
+          value:
+            ctx.attrs?.expirationDate === undefined
+              ? undefined
+              : String(ctx.attrs.expirationDate),
+        },
+      ],
+    },
+  );
+
+export const VirtualMFADeviceUI = UIProvider.succeed<VirtualMFADevice>(
+  "AWS.IAM.VirtualMFADevice",
+  {
+    displayName: "IAM Virtual MFA Device",
+    icon: "smartphone",
+    color: IAM_RED,
+    category: "security",
+    summary: (ctx) => ctx.attrs?.serialNumber,
+    facts: (ctx) => [
+      {
+        label: "serial number",
+        value: ctx.attrs?.serialNumber,
+        mono: true,
+        copy: true,
+      },
+      { label: "user", value: ctx.attrs?.userName, copy: true },
+      {
+        label: "enabled",
+        value:
+          ctx.attrs?.enableDate === undefined
+            ? undefined
+            : String(ctx.attrs.enableDate),
+      },
+    ],
+  },
+);
+
+export const AccountAliasUI = UIProvider.succeed<AccountAlias>(
+  "AWS.IAM.AccountAlias",
+  {
+    displayName: "IAM Account Alias",
+    icon: "at-sign",
+    color: IAM_RED,
+    category: "config",
+    summary: (ctx) => ctx.attrs?.accountAlias,
+    link: (ctx) =>
+      ctx.attrs?.accountAlias === undefined
+        ? undefined
+        : `https://${ctx.attrs.accountAlias}.signin.aws.amazon.com/console`,
+    facts: (ctx) => [
+      { label: "alias", value: ctx.attrs?.accountAlias, copy: true },
+      {
+        label: "sign-in url",
+        value:
+          ctx.attrs?.accountAlias === undefined
+            ? undefined
+            : `https://${ctx.attrs.accountAlias}.signin.aws.amazon.com/console`,
+        href:
+          ctx.attrs?.accountAlias === undefined
+            ? undefined
+            : `https://${ctx.attrs.accountAlias}.signin.aws.amazon.com/console`,
+        copy: true,
+      },
+    ],
+  },
+);
+
+export const AccountPasswordPolicyUI =
+  UIProvider.succeed<AccountPasswordPolicy>("AWS.IAM.AccountPasswordPolicy", {
+    displayName: "IAM Password Policy",
+    icon: "lock-keyhole",
+    color: IAM_RED,
+    category: "security",
+    summary: (ctx) =>
+      ctx.attrs?.MinimumPasswordLength === undefined
+        ? undefined
+        : `min length ${ctx.attrs.MinimumPasswordLength}`,
+    consoleUrl: () =>
+      "https://console.aws.amazon.com/iam/home#/account_settings",
+    facts: (ctx) => [
+      { label: "min length", value: ctx.attrs?.MinimumPasswordLength },
+      { label: "require symbols", value: ctx.attrs?.RequireSymbols },
+      { label: "require numbers", value: ctx.attrs?.RequireNumbers },
+      {
+        label: "require uppercase",
+        value: ctx.attrs?.RequireUppercaseCharacters,
+      },
+      {
+        label: "require lowercase",
+        value: ctx.attrs?.RequireLowercaseCharacters,
+      },
+      { label: "max age (days)", value: ctx.attrs?.MaxPasswordAge },
+      { label: "reuse prevention", value: ctx.attrs?.PasswordReusePrevention },
+    ],
+  });
+
+export const ServiceLinkedRoleUI = UIProvider.succeed<ServiceLinkedRole>(
+  "AWS.IAM.ServiceLinkedRole",
+  {
+    displayName: "IAM Service-Linked Role",
+    icon: "link",
+    color: IAM_RED,
+    category: "auth",
+    summary: (ctx) => ctx.attrs?.roleName,
+    consoleUrl: (ctx) =>
+      ctx.attrs?.roleName === undefined
+        ? undefined
+        : `https://console.aws.amazon.com/iam/home#/roles/details/${ctx.attrs.roleName}`,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.roleName, copy: true },
+      { label: "arn", value: ctx.attrs?.roleArn, mono: true, copy: true },
+      { label: "id", value: ctx.attrs?.roleId, mono: true },
+      { label: "service", value: ctx.attrs?.awsServiceName },
+      { label: "suffix", value: ctx.attrs?.customSuffix },
+      { label: "description", value: ctx.attrs?.description },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(
+    RoleUI,
+    UserUI,
+    GroupUI,
+    GroupMembershipUI,
+    PolicyUI,
+    InstanceProfileUI,
+    AccessKeyUI,
+    LoginProfileUI,
+    OpenIDConnectProviderUI,
+    SAMLProviderUI,
+    ServerCertificateUI,
+    SigningCertificateUI,
+    SSHPublicKeyUI,
+    ServiceSpecificCredentialUI,
+    VirtualMFADeviceUI,
+    AccountAliasUI,
+    AccountPasswordPolicyUI,
+    ServiceLinkedRoleUI,
+  );

--- a/packages/alchemy/src/AWS/IVS/ui.ts
+++ b/packages/alchemy/src/AWS/IVS/ui.ts
@@ -1,0 +1,143 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Channel } from "./Channel.ts";
+import type { PlaybackKeyPair } from "./PlaybackKeyPair.ts";
+import type { PlaybackRestrictionPolicy } from "./PlaybackRestrictionPolicy.ts";
+import type { RecordingConfiguration } from "./RecordingConfiguration.ts";
+import type { StreamKey } from "./StreamKey.ts";
+
+/**
+ * Dashboard UI providers for AWS IVS resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+const IVS_COLOR = "#ED7100";
+
+export const ChannelUI = UIProvider.succeed<Channel>("AWS.IVS.Channel", {
+  displayName: "IVS Channel",
+  icon: "video",
+  color: IVS_COLOR,
+  category: "media",
+  summary: (ctx) => ctx.attrs?.channelName,
+  link: (ctx) => ctx.attrs?.playbackUrl,
+  facts: (ctx) => [
+    { label: "channel", value: ctx.attrs?.channelName, copy: true },
+    { label: "arn", value: ctx.attrs?.channelArn, mono: true, copy: true },
+    { label: "ingest", value: ctx.attrs?.ingestEndpoint, mono: true },
+    {
+      label: "playback",
+      value: ctx.attrs?.playbackUrl,
+      href: ctx.attrs?.playbackUrl,
+      copy: true,
+    },
+    { label: "type", value: ctx.attrs?.type },
+    { label: "latency mode", value: ctx.attrs?.latencyMode },
+    { label: "authorized", value: ctx.attrs?.authorized },
+  ],
+});
+
+export const PlaybackKeyPairUI = UIProvider.succeed<PlaybackKeyPair>(
+  "AWS.IVS.PlaybackKeyPair",
+  {
+    displayName: "IVS Playback Key Pair",
+    icon: "key",
+    color: IVS_COLOR,
+    category: "security",
+    summary: (ctx) => ctx.attrs?.playbackKeyPairName,
+    facts: (ctx) => [
+      {
+        label: "key pair",
+        value: ctx.attrs?.playbackKeyPairName,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.playbackKeyPairArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "fingerprint", value: ctx.attrs?.fingerprint, mono: true },
+    ],
+  },
+);
+
+export const PlaybackRestrictionPolicyUI =
+  UIProvider.succeed<PlaybackRestrictionPolicy>(
+    "AWS.IVS.PlaybackRestrictionPolicy",
+    {
+      displayName: "IVS Playback Restriction Policy",
+      icon: "shield",
+      color: IVS_COLOR,
+      category: "security",
+      summary: (ctx) => ctx.attrs?.playbackRestrictionPolicyName,
+      facts: (ctx) => [
+        {
+          label: "policy",
+          value: ctx.attrs?.playbackRestrictionPolicyName,
+          copy: true,
+        },
+        {
+          label: "arn",
+          value: ctx.attrs?.playbackRestrictionPolicyArn,
+          mono: true,
+          copy: true,
+        },
+        {
+          label: "countries",
+          value: ctx.attrs?.allowedCountries?.join(", "),
+        },
+        { label: "origins", value: ctx.attrs?.allowedOrigins?.join(", ") },
+        {
+          label: "strict origin",
+          value: ctx.attrs?.enableStrictOriginEnforcement,
+        },
+      ],
+    },
+  );
+
+export const RecordingConfigurationUI =
+  UIProvider.succeed<RecordingConfiguration>("AWS.IVS.RecordingConfiguration", {
+    displayName: "IVS Recording Configuration",
+    icon: "film",
+    color: IVS_COLOR,
+    category: "media",
+    summary: (ctx) => ctx.attrs?.recordingConfigurationName,
+    facts: (ctx) => [
+      {
+        label: "config",
+        value: ctx.attrs?.recordingConfigurationName,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.recordingConfigurationArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "bucket", value: ctx.attrs?.bucketName, mono: true },
+      { label: "state", value: ctx.attrs?.state },
+    ],
+  });
+
+export const StreamKeyUI = UIProvider.succeed<StreamKey>("AWS.IVS.StreamKey", {
+  displayName: "IVS Stream Key",
+  icon: "key-round",
+  color: IVS_COLOR,
+  category: "security",
+  summary: (ctx) => ctx.attrs?.streamKeyArn,
+  facts: (ctx) => [
+    { label: "arn", value: ctx.attrs?.streamKeyArn, mono: true, copy: true },
+    { label: "channel", value: ctx.attrs?.channelArn, mono: true },
+  ],
+});
+
+export const ui = () =>
+  Layer.mergeAll(
+    ChannelUI,
+    PlaybackKeyPairUI,
+    PlaybackRestrictionPolicyUI,
+    RecordingConfigurationUI,
+    StreamKeyUI,
+  );

--- a/packages/alchemy/src/AWS/IVSChat/ui.ts
+++ b/packages/alchemy/src/AWS/IVSChat/ui.ts
@@ -1,0 +1,75 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { LoggingConfiguration } from "./LoggingConfiguration.ts";
+import type { Room } from "./Room.ts";
+
+/**
+ * Dashboard UI providers for AWS IVSChat resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** AWS Media Services (IVS Chat) brand orange. */
+const COLOR = "#ED7100";
+
+export const LoggingConfigurationUI = UIProvider.succeed<LoggingConfiguration>(
+  "AWS.IVSChat.LoggingConfiguration",
+  {
+    displayName: "IVS Chat Logging Configuration",
+    icon: "scroll-text",
+    color: COLOR,
+    category: "media",
+    summary: (ctx) => ctx.attrs?.loggingConfigurationName,
+    facts: (ctx) => [
+      {
+        label: "name",
+        value: ctx.attrs?.loggingConfigurationName,
+        copy: true,
+      },
+      {
+        label: "id",
+        value: ctx.attrs?.loggingConfigurationId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.loggingConfigurationArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "state", value: ctx.attrs?.state },
+      {
+        label: "destination",
+        value: ctx.props?.destinationConfiguration?.s3
+          ? "s3"
+          : ctx.props?.destinationConfiguration?.cloudWatchLogs
+            ? "cloudwatch logs"
+            : ctx.props?.destinationConfiguration?.firehose
+              ? "firehose"
+              : undefined,
+      },
+    ],
+  },
+);
+
+export const RoomUI = UIProvider.succeed<Room>("AWS.IVSChat.Room", {
+  displayName: "IVS Chat Room",
+  icon: "message-square",
+  color: COLOR,
+  category: "media",
+  summary: (ctx) => ctx.attrs?.roomName,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.roomName, copy: true },
+    { label: "id", value: ctx.attrs?.roomId, mono: true, copy: true },
+    { label: "arn", value: ctx.attrs?.roomArn, mono: true, copy: true },
+    {
+      label: "max message rate",
+      value: ctx.props?.maximumMessageRatePerSecond,
+    },
+    { label: "max message length", value: ctx.props?.maximumMessageLength },
+  ],
+});
+
+export const ui = () => Layer.mergeAll(LoggingConfigurationUI, RoomUI);

--- a/packages/alchemy/src/AWS/IVSRealtime/ui.ts
+++ b/packages/alchemy/src/AWS/IVSRealtime/ui.ts
@@ -1,0 +1,36 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Stage } from "./Stage.ts";
+
+/**
+ * Dashboard UI providers for AWS IVSRealtime resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** AWS Media Services (IVS Real-Time) brand orange. */
+const COLOR = "#ED7100";
+
+export const StageUI = UIProvider.succeed<Stage>("AWS.IVSRealtime.Stage", {
+  displayName: "IVS Real-Time Stage",
+  icon: "video",
+  color: COLOR,
+  category: "media",
+  summary: (ctx) => ctx.attrs?.stageName,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.stageName, copy: true },
+    { label: "arn", value: ctx.attrs?.stageArn, mono: true, copy: true },
+    {
+      label: "whip endpoint",
+      value: ctx.attrs?.whipEndpoint,
+      mono: true,
+      copy: true,
+    },
+    { label: "rtmp endpoint", value: ctx.attrs?.rtmpEndpoint, mono: true },
+    { label: "rtmps endpoint", value: ctx.attrs?.rtmpsEndpoint, mono: true },
+    { label: "events endpoint", value: ctx.attrs?.eventsEndpoint, mono: true },
+  ],
+});
+
+export const ui = () => Layer.mergeAll(StageUI);

--- a/packages/alchemy/src/AWS/IdentityCenter/ui.ts
+++ b/packages/alchemy/src/AWS/IdentityCenter/ui.ts
@@ -1,0 +1,152 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { AccountAssignment } from "./AccountAssignment.ts";
+import type { Group } from "./Group.ts";
+import type { Instance } from "./Instance.ts";
+import type { PermissionSet } from "./PermissionSet.ts";
+
+/**
+ * Dashboard UI providers for AWS IAM Identity Center resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+const IDENTITY_RED = "#DD344C";
+
+export const InstanceUI = UIProvider.succeed<Instance>(
+  "AWS.IdentityCenter.Instance",
+  {
+    displayName: "Identity Center Instance",
+    icon: "building-2",
+    color: IDENTITY_RED,
+    category: "auth",
+    summary: (ctx) => ctx.attrs?.name ?? ctx.attrs?.identityStoreId,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name },
+      { label: "arn", value: ctx.attrs?.instanceArn, mono: true, copy: true },
+      {
+        label: "identity store",
+        value: ctx.attrs?.identityStoreId,
+        mono: true,
+        copy: true,
+      },
+      { label: "owner account", value: ctx.attrs?.ownerAccountId, mono: true },
+      { label: "status", value: ctx.attrs?.status },
+      { label: "mode", value: ctx.attrs?.mode },
+      {
+        label: "created",
+        value:
+          ctx.attrs?.createdDate === undefined
+            ? undefined
+            : String(ctx.attrs.createdDate),
+      },
+    ],
+  },
+);
+
+export const PermissionSetUI = UIProvider.succeed<PermissionSet>(
+  "AWS.IdentityCenter.PermissionSet",
+  {
+    displayName: "Permission Set",
+    icon: "shield",
+    color: IDENTITY_RED,
+    category: "auth",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.permissionSetArn,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "instance arn",
+        value: ctx.attrs?.instanceArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "session duration", value: ctx.attrs?.sessionDuration },
+      { label: "relay state", value: ctx.attrs?.relayState },
+      { label: "description", value: ctx.attrs?.description },
+      {
+        label: "created",
+        value:
+          ctx.attrs?.createdDate === undefined
+            ? undefined
+            : String(ctx.attrs.createdDate),
+      },
+    ],
+  },
+);
+
+export const GroupUI = UIProvider.succeed<Group>("AWS.IdentityCenter.Group", {
+  displayName: "Identity Center Group",
+  icon: "users",
+  color: IDENTITY_RED,
+  category: "auth",
+  summary: (ctx) => ctx.attrs?.displayName ?? ctx.attrs?.groupId,
+  facts: (ctx) => [
+    { label: "display name", value: ctx.attrs?.displayName, copy: true },
+    { label: "group id", value: ctx.attrs?.groupId, mono: true, copy: true },
+    {
+      label: "identity store",
+      value: ctx.attrs?.identityStoreId,
+      mono: true,
+      copy: true,
+    },
+    { label: "description", value: ctx.attrs?.description },
+    {
+      label: "created",
+      value:
+        ctx.attrs?.createdAt === undefined
+          ? undefined
+          : String(ctx.attrs.createdAt),
+    },
+  ],
+});
+
+export const AccountAssignmentUI = UIProvider.succeed<AccountAssignment>(
+  "AWS.IdentityCenter.AccountAssignment",
+  {
+    displayName: "Account Assignment",
+    icon: "link",
+    color: IDENTITY_RED,
+    category: "auth",
+    summary: (ctx) =>
+      ctx.attrs?.principalId === undefined || ctx.attrs?.targetId === undefined
+        ? undefined
+        : `${ctx.attrs.principalType ?? "principal"} ${ctx.attrs.principalId} → ${ctx.attrs.targetId}`,
+    facts: (ctx) => [
+      {
+        label: "principal id",
+        value: ctx.attrs?.principalId,
+        mono: true,
+        copy: true,
+      },
+      { label: "principal type", value: ctx.attrs?.principalType },
+      {
+        label: "target account",
+        value: ctx.attrs?.targetId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "permission set",
+        value: ctx.attrs?.permissionSetArn,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "instance arn",
+        value: ctx.attrs?.instanceArn,
+        mono: true,
+        copy: true,
+      },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(InstanceUI, PermissionSetUI, GroupUI, AccountAssignmentUI);

--- a/packages/alchemy/src/AWS/ImageBuilder/ui.ts
+++ b/packages/alchemy/src/AWS/ImageBuilder/ui.ts
@@ -1,0 +1,149 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Component } from "./Component.ts";
+import type { DistributionConfiguration } from "./DistributionConfiguration.ts";
+import type { ImagePipeline } from "./ImagePipeline.ts";
+import type { ImageRecipe } from "./ImageRecipe.ts";
+import type { InfrastructureConfiguration } from "./InfrastructureConfiguration.ts";
+
+/**
+ * Dashboard UI providers for AWS Image Builder resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+const COLOR = "#ED7100";
+
+export const ComponentUI = UIProvider.succeed<Component>(
+  "AWS.ImageBuilder.Component",
+  {
+    displayName: "Image Builder Component",
+    icon: "package",
+    color: COLOR,
+    category: "compute",
+    summary: (ctx) => ctx.attrs?.componentName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.componentName, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.componentBuildVersionArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "version", value: ctx.attrs?.semanticVersion },
+      { label: "platform", value: ctx.attrs?.platform },
+      { label: "type", value: ctx.attrs?.type },
+    ],
+  },
+);
+
+export const DistributionConfigurationUI =
+  UIProvider.succeed<DistributionConfiguration>(
+    "AWS.ImageBuilder.DistributionConfiguration",
+    {
+      displayName: "Image Builder Distribution Configuration",
+      icon: "share-2",
+      color: COLOR,
+      category: "compute",
+      summary: (ctx) => ctx.attrs?.distributionConfigurationName,
+      facts: (ctx) => [
+        {
+          label: "name",
+          value: ctx.attrs?.distributionConfigurationName,
+          copy: true,
+        },
+        {
+          label: "arn",
+          value: ctx.attrs?.distributionConfigurationArn,
+          mono: true,
+          copy: true,
+        },
+        { label: "created", value: ctx.attrs?.dateCreated },
+      ],
+    },
+  );
+
+export const ImagePipelineUI = UIProvider.succeed<ImagePipeline>(
+  "AWS.ImageBuilder.ImagePipeline",
+  {
+    displayName: "Image Builder Pipeline",
+    icon: "workflow",
+    color: COLOR,
+    category: "compute",
+    summary: (ctx) => ctx.attrs?.imagePipelineName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.imagePipelineName, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.imagePipelineArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "status", value: ctx.attrs?.status },
+      { label: "platform", value: ctx.attrs?.platform },
+    ],
+  },
+);
+
+export const ImageRecipeUI = UIProvider.succeed<ImageRecipe>(
+  "AWS.ImageBuilder.ImageRecipe",
+  {
+    displayName: "Image Builder Recipe",
+    icon: "book-open",
+    color: COLOR,
+    category: "compute",
+    summary: (ctx) => ctx.attrs?.imageRecipeName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.imageRecipeName, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.imageRecipeArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "version", value: ctx.attrs?.semanticVersion },
+      { label: "platform", value: ctx.attrs?.platform },
+      { label: "parent image", value: ctx.attrs?.parentImage, mono: true },
+    ],
+  },
+);
+
+export const InfrastructureConfigurationUI =
+  UIProvider.succeed<InfrastructureConfiguration>(
+    "AWS.ImageBuilder.InfrastructureConfiguration",
+    {
+      displayName: "Image Builder Infrastructure Configuration",
+      icon: "server",
+      color: COLOR,
+      category: "compute",
+      summary: (ctx) => ctx.attrs?.infrastructureConfigurationName,
+      facts: (ctx) => [
+        {
+          label: "name",
+          value: ctx.attrs?.infrastructureConfigurationName,
+          copy: true,
+        },
+        {
+          label: "arn",
+          value: ctx.attrs?.infrastructureConfigurationArn,
+          mono: true,
+          copy: true,
+        },
+        {
+          label: "instance profile",
+          value: ctx.attrs?.instanceProfileName,
+          mono: true,
+        },
+      ],
+    },
+  );
+
+export const ui = () =>
+  Layer.mergeAll(
+    ComponentUI,
+    DistributionConfigurationUI,
+    ImagePipelineUI,
+    ImageRecipeUI,
+    InfrastructureConfigurationUI,
+  );

--- a/packages/alchemy/src/AWS/Inspector2/ui.ts
+++ b/packages/alchemy/src/AWS/Inspector2/ui.ts
@@ -1,0 +1,73 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { CisScanConfiguration } from "./CisScanConfiguration.ts";
+import type { Enabler } from "./Enabler.ts";
+import type { Filter } from "./Filter.ts";
+
+/**
+ * Dashboard UI providers for AWS Inspector2 resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** AWS Security, Identity & Compliance (Inspector) brand red. */
+const COLOR = "#DD344C";
+
+export const CisScanConfigurationUI = UIProvider.succeed<CisScanConfiguration>(
+  "AWS.Inspector2.CisScanConfiguration",
+  {
+    displayName: "Inspector CIS Scan Configuration",
+    icon: "scale",
+    color: COLOR,
+    category: "security",
+    summary: (ctx) => ctx.attrs?.scanName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.scanName, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.scanConfigurationArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "security level", value: ctx.attrs?.securityLevel },
+      { label: "owner", value: ctx.attrs?.ownerId, mono: true },
+    ],
+  },
+);
+
+export const EnablerUI = UIProvider.succeed<Enabler>("AWS.Inspector2.Enabler", {
+  displayName: "Inspector Enabler",
+  icon: "settings",
+  color: COLOR,
+  category: "security",
+  summary: (ctx) => ctx.attrs?.accountId,
+  facts: (ctx) => [
+    { label: "account", value: ctx.attrs?.accountId, mono: true, copy: true },
+    { label: "state", value: ctx.attrs?.state },
+    {
+      label: "resource types",
+      value: ctx.attrs?.resourceTypes?.length
+        ? ctx.attrs.resourceTypes.join(", ")
+        : undefined,
+    },
+  ],
+});
+
+export const FilterUI = UIProvider.succeed<Filter>("AWS.Inspector2.Filter", {
+  displayName: "Inspector Filter",
+  icon: "filter",
+  color: COLOR,
+  category: "security",
+  summary: (ctx) => ctx.attrs?.name,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.name, copy: true },
+    { label: "arn", value: ctx.attrs?.arn, mono: true, copy: true },
+    { label: "owner", value: ctx.attrs?.ownerId, mono: true },
+    { label: "action", value: ctx.attrs?.action },
+    { label: "reason", value: ctx.attrs?.reason },
+  ],
+});
+
+export const ui = () =>
+  Layer.mergeAll(CisScanConfigurationUI, EnablerUI, FilterUI);

--- a/packages/alchemy/src/AWS/InternetMonitor/ui.ts
+++ b/packages/alchemy/src/AWS/InternetMonitor/ui.ts
@@ -1,0 +1,44 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Monitor } from "./Monitor.ts";
+
+/**
+ * Dashboard UI providers for AWS InternetMonitor resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+export const MonitorUI = UIProvider.succeed<Monitor>(
+  "AWS.InternetMonitor.Monitor",
+  {
+    displayName: "Internet Monitor",
+    icon: "globe",
+    color: "#E7157B",
+    category: "observability",
+    summary: (ctx) => ctx.attrs?.monitorName,
+    facts: (ctx) => [
+      { label: "monitor", value: ctx.attrs?.monitorName, copy: true },
+      { label: "arn", value: ctx.attrs?.monitorArn, mono: true, copy: true },
+      { label: "status", value: ctx.attrs?.status },
+      { label: "processing", value: ctx.attrs?.processingStatus },
+      {
+        label: "resources",
+        value: ctx.attrs?.resources?.length
+          ? ctx.attrs.resources.join(", ")
+          : undefined,
+        mono: true,
+      },
+      {
+        label: "max city networks",
+        value: ctx.attrs?.maxCityNetworksToMonitor,
+      },
+      {
+        label: "traffic %",
+        value: ctx.attrs?.trafficPercentageToMonitor,
+      },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(MonitorUI);

--- a/packages/alchemy/src/AWS/IoT/ui.ts
+++ b/packages/alchemy/src/AWS/IoT/ui.ts
@@ -1,0 +1,99 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Policy } from "./Policy.ts";
+import type { Thing } from "./Thing.ts";
+import type { ThingType } from "./ThingType.ts";
+import type { TopicRule } from "./TopicRule.ts";
+
+/**
+ * Dashboard UI providers for AWS IoT resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+const IOT_COLOR = "#8C4FFF";
+
+const regionOf = (arn: string | undefined) => arn?.split(":")[3];
+
+export const PolicyUI = UIProvider.succeed<Policy>("AWS.IoT.Policy", {
+  displayName: "IoT Policy",
+  icon: "key-round",
+  color: IOT_COLOR,
+  category: "security",
+  summary: (ctx) => ctx.attrs?.policyName,
+  consoleUrl: (ctx) => {
+    const region = regionOf(ctx.attrs?.policyArn);
+    return ctx.attrs?.policyName === undefined || region === undefined
+      ? undefined
+      : `https://${region}.console.aws.amazon.com/iot/home?region=${region}#/policy/${encodeURIComponent(ctx.attrs.policyName)}`;
+  },
+  facts: (ctx) => [
+    { label: "policy", value: ctx.attrs?.policyName, copy: true },
+    { label: "arn", value: ctx.attrs?.policyArn, mono: true, copy: true },
+  ],
+});
+
+export const ThingUI = UIProvider.succeed<Thing>("AWS.IoT.Thing", {
+  displayName: "IoT Thing",
+  icon: "cpu",
+  color: IOT_COLOR,
+  category: "network",
+  summary: (ctx) => ctx.attrs?.thingName,
+  consoleUrl: (ctx) => {
+    const region = regionOf(ctx.attrs?.thingArn);
+    return ctx.attrs?.thingName === undefined || region === undefined
+      ? undefined
+      : `https://${region}.console.aws.amazon.com/iot/home?region=${region}#/thing/${encodeURIComponent(ctx.attrs.thingName)}`;
+  },
+  facts: (ctx) => [
+    { label: "thing", value: ctx.attrs?.thingName, copy: true },
+    { label: "arn", value: ctx.attrs?.thingArn, mono: true, copy: true },
+    { label: "type", value: ctx.props?.thingTypeName },
+  ],
+});
+
+export const ThingTypeUI = UIProvider.succeed<ThingType>("AWS.IoT.ThingType", {
+  displayName: "IoT Thing Type",
+  icon: "layers",
+  color: IOT_COLOR,
+  category: "network",
+  summary: (ctx) => ctx.attrs?.thingTypeName,
+  consoleUrl: (ctx) => {
+    const region = regionOf(ctx.attrs?.thingTypeArn);
+    return ctx.attrs?.thingTypeName === undefined || region === undefined
+      ? undefined
+      : `https://${region}.console.aws.amazon.com/iot/home?region=${region}#/thingtype/${encodeURIComponent(ctx.attrs.thingTypeName)}`;
+  },
+  facts: (ctx) => [
+    { label: "type", value: ctx.attrs?.thingTypeName, copy: true },
+    { label: "arn", value: ctx.attrs?.thingTypeArn, mono: true, copy: true },
+    {
+      label: "searchable attributes",
+      value: ctx.props?.searchableAttributes?.join(", "),
+    },
+  ],
+});
+
+export const TopicRuleUI = UIProvider.succeed<TopicRule>("AWS.IoT.TopicRule", {
+  displayName: "IoT Topic Rule",
+  icon: "route",
+  color: IOT_COLOR,
+  category: "eventing",
+  summary: (ctx) => ctx.attrs?.ruleName,
+  consoleUrl: (ctx) => {
+    const region = regionOf(ctx.attrs?.ruleArn);
+    return ctx.attrs?.ruleName === undefined || region === undefined
+      ? undefined
+      : `https://${region}.console.aws.amazon.com/iot/home?region=${region}#/rule/${encodeURIComponent(ctx.attrs.ruleName)}`;
+  },
+  facts: (ctx) => [
+    { label: "rule", value: ctx.attrs?.ruleName, copy: true },
+    { label: "arn", value: ctx.attrs?.ruleArn, mono: true, copy: true },
+    { label: "sql", value: ctx.props?.sql, mono: true },
+    { label: "disabled", value: ctx.props?.ruleDisabled },
+  ],
+});
+
+export const ui = () =>
+  Layer.mergeAll(PolicyUI, ThingUI, ThingTypeUI, TopicRuleUI);

--- a/packages/alchemy/src/AWS/IoTFleetWise/ui.ts
+++ b/packages/alchemy/src/AWS/IoTFleetWise/ui.ts
@@ -1,0 +1,213 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Campaign } from "./Campaign.ts";
+import type { DecoderManifest } from "./DecoderManifest.ts";
+import type { Fleet } from "./Fleet.ts";
+import type { ModelManifest } from "./ModelManifest.ts";
+import type { SignalCatalog } from "./SignalCatalog.ts";
+import type { StateTemplate } from "./StateTemplate.ts";
+import type { Vehicle } from "./Vehicle.ts";
+
+/**
+ * Dashboard UI providers for AWS IoTFleetWise resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** AWS Analytics (IoT FleetWise: signals, manifests, campaigns) brand purple. */
+const COLOR = "#8C4FFF";
+
+export const SignalCatalogUI = UIProvider.succeed<SignalCatalog>(
+  "AWS.IoTFleetWise.SignalCatalog",
+  {
+    displayName: "IoT FleetWise Signal Catalog",
+    icon: "table",
+    color: COLOR,
+    category: "config",
+    summary: (ctx) => ctx.attrs?.signalCatalogName,
+    facts: (ctx) => [
+      { label: "catalog", value: ctx.attrs?.signalCatalogName, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.signalCatalogArn,
+        mono: true,
+        copy: true,
+      },
+    ],
+  },
+);
+
+export const ModelManifestUI = UIProvider.succeed<ModelManifest>(
+  "AWS.IoTFleetWise.ModelManifest",
+  {
+    displayName: "IoT FleetWise Model Manifest",
+    icon: "file-text",
+    color: COLOR,
+    category: "config",
+    summary: (ctx) => ctx.attrs?.modelManifestName,
+    facts: (ctx) => [
+      { label: "manifest", value: ctx.attrs?.modelManifestName, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.modelManifestArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "status", value: ctx.attrs?.status },
+      {
+        label: "signal catalog",
+        value: ctx.attrs?.signalCatalogArn,
+        mono: true,
+      },
+    ],
+  },
+);
+
+export const DecoderManifestUI = UIProvider.succeed<DecoderManifest>(
+  "AWS.IoTFleetWise.DecoderManifest",
+  {
+    displayName: "IoT FleetWise Decoder Manifest",
+    icon: "code",
+    color: COLOR,
+    category: "config",
+    summary: (ctx) => ctx.attrs?.decoderManifestName,
+    facts: (ctx) => [
+      {
+        label: "manifest",
+        value: ctx.attrs?.decoderManifestName,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.decoderManifestArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "status", value: ctx.attrs?.status },
+      {
+        label: "model manifest",
+        value: ctx.attrs?.modelManifestArn,
+        mono: true,
+      },
+    ],
+  },
+);
+
+export const StateTemplateUI = UIProvider.succeed<StateTemplate>(
+  "AWS.IoTFleetWise.StateTemplate",
+  {
+    displayName: "IoT FleetWise State Template",
+    icon: "layers",
+    color: COLOR,
+    category: "config",
+    summary: (ctx) => ctx.attrs?.stateTemplateName,
+    facts: (ctx) => [
+      { label: "template", value: ctx.attrs?.stateTemplateName, copy: true },
+      {
+        label: "id",
+        value: ctx.attrs?.stateTemplateId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.stateTemplateArn,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "signal catalog",
+        value: ctx.attrs?.signalCatalogArn,
+        mono: true,
+      },
+      {
+        label: "properties",
+        value: ctx.attrs?.stateTemplateProperties?.length
+          ? ctx.attrs.stateTemplateProperties.join(", ")
+          : undefined,
+        mono: true,
+      },
+    ],
+  },
+);
+
+export const FleetUI = UIProvider.succeed<Fleet>("AWS.IoTFleetWise.Fleet", {
+  displayName: "IoT FleetWise Fleet",
+  icon: "boxes",
+  color: COLOR,
+  category: "other",
+  summary: (ctx) => ctx.attrs?.fleetId,
+  facts: (ctx) => [
+    { label: "fleet", value: ctx.attrs?.fleetId, mono: true, copy: true },
+    { label: "arn", value: ctx.attrs?.fleetArn, mono: true, copy: true },
+    {
+      label: "signal catalog",
+      value: ctx.attrs?.signalCatalogArn,
+      mono: true,
+    },
+  ],
+});
+
+export const VehicleUI = UIProvider.succeed<Vehicle>(
+  "AWS.IoTFleetWise.Vehicle",
+  {
+    displayName: "IoT FleetWise Vehicle",
+    icon: "box",
+    color: COLOR,
+    category: "other",
+    summary: (ctx) => ctx.attrs?.vehicleName,
+    facts: (ctx) => [
+      { label: "vehicle", value: ctx.attrs?.vehicleName, copy: true },
+      { label: "arn", value: ctx.attrs?.vehicleArn, mono: true, copy: true },
+      {
+        label: "model manifest",
+        value: ctx.attrs?.modelManifestArn,
+        mono: true,
+      },
+      {
+        label: "decoder manifest",
+        value: ctx.attrs?.decoderManifestArn,
+        mono: true,
+      },
+    ],
+  },
+);
+
+export const CampaignUI = UIProvider.succeed<Campaign>(
+  "AWS.IoTFleetWise.Campaign",
+  {
+    displayName: "IoT FleetWise Campaign",
+    icon: "workflow",
+    color: COLOR,
+    category: "eventing",
+    summary: (ctx) => ctx.attrs?.campaignName,
+    facts: (ctx) => [
+      { label: "campaign", value: ctx.attrs?.campaignName, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.campaignArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "status", value: ctx.attrs?.status },
+      {
+        label: "signal catalog",
+        value: ctx.attrs?.signalCatalogArn,
+        mono: true,
+      },
+      { label: "target", value: ctx.attrs?.targetArn, mono: true },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(
+    SignalCatalogUI,
+    ModelManifestUI,
+    DecoderManifestUI,
+    StateTemplateUI,
+    FleetUI,
+    VehicleUI,
+    CampaignUI,
+  );

--- a/packages/alchemy/src/AWS/IoTManagedIntegrations/ui.ts
+++ b/packages/alchemy/src/AWS/IoTManagedIntegrations/ui.ts
@@ -1,0 +1,110 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { CredentialLocker } from "./CredentialLocker.ts";
+import type { Destination } from "./Destination.ts";
+import type { ManagedThing } from "./ManagedThing.ts";
+import type { NotificationConfiguration } from "./NotificationConfiguration.ts";
+
+/**
+ * Dashboard UI providers for AWS IoT Managed Integrations resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+export const CredentialLockerUI = UIProvider.succeed<CredentialLocker>(
+  "AWS.IoTManagedIntegrations.CredentialLocker",
+  {
+    displayName: "IoT Credential Locker",
+    icon: "lock",
+    color: "#DD344C",
+    category: "security",
+    summary: (ctx) => ctx.attrs?.credentialLockerName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.credentialLockerName, copy: true },
+      { label: "id", value: ctx.attrs?.credentialLockerId, mono: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.credentialLockerArn,
+        mono: true,
+        copy: true,
+      },
+    ],
+  },
+);
+
+export const DestinationUI = UIProvider.succeed<Destination>(
+  "AWS.IoTManagedIntegrations.Destination",
+  {
+    displayName: "IoT Managed Integrations Destination",
+    icon: "send",
+    color: "#E7157B",
+    category: "eventing",
+    summary: (ctx) => ctx.attrs?.destinationName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.destinationName, copy: true },
+      {
+        label: "delivery arn",
+        value: ctx.attrs?.deliveryDestinationArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "type", value: ctx.attrs?.deliveryDestinationType },
+      { label: "role", value: ctx.attrs?.roleArn, mono: true },
+      { label: "description", value: ctx.attrs?.description },
+    ],
+  },
+);
+
+export const ManagedThingUI = UIProvider.succeed<ManagedThing>(
+  "AWS.IoTManagedIntegrations.ManagedThing",
+  {
+    displayName: "IoT Managed Thing",
+    icon: "cpu",
+    color: "#8C4FFF",
+    category: "network",
+    summary: (ctx) => ctx.attrs?.managedThingName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.managedThingName, copy: true },
+      { label: "id", value: ctx.attrs?.managedThingId, mono: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.managedThingArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "role", value: ctx.attrs?.role },
+      { label: "status", value: ctx.attrs?.provisioningStatus },
+    ],
+  },
+);
+
+export const NotificationConfigurationUI =
+  UIProvider.succeed<NotificationConfiguration>(
+    "AWS.IoTManagedIntegrations.NotificationConfiguration",
+    {
+      displayName: "IoT Notification Configuration",
+      icon: "bell",
+      color: "#E7157B",
+      category: "eventing",
+      summary: (ctx) => ctx.attrs?.eventType,
+      facts: (ctx) => [
+        { label: "event type", value: ctx.attrs?.eventType, copy: true },
+        { label: "destination", value: ctx.attrs?.destinationName },
+        {
+          label: "arn",
+          value: ctx.attrs?.notificationConfigurationArn,
+          mono: true,
+          copy: true,
+        },
+      ],
+    },
+  );
+
+export const ui = () =>
+  Layer.mergeAll(
+    CredentialLockerUI,
+    DestinationUI,
+    ManagedThingUI,
+    NotificationConfigurationUI,
+  );

--- a/packages/alchemy/src/AWS/IoTSiteWise/ui.ts
+++ b/packages/alchemy/src/AWS/IoTSiteWise/ui.ts
@@ -1,0 +1,71 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Asset } from "./Asset.ts";
+import type { AssetModel } from "./AssetModel.ts";
+import type { Gateway } from "./Gateway.ts";
+
+/**
+ * Dashboard UI providers for AWS IoTSiteWise resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+const IOTSITEWISE_COLOR = "#8C4FFF";
+
+export const AssetUI = UIProvider.succeed<Asset>("AWS.IoTSiteWise.Asset", {
+  displayName: "IoT SiteWise Asset",
+  icon: "box",
+  color: IOTSITEWISE_COLOR,
+  category: "other",
+  summary: (ctx) => ctx.attrs?.assetName,
+  facts: (ctx) => [
+    { label: "asset", value: ctx.attrs?.assetName, copy: true },
+    { label: "id", value: ctx.attrs?.assetId, mono: true },
+    { label: "arn", value: ctx.attrs?.assetArn, mono: true, copy: true },
+    { label: "model", value: ctx.attrs?.assetModelId, mono: true },
+    { label: "state", value: ctx.attrs?.state },
+  ],
+});
+
+export const AssetModelUI = UIProvider.succeed<AssetModel>(
+  "AWS.IoTSiteWise.AssetModel",
+  {
+    displayName: "IoT SiteWise Asset Model",
+    icon: "layers",
+    color: IOTSITEWISE_COLOR,
+    category: "other",
+    summary: (ctx) => ctx.attrs?.assetModelName,
+    facts: (ctx) => [
+      { label: "model", value: ctx.attrs?.assetModelName, copy: true },
+      { label: "id", value: ctx.attrs?.assetModelId, mono: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.assetModelArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "type", value: ctx.attrs?.assetModelType },
+      { label: "state", value: ctx.attrs?.state },
+    ],
+  },
+);
+
+export const GatewayUI = UIProvider.succeed<Gateway>(
+  "AWS.IoTSiteWise.Gateway",
+  {
+    displayName: "IoT SiteWise Gateway",
+    icon: "cable",
+    color: IOTSITEWISE_COLOR,
+    category: "network",
+    summary: (ctx) => ctx.attrs?.gatewayName,
+    facts: (ctx) => [
+      { label: "gateway", value: ctx.attrs?.gatewayName, copy: true },
+      { label: "id", value: ctx.attrs?.gatewayId, mono: true },
+      { label: "arn", value: ctx.attrs?.gatewayArn, mono: true, copy: true },
+      { label: "version", value: ctx.attrs?.gatewayVersion },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(AssetUI, AssetModelUI, GatewayUI);

--- a/packages/alchemy/src/AWS/IoTWireless/ui.ts
+++ b/packages/alchemy/src/AWS/IoTWireless/ui.ts
@@ -1,0 +1,133 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Destination } from "./Destination.ts";
+import type { DeviceProfile } from "./DeviceProfile.ts";
+import type { ServiceProfile } from "./ServiceProfile.ts";
+import type { WirelessDevice } from "./WirelessDevice.ts";
+import type { WirelessGateway } from "./WirelessGateway.ts";
+
+/**
+ * Dashboard UI providers for AWS IoTWireless resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+export const DestinationUI = UIProvider.succeed<Destination>(
+  "AWS.IoTWireless.Destination",
+  {
+    displayName: "IoT Wireless Destination",
+    icon: "route",
+    color: "#8C4FFF",
+    category: "network",
+    summary: (ctx) => ctx.attrs?.destinationName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.destinationName, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.destinationArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "expression type", value: ctx.attrs?.expressionType },
+      { label: "expression", value: ctx.attrs?.expression, mono: true },
+      { label: "role", value: ctx.attrs?.roleArn, mono: true },
+    ],
+  },
+);
+
+export const DeviceProfileUI = UIProvider.succeed<DeviceProfile>(
+  "AWS.IoTWireless.DeviceProfile",
+  {
+    displayName: "IoT Wireless Device Profile",
+    icon: "cpu",
+    color: "#8C4FFF",
+    category: "network",
+    summary: (ctx) => ctx.attrs?.deviceProfileName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.deviceProfileName, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.deviceProfileArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "id", value: ctx.attrs?.deviceProfileId, mono: true },
+    ],
+  },
+);
+
+export const ServiceProfileUI = UIProvider.succeed<ServiceProfile>(
+  "AWS.IoTWireless.ServiceProfile",
+  {
+    displayName: "IoT Wireless Service Profile",
+    icon: "settings",
+    color: "#8C4FFF",
+    category: "network",
+    summary: (ctx) => ctx.attrs?.serviceProfileName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.serviceProfileName, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.serviceProfileArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "id", value: ctx.attrs?.serviceProfileId, mono: true },
+    ],
+  },
+);
+
+export const WirelessDeviceUI = UIProvider.succeed<WirelessDevice>(
+  "AWS.IoTWireless.WirelessDevice",
+  {
+    displayName: "IoT Wireless Device",
+    icon: "radio",
+    color: "#8C4FFF",
+    category: "network",
+    summary: (ctx) => ctx.attrs?.wirelessDeviceName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.wirelessDeviceName, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.wirelessDeviceArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "id", value: ctx.attrs?.wirelessDeviceId, mono: true },
+      { label: "type", value: ctx.attrs?.type },
+      { label: "destination", value: ctx.attrs?.destinationName, mono: true },
+    ],
+  },
+);
+
+export const WirelessGatewayUI = UIProvider.succeed<WirelessGateway>(
+  "AWS.IoTWireless.WirelessGateway",
+  {
+    displayName: "IoT Wireless Gateway",
+    icon: "cable",
+    color: "#8C4FFF",
+    category: "network",
+    summary: (ctx) => ctx.attrs?.wirelessGatewayName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.wirelessGatewayName, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.wirelessGatewayArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "id", value: ctx.attrs?.wirelessGatewayId, mono: true },
+      { label: "gateway eui", value: ctx.attrs?.gatewayEui, mono: true },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(
+    DestinationUI,
+    DeviceProfileUI,
+    ServiceProfileUI,
+    WirelessDeviceUI,
+    WirelessGatewayUI,
+  );

--- a/packages/alchemy/src/AWS/KMS/ui.ts
+++ b/packages/alchemy/src/AWS/KMS/ui.ts
@@ -1,0 +1,52 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Alias } from "./Alias.ts";
+import type { Key } from "./Key.ts";
+
+/**
+ * Dashboard UI providers for AWS KMS resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+export const KeyUI = UIProvider.succeed<Key>("AWS.KMS.Key", {
+  displayName: "KMS Key",
+  icon: "key-round",
+  color: "#DD344C",
+  category: "security",
+  summary: (ctx) => ctx.attrs?.keyId,
+  consoleUrl: (ctx) =>
+    ctx.attrs?.keyId === undefined
+      ? undefined
+      : `https://console.aws.amazon.com/kms/home#/kms/keys/${ctx.attrs.keyId}`,
+  facts: (ctx) => [
+    { label: "key id", value: ctx.attrs?.keyId, mono: true, copy: true },
+    { label: "arn", value: ctx.attrs?.keyArn, mono: true, copy: true },
+    { label: "spec", value: ctx.attrs?.keySpec },
+    { label: "usage", value: ctx.attrs?.keyUsage },
+    { label: "state", value: ctx.attrs?.keyState },
+    { label: "enabled", value: ctx.attrs?.enabled },
+    { label: "rotation", value: ctx.attrs?.keyRotationEnabled },
+    { label: "multi-region", value: ctx.attrs?.multiRegion },
+  ],
+});
+
+export const AliasUI = UIProvider.succeed<Alias>("AWS.KMS.Alias", {
+  displayName: "KMS Alias",
+  icon: "tag",
+  color: "#DD344C",
+  category: "security",
+  summary: (ctx) => ctx.attrs?.aliasName,
+  facts: (ctx) => [
+    { label: "alias", value: ctx.attrs?.aliasName, mono: true, copy: true },
+    { label: "arn", value: ctx.attrs?.aliasArn, mono: true, copy: true },
+    {
+      label: "target key",
+      value: ctx.attrs?.targetKeyId,
+      mono: true,
+      copy: true,
+    },
+  ],
+});
+
+export const ui = () => Layer.mergeAll(KeyUI, AliasUI);

--- a/packages/alchemy/src/AWS/Kafka/ui.ts
+++ b/packages/alchemy/src/AWS/Kafka/ui.ts
@@ -1,0 +1,35 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { ServerlessCluster } from "./ServerlessCluster.ts";
+
+/**
+ * Dashboard UI providers for AWS Kafka resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+export const ServerlessClusterUI = UIProvider.succeed<ServerlessCluster>(
+  "AWS.Kafka.ServerlessCluster",
+  {
+    displayName: "MSK Serverless Cluster",
+    icon: "cable",
+    color: "#8C4FFF",
+    category: "queue",
+    summary: (ctx) => ctx.attrs?.clusterName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.clusterName, copy: true },
+      { label: "arn", value: ctx.attrs?.clusterArn, mono: true, copy: true },
+      { label: "state", value: ctx.attrs?.state },
+      {
+        label: "bootstrap brokers",
+        value: ctx.attrs?.bootstrapBrokerStringSaslIam,
+        mono: true,
+        copy: true,
+      },
+      { label: "subnets", value: ctx.attrs?.subnetIds?.join(", "), mono: true },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(ServerlessClusterUI);

--- a/packages/alchemy/src/AWS/Kendra/ui.ts
+++ b/packages/alchemy/src/AWS/Kendra/ui.ts
@@ -1,0 +1,50 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { DataSource } from "./DataSource.ts";
+import type { Index } from "./SearchIndex.ts";
+
+/**
+ * Dashboard UI providers for AWS Kendra resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+const KENDRA_COLOR = "#01A88D";
+
+export const DataSourceUI = UIProvider.succeed<DataSource>(
+  "AWS.Kendra.DataSource",
+  {
+    displayName: "Kendra Data Source",
+    icon: "plug",
+    color: KENDRA_COLOR,
+    category: "ai",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "source", value: ctx.attrs?.name, copy: true },
+      { label: "id", value: ctx.attrs?.id, mono: true },
+      { label: "index", value: ctx.attrs?.indexId, mono: true },
+      { label: "arn", value: ctx.attrs?.arn, mono: true, copy: true },
+      { label: "type", value: ctx.attrs?.type },
+      { label: "status", value: ctx.attrs?.status },
+    ],
+  },
+);
+
+export const IndexUI = UIProvider.succeed<Index>("AWS.Kendra.Index", {
+  displayName: "Kendra Index",
+  icon: "search",
+  color: KENDRA_COLOR,
+  category: "ai",
+  summary: (ctx) => ctx.attrs?.name,
+  facts: (ctx) => [
+    { label: "index", value: ctx.attrs?.name, copy: true },
+    { label: "id", value: ctx.attrs?.id, mono: true },
+    { label: "arn", value: ctx.attrs?.arn, mono: true, copy: true },
+    { label: "edition", value: ctx.attrs?.edition },
+    { label: "status", value: ctx.attrs?.status },
+    { label: "role", value: ctx.attrs?.roleArn, mono: true },
+  ],
+});
+
+export const ui = () => Layer.mergeAll(DataSourceUI, IndexUI);

--- a/packages/alchemy/src/AWS/Keyspaces/ui.ts
+++ b/packages/alchemy/src/AWS/Keyspaces/ui.ts
@@ -1,0 +1,60 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Keyspace } from "./Keyspace.ts";
+import type { Table } from "./Table.ts";
+import type { Type } from "./Type.ts";
+
+/**
+ * Dashboard UI providers for AWS Keyspaces (for Apache Cassandra) resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+const COLOR = "#C925D1";
+
+export const KeyspaceUI = UIProvider.succeed<Keyspace>(
+  "AWS.Keyspaces.Keyspace",
+  {
+    displayName: "Keyspaces Keyspace",
+    icon: "database",
+    color: COLOR,
+    category: "database",
+    summary: (ctx) => ctx.attrs?.keyspaceName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.keyspaceName, copy: true },
+      { label: "arn", value: ctx.attrs?.keyspaceArn, mono: true, copy: true },
+      { label: "replication", value: ctx.attrs?.replicationStrategy },
+    ],
+  },
+);
+
+export const TableUI = UIProvider.succeed<Table>("AWS.Keyspaces.Table", {
+  displayName: "Keyspaces Table",
+  icon: "table",
+  color: COLOR,
+  category: "database",
+  summary: (ctx) => ctx.attrs?.tableName,
+  facts: (ctx) => [
+    { label: "table", value: ctx.attrs?.tableName, copy: true },
+    { label: "keyspace", value: ctx.attrs?.keyspaceName, mono: true },
+    { label: "arn", value: ctx.attrs?.tableArn, mono: true, copy: true },
+    { label: "status", value: ctx.attrs?.status },
+    { label: "stream arn", value: ctx.attrs?.latestStreamArn, mono: true },
+  ],
+});
+
+export const TypeUI = UIProvider.succeed<Type>("AWS.Keyspaces.Type", {
+  displayName: "Keyspaces Type",
+  icon: "layers",
+  color: COLOR,
+  category: "database",
+  summary: (ctx) => ctx.attrs?.typeName,
+  facts: (ctx) => [
+    { label: "type", value: ctx.attrs?.typeName, copy: true },
+    { label: "keyspace", value: ctx.attrs?.keyspaceName, mono: true },
+    { label: "keyspace arn", value: ctx.attrs?.keyspaceArn, mono: true },
+  ],
+});
+
+export const ui = () => Layer.mergeAll(KeyspaceUI, TableUI, TypeUI);

--- a/packages/alchemy/src/AWS/Kinesis/ui.ts
+++ b/packages/alchemy/src/AWS/Kinesis/ui.ts
@@ -1,0 +1,55 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Stream } from "./Stream.ts";
+import type { StreamConsumer } from "./StreamConsumer.ts";
+
+/**
+ * Dashboard UI providers for AWS Kinesis resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+const regionOf = (arn: string | undefined) => arn?.split(":")[3];
+
+export const StreamUI = UIProvider.succeed<Stream>("AWS.Kinesis.Stream", {
+  displayName: "Kinesis Stream",
+  icon: "waves",
+  color: "#8C4FFF",
+  category: "queue",
+  summary: (ctx) => ctx.attrs?.streamName,
+  consoleUrl: (ctx) => {
+    const region = regionOf(ctx.attrs?.streamArn);
+    return ctx.attrs?.streamName === undefined || region === undefined
+      ? undefined
+      : `https://${region}.console.aws.amazon.com/kinesis/home?region=${region}#/streams/details/${encodeURIComponent(ctx.attrs.streamName)}`;
+  },
+  facts: (ctx) => [
+    { label: "stream", value: ctx.attrs?.streamName, copy: true },
+    { label: "arn", value: ctx.attrs?.streamArn, mono: true, copy: true },
+    { label: "status", value: ctx.attrs?.streamStatus },
+    { label: "mode", value: ctx.attrs?.streamMode },
+    { label: "open shards", value: ctx.attrs?.openShardCount },
+    { label: "retention (h)", value: ctx.attrs?.retentionPeriodHours },
+    { label: "encryption", value: ctx.attrs?.encryptionType },
+  ],
+});
+
+export const StreamConsumerUI = UIProvider.succeed<StreamConsumer>(
+  "AWS.Kinesis.StreamConsumer",
+  {
+    displayName: "Kinesis Stream Consumer",
+    icon: "download",
+    color: "#8C4FFF",
+    category: "queue",
+    summary: (ctx) => ctx.attrs?.consumerName,
+    facts: (ctx) => [
+      { label: "consumer", value: ctx.attrs?.consumerName, copy: true },
+      { label: "arn", value: ctx.attrs?.consumerArn, mono: true, copy: true },
+      { label: "status", value: ctx.attrs?.consumerStatus },
+      { label: "stream", value: ctx.attrs?.streamArn, mono: true, copy: true },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(StreamUI, StreamConsumerUI);

--- a/packages/alchemy/src/AWS/KinesisAnalyticsV2/ui.ts
+++ b/packages/alchemy/src/AWS/KinesisAnalyticsV2/ui.ts
@@ -1,0 +1,87 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Application } from "./Application.ts";
+import type { ApplicationCloudWatchLoggingOption } from "./ApplicationCloudWatchLoggingOption.ts";
+import type { ApplicationSnapshot } from "./ApplicationSnapshot.ts";
+
+/**
+ * Dashboard UI providers for AWS KinesisAnalyticsV2 resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+export const ApplicationUI = UIProvider.succeed<Application>(
+  "AWS.KinesisAnalyticsV2.Application",
+  {
+    displayName: "Managed Flink Application",
+    icon: "activity",
+    color: "#8C4FFF",
+    category: "other",
+    summary: (ctx) => ctx.attrs?.applicationName,
+    facts: (ctx) => [
+      { label: "application", value: ctx.attrs?.applicationName, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.applicationArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "status", value: ctx.attrs?.applicationStatus },
+      { label: "runtime", value: ctx.attrs?.runtimeEnvironment },
+      { label: "mode", value: ctx.attrs?.applicationMode },
+      { label: "version", value: ctx.attrs?.applicationVersionId },
+      { label: "role", value: ctx.attrs?.serviceExecutionRole, mono: true },
+    ],
+  },
+);
+
+export const ApplicationCloudWatchLoggingOptionUI =
+  UIProvider.succeed<ApplicationCloudWatchLoggingOption>(
+    "AWS.KinesisAnalyticsV2.ApplicationCloudWatchLoggingOption",
+    {
+      displayName: "Kinesis Analytics Logging Option",
+      icon: "scroll-text",
+      color: "#8C4FFF",
+      category: "observability",
+      summary: (ctx) => ctx.attrs?.logStreamArn,
+      facts: (ctx) => [
+        { label: "application", value: ctx.attrs?.applicationName },
+        {
+          label: "log stream",
+          value: ctx.attrs?.logStreamArn,
+          mono: true,
+          copy: true,
+        },
+        {
+          label: "option id",
+          value: ctx.attrs?.cloudWatchLoggingOptionId,
+          mono: true,
+        },
+      ],
+    },
+  );
+
+export const ApplicationSnapshotUI = UIProvider.succeed<ApplicationSnapshot>(
+  "AWS.KinesisAnalyticsV2.ApplicationSnapshot",
+  {
+    displayName: "Kinesis Analytics Snapshot",
+    icon: "camera",
+    color: "#8C4FFF",
+    category: "other",
+    summary: (ctx) => ctx.attrs?.snapshotName,
+    facts: (ctx) => [
+      { label: "snapshot", value: ctx.attrs?.snapshotName, copy: true },
+      { label: "application", value: ctx.attrs?.applicationName },
+      { label: "status", value: ctx.attrs?.snapshotStatus },
+      { label: "app version", value: ctx.attrs?.applicationVersionId },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(
+    ApplicationUI,
+    ApplicationCloudWatchLoggingOptionUI,
+    ApplicationSnapshotUI,
+  );

--- a/packages/alchemy/src/AWS/KinesisVideo/ui.ts
+++ b/packages/alchemy/src/AWS/KinesisVideo/ui.ts
@@ -1,0 +1,45 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { SignalingChannel } from "./SignalingChannel.ts";
+import type { Stream } from "./Stream.ts";
+
+/**
+ * Dashboard UI providers for AWS Kinesis Video Streams resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+const COLOR = "#8C4FFF";
+
+export const SignalingChannelUI = UIProvider.succeed<SignalingChannel>(
+  "AWS.KinesisVideo.SignalingChannel",
+  {
+    displayName: "Kinesis Video Signaling Channel",
+    icon: "radio",
+    color: COLOR,
+    category: "media",
+    summary: (ctx) => ctx.attrs?.channelName,
+    facts: (ctx) => [
+      { label: "channel", value: ctx.attrs?.channelName, copy: true },
+      { label: "arn", value: ctx.attrs?.channelArn, mono: true, copy: true },
+      { label: "type", value: ctx.props?.type },
+    ],
+  },
+);
+
+export const StreamUI = UIProvider.succeed<Stream>("AWS.KinesisVideo.Stream", {
+  displayName: "Kinesis Video Stream",
+  icon: "video",
+  color: COLOR,
+  category: "media",
+  summary: (ctx) => ctx.attrs?.streamName,
+  facts: (ctx) => [
+    { label: "stream", value: ctx.attrs?.streamName, copy: true },
+    { label: "arn", value: ctx.attrs?.streamArn, mono: true, copy: true },
+    { label: "media type", value: ctx.props?.mediaType },
+    { label: "device", value: ctx.props?.deviceName },
+  ],
+});
+
+export const ui = () => Layer.mergeAll(SignalingChannelUI, StreamUI);

--- a/packages/alchemy/src/AWS/LakeFormation/ui.ts
+++ b/packages/alchemy/src/AWS/LakeFormation/ui.ts
@@ -1,0 +1,207 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { DataCellsFilter } from "./DataCellsFilter.ts";
+import type { DataLakeSettings } from "./DataLakeSettings.ts";
+import type { LFTag } from "./LFTag.ts";
+import type { LFTagAssociation } from "./LFTagAssociation.ts";
+import type { LFTagExpression } from "./LFTagExpression.ts";
+import type { OptIn } from "./OptIn.ts";
+import type { Permissions } from "./Permissions.ts";
+
+/**
+ * Dashboard UI providers for AWS LakeFormation resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** AWS analytics brand purple (Lake Formation). */
+const COLOR = "#8C4FFF";
+
+/** A Lake Formation resource union's best single-line label. */
+const resourceLabel = (
+  resource:
+    | {
+        Database?: { Name?: string };
+        Table?: { Name?: string };
+        TableWithColumns?: { Name?: string };
+        DataLocation?: { ResourceArn?: string };
+        LFTag?: { TagKey?: string };
+        LFTagPolicy?: { ResourceType?: string };
+        Catalog?: { Id?: string };
+      }
+    | undefined,
+): string | undefined =>
+  resource?.Database?.Name ??
+  resource?.Table?.Name ??
+  resource?.TableWithColumns?.Name ??
+  resource?.DataLocation?.ResourceArn ??
+  resource?.LFTag?.TagKey ??
+  resource?.LFTagPolicy?.ResourceType ??
+  resource?.Catalog?.Id;
+
+export const DataCellsFilterUI = UIProvider.succeed<DataCellsFilter>(
+  "AWS.LakeFormation.DataCellsFilter",
+  {
+    displayName: "Data Cells Filter",
+    icon: "filter",
+    color: COLOR,
+    category: "security",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      { label: "database", value: ctx.attrs?.databaseName, mono: true },
+      { label: "table", value: ctx.attrs?.tableName, mono: true },
+      { label: "catalog id", value: ctx.attrs?.tableCatalogId, mono: true },
+      { label: "version", value: ctx.attrs?.versionId, mono: true },
+    ],
+  },
+);
+
+export const DataLakeSettingsUI = UIProvider.succeed<DataLakeSettings>(
+  "AWS.LakeFormation.DataLakeSettings",
+  {
+    displayName: "Data Lake Settings",
+    icon: "settings",
+    color: COLOR,
+    category: "config",
+    summary: (ctx) => ctx.attrs?.catalogId,
+    facts: (ctx) => [
+      {
+        label: "catalog id",
+        value: ctx.attrs?.catalogId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "admins",
+        value: ctx.attrs?.dataLakeAdmins?.join(", "),
+        mono: true,
+      },
+      {
+        label: "read-only admins",
+        value: ctx.attrs?.readOnlyAdmins?.join(", "),
+        mono: true,
+      },
+      { label: "managed fields", value: ctx.attrs?.managedFields?.join(", ") },
+    ],
+  },
+);
+
+export const LFTagUI = UIProvider.succeed<LFTag>("AWS.LakeFormation.LFTag", {
+  displayName: "LF-Tag",
+  icon: "tag",
+  color: COLOR,
+  category: "other",
+  summary: (ctx) => ctx.attrs?.tagKey,
+  facts: (ctx) => [
+    { label: "key", value: ctx.attrs?.tagKey, copy: true },
+    { label: "values", value: ctx.attrs?.tagValues?.join(", ") },
+    { label: "catalog id", value: ctx.attrs?.catalogId, mono: true },
+  ],
+});
+
+export const LFTagAssociationUI = UIProvider.succeed<LFTagAssociation>(
+  "AWS.LakeFormation.LFTagAssociation",
+  {
+    displayName: "LF-Tag Association",
+    icon: "tags",
+    color: COLOR,
+    category: "other",
+    summary: (ctx) => resourceLabel(ctx.attrs?.resource),
+    facts: (ctx) => [
+      {
+        label: "resource",
+        value: resourceLabel(ctx.attrs?.resource),
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "tags",
+        value: ctx.attrs?.lfTags
+          ?.map((t) => `${t.tagKey}=${t.tagValues.join("/")}`)
+          .join(", "),
+      },
+      { label: "catalog id", value: ctx.attrs?.catalogId, mono: true },
+    ],
+  },
+);
+
+export const LFTagExpressionUI = UIProvider.succeed<LFTagExpression>(
+  "AWS.LakeFormation.LFTagExpression",
+  {
+    displayName: "LF-Tag Expression",
+    icon: "scroll-text",
+    color: COLOR,
+    category: "other",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      { label: "description", value: ctx.attrs?.description },
+      {
+        label: "expression",
+        value: ctx.attrs?.expression
+          ?.map((e) => `${e.tagKey}=${e.tagValues.join("/")}`)
+          .join(", "),
+      },
+      { label: "catalog id", value: ctx.attrs?.catalogId, mono: true },
+    ],
+  },
+);
+
+export const OptInUI = UIProvider.succeed<OptIn>("AWS.LakeFormation.OptIn", {
+  displayName: "Lake Formation Opt-In",
+  icon: "shield-check",
+  color: COLOR,
+  category: "security",
+  summary: (ctx) => ctx.attrs?.principal,
+  facts: (ctx) => [
+    { label: "principal", value: ctx.attrs?.principal, mono: true, copy: true },
+    {
+      label: "resource",
+      value: resourceLabel(ctx.attrs?.resource),
+      mono: true,
+    },
+  ],
+});
+
+export const PermissionsUI = UIProvider.succeed<Permissions>(
+  "AWS.LakeFormation.Permissions",
+  {
+    displayName: "Lake Formation Permissions",
+    icon: "key-round",
+    color: COLOR,
+    category: "security",
+    summary: (ctx) => ctx.attrs?.principal,
+    facts: (ctx) => [
+      {
+        label: "principal",
+        value: ctx.attrs?.principal,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "resource",
+        value: resourceLabel(ctx.attrs?.resource),
+        mono: true,
+      },
+      { label: "permissions", value: ctx.attrs?.permissions?.join(", ") },
+      {
+        label: "grant option",
+        value: ctx.attrs?.permissionsWithGrantOption?.join(", "),
+      },
+      { label: "catalog id", value: ctx.attrs?.catalogId, mono: true },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(
+    DataCellsFilterUI,
+    DataLakeSettingsUI,
+    LFTagUI,
+    LFTagAssociationUI,
+    LFTagExpressionUI,
+    OptInUI,
+    PermissionsUI,
+  );

--- a/packages/alchemy/src/AWS/Lambda/ui.ts
+++ b/packages/alchemy/src/AWS/Lambda/ui.ts
@@ -1,0 +1,246 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Alias } from "./Alias.ts";
+import type { EventSourceMapping } from "./EventSourceMapping.ts";
+import type { Function } from "./Function.ts";
+import type { LayerVersion } from "./LayerVersion.ts";
+import type { MicrovmImage } from "./MicrovmImage.ts";
+import type { NetworkConnector } from "./NetworkConnector.ts";
+import type { Permission } from "./Permission.ts";
+import type { Version } from "./Version.ts";
+
+/**
+ * Dashboard UI providers for AWS Lambda resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+const regionOf = (arn: string | undefined): string | undefined =>
+  arn?.split(":")[3] || undefined;
+
+export const FunctionUI = UIProvider.succeed<Function>("AWS.Lambda.Function", {
+  displayName: "Lambda Function",
+  icon: "zap",
+  color: "#ED7100",
+  category: "compute",
+  summary: (ctx) => ctx.attrs?.functionName,
+  link: (ctx) => ctx.attrs?.functionUrl,
+  consoleUrl: (ctx) => {
+    const region = regionOf(ctx.attrs?.functionArn);
+    return region === undefined || ctx.attrs?.functionName === undefined
+      ? undefined
+      : `https://${region}.console.aws.amazon.com/lambda/home?region=${region}#/functions/${ctx.attrs.functionName}`;
+  },
+  facts: (ctx) => [
+    { label: "function", value: ctx.attrs?.functionName, copy: true },
+    { label: "arn", value: ctx.attrs?.functionArn, mono: true, copy: true },
+    {
+      label: "url",
+      value: ctx.attrs?.functionUrl,
+      href: ctx.attrs?.functionUrl,
+      copy: true,
+    },
+    { label: "role", value: ctx.attrs?.roleArn, mono: true, copy: true },
+    { label: "runtime", value: ctx.props?.runtime },
+    { label: "memory", value: ctx.props?.memorySize },
+    { label: "code hash", value: ctx.attrs?.code?.hash, mono: true },
+    {
+      label: "reserved concurrency",
+      value: ctx.attrs?.reservedConcurrentExecutions,
+    },
+  ],
+});
+
+export const PermissionUI = UIProvider.succeed<Permission>(
+  "AWS.Lambda.Permission",
+  {
+    displayName: "Lambda Permission",
+    icon: "key-round",
+    color: "#ED7100",
+    category: "security",
+    summary: (ctx) => ctx.attrs?.statementId,
+    facts: (ctx) => [
+      { label: "statement", value: ctx.attrs?.statementId, mono: true },
+      {
+        label: "function",
+        value: ctx.attrs?.functionName,
+        mono: true,
+        copy: true,
+      },
+      { label: "action", value: ctx.props?.action, mono: true },
+      { label: "principal", value: ctx.props?.principal, mono: true },
+      { label: "source arn", value: ctx.props?.sourceArn, mono: true },
+    ],
+  },
+);
+
+export const EventSourceMappingUI = UIProvider.succeed<EventSourceMapping>(
+  "AWS.Lambda.EventSourceMapping",
+  {
+    displayName: "Event Source Mapping",
+    icon: "webhook",
+    color: "#ED7100",
+    category: "eventing",
+    summary: (ctx) => ctx.attrs?.uuid,
+    facts: (ctx) => [
+      { label: "uuid", value: ctx.attrs?.uuid, mono: true, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.eventSourceMappingArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "function", value: ctx.attrs?.functionArn, mono: true },
+      { label: "source", value: ctx.props?.eventSourceArn, mono: true },
+      { label: "state", value: ctx.attrs?.state },
+      { label: "batch size", value: ctx.props?.batchSize },
+    ],
+  },
+);
+
+export const AliasUI = UIProvider.succeed<Alias>("AWS.Lambda.Alias", {
+  displayName: "Lambda Alias",
+  icon: "tag",
+  color: "#ED7100",
+  category: "compute",
+  summary: (ctx) => ctx.attrs?.aliasName,
+  facts: (ctx) => [
+    { label: "alias", value: ctx.attrs?.aliasName },
+    { label: "arn", value: ctx.attrs?.aliasArn, mono: true, copy: true },
+    { label: "function", value: ctx.attrs?.functionName, mono: true },
+    { label: "version", value: ctx.attrs?.functionVersion, mono: true },
+  ],
+});
+
+export const VersionUI = UIProvider.succeed<Version>("AWS.Lambda.Version", {
+  displayName: "Lambda Version",
+  icon: "git-commit-horizontal",
+  color: "#ED7100",
+  category: "compute",
+  summary: (ctx) =>
+    ctx.attrs === undefined
+      ? undefined
+      : `${ctx.attrs.functionName}:${ctx.attrs.version}`,
+  consoleUrl: (ctx) => {
+    const region = regionOf(ctx.attrs?.functionArn);
+    return region === undefined || ctx.attrs === undefined
+      ? undefined
+      : `https://${region}.console.aws.amazon.com/lambda/home?region=${region}#/functions/${ctx.attrs.functionName}/versions/${ctx.attrs.version}`;
+  },
+  facts: (ctx) => [
+    { label: "version", value: ctx.attrs?.version, mono: true, copy: true },
+    { label: "function", value: ctx.attrs?.functionName, mono: true },
+    { label: "arn", value: ctx.attrs?.versionArn, mono: true, copy: true },
+    { label: "code sha256", value: ctx.attrs?.codeSha256, mono: true },
+    { label: "config sha256", value: ctx.attrs?.configSha256, mono: true },
+  ],
+});
+
+export const NetworkConnectorUI = UIProvider.succeed<NetworkConnector>(
+  "AWS.Lambda.NetworkConnector",
+  {
+    displayName: "Lambda Network Connector",
+    icon: "network",
+    color: "#ED7100",
+    category: "network",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.networkConnectorArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "id", value: ctx.attrs?.networkConnectorId, mono: true },
+      { label: "state", value: ctx.attrs?.state },
+      {
+        label: "subnets",
+        value: ctx.attrs?.subnetIds?.length
+          ? ctx.attrs.subnetIds.join(", ")
+          : undefined,
+        mono: true,
+      },
+      {
+        label: "security groups",
+        value: ctx.attrs?.securityGroupIds?.length
+          ? ctx.attrs.securityGroupIds.join(", ")
+          : undefined,
+        mono: true,
+      },
+    ],
+  },
+);
+
+/**
+ * Tag provenance: MicrovmImage registers via `Platform(MicrovmImageTypeId, ...)`
+ * in MicrovmImage.ts, where the id is declared in MicrovmRuntimeContext.ts as
+ * `const MicrovmImageTypeId = "AWS.Lambda.MicrovmImage"` (that module is not
+ * browser-safe, so the string is inlined here).
+ */
+export const MicrovmImageUI = UIProvider.succeed<MicrovmImage>(
+  "AWS.Lambda.MicrovmImage",
+  {
+    displayName: "Lambda MicroVM Image",
+    icon: "box",
+    color: "#ED7100",
+    category: "compute",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "image", value: ctx.attrs?.name, copy: true },
+      { label: "arn", value: ctx.attrs?.imageArn, mono: true, copy: true },
+      { label: "state", value: ctx.attrs?.state },
+      { label: "version", value: ctx.attrs?.imageVersion, mono: true },
+      {
+        label: "active version",
+        value: ctx.attrs?.latestActiveImageVersion,
+        mono: true,
+      },
+      {
+        label: "code hash",
+        value: ctx.attrs?.codeArtifact?.hash,
+        mono: true,
+      },
+    ],
+  },
+);
+
+export const LayerVersionUI = UIProvider.succeed<LayerVersion>(
+  "AWS.Lambda.LayerVersion",
+  {
+    displayName: "Lambda Layer Version",
+    icon: "layers",
+    color: "#ED7100",
+    category: "compute",
+    summary: (ctx) =>
+      ctx.attrs?.layerName === undefined
+        ? undefined
+        : `${ctx.attrs.layerName}:${ctx.attrs.version ?? ""}`,
+    facts: (ctx) => [
+      { label: "layer", value: ctx.attrs?.layerName, copy: true },
+      { label: "arn", value: ctx.attrs?.layerArn, mono: true, copy: true },
+      {
+        label: "version arn",
+        value: ctx.attrs?.layerVersionArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "version", value: ctx.attrs?.version },
+      { label: "code size", value: ctx.attrs?.codeSize },
+      { label: "license", value: ctx.attrs?.licenseInfo },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(
+    FunctionUI,
+    PermissionUI,
+    EventSourceMappingUI,
+    AliasUI,
+    VersionUI,
+    NetworkConnectorUI,
+    MicrovmImageUI,
+    LayerVersionUI,
+  );

--- a/packages/alchemy/src/AWS/LexV2/ui.ts
+++ b/packages/alchemy/src/AWS/LexV2/ui.ts
@@ -1,0 +1,134 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Bot } from "./Bot.ts";
+import type { BotAlias } from "./BotAlias.ts";
+import type { BotLocale } from "./BotLocale.ts";
+import type { BotVersion } from "./BotVersion.ts";
+import type { Intent } from "./Intent.ts";
+import type { SlotType } from "./SlotType.ts";
+
+/**
+ * Dashboard UI providers for AWS Lex V2 resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+const COLOR = "#01A88D";
+
+const regionOf = (arn: string | undefined): string | undefined =>
+  arn?.split(":")[3] || undefined;
+
+export const BotUI = UIProvider.succeed<Bot>("AWS.LexV2.Bot", {
+  displayName: "Lex Bot",
+  icon: "bot",
+  color: COLOR,
+  category: "ai",
+  summary: (ctx) => ctx.attrs?.botName,
+  consoleUrl: (ctx) => {
+    const region = regionOf(ctx.attrs?.botArn);
+    return ctx.attrs?.botId === undefined || region === undefined
+      ? undefined
+      : `https://${region}.console.aws.amazon.com/lexv2/home?region=${region}#bot/${ctx.attrs.botId}`;
+  },
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.botName, copy: true },
+    { label: "id", value: ctx.attrs?.botId, mono: true, copy: true },
+    { label: "arn", value: ctx.attrs?.botArn, mono: true, copy: true },
+    { label: "status", value: ctx.attrs?.botStatus },
+    { label: "role", value: ctx.attrs?.roleArn, mono: true },
+  ],
+});
+
+export const BotAliasUI = UIProvider.succeed<BotAlias>("AWS.LexV2.BotAlias", {
+  displayName: "Lex Bot Alias",
+  icon: "tag",
+  color: COLOR,
+  category: "ai",
+  summary: (ctx) => ctx.attrs?.botAliasName,
+  facts: (ctx) => [
+    { label: "alias", value: ctx.attrs?.botAliasName, copy: true },
+    { label: "id", value: ctx.attrs?.botAliasId, mono: true, copy: true },
+    { label: "arn", value: ctx.attrs?.botAliasArn, mono: true, copy: true },
+    { label: "bot", value: ctx.attrs?.botId, mono: true },
+    { label: "version", value: ctx.attrs?.botVersion },
+    { label: "status", value: ctx.attrs?.botAliasStatus },
+  ],
+});
+
+export const BotLocaleUI = UIProvider.succeed<BotLocale>(
+  "AWS.LexV2.BotLocale",
+  {
+    displayName: "Lex Bot Locale",
+    icon: "languages",
+    color: COLOR,
+    category: "ai",
+    summary: (ctx) => ctx.attrs?.localeName ?? ctx.attrs?.localeId,
+    facts: (ctx) => [
+      { label: "locale", value: ctx.attrs?.localeId, copy: true },
+      { label: "name", value: ctx.attrs?.localeName },
+      { label: "bot", value: ctx.attrs?.botId, mono: true },
+      { label: "status", value: ctx.attrs?.botLocaleStatus },
+    ],
+  },
+);
+
+export const BotVersionUI = UIProvider.succeed<BotVersion>(
+  "AWS.LexV2.BotVersion",
+  {
+    displayName: "Lex Bot Version",
+    icon: "git-branch",
+    color: COLOR,
+    category: "ai",
+    summary: (ctx) => ctx.attrs?.botVersion,
+    facts: (ctx) => [
+      { label: "version", value: ctx.attrs?.botVersion, copy: true },
+      { label: "bot", value: ctx.attrs?.botId, mono: true },
+      { label: "status", value: ctx.attrs?.botStatus },
+      {
+        label: "locales",
+        value: ctx.attrs?.localeIds?.length
+          ? ctx.attrs.localeIds.join(", ")
+          : undefined,
+      },
+    ],
+  },
+);
+
+export const IntentUI = UIProvider.succeed<Intent>("AWS.LexV2.Intent", {
+  displayName: "Lex Intent",
+  icon: "message-square",
+  color: COLOR,
+  category: "ai",
+  summary: (ctx) => ctx.attrs?.intentName,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.intentName, copy: true },
+    { label: "id", value: ctx.attrs?.intentId, mono: true, copy: true },
+    { label: "bot", value: ctx.attrs?.botId, mono: true },
+    { label: "locale", value: ctx.attrs?.localeId },
+  ],
+});
+
+export const SlotTypeUI = UIProvider.succeed<SlotType>("AWS.LexV2.SlotType", {
+  displayName: "Lex Slot Type",
+  icon: "list-ordered",
+  color: COLOR,
+  category: "ai",
+  summary: (ctx) => ctx.attrs?.slotTypeName,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.slotTypeName, copy: true },
+    { label: "id", value: ctx.attrs?.slotTypeId, mono: true, copy: true },
+    { label: "bot", value: ctx.attrs?.botId, mono: true },
+    { label: "locale", value: ctx.attrs?.localeId },
+  ],
+});
+
+export const ui = () =>
+  Layer.mergeAll(
+    BotUI,
+    BotAliasUI,
+    BotLocaleUI,
+    BotVersionUI,
+    IntentUI,
+    SlotTypeUI,
+  );

--- a/packages/alchemy/src/AWS/LicenseManager/ui.ts
+++ b/packages/alchemy/src/AWS/LicenseManager/ui.ts
@@ -1,0 +1,39 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { LicenseConfiguration } from "./LicenseConfiguration.ts";
+
+/**
+ * Dashboard UI providers for AWS License Manager resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+export const LicenseConfigurationUI = UIProvider.succeed<LicenseConfiguration>(
+  "AWS.LicenseManager.LicenseConfiguration",
+  {
+    displayName: "License Manager Configuration",
+    icon: "scroll-text",
+    color: "#E7157B",
+    category: "config",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "configuration", value: ctx.attrs?.name, copy: true },
+      {
+        label: "id",
+        value: ctx.attrs?.licenseConfigurationId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.licenseConfigurationArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "counting type", value: ctx.attrs?.licenseCountingType },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(LicenseConfigurationUI);

--- a/packages/alchemy/src/AWS/Location/ui.ts
+++ b/packages/alchemy/src/AWS/Location/ui.ts
@@ -1,0 +1,153 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { ApiKey } from "./ApiKey.ts";
+import type { GeofenceCollection } from "./GeofenceCollection.ts";
+import type { Map } from "./Map.ts";
+import type { PlaceIndex } from "./PlaceIndex.ts";
+import type { RouteCalculator } from "./RouteCalculator.ts";
+import type { Tracker } from "./Tracker.ts";
+import type { TrackerConsumer } from "./TrackerConsumer.ts";
+
+/**
+ * Dashboard UI providers for AWS Location resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** AWS Front-End Web & Mobile (Location Service) brand pink. */
+const COLOR = "#E7157B";
+
+export const MapUI = UIProvider.succeed<Map>("AWS.Location.Map", {
+  displayName: "Location Map",
+  icon: "map",
+  color: COLOR,
+  category: "other",
+  summary: (ctx) => ctx.attrs?.mapName,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.mapName, copy: true },
+    { label: "arn", value: ctx.attrs?.mapArn, mono: true, copy: true },
+    { label: "style", value: ctx.attrs?.style },
+    { label: "data source", value: ctx.attrs?.dataSource },
+    { label: "political view", value: ctx.attrs?.politicalView },
+  ],
+});
+
+export const PlaceIndexUI = UIProvider.succeed<PlaceIndex>(
+  "AWS.Location.PlaceIndex",
+  {
+    displayName: "Location Place Index",
+    icon: "search",
+    color: COLOR,
+    category: "other",
+    summary: (ctx) => ctx.attrs?.indexName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.indexName, copy: true },
+      { label: "arn", value: ctx.attrs?.indexArn, mono: true, copy: true },
+      { label: "data source", value: ctx.attrs?.dataSource },
+      { label: "intended use", value: ctx.attrs?.intendedUse },
+    ],
+  },
+);
+
+export const RouteCalculatorUI = UIProvider.succeed<RouteCalculator>(
+  "AWS.Location.RouteCalculator",
+  {
+    displayName: "Location Route Calculator",
+    icon: "route",
+    color: COLOR,
+    category: "other",
+    summary: (ctx) => ctx.attrs?.calculatorName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.calculatorName, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.calculatorArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "data source", value: ctx.attrs?.dataSource },
+    ],
+  },
+);
+
+export const TrackerUI = UIProvider.succeed<Tracker>("AWS.Location.Tracker", {
+  displayName: "Location Tracker",
+  icon: "map-pin",
+  color: COLOR,
+  category: "other",
+  summary: (ctx) => ctx.attrs?.trackerName,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.trackerName, copy: true },
+    { label: "arn", value: ctx.attrs?.trackerArn, mono: true, copy: true },
+    { label: "position filtering", value: ctx.attrs?.positionFiltering },
+    { label: "eventbridge", value: ctx.attrs?.eventBridgeEnabled },
+    { label: "kms key", value: ctx.attrs?.kmsKeyId, mono: true },
+  ],
+});
+
+export const GeofenceCollectionUI = UIProvider.succeed<GeofenceCollection>(
+  "AWS.Location.GeofenceCollection",
+  {
+    displayName: "Location Geofence Collection",
+    icon: "map-pin",
+    color: COLOR,
+    category: "other",
+    summary: (ctx) => ctx.attrs?.collectionName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.collectionName, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.collectionArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "kms key", value: ctx.attrs?.kmsKeyId, mono: true },
+    ],
+  },
+);
+
+export const TrackerConsumerUI = UIProvider.succeed<TrackerConsumer>(
+  "AWS.Location.TrackerConsumer",
+  {
+    displayName: "Location Tracker Consumer",
+    icon: "link",
+    color: COLOR,
+    category: "other",
+    summary: (ctx) => ctx.attrs?.trackerName,
+    facts: (ctx) => [
+      { label: "tracker", value: ctx.attrs?.trackerName, copy: true },
+      {
+        label: "consumer",
+        value: ctx.attrs?.consumerArn,
+        mono: true,
+        copy: true,
+      },
+    ],
+  },
+);
+
+export const ApiKeyUI = UIProvider.succeed<ApiKey>("AWS.Location.ApiKey", {
+  displayName: "Location API Key",
+  icon: "key-round",
+  color: COLOR,
+  category: "auth",
+  summary: (ctx) => ctx.attrs?.keyName,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.keyName, copy: true },
+    { label: "arn", value: ctx.attrs?.keyArn, mono: true, copy: true },
+    { label: "expires", value: ctx.attrs?.expireTime },
+    { label: "description", value: ctx.attrs?.description },
+  ],
+});
+
+export const ui = () =>
+  Layer.mergeAll(
+    MapUI,
+    PlaceIndexUI,
+    RouteCalculatorUI,
+    TrackerUI,
+    GeofenceCollectionUI,
+    TrackerConsumerUI,
+    ApiKeyUI,
+  );

--- a/packages/alchemy/src/AWS/Logs/ui.ts
+++ b/packages/alchemy/src/AWS/Logs/ui.ts
@@ -1,0 +1,176 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Destination } from "./Destination.ts";
+import type { LogGroup } from "./LogGroup.ts";
+import type { LogStream } from "./LogStream.ts";
+import type { MetricFilter } from "./MetricFilter.ts";
+import type { ResourcePolicy } from "./ResourcePolicy.ts";
+import type { SubscriptionFilter } from "./SubscriptionFilter.ts";
+
+/**
+ * Dashboard UI providers for AWS Logs (CloudWatch Logs) resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+const regionOf = (arn: string | undefined) => arn?.split(":")[3];
+
+export const LogGroupUI = UIProvider.succeed<LogGroup>("AWS.Logs.LogGroup", {
+  displayName: "Log Group",
+  icon: "scroll-text",
+  color: "#E7157B",
+  category: "observability",
+  summary: (ctx) => ctx.attrs?.logGroupName,
+  consoleUrl: (ctx) => {
+    const region = regionOf(ctx.attrs?.logGroupArn);
+    return ctx.attrs?.logGroupName === undefined || region === undefined
+      ? undefined
+      : `https://${region}.console.aws.amazon.com/cloudwatch/home?region=${region}#logsV2:log-groups/log-group/${encodeURIComponent(encodeURIComponent(ctx.attrs.logGroupName))}`;
+  },
+  facts: (ctx) => [
+    { label: "log group", value: ctx.attrs?.logGroupName, copy: true },
+    { label: "arn", value: ctx.attrs?.logGroupArn, mono: true, copy: true },
+    {
+      label: "retention",
+      value:
+        ctx.attrs?.retentionInDays === undefined
+          ? "never expire"
+          : `${ctx.attrs.retentionInDays} days`,
+    },
+    { label: "class", value: ctx.attrs?.logGroupClass },
+    { label: "kms key", value: ctx.attrs?.kmsKeyId, mono: true, copy: true },
+    {
+      label: "deletion protection",
+      value: ctx.attrs?.deletionProtectionEnabled,
+    },
+  ],
+});
+
+export const DestinationUI = UIProvider.succeed<Destination>(
+  "AWS.Logs.Destination",
+  {
+    displayName: "Log Destination",
+    icon: "share-2",
+    color: "#E7157B",
+    category: "observability",
+    summary: (ctx) => ctx.attrs?.destinationName,
+    facts: (ctx) => [
+      { label: "destination", value: ctx.attrs?.destinationName, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.destinationArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "target", value: ctx.attrs?.targetArn, mono: true },
+      { label: "role", value: ctx.attrs?.roleArn, mono: true },
+      {
+        label: "access policy",
+        value: ctx.attrs?.accessPolicy !== undefined,
+      },
+    ],
+  },
+);
+
+export const LogStreamUI = UIProvider.succeed<LogStream>("AWS.Logs.LogStream", {
+  displayName: "Log Stream",
+  icon: "file-text",
+  color: "#E7157B",
+  category: "observability",
+  summary: (ctx) => ctx.attrs?.logStreamName,
+  consoleUrl: (ctx) => {
+    const region = regionOf(ctx.attrs?.logStreamArn);
+    return ctx.attrs?.logGroupName === undefined ||
+      ctx.attrs?.logStreamName === undefined ||
+      region === undefined
+      ? undefined
+      : `https://${region}.console.aws.amazon.com/cloudwatch/home?region=${region}#logsV2:log-groups/log-group/${encodeURIComponent(encodeURIComponent(ctx.attrs.logGroupName))}/log-events/${encodeURIComponent(encodeURIComponent(ctx.attrs.logStreamName))}`;
+  },
+  facts: (ctx) => [
+    { label: "stream", value: ctx.attrs?.logStreamName, copy: true },
+    { label: "log group", value: ctx.attrs?.logGroupName, copy: true },
+    { label: "arn", value: ctx.attrs?.logStreamArn, mono: true, copy: true },
+  ],
+});
+
+export const MetricFilterUI = UIProvider.succeed<MetricFilter>(
+  "AWS.Logs.MetricFilter",
+  {
+    displayName: "Log Metric Filter",
+    icon: "filter",
+    color: "#E7157B",
+    category: "observability",
+    summary: (ctx) => ctx.attrs?.filterName,
+    facts: (ctx) => [
+      { label: "filter", value: ctx.attrs?.filterName, copy: true },
+      { label: "log group", value: ctx.attrs?.logGroupName, copy: true },
+      { label: "pattern", value: ctx.attrs?.filterPattern, mono: true },
+      {
+        label: "metric",
+        value: ctx.attrs?.metricTransformations?.[0]?.metricName,
+      },
+      {
+        label: "transformations",
+        value: ctx.attrs?.metricTransformations?.length,
+      },
+    ],
+  },
+);
+
+export const ResourcePolicyUI = UIProvider.succeed<ResourcePolicy>(
+  "AWS.Logs.ResourcePolicy",
+  {
+    displayName: "Log Resource Policy",
+    icon: "lock",
+    color: "#E7157B",
+    category: "security",
+    summary: (ctx) => ctx.attrs?.policyName,
+    facts: (ctx) => [
+      { label: "policy", value: ctx.attrs?.policyName, copy: true },
+      {
+        label: "document",
+        value: ctx.attrs?.policyDocument,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "document length",
+        value: ctx.attrs?.policyDocument?.length,
+      },
+    ],
+  },
+);
+
+export const SubscriptionFilterUI = UIProvider.succeed<SubscriptionFilter>(
+  "AWS.Logs.SubscriptionFilter",
+  {
+    displayName: "Log Subscription Filter",
+    icon: "send",
+    color: "#E7157B",
+    category: "observability",
+    summary: (ctx) => ctx.attrs?.filterName,
+    facts: (ctx) => [
+      { label: "filter", value: ctx.attrs?.filterName, copy: true },
+      { label: "log group", value: ctx.attrs?.logGroupName, copy: true },
+      {
+        label: "destination",
+        value: ctx.attrs?.destinationArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "pattern", value: ctx.attrs?.filterPattern, mono: true },
+      { label: "distribution", value: ctx.attrs?.distribution },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(
+    LogGroupUI,
+    DestinationUI,
+    LogStreamUI,
+    MetricFilterUI,
+    ResourcePolicyUI,
+    SubscriptionFilterUI,
+  );

--- a/packages/alchemy/src/AWS/MQ/ui.ts
+++ b/packages/alchemy/src/AWS/MQ/ui.ts
@@ -1,0 +1,79 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Broker } from "./Broker.ts";
+import type { Configuration } from "./Configuration.ts";
+
+/**
+ * Dashboard UI providers for AWS MQ resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+const regionOf = (arn: string | undefined): string | undefined =>
+  arn?.split(":")[3] || undefined;
+
+export const BrokerUI = UIProvider.succeed<Broker>("AWS.MQ.Broker", {
+  displayName: "MQ Broker",
+  icon: "message-square",
+  color: "#E7157B",
+  category: "queue",
+  summary: (ctx) => ctx.attrs?.brokerName,
+  link: (ctx) => ctx.attrs?.consoleUrl,
+  consoleUrl: (ctx) => {
+    const region = regionOf(ctx.attrs?.brokerArn);
+    return ctx.attrs?.brokerId === undefined || region === undefined
+      ? undefined
+      : `https://${region}.console.aws.amazon.com/amazon-mq/home?region=${region}#/brokers/${ctx.attrs.brokerId}`;
+  },
+  facts: (ctx) => [
+    { label: "broker", value: ctx.attrs?.brokerName, copy: true },
+    { label: "id", value: ctx.attrs?.brokerId, mono: true, copy: true },
+    { label: "arn", value: ctx.attrs?.brokerArn, mono: true, copy: true },
+    { label: "state", value: ctx.attrs?.brokerState },
+    { label: "engine", value: ctx.props?.engineType },
+    { label: "instance type", value: ctx.props?.hostInstanceType },
+    {
+      label: "endpoints",
+      value: ctx.attrs?.endpoints?.length
+        ? ctx.attrs.endpoints.join(", ")
+        : undefined,
+      mono: true,
+    },
+  ],
+});
+
+export const ConfigurationUI = UIProvider.succeed<Configuration>(
+  "AWS.MQ.Configuration",
+  {
+    displayName: "MQ Configuration",
+    icon: "settings",
+    color: "#E7157B",
+    category: "queue",
+    summary: (ctx) => ctx.attrs?.configurationName,
+    facts: (ctx) => [
+      {
+        label: "configuration",
+        value: ctx.attrs?.configurationName,
+        copy: true,
+      },
+      {
+        label: "id",
+        value: ctx.attrs?.configurationId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.configurationArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "engine", value: ctx.attrs?.engineType },
+      { label: "engine version", value: ctx.attrs?.engineVersion },
+      { label: "revision", value: ctx.attrs?.configurationRevision },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(BrokerUI, ConfigurationUI);

--- a/packages/alchemy/src/AWS/MWAA/ui.ts
+++ b/packages/alchemy/src/AWS/MWAA/ui.ts
@@ -1,0 +1,42 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Environment } from "./Environment.ts";
+
+/**
+ * Dashboard UI providers for AWS MWAA resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+export const EnvironmentUI = UIProvider.succeed<Environment>(
+  "AWS.MWAA.Environment",
+  {
+    displayName: "MWAA Environment",
+    icon: "workflow",
+    color: "#8C4FFF",
+    category: "eventing",
+    summary: (ctx) => ctx.attrs?.environmentName,
+    link: (ctx) =>
+      ctx.attrs?.webserverUrl === undefined
+        ? undefined
+        : `https://${ctx.attrs.webserverUrl}`,
+    facts: (ctx) => [
+      { label: "environment", value: ctx.attrs?.environmentName, copy: true },
+      { label: "arn", value: ctx.attrs?.arn, mono: true, copy: true },
+      { label: "status", value: ctx.attrs?.status },
+      { label: "airflow version", value: ctx.attrs?.airflowVersion },
+      { label: "class", value: ctx.attrs?.environmentClass },
+      {
+        label: "webserver",
+        value: ctx.attrs?.webserverUrl,
+        href:
+          ctx.attrs?.webserverUrl === undefined
+            ? undefined
+            : `https://${ctx.attrs.webserverUrl}`,
+      },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(EnvironmentUI);

--- a/packages/alchemy/src/AWS/MWAAServerless/ui.ts
+++ b/packages/alchemy/src/AWS/MWAAServerless/ui.ts
@@ -1,0 +1,36 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Workflow } from "./Workflow.ts";
+
+/**
+ * Dashboard UI providers for AWS MWAAServerless resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+export const WorkflowUI = UIProvider.succeed<Workflow>(
+  "AWS.MWAAServerless.Workflow",
+  {
+    displayName: "MWAA Serverless Workflow",
+    icon: "workflow",
+    color: "#E7157B",
+    category: "eventing",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.workflowArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "version", value: ctx.attrs?.workflowVersion },
+      { label: "status", value: ctx.attrs?.workflowStatus },
+      { label: "role", value: ctx.attrs?.roleArn, mono: true },
+      { label: "trigger mode", value: ctx.attrs?.triggerMode },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(WorkflowUI);

--- a/packages/alchemy/src/AWS/Macie2/ui.ts
+++ b/packages/alchemy/src/AWS/Macie2/ui.ts
@@ -1,0 +1,111 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { AllowList } from "./AllowList.ts";
+import type { ClassificationJob } from "./ClassificationJob.ts";
+import type { CustomDataIdentifier } from "./CustomDataIdentifier.ts";
+import type { FindingsFilter } from "./FindingsFilter.ts";
+import type { Session } from "./Session.ts";
+
+/**
+ * Dashboard UI providers for AWS Macie2 resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** AWS Security, Identity & Compliance (Macie) brand red. */
+const COLOR = "#DD344C";
+
+export const AllowListUI = UIProvider.succeed<AllowList>(
+  "AWS.Macie2.AllowList",
+  {
+    displayName: "Macie Allow List",
+    icon: "list-ordered",
+    color: COLOR,
+    category: "security",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      { label: "id", value: ctx.attrs?.id, mono: true, copy: true },
+      { label: "arn", value: ctx.attrs?.arn, mono: true, copy: true },
+      { label: "status", value: ctx.attrs?.status },
+    ],
+  },
+);
+
+export const ClassificationJobUI = UIProvider.succeed<ClassificationJob>(
+  "AWS.Macie2.ClassificationJob",
+  {
+    displayName: "Macie Classification Job",
+    icon: "search",
+    color: COLOR,
+    category: "security",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      { label: "job id", value: ctx.attrs?.jobId, mono: true, copy: true },
+      { label: "arn", value: ctx.attrs?.jobArn, mono: true, copy: true },
+      { label: "status", value: ctx.attrs?.jobStatus },
+    ],
+  },
+);
+
+export const CustomDataIdentifierUI = UIProvider.succeed<CustomDataIdentifier>(
+  "AWS.Macie2.CustomDataIdentifier",
+  {
+    displayName: "Macie Custom Data Identifier",
+    icon: "fingerprint",
+    color: COLOR,
+    category: "security",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      { label: "id", value: ctx.attrs?.id, mono: true, copy: true },
+      { label: "arn", value: ctx.attrs?.arn, mono: true, copy: true },
+    ],
+  },
+);
+
+export const FindingsFilterUI = UIProvider.succeed<FindingsFilter>(
+  "AWS.Macie2.FindingsFilter",
+  {
+    displayName: "Macie Findings Filter",
+    icon: "filter",
+    color: COLOR,
+    category: "security",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      { label: "id", value: ctx.attrs?.id, mono: true, copy: true },
+      { label: "arn", value: ctx.attrs?.arn, mono: true, copy: true },
+      { label: "action", value: ctx.attrs?.action },
+    ],
+  },
+);
+
+export const SessionUI = UIProvider.succeed<Session>("AWS.Macie2.Session", {
+  displayName: "Macie Session",
+  icon: "shield",
+  color: COLOR,
+  category: "security",
+  summary: (ctx) => ctx.attrs?.accountId,
+  facts: (ctx) => [
+    { label: "account", value: ctx.attrs?.accountId, mono: true, copy: true },
+    { label: "status", value: ctx.attrs?.status },
+    {
+      label: "finding frequency",
+      value: ctx.attrs?.findingPublishingFrequency,
+    },
+    { label: "service role", value: ctx.attrs?.serviceRole, mono: true },
+    { label: "created", value: ctx.attrs?.createdAt },
+  ],
+});
+
+export const ui = () =>
+  Layer.mergeAll(
+    AllowListUI,
+    ClassificationJobUI,
+    CustomDataIdentifierUI,
+    FindingsFilterUI,
+    SessionUI,
+  );

--- a/packages/alchemy/src/AWS/MailManager/ui.ts
+++ b/packages/alchemy/src/AWS/MailManager/ui.ts
@@ -1,0 +1,219 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { AddonInstance } from "./AddonInstance.ts";
+import type { AddonSubscription } from "./AddonSubscription.ts";
+import type { AddressList } from "./AddressList.ts";
+import type { Archive } from "./Archive.ts";
+import type { IngressPoint } from "./IngressPoint.ts";
+import type { Relay } from "./Relay.ts";
+import type { RuleSet } from "./RuleSet.ts";
+import type { TrafficPolicy } from "./TrafficPolicy.ts";
+
+/**
+ * Dashboard UI providers for AWS MailManager resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+export const AddonInstanceUI = UIProvider.succeed<AddonInstance>(
+  "AWS.MailManager.AddonInstance",
+  {
+    displayName: "Mail Manager Add On Instance",
+    icon: "plug",
+    color: "#E7157B",
+    category: "email",
+    summary: (ctx) => ctx.attrs?.addonName ?? ctx.attrs?.addonInstanceId,
+    facts: (ctx) => [
+      {
+        label: "id",
+        value: ctx.attrs?.addonInstanceId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.addonInstanceArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "add on", value: ctx.attrs?.addonName },
+      {
+        label: "subscription",
+        value: ctx.attrs?.addonSubscriptionId,
+        mono: true,
+      },
+    ],
+  },
+);
+
+export const AddonSubscriptionUI = UIProvider.succeed<AddonSubscription>(
+  "AWS.MailManager.AddonSubscription",
+  {
+    displayName: "Mail Manager Add On Subscription",
+    icon: "package",
+    color: "#E7157B",
+    category: "email",
+    summary: (ctx) => ctx.attrs?.addonName,
+    facts: (ctx) => [
+      { label: "add on", value: ctx.attrs?.addonName, copy: true },
+      {
+        label: "id",
+        value: ctx.attrs?.addonSubscriptionId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.addonSubscriptionArn,
+        mono: true,
+        copy: true,
+      },
+    ],
+  },
+);
+
+export const AddressListUI = UIProvider.succeed<AddressList>(
+  "AWS.MailManager.AddressList",
+  {
+    displayName: "Mail Manager Address List",
+    icon: "list-ordered",
+    color: "#E7157B",
+    category: "email",
+    summary: (ctx) => ctx.attrs?.addressListName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.addressListName, copy: true },
+      {
+        label: "id",
+        value: ctx.attrs?.addressListId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.addressListArn,
+        mono: true,
+        copy: true,
+      },
+    ],
+  },
+);
+
+export const ArchiveUI = UIProvider.succeed<Archive>(
+  "AWS.MailManager.Archive",
+  {
+    displayName: "Mail Manager Archive",
+    icon: "archive",
+    color: "#E7157B",
+    category: "email",
+    summary: (ctx) => ctx.attrs?.archiveName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.archiveName, copy: true },
+      { label: "id", value: ctx.attrs?.archiveId, mono: true, copy: true },
+      { label: "arn", value: ctx.attrs?.archiveArn, mono: true, copy: true },
+      { label: "state", value: ctx.attrs?.archiveState },
+      { label: "retention", value: ctx.props?.retentionPeriod },
+    ],
+  },
+);
+
+export const IngressPointUI = UIProvider.succeed<IngressPoint>(
+  "AWS.MailManager.IngressPoint",
+  {
+    displayName: "Mail Manager Ingress Point",
+    icon: "inbox",
+    color: "#E7157B",
+    category: "email",
+    summary: (ctx) => ctx.attrs?.ingressPointName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.ingressPointName, copy: true },
+      {
+        label: "id",
+        value: ctx.attrs?.ingressPointId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.ingressPointArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "status", value: ctx.attrs?.status },
+      { label: "a record", value: ctx.attrs?.aRecord, mono: true, copy: true },
+      { label: "type", value: ctx.props?.type },
+    ],
+  },
+);
+
+export const RelayUI = UIProvider.succeed<Relay>("AWS.MailManager.Relay", {
+  displayName: "Mail Manager Relay",
+  icon: "send",
+  color: "#E7157B",
+  category: "email",
+  summary: (ctx) => ctx.attrs?.relayName,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.relayName, copy: true },
+    { label: "id", value: ctx.attrs?.relayId, mono: true, copy: true },
+    { label: "arn", value: ctx.attrs?.relayArn, mono: true, copy: true },
+    { label: "server", value: ctx.props?.serverName, mono: true },
+    { label: "port", value: ctx.props?.serverPort },
+  ],
+});
+
+export const RuleSetUI = UIProvider.succeed<RuleSet>(
+  "AWS.MailManager.RuleSet",
+  {
+    displayName: "Mail Manager Rule Set",
+    icon: "filter",
+    color: "#E7157B",
+    category: "email",
+    summary: (ctx) => ctx.attrs?.ruleSetName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.ruleSetName, copy: true },
+      { label: "id", value: ctx.attrs?.ruleSetId, mono: true, copy: true },
+      { label: "arn", value: ctx.attrs?.ruleSetArn, mono: true, copy: true },
+      { label: "rules", value: ctx.props?.rules?.length },
+    ],
+  },
+);
+
+export const TrafficPolicyUI = UIProvider.succeed<TrafficPolicy>(
+  "AWS.MailManager.TrafficPolicy",
+  {
+    displayName: "Mail Manager Traffic Policy",
+    icon: "scale",
+    color: "#E7157B",
+    category: "email",
+    summary: (ctx) => ctx.attrs?.trafficPolicyName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.trafficPolicyName, copy: true },
+      {
+        label: "id",
+        value: ctx.attrs?.trafficPolicyId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.trafficPolicyArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "default action", value: ctx.props?.defaultAction },
+      { label: "max message size", value: ctx.props?.maxMessageSizeBytes },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(
+    AddonInstanceUI,
+    AddonSubscriptionUI,
+    AddressListUI,
+    ArchiveUI,
+    IngressPointUI,
+    RelayUI,
+    RuleSetUI,
+    TrafficPolicyUI,
+  );

--- a/packages/alchemy/src/AWS/MediaConnect/ui.ts
+++ b/packages/alchemy/src/AWS/MediaConnect/ui.ts
@@ -1,0 +1,29 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Flow } from "./Flow.ts";
+
+/**
+ * Dashboard UI providers for AWS MediaConnect resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+export const FlowUI = UIProvider.succeed<Flow>("AWS.MediaConnect.Flow", {
+  displayName: "MediaConnect Flow",
+  icon: "radio",
+  color: "#ED7100",
+  category: "media",
+  summary: (ctx) => ctx.attrs?.flowName,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.flowName, copy: true },
+    { label: "arn", value: ctx.attrs?.flowArn, mono: true, copy: true },
+    { label: "status", value: ctx.attrs?.status },
+    { label: "availability zone", value: ctx.attrs?.availabilityZone },
+    { label: "egress ip", value: ctx.attrs?.egressIp, mono: true },
+    { label: "source ingest ip", value: ctx.attrs?.sourceIngestIp, mono: true },
+    { label: "outputs", value: ctx.attrs?.outputs?.length },
+  ],
+});
+
+export const ui = () => Layer.mergeAll(FlowUI);

--- a/packages/alchemy/src/AWS/MediaConvert/ui.ts
+++ b/packages/alchemy/src/AWS/MediaConvert/ui.ts
@@ -1,0 +1,80 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Job } from "./Job.ts";
+import type { JobTemplate } from "./JobTemplate.ts";
+import type { Preset } from "./Preset.ts";
+import type { Queue } from "./Queue.ts";
+
+/**
+ * Dashboard UI providers for AWS MediaConvert resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+export const JobUI = UIProvider.succeed<Job>("AWS.MediaConvert.Job", {
+  displayName: "MediaConvert Job",
+  icon: "play",
+  color: "#ED7100",
+  category: "media",
+  summary: (ctx) => ctx.attrs?.jobId,
+  facts: (ctx) => [
+    { label: "id", value: ctx.attrs?.jobId, mono: true, copy: true },
+    { label: "arn", value: ctx.attrs?.jobArn, mono: true, copy: true },
+    { label: "status", value: ctx.attrs?.status },
+    { label: "queue", value: ctx.attrs?.queue },
+  ],
+});
+
+export const JobTemplateUI = UIProvider.succeed<JobTemplate>(
+  "AWS.MediaConvert.JobTemplate",
+  {
+    displayName: "MediaConvert Job Template",
+    icon: "file-text",
+    color: "#ED7100",
+    category: "media",
+    summary: (ctx) => ctx.attrs?.jobTemplateName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.jobTemplateName, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.jobTemplateArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "type", value: ctx.attrs?.type },
+      { label: "category", value: ctx.attrs?.category },
+    ],
+  },
+);
+
+export const PresetUI = UIProvider.succeed<Preset>("AWS.MediaConvert.Preset", {
+  displayName: "MediaConvert Preset",
+  icon: "pencil-ruler",
+  color: "#ED7100",
+  category: "media",
+  summary: (ctx) => ctx.attrs?.presetName,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.presetName, copy: true },
+    { label: "arn", value: ctx.attrs?.presetArn, mono: true, copy: true },
+    { label: "type", value: ctx.attrs?.type },
+    { label: "category", value: ctx.attrs?.category },
+  ],
+});
+
+export const QueueUI = UIProvider.succeed<Queue>("AWS.MediaConvert.Queue", {
+  displayName: "MediaConvert Queue",
+  icon: "list-ordered",
+  color: "#ED7100",
+  category: "media",
+  summary: (ctx) => ctx.attrs?.queueName,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.queueName, copy: true },
+    { label: "arn", value: ctx.attrs?.queueArn, mono: true, copy: true },
+    { label: "type", value: ctx.attrs?.type },
+    { label: "status", value: ctx.attrs?.status },
+    { label: "pricing plan", value: ctx.attrs?.pricingPlan },
+  ],
+});
+
+export const ui = () => Layer.mergeAll(JobUI, JobTemplateUI, PresetUI, QueueUI);

--- a/packages/alchemy/src/AWS/MediaLive/ui.ts
+++ b/packages/alchemy/src/AWS/MediaLive/ui.ts
@@ -1,0 +1,101 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Channel } from "./Channel.ts";
+import type { Input } from "./Input.ts";
+import type { InputSecurityGroup } from "./InputSecurityGroup.ts";
+
+/**
+ * Dashboard UI providers for AWS MediaLive resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+const regionOf = (arn: string | undefined) => arn?.split(":")[3];
+
+export const ChannelUI = UIProvider.succeed<Channel>("AWS.MediaLive.Channel", {
+  displayName: "MediaLive Channel",
+  icon: "video",
+  color: "#ED7100",
+  category: "media",
+  summary: (ctx) => ctx.attrs?.channelName ?? ctx.attrs?.channelId,
+  consoleUrl: (ctx) => {
+    const region = regionOf(ctx.attrs?.channelArn);
+    return ctx.attrs?.channelId === undefined || region === undefined
+      ? undefined
+      : `https://${region}.console.aws.amazon.com/medialive/home?region=${region}#/channels/${ctx.attrs.channelId}`;
+  },
+  facts: (ctx) => [
+    { label: "channel", value: ctx.attrs?.channelName, copy: true },
+    { label: "id", value: ctx.attrs?.channelId, mono: true, copy: true },
+    { label: "arn", value: ctx.attrs?.channelArn, mono: true, copy: true },
+    { label: "state", value: ctx.attrs?.state },
+    { label: "class", value: ctx.attrs?.channelClass },
+    {
+      label: "egress endpoints",
+      value: ctx.attrs?.egressEndpoints?.length,
+    },
+  ],
+});
+
+export const InputUI = UIProvider.succeed<Input>("AWS.MediaLive.Input", {
+  displayName: "MediaLive Input",
+  icon: "camera",
+  color: "#ED7100",
+  category: "media",
+  summary: (ctx) => ctx.attrs?.inputName ?? ctx.attrs?.inputId,
+  consoleUrl: (ctx) => {
+    const region = regionOf(ctx.attrs?.inputArn);
+    return ctx.attrs?.inputId === undefined || region === undefined
+      ? undefined
+      : `https://${region}.console.aws.amazon.com/medialive/home?region=${region}#/inputs/${ctx.attrs.inputId}`;
+  },
+  facts: (ctx) => [
+    { label: "input", value: ctx.attrs?.inputName, copy: true },
+    { label: "id", value: ctx.attrs?.inputId, mono: true, copy: true },
+    { label: "arn", value: ctx.attrs?.inputArn, mono: true, copy: true },
+    { label: "state", value: ctx.attrs?.state },
+    { label: "type", value: ctx.attrs?.type },
+    { label: "class", value: ctx.attrs?.inputClass },
+    {
+      label: "security groups",
+      value: ctx.attrs?.securityGroups?.length,
+    },
+  ],
+});
+
+export const InputSecurityGroupUI = UIProvider.succeed<InputSecurityGroup>(
+  "AWS.MediaLive.InputSecurityGroup",
+  {
+    displayName: "MediaLive Input Security Group",
+    icon: "shield",
+    color: "#ED7100",
+    category: "security",
+    summary: (ctx) => ctx.attrs?.inputSecurityGroupId,
+    facts: (ctx) => [
+      {
+        label: "group",
+        value: ctx.attrs?.inputSecurityGroupId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.inputSecurityGroupArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "state", value: ctx.attrs?.state },
+      {
+        label: "whitelist",
+        value: ctx.attrs?.whitelistRules?.length
+          ? ctx.attrs.whitelistRules.join(", ")
+          : undefined,
+        mono: true,
+      },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(ChannelUI, InputUI, InputSecurityGroupUI);

--- a/packages/alchemy/src/AWS/MediaPackageV2/ui.ts
+++ b/packages/alchemy/src/AWS/MediaPackageV2/ui.ts
@@ -1,0 +1,90 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Channel } from "./Channel.ts";
+import type { ChannelGroup } from "./ChannelGroup.ts";
+import type { OriginEndpoint } from "./OriginEndpoint.ts";
+
+/**
+ * Dashboard UI providers for AWS MediaPackageV2 resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** AWS Media Services (MediaPackage) brand orange. */
+const COLOR = "#ED7100";
+
+export const ChannelGroupUI = UIProvider.succeed<ChannelGroup>(
+  "AWS.MediaPackageV2.ChannelGroup",
+  {
+    displayName: "MediaPackage Channel Group",
+    icon: "folder",
+    color: COLOR,
+    category: "media",
+    summary: (ctx) => ctx.attrs?.channelGroupName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.channelGroupName, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.channelGroupArn,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "egress domain",
+        value: ctx.attrs?.egressDomain,
+        mono: true,
+        copy: true,
+      },
+    ],
+  },
+);
+
+export const ChannelUI = UIProvider.succeed<Channel>(
+  "AWS.MediaPackageV2.Channel",
+  {
+    displayName: "MediaPackage Channel",
+    icon: "video",
+    color: COLOR,
+    category: "media",
+    summary: (ctx) => ctx.attrs?.channelName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.channelName, copy: true },
+      { label: "group", value: ctx.attrs?.channelGroupName, mono: true },
+      { label: "arn", value: ctx.attrs?.channelArn, mono: true, copy: true },
+      { label: "input type", value: ctx.attrs?.inputType },
+      {
+        label: "ingest endpoints",
+        value: ctx.attrs?.ingestEndpoints?.length,
+      },
+    ],
+  },
+);
+
+export const OriginEndpointUI = UIProvider.succeed<OriginEndpoint>(
+  "AWS.MediaPackageV2.OriginEndpoint",
+  {
+    displayName: "MediaPackage Origin Endpoint",
+    icon: "share-2",
+    color: COLOR,
+    category: "media",
+    summary: (ctx) => ctx.attrs?.originEndpointName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.originEndpointName, copy: true },
+      { label: "channel", value: ctx.attrs?.channelName, mono: true },
+      { label: "group", value: ctx.attrs?.channelGroupName, mono: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.originEndpointArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "container type", value: ctx.attrs?.containerType },
+      { label: "hls manifests", value: ctx.attrs?.hlsManifests?.length },
+      { label: "dash manifests", value: ctx.attrs?.dashManifests?.length },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(ChannelGroupUI, ChannelUI, OriginEndpointUI);

--- a/packages/alchemy/src/AWS/MediaTailor/ui.ts
+++ b/packages/alchemy/src/AWS/MediaTailor/ui.ts
@@ -1,0 +1,48 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { PlaybackConfiguration } from "./PlaybackConfiguration.ts";
+
+/**
+ * Dashboard UI providers for AWS MediaTailor resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+export const PlaybackConfigurationUI =
+  UIProvider.succeed<PlaybackConfiguration>(
+    "AWS.MediaTailor.PlaybackConfiguration",
+    {
+      displayName: "MediaTailor Playback Configuration",
+      icon: "play",
+      color: "#ED7100",
+      category: "media",
+      summary: (ctx) => ctx.attrs?.name,
+      facts: (ctx) => [
+        { label: "config", value: ctx.attrs?.name, copy: true },
+        {
+          label: "arn",
+          value: ctx.attrs?.playbackConfigurationArn,
+          mono: true,
+          copy: true,
+        },
+        {
+          label: "playback endpoint",
+          value: ctx.attrs?.playbackEndpointPrefix,
+          mono: true,
+        },
+        {
+          label: "ad decision server",
+          value: ctx.props?.adDecisionServerUrl,
+          mono: true,
+        },
+        {
+          label: "content source",
+          value: ctx.props?.videoContentSourceUrl,
+          mono: true,
+        },
+      ],
+    },
+  );
+
+export const ui = () => Layer.mergeAll(PlaybackConfigurationUI);

--- a/packages/alchemy/src/AWS/MedicalImaging/ui.ts
+++ b/packages/alchemy/src/AWS/MedicalImaging/ui.ts
@@ -1,0 +1,30 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Datastore } from "./Datastore.ts";
+
+/**
+ * Dashboard UI providers for AWS HealthImaging (Medical Imaging) resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+export const DatastoreUI = UIProvider.succeed<Datastore>(
+  "AWS.MedicalImaging.Datastore",
+  {
+    displayName: "HealthImaging Data Store",
+    icon: "scan",
+    color: "#01A88D",
+    category: "storage",
+    summary: (ctx) => ctx.attrs?.datastoreName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.datastoreName, copy: true },
+      { label: "id", value: ctx.attrs?.datastoreId, mono: true, copy: true },
+      { label: "arn", value: ctx.attrs?.datastoreArn, mono: true, copy: true },
+      { label: "status", value: ctx.attrs?.datastoreStatus },
+      { label: "kms key", value: ctx.attrs?.kmsKeyArn, mono: true },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(DatastoreUI);

--- a/packages/alchemy/src/AWS/MemoryDB/ui.ts
+++ b/packages/alchemy/src/AWS/MemoryDB/ui.ts
@@ -1,0 +1,136 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { ACL } from "./ACL.ts";
+import type { Cluster } from "./Cluster.ts";
+import type { ParameterGroup } from "./ParameterGroup.ts";
+import type { SubnetGroup } from "./SubnetGroup.ts";
+import type { User } from "./User.ts";
+
+/**
+ * Dashboard UI providers for AWS MemoryDB resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** AWS Database (MemoryDB) brand purple/magenta. */
+const COLOR = "#C925D1";
+
+export const ClusterUI = UIProvider.succeed<Cluster>("AWS.MemoryDB.Cluster", {
+  displayName: "MemoryDB Cluster",
+  icon: "database",
+  color: COLOR,
+  category: "database",
+  summary: (ctx) => ctx.attrs?.clusterName,
+  facts: (ctx) => [
+    { label: "cluster", value: ctx.attrs?.clusterName, copy: true },
+    { label: "arn", value: ctx.attrs?.clusterArn, mono: true, copy: true },
+    {
+      label: "endpoint",
+      value:
+        ctx.attrs?.endpointAddress === undefined
+          ? undefined
+          : `${ctx.attrs.endpointAddress}:${ctx.attrs.endpointPort ?? ""}`,
+      mono: true,
+      copy: true,
+    },
+    {
+      label: "engine",
+      value:
+        ctx.attrs?.engine === undefined
+          ? undefined
+          : `${ctx.attrs.engine}${ctx.attrs.engineVersion ? ` ${ctx.attrs.engineVersion}` : ""}`,
+    },
+    { label: "node type", value: ctx.attrs?.nodeType },
+    { label: "status", value: ctx.attrs?.status },
+    { label: "acl", value: ctx.attrs?.aclName },
+    { label: "shards", value: ctx.attrs?.numberOfShards },
+  ],
+});
+
+export const ACLUI = UIProvider.succeed<ACL>("AWS.MemoryDB.ACL", {
+  displayName: "MemoryDB ACL",
+  icon: "shield",
+  color: COLOR,
+  category: "security",
+  summary: (ctx) => ctx.attrs?.aclName,
+  facts: (ctx) => [
+    { label: "acl", value: ctx.attrs?.aclName, copy: true },
+    { label: "arn", value: ctx.attrs?.aclArn, mono: true, copy: true },
+    { label: "status", value: ctx.attrs?.status },
+    {
+      label: "users",
+      value: ctx.attrs?.userNames?.length
+        ? ctx.attrs.userNames.join(", ")
+        : undefined,
+    },
+  ],
+});
+
+export const ParameterGroupUI = UIProvider.succeed<ParameterGroup>(
+  "AWS.MemoryDB.ParameterGroup",
+  {
+    displayName: "MemoryDB Parameter Group",
+    icon: "settings-2",
+    color: COLOR,
+    category: "config",
+    summary: (ctx) => ctx.attrs?.parameterGroupName,
+    facts: (ctx) => [
+      { label: "group", value: ctx.attrs?.parameterGroupName, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.parameterGroupArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "family", value: ctx.attrs?.family },
+      { label: "description", value: ctx.attrs?.description },
+    ],
+  },
+);
+
+export const SubnetGroupUI = UIProvider.succeed<SubnetGroup>(
+  "AWS.MemoryDB.SubnetGroup",
+  {
+    displayName: "MemoryDB Subnet Group",
+    icon: "network",
+    color: COLOR,
+    category: "network",
+    summary: (ctx) => ctx.attrs?.subnetGroupName,
+    facts: (ctx) => [
+      { label: "group", value: ctx.attrs?.subnetGroupName, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.subnetGroupArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "vpc", value: ctx.attrs?.vpcId, mono: true },
+      {
+        label: "subnets",
+        value: ctx.attrs?.subnetIds?.length
+          ? ctx.attrs.subnetIds.join(", ")
+          : undefined,
+        mono: true,
+      },
+    ],
+  },
+);
+
+export const UserUI = UIProvider.succeed<User>("AWS.MemoryDB.User", {
+  displayName: "MemoryDB User",
+  icon: "user",
+  color: COLOR,
+  category: "security",
+  summary: (ctx) => ctx.attrs?.userName,
+  facts: (ctx) => [
+    { label: "user", value: ctx.attrs?.userName, copy: true },
+    { label: "arn", value: ctx.attrs?.userArn, mono: true, copy: true },
+    { label: "status", value: ctx.attrs?.status },
+    { label: "access string", value: ctx.attrs?.accessString, mono: true },
+    { label: "authentication", value: ctx.attrs?.authenticationType },
+  ],
+});
+
+export const ui = () =>
+  Layer.mergeAll(ClusterUI, ACLUI, ParameterGroupUI, SubnetGroupUI, UserUI);

--- a/packages/alchemy/src/AWS/Neptune/ui.ts
+++ b/packages/alchemy/src/AWS/Neptune/ui.ts
@@ -1,0 +1,196 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { DBCluster } from "./DBCluster.ts";
+import type { DBClusterParameterGroup } from "./DBClusterParameterGroup.ts";
+import type { DBInstance } from "./DBInstance.ts";
+import type { DBParameterGroup } from "./DBParameterGroup.ts";
+import type { DBSubnetGroup } from "./DBSubnetGroup.ts";
+
+/**
+ * Dashboard UI providers for AWS Neptune resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** AWS purple/magenta database brand color. */
+const COLOR = "#C925D1";
+
+/** Extract the region segment from an AWS ARN (`arn:aws:neptune:REGION:...`). */
+const regionOfArn = (arn: string | undefined): string | undefined =>
+  arn?.split(":")[3] || undefined;
+
+export const DBClusterUI = UIProvider.succeed<DBCluster>(
+  "AWS.Neptune.DBCluster",
+  {
+    displayName: "Neptune Cluster",
+    icon: "database",
+    color: COLOR,
+    category: "database",
+    summary: (ctx) => ctx.attrs?.dbClusterIdentifier,
+    consoleUrl: (ctx) => {
+      const region = regionOfArn(ctx.attrs?.dbClusterArn);
+      return region === undefined ||
+        ctx.attrs?.dbClusterIdentifier === undefined
+        ? undefined
+        : `https://${region}.console.aws.amazon.com/neptune/home?region=${region}#database:id=${ctx.attrs.dbClusterIdentifier};is-cluster=true`;
+    },
+    facts: (ctx) => [
+      {
+        label: "identifier",
+        value: ctx.attrs?.dbClusterIdentifier,
+        copy: true,
+      },
+      { label: "arn", value: ctx.attrs?.dbClusterArn, mono: true, copy: true },
+      { label: "endpoint", value: ctx.attrs?.endpoint, mono: true, copy: true },
+      {
+        label: "reader endpoint",
+        value: ctx.attrs?.readerEndpoint,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "engine",
+        value:
+          ctx.attrs?.engineVersion === undefined
+            ? ctx.attrs?.engine
+            : `${ctx.attrs.engine} ${ctx.attrs.engineVersion}`,
+      },
+      { label: "status", value: ctx.attrs?.status },
+      { label: "members", value: ctx.attrs?.dbClusterMembers?.length },
+    ],
+  },
+);
+
+export const DBClusterParameterGroupUI =
+  UIProvider.succeed<DBClusterParameterGroup>(
+    "AWS.Neptune.DBClusterParameterGroup",
+    {
+      displayName: "Neptune Cluster Parameter Group",
+      icon: "settings",
+      color: COLOR,
+      category: "config",
+      summary: (ctx) => ctx.attrs?.dbClusterParameterGroupName,
+      consoleUrl: (ctx) => {
+        const region = regionOfArn(ctx.attrs?.dbClusterParameterGroupArn);
+        return region === undefined ||
+          ctx.attrs?.dbClusterParameterGroupName === undefined
+          ? undefined
+          : `https://${region}.console.aws.amazon.com/neptune/home?region=${region}#parameter-group-details:parameter-group-name=${ctx.attrs.dbClusterParameterGroupName}`;
+      },
+      facts: (ctx) => [
+        {
+          label: "name",
+          value: ctx.attrs?.dbClusterParameterGroupName,
+          copy: true,
+        },
+        {
+          label: "arn",
+          value: ctx.attrs?.dbClusterParameterGroupArn,
+          mono: true,
+          copy: true,
+        },
+        { label: "family", value: ctx.attrs?.family },
+        { label: "description", value: ctx.attrs?.description },
+      ],
+    },
+  );
+
+export const DBInstanceUI = UIProvider.succeed<DBInstance>(
+  "AWS.Neptune.DBInstance",
+  {
+    displayName: "Neptune Instance",
+    icon: "server",
+    color: COLOR,
+    category: "database",
+    summary: (ctx) => ctx.attrs?.dbInstanceIdentifier,
+    consoleUrl: (ctx) => {
+      const region = regionOfArn(ctx.attrs?.dbInstanceArn);
+      return region === undefined ||
+        ctx.attrs?.dbInstanceIdentifier === undefined
+        ? undefined
+        : `https://${region}.console.aws.amazon.com/neptune/home?region=${region}#database:id=${ctx.attrs.dbInstanceIdentifier};is-cluster=false`;
+    },
+    facts: (ctx) => [
+      {
+        label: "identifier",
+        value: ctx.attrs?.dbInstanceIdentifier,
+        copy: true,
+      },
+      { label: "arn", value: ctx.attrs?.dbInstanceArn, mono: true, copy: true },
+      {
+        label: "endpoint",
+        value:
+          ctx.attrs?.endpointAddress === undefined
+            ? undefined
+            : `${ctx.attrs.endpointAddress}:${ctx.attrs.endpointPort ?? ""}`,
+        mono: true,
+        copy: true,
+      },
+      { label: "cluster", value: ctx.attrs?.dbClusterIdentifier },
+      { label: "class", value: ctx.attrs?.dbInstanceClass },
+      { label: "status", value: ctx.attrs?.status },
+    ],
+  },
+);
+
+export const DBParameterGroupUI = UIProvider.succeed<DBParameterGroup>(
+  "AWS.Neptune.DBParameterGroup",
+  {
+    displayName: "Neptune Parameter Group",
+    icon: "settings",
+    color: COLOR,
+    category: "config",
+    summary: (ctx) => ctx.attrs?.dbParameterGroupName,
+    consoleUrl: (ctx) => {
+      const region = regionOfArn(ctx.attrs?.dbParameterGroupArn);
+      return region === undefined ||
+        ctx.attrs?.dbParameterGroupName === undefined
+        ? undefined
+        : `https://${region}.console.aws.amazon.com/neptune/home?region=${region}#parameter-group-details:parameter-group-name=${ctx.attrs.dbParameterGroupName}`;
+    },
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.dbParameterGroupName, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.dbParameterGroupArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "family", value: ctx.attrs?.family },
+      { label: "description", value: ctx.attrs?.description },
+    ],
+  },
+);
+
+export const DBSubnetGroupUI = UIProvider.succeed<DBSubnetGroup>(
+  "AWS.Neptune.DBSubnetGroup",
+  {
+    displayName: "Neptune Subnet Group",
+    icon: "network",
+    color: COLOR,
+    category: "network",
+    summary: (ctx) => ctx.attrs?.dbSubnetGroupName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.dbSubnetGroupName, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.dbSubnetGroupArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "vpc", value: ctx.attrs?.vpcId, mono: true },
+      { label: "subnets", value: ctx.attrs?.subnetIds?.join(", "), mono: true },
+      { label: "status", value: ctx.attrs?.status },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(
+    DBClusterUI,
+    DBClusterParameterGroupUI,
+    DBInstanceUI,
+    DBParameterGroupUI,
+    DBSubnetGroupUI,
+  );

--- a/packages/alchemy/src/AWS/NeptuneGraph/ui.ts
+++ b/packages/alchemy/src/AWS/NeptuneGraph/ui.ts
@@ -1,0 +1,29 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Graph } from "./Graph.ts";
+
+/**
+ * Dashboard UI providers for AWS NeptuneGraph resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+export const GraphUI = UIProvider.succeed<Graph>("AWS.NeptuneGraph.Graph", {
+  displayName: "Neptune Analytics Graph",
+  icon: "waypoints",
+  color: "#C925D1",
+  category: "database",
+  summary: (ctx) => ctx.attrs?.graphName,
+  facts: (ctx) => [
+    { label: "graph", value: ctx.attrs?.graphName, copy: true },
+    { label: "id", value: ctx.attrs?.graphId, mono: true, copy: true },
+    { label: "arn", value: ctx.attrs?.graphArn, mono: true, copy: true },
+    { label: "endpoint", value: ctx.attrs?.endpoint, mono: true, copy: true },
+    { label: "status", value: ctx.attrs?.status },
+    { label: "provisioned memory", value: ctx.attrs?.provisionedMemory },
+    { label: "public", value: ctx.attrs?.publicConnectivity },
+  ],
+});
+
+export const ui = () => Layer.mergeAll(GraphUI);

--- a/packages/alchemy/src/AWS/NetworkFirewall/ui.ts
+++ b/packages/alchemy/src/AWS/NetworkFirewall/ui.ts
@@ -1,0 +1,106 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Firewall } from "./Firewall.ts";
+import type { FirewallPolicy } from "./FirewallPolicy.ts";
+import type { LoggingConfiguration } from "./LoggingConfiguration.ts";
+import type { RuleGroup } from "./RuleGroup.ts";
+
+/**
+ * Dashboard UI providers for AWS NetworkFirewall resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+export const FirewallUI = UIProvider.succeed<Firewall>(
+  "AWS.NetworkFirewall.Firewall",
+  {
+    displayName: "Network Firewall",
+    icon: "shield-check",
+    color: "#8C4FFF",
+    category: "network",
+    summary: (ctx) => ctx.attrs?.firewallName,
+    facts: (ctx) => [
+      { label: "firewall", value: ctx.attrs?.firewallName, copy: true },
+      { label: "arn", value: ctx.attrs?.firewallArn, mono: true, copy: true },
+      { label: "id", value: ctx.attrs?.firewallId, mono: true },
+      { label: "vpc", value: ctx.attrs?.vpcId, mono: true },
+      { label: "endpoints", value: ctx.attrs?.endpointIds?.length },
+    ],
+  },
+);
+
+export const FirewallPolicyUI = UIProvider.succeed<FirewallPolicy>(
+  "AWS.NetworkFirewall.FirewallPolicy",
+  {
+    displayName: "Network Firewall Policy",
+    icon: "scroll-text",
+    color: "#8C4FFF",
+    category: "network",
+    summary: (ctx) => ctx.attrs?.firewallPolicyName,
+    facts: (ctx) => [
+      { label: "policy", value: ctx.attrs?.firewallPolicyName, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.firewallPolicyArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "id", value: ctx.attrs?.firewallPolicyId, mono: true },
+    ],
+  },
+);
+
+export const LoggingConfigurationUI = UIProvider.succeed<LoggingConfiguration>(
+  "AWS.NetworkFirewall.LoggingConfiguration",
+  {
+    displayName: "Network Firewall Logging",
+    icon: "file-text",
+    color: "#8C4FFF",
+    category: "observability",
+    summary: (ctx) => ctx.attrs?.firewallArn?.split("/").pop(),
+    facts: (ctx) => [
+      {
+        label: "firewall",
+        value: ctx.attrs?.firewallArn,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "destinations",
+        value: ctx.props?.logDestinationConfigs?.length,
+      },
+    ],
+  },
+);
+
+export const RuleGroupUI = UIProvider.succeed<RuleGroup>(
+  "AWS.NetworkFirewall.RuleGroup",
+  {
+    displayName: "Network Firewall Rule Group",
+    icon: "list-ordered",
+    color: "#8C4FFF",
+    category: "network",
+    summary: (ctx) => ctx.attrs?.ruleGroupName,
+    facts: (ctx) => [
+      { label: "rule group", value: ctx.attrs?.ruleGroupName, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.ruleGroupArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "id", value: ctx.attrs?.ruleGroupId, mono: true },
+      { label: "type", value: ctx.attrs?.type },
+      { label: "capacity", value: ctx.attrs?.capacity },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(
+    FirewallUI,
+    FirewallPolicyUI,
+    LoggingConfigurationUI,
+    RuleGroupUI,
+  );

--- a/packages/alchemy/src/AWS/Notifications/ui.ts
+++ b/packages/alchemy/src/AWS/Notifications/ui.ts
@@ -1,0 +1,118 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { ChannelAssociation } from "./ChannelAssociation.ts";
+import type { EventRule } from "./EventRule.ts";
+import type { NotificationConfiguration } from "./NotificationConfiguration.ts";
+import type { NotificationHub } from "./NotificationHub.ts";
+
+/**
+ * Dashboard UI providers for AWS Notifications resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** AWS Management & Governance (User Notifications) brand pink. */
+const COLOR = "#E7157B";
+
+export const NotificationConfigurationUI =
+  UIProvider.succeed<NotificationConfiguration>(
+    "AWS.Notifications.NotificationConfiguration",
+    {
+      displayName: "Notification Configuration",
+      icon: "bell",
+      color: COLOR,
+      category: "eventing",
+      summary: (ctx) => ctx.attrs?.name,
+      facts: (ctx) => [
+        { label: "name", value: ctx.attrs?.name, copy: true },
+        {
+          label: "arn",
+          value: ctx.attrs?.notificationConfigurationArn,
+          mono: true,
+          copy: true,
+        },
+        { label: "status", value: ctx.attrs?.status },
+        { label: "description", value: ctx.attrs?.description },
+      ],
+    },
+  );
+
+export const EventRuleUI = UIProvider.succeed<EventRule>(
+  "AWS.Notifications.EventRule",
+  {
+    displayName: "Notifications Event Rule",
+    icon: "webhook",
+    color: COLOR,
+    category: "eventing",
+    summary: (ctx) =>
+      ctx.attrs?.source === undefined || ctx.attrs?.eventType === undefined
+        ? undefined
+        : `${ctx.attrs.source}: ${ctx.attrs.eventType}`,
+    facts: (ctx) => [
+      {
+        label: "arn",
+        value: ctx.attrs?.eventRuleArn,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "configuration",
+        value: ctx.attrs?.notificationConfigurationArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "source", value: ctx.attrs?.source, mono: true },
+      { label: "event type", value: ctx.attrs?.eventType },
+      { label: "regions", value: ctx.attrs?.regions?.join(", "), mono: true },
+    ],
+  },
+);
+
+export const NotificationHubUI = UIProvider.succeed<NotificationHub>(
+  "AWS.Notifications.NotificationHub",
+  {
+    displayName: "Notification Hub",
+    icon: "waypoints",
+    color: COLOR,
+    category: "eventing",
+    summary: (ctx) => ctx.attrs?.notificationHubRegion,
+    facts: (ctx) => [
+      { label: "region", value: ctx.attrs?.notificationHubRegion, copy: true },
+      { label: "status", value: ctx.attrs?.status },
+    ],
+  },
+);
+
+export const ChannelAssociationUI = UIProvider.succeed<ChannelAssociation>(
+  "AWS.Notifications.ChannelAssociation",
+  {
+    displayName: "Notifications Channel Association",
+    icon: "link",
+    color: COLOR,
+    category: "eventing",
+    summary: (ctx) => ctx.attrs?.channelArn,
+    facts: (ctx) => [
+      {
+        label: "channel",
+        value: ctx.attrs?.channelArn,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "configuration",
+        value: ctx.attrs?.notificationConfigurationArn,
+        mono: true,
+        copy: true,
+      },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(
+    NotificationConfigurationUI,
+    EventRuleUI,
+    NotificationHubUI,
+    ChannelAssociationUI,
+  );

--- a/packages/alchemy/src/AWS/NotificationsContacts/ui.ts
+++ b/packages/alchemy/src/AWS/NotificationsContacts/ui.ts
@@ -1,0 +1,34 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { EmailContact } from "./EmailContact.ts";
+
+/**
+ * Dashboard UI providers for AWS NotificationsContacts resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+export const EmailContactUI = UIProvider.succeed<EmailContact>(
+  "AWS.NotificationsContacts.EmailContact",
+  {
+    displayName: "Notifications Email Contact",
+    icon: "mail",
+    color: "#E7157B",
+    category: "email",
+    summary: (ctx) => ctx.attrs?.emailAddress ?? ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      { label: "email", value: ctx.attrs?.emailAddress, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.emailContactArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "status", value: ctx.attrs?.status },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(EmailContactUI);

--- a/packages/alchemy/src/AWS/OAM/ui.ts
+++ b/packages/alchemy/src/AWS/OAM/ui.ts
@@ -1,0 +1,45 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Link } from "./Link.ts";
+import type { Sink } from "./Sink.ts";
+
+/**
+ * Dashboard UI providers for AWS OAM (CloudWatch Observability Access
+ * Manager) resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+export const LinkUI = UIProvider.succeed<Link>("AWS.OAM.Link", {
+  displayName: "OAM Link",
+  icon: "share-2",
+  color: "#E7157B",
+  category: "observability",
+  summary: (ctx) => ctx.attrs?.label,
+  facts: (ctx) => [
+    { label: "label", value: ctx.attrs?.label, copy: true },
+    { label: "arn", value: ctx.attrs?.linkArn, mono: true, copy: true },
+    { label: "id", value: ctx.attrs?.linkId, mono: true },
+    { label: "sink", value: ctx.attrs?.sinkArn, mono: true, copy: true },
+    {
+      label: "resource types",
+      value: ctx.props?.resourceTypes?.join(", "),
+    },
+  ],
+});
+
+export const SinkUI = UIProvider.succeed<Sink>("AWS.OAM.Sink", {
+  displayName: "OAM Sink",
+  icon: "inbox",
+  color: "#E7157B",
+  category: "observability",
+  summary: (ctx) => ctx.attrs?.sinkName,
+  facts: (ctx) => [
+    { label: "sink", value: ctx.attrs?.sinkName, copy: true },
+    { label: "arn", value: ctx.attrs?.sinkArn, mono: true, copy: true },
+    { label: "id", value: ctx.attrs?.sinkId, mono: true },
+  ],
+});
+
+export const ui = () => Layer.mergeAll(LinkUI, SinkUI);

--- a/packages/alchemy/src/AWS/OSIS/ui.ts
+++ b/packages/alchemy/src/AWS/OSIS/ui.ts
@@ -1,0 +1,92 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Pipeline } from "./Pipeline.ts";
+import type { PipelineEndpoint } from "./PipelineEndpoint.ts";
+import type { ResourcePolicy } from "./ResourcePolicy.ts";
+
+/**
+ * Dashboard UI providers for AWS OSIS resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** AWS Analytics (OpenSearch Ingestion) brand purple. */
+const COLOR = "#8C4FFF";
+
+export const PipelineUI = UIProvider.succeed<Pipeline>("AWS.OSIS.Pipeline", {
+  displayName: "OpenSearch Ingestion Pipeline",
+  icon: "workflow",
+  color: COLOR,
+  category: "eventing",
+  summary: (ctx) => ctx.attrs?.pipelineName,
+  facts: (ctx) => [
+    { label: "pipeline", value: ctx.attrs?.pipelineName, copy: true },
+    { label: "arn", value: ctx.attrs?.pipelineArn, mono: true, copy: true },
+    { label: "status", value: ctx.attrs?.status },
+    { label: "min units", value: ctx.attrs?.minUnits },
+    { label: "max units", value: ctx.attrs?.maxUnits },
+    {
+      label: "ingest urls",
+      value: ctx.attrs?.ingestEndpointUrls?.length
+        ? ctx.attrs.ingestEndpointUrls.join(", ")
+        : undefined,
+      mono: true,
+    },
+  ],
+});
+
+export const PipelineEndpointUI = UIProvider.succeed<PipelineEndpoint>(
+  "AWS.OSIS.PipelineEndpoint",
+  {
+    displayName: "OpenSearch Ingestion Pipeline Endpoint",
+    icon: "network",
+    color: COLOR,
+    category: "network",
+    summary: (ctx) => ctx.attrs?.endpointId,
+    facts: (ctx) => [
+      {
+        label: "endpoint",
+        value: ctx.attrs?.endpointId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "pipeline",
+        value: ctx.attrs?.pipelineArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "status", value: ctx.attrs?.status },
+      { label: "vpc", value: ctx.attrs?.vpcId, mono: true },
+      {
+        label: "ingest url",
+        value: ctx.attrs?.ingestEndpointUrl,
+        mono: true,
+      },
+    ],
+  },
+);
+
+export const ResourcePolicyUI = UIProvider.succeed<ResourcePolicy>(
+  "AWS.OSIS.ResourcePolicy",
+  {
+    displayName: "OpenSearch Ingestion Resource Policy",
+    icon: "lock",
+    color: COLOR,
+    category: "security",
+    summary: (ctx) => ctx.attrs?.resourceArn,
+    facts: (ctx) => [
+      {
+        label: "resource",
+        value: ctx.attrs?.resourceArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "policy", value: ctx.attrs?.policy, mono: true },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(PipelineUI, PipelineEndpointUI, ResourcePolicyUI);

--- a/packages/alchemy/src/AWS/ObservabilityAdmin/ui.ts
+++ b/packages/alchemy/src/AWS/ObservabilityAdmin/ui.ts
@@ -1,0 +1,48 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { TelemetryConfig } from "./TelemetryConfig.ts";
+import type { TelemetryRule } from "./TelemetryRule.ts";
+
+/**
+ * Dashboard UI providers for AWS ObservabilityAdmin resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** AWS Observability (CloudWatch family) brand pink. */
+const COLOR = "#E7157B";
+
+export const TelemetryConfigUI = UIProvider.succeed<TelemetryConfig>(
+  "AWS.ObservabilityAdmin.TelemetryConfig",
+  {
+    displayName: "Observability Admin Telemetry Config",
+    icon: "gauge",
+    color: COLOR,
+    category: "observability",
+    summary: (ctx) => ctx.attrs?.status,
+    facts: (ctx) => [
+      { label: "status", value: ctx.attrs?.status },
+      { label: "prior status", value: ctx.attrs?.priorStatus },
+    ],
+  },
+);
+
+export const TelemetryRuleUI = UIProvider.succeed<TelemetryRule>(
+  "AWS.ObservabilityAdmin.TelemetryRule",
+  {
+    displayName: "Observability Admin Telemetry Rule",
+    icon: "activity",
+    color: COLOR,
+    category: "observability",
+    summary: (ctx) => ctx.attrs?.ruleName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.ruleName, copy: true },
+      { label: "arn", value: ctx.attrs?.ruleArn, mono: true, copy: true },
+      { label: "telemetry type", value: ctx.attrs?.telemetryType },
+      { label: "resource type", value: ctx.attrs?.resourceType },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(TelemetryConfigUI, TelemetryRuleUI);

--- a/packages/alchemy/src/AWS/Omics/ui.ts
+++ b/packages/alchemy/src/AWS/Omics/ui.ts
@@ -1,0 +1,169 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { AnnotationStore } from "./AnnotationStore.ts";
+import type { ReferenceStore } from "./ReferenceStore.ts";
+import type { RunGroup } from "./RunGroup.ts";
+import type { SequenceStore } from "./SequenceStore.ts";
+import type { VariantStore } from "./VariantStore.ts";
+import type { Workflow } from "./Workflow.ts";
+
+/**
+ * Dashboard UI providers for AWS Omics resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+export const AnnotationStoreUI = UIProvider.succeed<AnnotationStore>(
+  "AWS.Omics.AnnotationStore",
+  {
+    displayName: "HealthOmics Annotation Store",
+    icon: "tags",
+    color: "#01A88D",
+    category: "ai",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      {
+        label: "id",
+        value: ctx.attrs?.annotationStoreId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.annotationStoreArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "status", value: ctx.attrs?.status },
+      { label: "format", value: ctx.props?.storeFormat },
+    ],
+  },
+);
+
+export const ReferenceStoreUI = UIProvider.succeed<ReferenceStore>(
+  "AWS.Omics.ReferenceStore",
+  {
+    displayName: "HealthOmics Reference Store",
+    icon: "book-open",
+    color: "#01A88D",
+    category: "ai",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      {
+        label: "id",
+        value: ctx.attrs?.referenceStoreId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.referenceStoreArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "created", value: ctx.attrs?.creationTime },
+    ],
+  },
+);
+
+export const RunGroupUI = UIProvider.succeed<RunGroup>("AWS.Omics.RunGroup", {
+  displayName: "HealthOmics Run Group",
+  icon: "layers",
+  color: "#01A88D",
+  category: "ai",
+  summary: (ctx) => ctx.attrs?.name,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.name, copy: true },
+    { label: "id", value: ctx.attrs?.runGroupId, mono: true, copy: true },
+    { label: "arn", value: ctx.attrs?.runGroupArn, mono: true, copy: true },
+    { label: "max cpus", value: ctx.props?.maxCpus },
+    { label: "max runs", value: ctx.props?.maxRuns },
+  ],
+});
+
+export const SequenceStoreUI = UIProvider.succeed<SequenceStore>(
+  "AWS.Omics.SequenceStore",
+  {
+    displayName: "HealthOmics Sequence Store",
+    icon: "scroll-text",
+    color: "#01A88D",
+    category: "ai",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      {
+        label: "id",
+        value: ctx.attrs?.sequenceStoreId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.sequenceStoreArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "created", value: ctx.attrs?.creationTime },
+    ],
+  },
+);
+
+export const VariantStoreUI = UIProvider.succeed<VariantStore>(
+  "AWS.Omics.VariantStore",
+  {
+    displayName: "HealthOmics Variant Store",
+    icon: "git-branch",
+    color: "#01A88D",
+    category: "ai",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      {
+        label: "id",
+        value: ctx.attrs?.variantStoreId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.variantStoreArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "status", value: ctx.attrs?.status },
+      {
+        label: "reference",
+        value: ctx.props?.reference?.referenceArn,
+        mono: true,
+      },
+    ],
+  },
+);
+
+export const WorkflowUI = UIProvider.succeed<Workflow>("AWS.Omics.Workflow", {
+  displayName: "HealthOmics Workflow",
+  icon: "workflow",
+  color: "#01A88D",
+  category: "ai",
+  summary: (ctx) => ctx.attrs?.name,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.name, copy: true },
+    { label: "id", value: ctx.attrs?.workflowId, mono: true, copy: true },
+    { label: "arn", value: ctx.attrs?.workflowArn, mono: true, copy: true },
+    { label: "status", value: ctx.attrs?.status },
+    { label: "engine", value: ctx.props?.engine },
+  ],
+});
+
+export const ui = () =>
+  Layer.mergeAll(
+    AnnotationStoreUI,
+    ReferenceStoreUI,
+    RunGroupUI,
+    SequenceStoreUI,
+    VariantStoreUI,
+    WorkflowUI,
+  );

--- a/packages/alchemy/src/AWS/OpenSearch/ui.ts
+++ b/packages/alchemy/src/AWS/OpenSearch/ui.ts
@@ -1,0 +1,44 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Domain } from "./Domain.ts";
+
+/**
+ * Dashboard UI providers for AWS OpenSearch resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** AWS Analytics (OpenSearch) brand purple. */
+const COLOR = "#8C4FFF";
+
+export const DomainUI = UIProvider.succeed<Domain>("AWS.OpenSearch.Domain", {
+  displayName: "OpenSearch Domain",
+  icon: "search",
+  color: COLOR,
+  category: "database",
+  summary: (ctx) => ctx.attrs?.domainName,
+  link: (ctx) =>
+    ctx.attrs?.endpoint === undefined
+      ? undefined
+      : `https://${ctx.attrs.endpoint}`,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.domainName, copy: true },
+    { label: "arn", value: ctx.attrs?.domainArn, mono: true, copy: true },
+    { label: "id", value: ctx.attrs?.domainId, mono: true },
+    {
+      label: "endpoint",
+      value: ctx.attrs?.endpoint,
+      href:
+        ctx.attrs?.endpoint === undefined
+          ? undefined
+          : `https://${ctx.attrs.endpoint}`,
+      mono: true,
+      copy: true,
+    },
+    { label: "engine version", value: ctx.attrs?.engineVersion },
+    { label: "processing", value: ctx.attrs?.processing },
+  ],
+});
+
+export const ui = () => Layer.mergeAll(DomainUI);

--- a/packages/alchemy/src/AWS/OpenSearchServerless/ui.ts
+++ b/packages/alchemy/src/AWS/OpenSearchServerless/ui.ts
@@ -1,0 +1,181 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { AccessPolicy } from "./AccessPolicy.ts";
+import type { Collection } from "./Collection.ts";
+import type { CollectionGroup } from "./CollectionGroup.ts";
+import type { LifecyclePolicy } from "./LifecyclePolicy.ts";
+import type { SecurityConfig } from "./SecurityConfig.ts";
+import type { SecurityPolicy } from "./SecurityPolicy.ts";
+import type { VpcEndpoint } from "./VpcEndpoint.ts";
+
+/**
+ * Dashboard UI providers for AWS OpenSearchServerless resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** AWS Analytics (OpenSearch Serverless) brand purple. */
+const COLOR = "#8C4FFF";
+
+export const CollectionUI = UIProvider.succeed<Collection>(
+  "AWS.OpenSearchServerless.Collection",
+  {
+    displayName: "OpenSearch Serverless Collection",
+    icon: "database",
+    color: COLOR,
+    category: "database",
+    summary: (ctx) => ctx.attrs?.collectionName,
+    link: (ctx) => ctx.attrs?.collectionEndpoint,
+    facts: (ctx) => [
+      { label: "collection", value: ctx.attrs?.collectionName, copy: true },
+      { label: "id", value: ctx.attrs?.collectionId, mono: true, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.collectionArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "type", value: ctx.attrs?.type },
+      { label: "status", value: ctx.attrs?.status },
+      {
+        label: "endpoint",
+        value: ctx.attrs?.collectionEndpoint,
+        mono: true,
+        copy: true,
+      },
+      { label: "dashboard", value: ctx.attrs?.dashboardEndpoint, mono: true },
+      { label: "kms key", value: ctx.attrs?.kmsKeyArn, mono: true },
+    ],
+  },
+);
+
+export const CollectionGroupUI = UIProvider.succeed<CollectionGroup>(
+  "AWS.OpenSearchServerless.CollectionGroup",
+  {
+    displayName: "OpenSearch Serverless Collection Group",
+    icon: "boxes",
+    color: COLOR,
+    category: "database",
+    summary: (ctx) => ctx.attrs?.collectionGroupName,
+    facts: (ctx) => [
+      { label: "group", value: ctx.attrs?.collectionGroupName, copy: true },
+      {
+        label: "id",
+        value: ctx.attrs?.collectionGroupId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.collectionGroupArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "standby replicas", value: ctx.attrs?.standbyReplicas },
+      { label: "collections", value: ctx.attrs?.numberOfCollections },
+    ],
+  },
+);
+
+export const AccessPolicyUI = UIProvider.succeed<AccessPolicy>(
+  "AWS.OpenSearchServerless.AccessPolicy",
+  {
+    displayName: "OpenSearch Serverless Access Policy",
+    icon: "shield-check",
+    color: COLOR,
+    category: "security",
+    summary: (ctx) => ctx.attrs?.policyName,
+    facts: (ctx) => [
+      { label: "policy", value: ctx.attrs?.policyName, copy: true },
+      { label: "type", value: ctx.attrs?.type },
+      { label: "version", value: ctx.attrs?.policyVersion, mono: true },
+      { label: "description", value: ctx.attrs?.description },
+    ],
+  },
+);
+
+export const SecurityPolicyUI = UIProvider.succeed<SecurityPolicy>(
+  "AWS.OpenSearchServerless.SecurityPolicy",
+  {
+    displayName: "OpenSearch Serverless Security Policy",
+    icon: "shield",
+    color: COLOR,
+    category: "security",
+    summary: (ctx) => ctx.attrs?.policyName,
+    facts: (ctx) => [
+      { label: "policy", value: ctx.attrs?.policyName, copy: true },
+      { label: "type", value: ctx.attrs?.type },
+      { label: "version", value: ctx.attrs?.policyVersion, mono: true },
+      { label: "description", value: ctx.attrs?.description },
+    ],
+  },
+);
+
+export const LifecyclePolicyUI = UIProvider.succeed<LifecyclePolicy>(
+  "AWS.OpenSearchServerless.LifecyclePolicy",
+  {
+    displayName: "OpenSearch Serverless Lifecycle Policy",
+    icon: "clock",
+    color: COLOR,
+    category: "config",
+    summary: (ctx) => ctx.attrs?.policyName,
+    facts: (ctx) => [
+      { label: "policy", value: ctx.attrs?.policyName, copy: true },
+      { label: "type", value: ctx.attrs?.type },
+      { label: "version", value: ctx.attrs?.policyVersion, mono: true },
+      { label: "description", value: ctx.attrs?.description },
+    ],
+  },
+);
+
+export const SecurityConfigUI = UIProvider.succeed<SecurityConfig>(
+  "AWS.OpenSearchServerless.SecurityConfig",
+  {
+    displayName: "OpenSearch Serverless Security Config",
+    icon: "fingerprint",
+    color: COLOR,
+    category: "auth",
+    summary: (ctx) => ctx.attrs?.configName,
+    facts: (ctx) => [
+      { label: "config", value: ctx.attrs?.configName, copy: true },
+      { label: "id", value: ctx.attrs?.configId, mono: true, copy: true },
+      { label: "type", value: ctx.attrs?.type },
+      { label: "version", value: ctx.attrs?.configVersion, mono: true },
+      { label: "description", value: ctx.attrs?.description },
+    ],
+  },
+);
+
+export const VpcEndpointUI = UIProvider.succeed<VpcEndpoint>(
+  "AWS.OpenSearchServerless.VpcEndpoint",
+  {
+    displayName: "OpenSearch Serverless VPC Endpoint",
+    icon: "network",
+    color: COLOR,
+    category: "network",
+    summary: (ctx) => ctx.attrs?.endpointName,
+    facts: (ctx) => [
+      { label: "endpoint", value: ctx.attrs?.endpointName, copy: true },
+      {
+        label: "id",
+        value: ctx.attrs?.vpcEndpointId,
+        mono: true,
+        copy: true,
+      },
+      { label: "status", value: ctx.attrs?.status },
+      { label: "vpc", value: ctx.props?.vpcId, mono: true },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(
+    CollectionUI,
+    CollectionGroupUI,
+    AccessPolicyUI,
+    SecurityPolicyUI,
+    LifecyclePolicyUI,
+    SecurityConfigUI,
+    VpcEndpointUI,
+  );

--- a/packages/alchemy/src/AWS/Organizations/ui.ts
+++ b/packages/alchemy/src/AWS/Organizations/ui.ts
@@ -1,0 +1,255 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Account } from "./Account.ts";
+import type { DelegatedAdministrator } from "./DelegatedAdministrator.ts";
+import type { Organization } from "./Organization.ts";
+import type { OrganizationResourcePolicy } from "./OrganizationResourcePolicy.ts";
+import type { OrganizationalUnit } from "./OrganizationalUnit.ts";
+import type { Policy } from "./Policy.ts";
+import type { PolicyAttachment } from "./PolicyAttachment.ts";
+import type { Root } from "./Root.ts";
+import type { RootPolicyType } from "./RootPolicyType.ts";
+import type { TrustedServiceAccess } from "./TrustedServiceAccess.ts";
+
+/**
+ * Dashboard UI providers for AWS Organizations resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+export const OrganizationUI = UIProvider.succeed<Organization>(
+  "AWS.Organizations.Organization",
+  {
+    displayName: "Organization",
+    icon: "network",
+    color: "#E7157B",
+    category: "config",
+    summary: (ctx) => ctx.attrs?.organizationId,
+    consoleUrl: () =>
+      "https://console.aws.amazon.com/organizations/v2/home/accounts",
+    facts: (ctx) => [
+      { label: "id", value: ctx.attrs?.organizationId, mono: true, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.organizationArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "feature set", value: ctx.attrs?.featureSet },
+      {
+        label: "management account",
+        value: ctx.attrs?.managementAccountId,
+        mono: true,
+        copy: true,
+      },
+    ],
+  },
+);
+
+export const AccountUI = UIProvider.succeed<Account>(
+  "AWS.Organizations.Account",
+  {
+    displayName: "Organizations Account",
+    icon: "landmark",
+    color: "#E7157B",
+    category: "config",
+    summary: (ctx) => ctx.attrs?.accountId,
+    consoleUrl: (ctx) =>
+      ctx.attrs?.accountId === undefined
+        ? undefined
+        : `https://console.aws.amazon.com/organizations/v2/home/accounts/${ctx.attrs.accountId}`,
+    facts: (ctx) => [
+      {
+        label: "account id",
+        value: ctx.attrs?.accountId,
+        mono: true,
+        copy: true,
+      },
+      { label: "arn", value: ctx.attrs?.accountArn, mono: true, copy: true },
+      { label: "status", value: ctx.attrs?.status },
+      { label: "parent", value: ctx.attrs?.parentId, mono: true },
+    ],
+  },
+);
+
+export const OrganizationalUnitUI = UIProvider.succeed<OrganizationalUnit>(
+  "AWS.Organizations.OrganizationalUnit",
+  {
+    displayName: "Organizational Unit",
+    icon: "folder-tree",
+    color: "#E7157B",
+    category: "config",
+    summary: (ctx) => ctx.attrs?.name ?? ctx.attrs?.ouId,
+    consoleUrl: (ctx) =>
+      ctx.attrs?.ouId === undefined
+        ? undefined
+        : `https://console.aws.amazon.com/organizations/v2/home/accounts/${ctx.attrs.ouId}`,
+    facts: (ctx) => [
+      { label: "ou id", value: ctx.attrs?.ouId, mono: true, copy: true },
+      { label: "arn", value: ctx.attrs?.ouArn, mono: true, copy: true },
+      { label: "name", value: ctx.attrs?.name },
+      { label: "parent", value: ctx.attrs?.parentId, mono: true },
+    ],
+  },
+);
+
+export const PolicyUI = UIProvider.succeed<Policy>("AWS.Organizations.Policy", {
+  displayName: "Organizations Policy",
+  icon: "scroll-text",
+  color: "#E7157B",
+  category: "security",
+  summary: (ctx) => ctx.attrs?.name ?? ctx.attrs?.policyId,
+  facts: (ctx) => [
+    {
+      label: "policy id",
+      value: ctx.attrs?.policyId,
+      mono: true,
+      copy: true,
+    },
+    { label: "arn", value: ctx.attrs?.policyArn, mono: true, copy: true },
+    { label: "name", value: ctx.attrs?.name },
+    { label: "type", value: ctx.attrs?.type },
+    { label: "aws managed", value: ctx.attrs?.awsManaged },
+    { label: "description", value: ctx.attrs?.description },
+  ],
+});
+
+export const PolicyAttachmentUI = UIProvider.succeed<PolicyAttachment>(
+  "AWS.Organizations.PolicyAttachment",
+  {
+    displayName: "Policy Attachment",
+    icon: "paperclip",
+    color: "#E7157B",
+    category: "security",
+    summary: (ctx) =>
+      ctx.attrs?.policyId === undefined || ctx.attrs?.targetId === undefined
+        ? (ctx.attrs?.policyId ?? ctx.attrs?.targetId)
+        : `${ctx.attrs.policyId} → ${ctx.attrs.targetId}`,
+    facts: (ctx) => [
+      { label: "policy", value: ctx.attrs?.policyId, mono: true, copy: true },
+      { label: "target", value: ctx.attrs?.targetId, mono: true, copy: true },
+      { label: "target name", value: ctx.attrs?.targetName },
+      { label: "target type", value: ctx.attrs?.targetType },
+    ],
+  },
+);
+
+export const RootUI = UIProvider.succeed<Root>("AWS.Organizations.Root", {
+  displayName: "Organizations Root",
+  icon: "git-branch",
+  color: "#E7157B",
+  category: "config",
+  summary: (ctx) => ctx.attrs?.rootName ?? ctx.attrs?.rootId,
+  facts: (ctx) => [
+    { label: "root id", value: ctx.attrs?.rootId, mono: true, copy: true },
+    { label: "arn", value: ctx.attrs?.rootArn, mono: true, copy: true },
+    { label: "name", value: ctx.attrs?.rootName },
+    {
+      label: "policy types",
+      value: ctx.attrs?.policyTypes
+        ?.map((p) => p.Type)
+        .filter((t) => t !== undefined)
+        .join(", "),
+    },
+  ],
+});
+
+export const RootPolicyTypeUI = UIProvider.succeed<RootPolicyType>(
+  "AWS.Organizations.RootPolicyType",
+  {
+    displayName: "Root Policy Type",
+    icon: "toggle-right",
+    color: "#E7157B",
+    category: "security",
+    summary: (ctx) => ctx.attrs?.policyType,
+    facts: (ctx) => [
+      { label: "root", value: ctx.attrs?.rootId, mono: true, copy: true },
+      { label: "policy type", value: ctx.attrs?.policyType },
+      { label: "status", value: ctx.attrs?.status },
+    ],
+  },
+);
+
+export const DelegatedAdministratorUI =
+  UIProvider.succeed<DelegatedAdministrator>(
+    "AWS.Organizations.DelegatedAdministrator",
+    {
+      displayName: "Delegated Administrator",
+      icon: "user-cog",
+      color: "#E7157B",
+      category: "security",
+      summary: (ctx) => ctx.attrs?.accountId,
+      facts: (ctx) => [
+        {
+          label: "account id",
+          value: ctx.attrs?.accountId,
+          mono: true,
+          copy: true,
+        },
+        {
+          label: "service principal",
+          value: ctx.attrs?.servicePrincipal,
+          mono: true,
+        },
+      ],
+    },
+  );
+
+export const TrustedServiceAccessUI = UIProvider.succeed<TrustedServiceAccess>(
+  "AWS.Organizations.TrustedServiceAccess",
+  {
+    displayName: "Trusted Service Access",
+    icon: "handshake",
+    color: "#E7157B",
+    category: "security",
+    summary: (ctx) => ctx.attrs?.servicePrincipal,
+    facts: (ctx) => [
+      {
+        label: "service principal",
+        value: ctx.attrs?.servicePrincipal,
+        mono: true,
+        copy: true,
+      },
+    ],
+  },
+);
+
+export const OrganizationResourcePolicyUI =
+  UIProvider.succeed<OrganizationResourcePolicy>(
+    "AWS.Organizations.OrganizationResourcePolicy",
+    {
+      displayName: "Organization Resource Policy",
+      icon: "file-lock-2",
+      color: "#E7157B",
+      category: "security",
+      summary: (ctx) => ctx.attrs?.resourcePolicyId,
+      facts: (ctx) => [
+        {
+          label: "policy id",
+          value: ctx.attrs?.resourcePolicyId,
+          mono: true,
+          copy: true,
+        },
+        {
+          label: "arn",
+          value: ctx.attrs?.resourcePolicyArn,
+          mono: true,
+          copy: true,
+        },
+      ],
+    },
+  );
+
+export const ui = () =>
+  Layer.mergeAll(
+    OrganizationUI,
+    AccountUI,
+    OrganizationalUnitUI,
+    PolicyUI,
+    PolicyAttachmentUI,
+    RootUI,
+    RootPolicyTypeUI,
+    DelegatedAdministratorUI,
+    TrustedServiceAccessUI,
+    OrganizationResourcePolicyUI,
+  );

--- a/packages/alchemy/src/AWS/PaymentCryptography/ui.ts
+++ b/packages/alchemy/src/AWS/PaymentCryptography/ui.ts
@@ -1,0 +1,51 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Alias } from "./Alias.ts";
+import type { Key } from "./Key.ts";
+
+/**
+ * Dashboard UI providers for AWS PaymentCryptography resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** AWS Security, Identity & Compliance (Payment Cryptography) brand red. */
+const COLOR = "#DD344C";
+
+export const KeyUI = UIProvider.succeed<Key>("AWS.PaymentCryptography.Key", {
+  displayName: "Payment Cryptography Key",
+  icon: "key-round",
+  color: COLOR,
+  category: "security",
+  summary: (ctx) => ctx.attrs?.keyArn,
+  facts: (ctx) => [
+    { label: "arn", value: ctx.attrs?.keyArn, mono: true, copy: true },
+    { label: "state", value: ctx.attrs?.keyState },
+    {
+      label: "check value",
+      value: ctx.attrs?.keyCheckValue,
+      mono: true,
+    },
+    { label: "enabled", value: ctx.attrs?.enabled },
+    { label: "exportable", value: ctx.attrs?.exportable },
+    { label: "algorithm", value: ctx.props?.keyAttributes?.keyAlgorithm },
+  ],
+});
+
+export const AliasUI = UIProvider.succeed<Alias>(
+  "AWS.PaymentCryptography.Alias",
+  {
+    displayName: "Payment Cryptography Alias",
+    icon: "tag",
+    color: COLOR,
+    category: "security",
+    summary: (ctx) => ctx.attrs?.aliasName,
+    facts: (ctx) => [
+      { label: "alias", value: ctx.attrs?.aliasName, mono: true, copy: true },
+      { label: "key", value: ctx.attrs?.keyArn, mono: true, copy: true },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(KeyUI, AliasUI);

--- a/packages/alchemy/src/AWS/Personalize/ui.ts
+++ b/packages/alchemy/src/AWS/Personalize/ui.ts
@@ -1,0 +1,109 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Dataset } from "./Dataset.ts";
+import type { DatasetGroup } from "./DatasetGroup.ts";
+import type { EventTracker } from "./EventTracker.ts";
+import type { Schema } from "./Schema.ts";
+
+/**
+ * Dashboard UI providers for AWS Personalize resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** AWS Machine Learning & AI (Personalize) brand teal. */
+const COLOR = "#01A88D";
+
+export const DatasetGroupUI = UIProvider.succeed<DatasetGroup>(
+  "AWS.Personalize.DatasetGroup",
+  {
+    displayName: "Personalize Dataset Group",
+    icon: "boxes",
+    color: COLOR,
+    category: "ai",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "group", value: ctx.attrs?.name, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.datasetGroupArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "status", value: ctx.attrs?.status },
+      { label: "domain", value: ctx.attrs?.domain },
+    ],
+  },
+);
+
+export const DatasetUI = UIProvider.succeed<Dataset>(
+  "AWS.Personalize.Dataset",
+  {
+    displayName: "Personalize Dataset",
+    icon: "table",
+    color: COLOR,
+    category: "ai",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "dataset", value: ctx.attrs?.name, copy: true },
+      { label: "arn", value: ctx.attrs?.datasetArn, mono: true, copy: true },
+      { label: "type", value: ctx.attrs?.datasetType },
+      { label: "status", value: ctx.attrs?.status },
+      {
+        label: "dataset group",
+        value: ctx.attrs?.datasetGroupArn,
+        mono: true,
+      },
+      { label: "schema", value: ctx.attrs?.schemaArn, mono: true },
+    ],
+  },
+);
+
+export const SchemaUI = UIProvider.succeed<Schema>("AWS.Personalize.Schema", {
+  displayName: "Personalize Schema",
+  icon: "file-text",
+  color: COLOR,
+  category: "ai",
+  summary: (ctx) => ctx.attrs?.name,
+  facts: (ctx) => [
+    { label: "schema", value: ctx.attrs?.name, copy: true },
+    { label: "arn", value: ctx.attrs?.schemaArn, mono: true, copy: true },
+    { label: "domain", value: ctx.attrs?.domain },
+  ],
+});
+
+export const EventTrackerUI = UIProvider.succeed<EventTracker>(
+  "AWS.Personalize.EventTracker",
+  {
+    displayName: "Personalize Event Tracker",
+    icon: "activity",
+    color: COLOR,
+    category: "ai",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "tracker", value: ctx.attrs?.name, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.eventTrackerArn,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "tracking id",
+        value: ctx.attrs?.trackingId,
+        mono: true,
+        copy: true,
+      },
+      { label: "status", value: ctx.attrs?.status },
+      {
+        label: "dataset group",
+        value: ctx.attrs?.datasetGroupArn,
+        mono: true,
+      },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(DatasetGroupUI, DatasetUI, SchemaUI, EventTrackerUI);

--- a/packages/alchemy/src/AWS/PinpointSMSVoiceV2/ui.ts
+++ b/packages/alchemy/src/AWS/PinpointSMSVoiceV2/ui.ts
@@ -1,0 +1,107 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { ConfigurationSet } from "./ConfigurationSet.ts";
+import type { EventDestination } from "./EventDestination.ts";
+import type { OptOutList } from "./OptOutList.ts";
+import type { PhoneNumber } from "./PhoneNumber.ts";
+
+/**
+ * Dashboard UI providers for AWS PinpointSMSVoiceV2 resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** AWS app integration / messaging brand pink. */
+const COLOR = "#E7157B";
+
+export const ConfigurationSetUI = UIProvider.succeed<ConfigurationSet>(
+  "AWS.PinpointSMSVoiceV2.ConfigurationSet",
+  {
+    displayName: "SMS Configuration Set",
+    icon: "settings",
+    color: COLOR,
+    category: "other",
+    summary: (ctx) => ctx.attrs?.configurationSetName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.configurationSetName, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.configurationSetArn,
+        mono: true,
+        copy: true,
+      },
+    ],
+  },
+);
+
+export const EventDestinationUI = UIProvider.succeed<EventDestination>(
+  "AWS.PinpointSMSVoiceV2.EventDestination",
+  {
+    displayName: "SMS Event Destination",
+    icon: "webhook",
+    color: COLOR,
+    category: "eventing",
+    summary: (ctx) => ctx.attrs?.eventDestinationName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.eventDestinationName, copy: true },
+      { label: "configuration set", value: ctx.attrs?.configurationSetName },
+      { label: "enabled", value: ctx.attrs?.enabled },
+      {
+        label: "event types",
+        value: ctx.attrs?.matchingEventTypes?.join(", "),
+      },
+    ],
+  },
+);
+
+export const OptOutListUI = UIProvider.succeed<OptOutList>(
+  "AWS.PinpointSMSVoiceV2.OptOutList",
+  {
+    displayName: "SMS Opt-Out List",
+    icon: "list-ordered",
+    color: COLOR,
+    category: "other",
+    summary: (ctx) => ctx.attrs?.optOutListName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.optOutListName, copy: true },
+      { label: "arn", value: ctx.attrs?.optOutListArn, mono: true, copy: true },
+    ],
+  },
+);
+
+export const PhoneNumberUI = UIProvider.succeed<PhoneNumber>(
+  "AWS.PinpointSMSVoiceV2.PhoneNumber",
+  {
+    displayName: "SMS Phone Number",
+    icon: "phone",
+    color: COLOR,
+    category: "other",
+    summary: (ctx) => ctx.attrs?.phoneNumber,
+    facts: (ctx) => [
+      { label: "number", value: ctx.attrs?.phoneNumber, copy: true },
+      { label: "id", value: ctx.attrs?.phoneNumberId, mono: true, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.phoneNumberArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "status", value: ctx.attrs?.status },
+      { label: "country", value: ctx.attrs?.isoCountryCode },
+      { label: "type", value: ctx.attrs?.numberType },
+      {
+        label: "capabilities",
+        value: ctx.attrs?.numberCapabilities?.join(", "),
+      },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(
+    ConfigurationSetUI,
+    EventDestinationUI,
+    OptOutListUI,
+    PhoneNumberUI,
+  );

--- a/packages/alchemy/src/AWS/Pipes/ui.ts
+++ b/packages/alchemy/src/AWS/Pipes/ui.ts
@@ -1,0 +1,37 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Pipe } from "./Pipe.ts";
+
+/**
+ * Dashboard UI providers for AWS Pipes resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+const regionOf = (arn: string | undefined): string | undefined =>
+  arn?.split(":")[3] || undefined;
+
+export const PipeUI = UIProvider.succeed<Pipe>("AWS.Pipes.Pipe", {
+  displayName: "EventBridge Pipe",
+  icon: "route",
+  color: "#E7157B",
+  category: "eventing",
+  summary: (ctx) => ctx.attrs?.pipeName,
+  consoleUrl: (ctx) => {
+    const region = regionOf(ctx.attrs?.pipeArn);
+    return region === undefined || ctx.attrs?.pipeName === undefined
+      ? undefined
+      : `https://${region}.console.aws.amazon.com/pipes/home?region=${region}#/pipes/${ctx.attrs.pipeName}`;
+  },
+  facts: (ctx) => [
+    { label: "pipe", value: ctx.attrs?.pipeName, copy: true },
+    { label: "arn", value: ctx.attrs?.pipeArn, mono: true, copy: true },
+    { label: "state", value: ctx.attrs?.currentState },
+    { label: "source", value: ctx.props?.source, mono: true },
+    { label: "target", value: ctx.props?.target, mono: true },
+    { label: "role", value: ctx.props?.roleArn, mono: true },
+  ],
+});
+
+export const ui = () => Layer.mergeAll(PipeUI);

--- a/packages/alchemy/src/AWS/Polly/ui.ts
+++ b/packages/alchemy/src/AWS/Polly/ui.ts
@@ -1,0 +1,27 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Lexicon } from "./Lexicon.ts";
+
+/**
+ * Dashboard UI providers for AWS Polly resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+export const LexiconUI = UIProvider.succeed<Lexicon>("AWS.Polly.Lexicon", {
+  displayName: "Polly Lexicon",
+  icon: "languages",
+  color: "#01A88D",
+  category: "ai",
+  summary: (ctx) => ctx.attrs?.lexiconName,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.lexiconName, copy: true },
+    { label: "arn", value: ctx.attrs?.lexiconArn, mono: true, copy: true },
+    { label: "alphabet", value: ctx.attrs?.alphabet },
+    { label: "language", value: ctx.attrs?.languageCode },
+    { label: "lexemes", value: ctx.attrs?.lexemesCount },
+  ],
+});
+
+export const ui = () => Layer.mergeAll(LexiconUI);

--- a/packages/alchemy/src/AWS/QApps/ui.ts
+++ b/packages/alchemy/src/AWS/QApps/ui.ts
@@ -1,0 +1,28 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { QApp } from "./QApp.ts";
+
+/**
+ * Dashboard UI providers for AWS QApps resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+export const QAppUI = UIProvider.succeed<QApp>("AWS.QApps.QApp", {
+  displayName: "Q App",
+  icon: "sparkles",
+  color: "#01A88D",
+  category: "ai",
+  summary: (ctx) => ctx.attrs?.title,
+  facts: (ctx) => [
+    { label: "title", value: ctx.attrs?.title, copy: true },
+    { label: "id", value: ctx.attrs?.appId, mono: true, copy: true },
+    { label: "arn", value: ctx.attrs?.appArn, mono: true, copy: true },
+    { label: "instance", value: ctx.attrs?.instanceId, mono: true },
+    { label: "status", value: ctx.attrs?.status },
+    { label: "version", value: ctx.attrs?.appVersion },
+  ],
+});
+
+export const ui = () => Layer.mergeAll(QAppUI);

--- a/packages/alchemy/src/AWS/QBusiness/ui.ts
+++ b/packages/alchemy/src/AWS/QBusiness/ui.ts
@@ -1,0 +1,162 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Application } from "./Application.ts";
+import type { DataSource } from "./DataSource.ts";
+import type { Retriever } from "./Retriever.ts";
+import type { Index } from "./SearchIndex.ts";
+import type { WebExperience } from "./WebExperience.ts";
+
+/**
+ * Dashboard UI providers for AWS QBusiness resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+const COLOR = "#01A88D";
+
+export const ApplicationUI = UIProvider.succeed<Application>(
+  "AWS.QBusiness.Application",
+  {
+    displayName: "Q Business Application",
+    icon: "bot",
+    color: COLOR,
+    category: "ai",
+    summary: (ctx) => ctx.attrs?.displayName,
+    facts: (ctx) => [
+      { label: "application", value: ctx.attrs?.displayName, copy: true },
+      {
+        label: "id",
+        value: ctx.attrs?.applicationId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.applicationArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "status", value: ctx.attrs?.status },
+      { label: "identity type", value: ctx.attrs?.identityType },
+      { label: "role", value: ctx.attrs?.roleArn, mono: true },
+    ],
+  },
+);
+
+export const IndexUI = UIProvider.succeed<Index>("AWS.QBusiness.Index", {
+  displayName: "Q Business Index",
+  icon: "search",
+  color: COLOR,
+  category: "ai",
+  summary: (ctx) => ctx.attrs?.displayName,
+  facts: (ctx) => [
+    { label: "index", value: ctx.attrs?.displayName, copy: true },
+    { label: "id", value: ctx.attrs?.indexId, mono: true, copy: true },
+    { label: "arn", value: ctx.attrs?.indexArn, mono: true, copy: true },
+    { label: "application", value: ctx.attrs?.applicationId, mono: true },
+    { label: "type", value: ctx.attrs?.type },
+    { label: "status", value: ctx.attrs?.status },
+  ],
+});
+
+export const DataSourceUI = UIProvider.succeed<DataSource>(
+  "AWS.QBusiness.DataSource",
+  {
+    displayName: "Q Business Data Source",
+    icon: "database",
+    color: COLOR,
+    category: "ai",
+    summary: (ctx) => ctx.attrs?.displayName,
+    facts: (ctx) => [
+      { label: "data source", value: ctx.attrs?.displayName, copy: true },
+      {
+        label: "id",
+        value: ctx.attrs?.dataSourceId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.dataSourceArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "index", value: ctx.attrs?.indexId, mono: true },
+      { label: "type", value: ctx.attrs?.type },
+      { label: "status", value: ctx.attrs?.status },
+    ],
+  },
+);
+
+export const RetrieverUI = UIProvider.succeed<Retriever>(
+  "AWS.QBusiness.Retriever",
+  {
+    displayName: "Q Business Retriever",
+    icon: "search",
+    color: COLOR,
+    category: "ai",
+    summary: (ctx) => ctx.attrs?.displayName,
+    facts: (ctx) => [
+      { label: "retriever", value: ctx.attrs?.displayName, copy: true },
+      {
+        label: "id",
+        value: ctx.attrs?.retrieverId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.retrieverArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "application", value: ctx.attrs?.applicationId, mono: true },
+      { label: "type", value: ctx.attrs?.type },
+      { label: "status", value: ctx.attrs?.status },
+    ],
+  },
+);
+
+export const WebExperienceUI = UIProvider.succeed<WebExperience>(
+  "AWS.QBusiness.WebExperience",
+  {
+    displayName: "Q Business Web Experience",
+    icon: "message-square",
+    color: COLOR,
+    category: "ai",
+    summary: (ctx) => ctx.attrs?.webExperienceId,
+    link: (ctx) => ctx.attrs?.defaultEndpoint,
+    facts: (ctx) => [
+      {
+        label: "id",
+        value: ctx.attrs?.webExperienceId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.webExperienceArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "application", value: ctx.attrs?.applicationId, mono: true },
+      {
+        label: "endpoint",
+        value: ctx.attrs?.defaultEndpoint,
+        href: ctx.attrs?.defaultEndpoint,
+        copy: true,
+      },
+      { label: "status", value: ctx.attrs?.status },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(
+    ApplicationUI,
+    IndexUI,
+    DataSourceUI,
+    RetrieverUI,
+    WebExperienceUI,
+  );

--- a/packages/alchemy/src/AWS/QuickSight/ui.ts
+++ b/packages/alchemy/src/AWS/QuickSight/ui.ts
@@ -1,0 +1,84 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Analysis } from "./Analysis.ts";
+import type { Dashboard } from "./Dashboard.ts";
+import type { DataSet } from "./DataSet.ts";
+import type { DataSource } from "./DataSource.ts";
+
+/**
+ * Dashboard UI providers for AWS QuickSight resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+const COLOR = "#8C4FFF";
+
+export const DataSourceUI = UIProvider.succeed<DataSource>(
+  "AWS.QuickSight.DataSource",
+  {
+    displayName: "QuickSight Data Source",
+    icon: "database",
+    color: COLOR,
+    category: "database",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "data source", value: ctx.attrs?.name, copy: true },
+      { label: "id", value: ctx.attrs?.dataSourceId, mono: true, copy: true },
+      { label: "arn", value: ctx.attrs?.arn, mono: true, copy: true },
+      { label: "type", value: ctx.attrs?.type },
+      { label: "status", value: ctx.attrs?.status },
+    ],
+  },
+);
+
+export const DataSetUI = UIProvider.succeed<DataSet>("AWS.QuickSight.DataSet", {
+  displayName: "QuickSight Dataset",
+  icon: "table",
+  color: COLOR,
+  category: "database",
+  summary: (ctx) => ctx.attrs?.name,
+  facts: (ctx) => [
+    { label: "dataset", value: ctx.attrs?.name, copy: true },
+    { label: "id", value: ctx.attrs?.dataSetId, mono: true, copy: true },
+    { label: "arn", value: ctx.attrs?.arn, mono: true, copy: true },
+    { label: "import mode", value: ctx.props?.importMode },
+  ],
+});
+
+export const AnalysisUI = UIProvider.succeed<Analysis>(
+  "AWS.QuickSight.Analysis",
+  {
+    displayName: "QuickSight Analysis",
+    icon: "chart-bar",
+    color: COLOR,
+    category: "other",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "analysis", value: ctx.attrs?.name, copy: true },
+      { label: "id", value: ctx.attrs?.analysisId, mono: true, copy: true },
+      { label: "arn", value: ctx.attrs?.arn, mono: true, copy: true },
+      { label: "status", value: ctx.attrs?.status },
+    ],
+  },
+);
+
+export const DashboardUI = UIProvider.succeed<Dashboard>(
+  "AWS.QuickSight.Dashboard",
+  {
+    displayName: "QuickSight Dashboard",
+    icon: "chart-line",
+    color: COLOR,
+    category: "other",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "dashboard", value: ctx.attrs?.name, copy: true },
+      { label: "id", value: ctx.attrs?.dashboardId, mono: true, copy: true },
+      { label: "arn", value: ctx.attrs?.arn, mono: true, copy: true },
+      { label: "status", value: ctx.attrs?.status },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(DataSourceUI, DataSetUI, AnalysisUI, DashboardUI);

--- a/packages/alchemy/src/AWS/RAM/ui.ts
+++ b/packages/alchemy/src/AWS/RAM/ui.ts
@@ -1,0 +1,64 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Permission } from "./Permission.ts";
+import type { ResourceShare } from "./ResourceShare.ts";
+
+/**
+ * Dashboard UI providers for AWS RAM resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** AWS management & governance brand pink. */
+const COLOR = "#E7157B";
+
+export const PermissionUI = UIProvider.succeed<Permission>(
+  "AWS.RAM.Permission",
+  {
+    displayName: "RAM Permission",
+    icon: "key-round",
+    color: COLOR,
+    category: "security",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      { label: "arn", value: ctx.attrs?.permissionArn, mono: true, copy: true },
+      { label: "resource type", value: ctx.attrs?.resourceType, mono: true },
+      { label: "version", value: ctx.attrs?.version },
+      { label: "status", value: ctx.attrs?.status },
+    ],
+  },
+);
+
+export const ResourceShareUI = UIProvider.succeed<ResourceShare>(
+  "AWS.RAM.ResourceShare",
+  {
+    displayName: "RAM Resource Share",
+    icon: "share-2",
+    color: COLOR,
+    category: "security",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.resourceShareArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "status", value: ctx.attrs?.status },
+      {
+        label: "owning account",
+        value: ctx.attrs?.owningAccountId,
+        mono: true,
+      },
+      {
+        label: "allow external principals",
+        value: ctx.attrs?.allowExternalPrincipals,
+      },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(PermissionUI, ResourceShareUI);

--- a/packages/alchemy/src/AWS/RDS/ui.ts
+++ b/packages/alchemy/src/AWS/RDS/ui.ts
@@ -1,0 +1,323 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { DBCluster } from "./DBCluster.ts";
+import type { DBClusterEndpoint } from "./DBClusterEndpoint.ts";
+import type { DBClusterParameterGroup } from "./DBClusterParameterGroup.ts";
+import type { DBInstance } from "./DBInstance.ts";
+import type { DBParameterGroup } from "./DBParameterGroup.ts";
+import type { DBProxy } from "./DBProxy.ts";
+import type { DBProxyEndpoint } from "./DBProxyEndpoint.ts";
+import type { DBProxyTargetGroup } from "./DBProxyTargetGroup.ts";
+import type { DBSubnetGroup } from "./DBSubnetGroup.ts";
+
+/**
+ * Dashboard UI providers for AWS RDS resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** AWS purple/magenta database brand color. */
+const RDS_COLOR = "#C925D1";
+
+/** Extract the region segment from an AWS ARN (`arn:aws:rds:REGION:...`). */
+const regionOfArn = (arn: string | undefined): string | undefined =>
+  arn?.split(":")[3] || undefined;
+
+export const DBInstanceUI = UIProvider.succeed<DBInstance>(
+  "AWS.RDS.DBInstance",
+  {
+    displayName: "RDS Instance",
+    icon: "database",
+    color: RDS_COLOR,
+    category: "database",
+    summary: (ctx) => ctx.attrs?.dbInstanceIdentifier,
+    consoleUrl: (ctx) => {
+      const region = regionOfArn(ctx.attrs?.dbInstanceArn);
+      return region === undefined ||
+        ctx.attrs?.dbInstanceIdentifier === undefined
+        ? undefined
+        : `https://${region}.console.aws.amazon.com/rds/home?region=${region}#database:id=${ctx.attrs.dbInstanceIdentifier};is-cluster=false`;
+    },
+    facts: (ctx) => [
+      {
+        label: "identifier",
+        value: ctx.attrs?.dbInstanceIdentifier,
+        copy: true,
+      },
+      { label: "arn", value: ctx.attrs?.dbInstanceArn, mono: true, copy: true },
+      {
+        label: "endpoint",
+        value:
+          ctx.attrs?.endpointAddress === undefined
+            ? undefined
+            : `${ctx.attrs.endpointAddress}:${ctx.attrs.endpointPort ?? ""}`,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "engine",
+        value:
+          ctx.attrs?.engine === undefined
+            ? undefined
+            : `${ctx.attrs.engine}${ctx.attrs.engineVersion ? ` ${ctx.attrs.engineVersion}` : ""}`,
+      },
+      { label: "class", value: ctx.attrs?.dbInstanceClass },
+      { label: "status", value: ctx.attrs?.status },
+      { label: "multi-az", value: ctx.attrs?.multiAZ },
+      {
+        label: "storage",
+        value:
+          ctx.attrs?.allocatedStorage === undefined
+            ? undefined
+            : `${ctx.attrs.allocatedStorage} GiB${ctx.attrs.storageType ? ` (${ctx.attrs.storageType})` : ""}`,
+      },
+    ],
+  },
+);
+
+export const DBClusterUI = UIProvider.succeed<DBCluster>("AWS.RDS.DBCluster", {
+  displayName: "RDS Cluster",
+  icon: "database-zap",
+  color: RDS_COLOR,
+  category: "database",
+  summary: (ctx) => ctx.attrs?.dbClusterIdentifier,
+  consoleUrl: (ctx) => {
+    const region = regionOfArn(ctx.attrs?.dbClusterArn);
+    return region === undefined || ctx.attrs?.dbClusterIdentifier === undefined
+      ? undefined
+      : `https://${region}.console.aws.amazon.com/rds/home?region=${region}#database:id=${ctx.attrs.dbClusterIdentifier};is-cluster=true`;
+  },
+  facts: (ctx) => [
+    { label: "identifier", value: ctx.attrs?.dbClusterIdentifier, copy: true },
+    { label: "arn", value: ctx.attrs?.dbClusterArn, mono: true, copy: true },
+    { label: "endpoint", value: ctx.attrs?.endpoint, mono: true, copy: true },
+    {
+      label: "reader endpoint",
+      value: ctx.attrs?.readerEndpoint,
+      mono: true,
+      copy: true,
+    },
+    {
+      label: "engine",
+      value:
+        ctx.attrs?.engine === undefined
+          ? undefined
+          : `${ctx.attrs.engine}${ctx.attrs.engineVersion ? ` ${ctx.attrs.engineVersion}` : ""}`,
+    },
+    { label: "status", value: ctx.attrs?.status },
+    { label: "database", value: ctx.attrs?.databaseName },
+    { label: "members", value: ctx.attrs?.dbClusterMembers?.length },
+  ],
+});
+
+export const DBClusterEndpointUI = UIProvider.succeed<DBClusterEndpoint>(
+  "AWS.RDS.DBClusterEndpoint",
+  {
+    displayName: "RDS Cluster Endpoint",
+    icon: "plug",
+    color: RDS_COLOR,
+    category: "database",
+    summary: (ctx) => ctx.attrs?.dbClusterEndpointIdentifier,
+    facts: (ctx) => [
+      {
+        label: "identifier",
+        value: ctx.attrs?.dbClusterEndpointIdentifier,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.dbClusterEndpointArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "endpoint", value: ctx.attrs?.endpoint, mono: true, copy: true },
+      { label: "cluster", value: ctx.attrs?.dbClusterIdentifier },
+      {
+        label: "type",
+        value: ctx.attrs?.customEndpointType ?? ctx.attrs?.endpointType,
+      },
+      { label: "status", value: ctx.attrs?.status },
+    ],
+  },
+);
+
+export const DBClusterParameterGroupUI =
+  UIProvider.succeed<DBClusterParameterGroup>(
+    "AWS.RDS.DBClusterParameterGroup",
+    {
+      displayName: "RDS Cluster Parameter Group",
+      icon: "settings-2",
+      color: RDS_COLOR,
+      category: "config",
+      summary: (ctx) => ctx.attrs?.dbClusterParameterGroupName,
+      consoleUrl: (ctx) => {
+        const region = regionOfArn(ctx.attrs?.dbClusterParameterGroupArn);
+        return region === undefined ||
+          ctx.attrs?.dbClusterParameterGroupName === undefined
+          ? undefined
+          : `https://${region}.console.aws.amazon.com/rds/home?region=${region}#parameter-group-details:parameter-group-name=${ctx.attrs.dbClusterParameterGroupName}`;
+      },
+      facts: (ctx) => [
+        {
+          label: "name",
+          value: ctx.attrs?.dbClusterParameterGroupName,
+          copy: true,
+        },
+        {
+          label: "arn",
+          value: ctx.attrs?.dbClusterParameterGroupArn,
+          mono: true,
+          copy: true,
+        },
+        { label: "family", value: ctx.attrs?.family },
+        { label: "description", value: ctx.attrs?.description },
+      ],
+    },
+  );
+
+export const DBParameterGroupUI = UIProvider.succeed<DBParameterGroup>(
+  "AWS.RDS.DBParameterGroup",
+  {
+    displayName: "RDS Parameter Group",
+    icon: "settings-2",
+    color: RDS_COLOR,
+    category: "config",
+    summary: (ctx) => ctx.attrs?.dbParameterGroupName,
+    consoleUrl: (ctx) => {
+      const region = regionOfArn(ctx.attrs?.dbParameterGroupArn);
+      return region === undefined ||
+        ctx.attrs?.dbParameterGroupName === undefined
+        ? undefined
+        : `https://${region}.console.aws.amazon.com/rds/home?region=${region}#parameter-group-details:parameter-group-name=${ctx.attrs.dbParameterGroupName}`;
+    },
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.dbParameterGroupName, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.dbParameterGroupArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "family", value: ctx.attrs?.family },
+      { label: "description", value: ctx.attrs?.description },
+    ],
+  },
+);
+
+export const DBProxyUI = UIProvider.succeed<DBProxy>("AWS.RDS.DBProxy", {
+  displayName: "RDS Proxy",
+  icon: "waypoints",
+  color: RDS_COLOR,
+  category: "database",
+  summary: (ctx) => ctx.attrs?.dbProxyName,
+  consoleUrl: (ctx) => {
+    const region = regionOfArn(ctx.attrs?.dbProxyArn);
+    return region === undefined || ctx.attrs?.dbProxyName === undefined
+      ? undefined
+      : `https://${region}.console.aws.amazon.com/rds/home?region=${region}#proxy:id=${ctx.attrs.dbProxyName}`;
+  },
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.dbProxyName, copy: true },
+    { label: "arn", value: ctx.attrs?.dbProxyArn, mono: true, copy: true },
+    { label: "endpoint", value: ctx.attrs?.endpoint, mono: true, copy: true },
+    { label: "engine family", value: ctx.attrs?.engineFamily },
+    { label: "status", value: ctx.attrs?.status },
+    { label: "require tls", value: ctx.attrs?.requireTLS },
+    { label: "vpc", value: ctx.attrs?.vpcId, mono: true },
+  ],
+});
+
+export const DBProxyEndpointUI = UIProvider.succeed<DBProxyEndpoint>(
+  "AWS.RDS.DBProxyEndpoint",
+  {
+    displayName: "RDS Proxy Endpoint",
+    icon: "plug-zap",
+    color: RDS_COLOR,
+    category: "database",
+    summary: (ctx) => ctx.attrs?.dbProxyEndpointName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.dbProxyEndpointName, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.dbProxyEndpointArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "endpoint", value: ctx.attrs?.endpoint, mono: true, copy: true },
+      { label: "proxy", value: ctx.attrs?.dbProxyName },
+      { label: "target role", value: ctx.attrs?.targetRole },
+      { label: "status", value: ctx.attrs?.status },
+    ],
+  },
+);
+
+export const DBProxyTargetGroupUI = UIProvider.succeed<DBProxyTargetGroup>(
+  "AWS.RDS.DBProxyTargetGroup",
+  {
+    displayName: "RDS Proxy Target Group",
+    icon: "target",
+    color: RDS_COLOR,
+    category: "database",
+    summary: (ctx) => ctx.attrs?.targetGroupName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.targetGroupName, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.targetGroupArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "proxy", value: ctx.attrs?.dbProxyName },
+      { label: "status", value: ctx.attrs?.status },
+      { label: "default", value: ctx.attrs?.isDefault },
+      {
+        label: "targets",
+        value:
+          ctx.attrs?.dbClusterIdentifiers === undefined &&
+          ctx.attrs?.dbInstanceIdentifiers === undefined
+            ? undefined
+            : [
+                ...(ctx.attrs?.dbClusterIdentifiers ?? []),
+                ...(ctx.attrs?.dbInstanceIdentifiers ?? []),
+              ].join(", ") || undefined,
+      },
+    ],
+  },
+);
+
+export const DBSubnetGroupUI = UIProvider.succeed<DBSubnetGroup>(
+  "AWS.RDS.DBSubnetGroup",
+  {
+    displayName: "RDS Subnet Group",
+    icon: "network",
+    color: RDS_COLOR,
+    category: "network",
+    summary: (ctx) => ctx.attrs?.dbSubnetGroupName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.dbSubnetGroupName, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.dbSubnetGroupArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "vpc", value: ctx.attrs?.vpcId, mono: true },
+      { label: "subnets", value: ctx.attrs?.subnetIds?.join(", "), mono: true },
+      { label: "status", value: ctx.attrs?.status },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(
+    DBInstanceUI,
+    DBClusterUI,
+    DBClusterEndpointUI,
+    DBClusterParameterGroupUI,
+    DBParameterGroupUI,
+    DBProxyUI,
+    DBProxyEndpointUI,
+    DBProxyTargetGroupUI,
+    DBSubnetGroupUI,
+  );

--- a/packages/alchemy/src/AWS/RUM/ui.ts
+++ b/packages/alchemy/src/AWS/RUM/ui.ts
@@ -1,0 +1,71 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { AppMonitor } from "./AppMonitor.ts";
+import type { MetricsDestination } from "./MetricsDestination.ts";
+import type { ResourcePolicy } from "./ResourcePolicy.ts";
+
+/**
+ * Dashboard UI providers for AWS RUM resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** AWS management & governance / observability brand pink. */
+const COLOR = "#E7157B";
+
+export const AppMonitorUI = UIProvider.succeed<AppMonitor>(
+  "AWS.RUM.AppMonitor",
+  {
+    displayName: "RUM App Monitor",
+    icon: "activity",
+    color: COLOR,
+    category: "observability",
+    summary: (ctx) => ctx.attrs?.appMonitorName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.appMonitorName, copy: true },
+      { label: "id", value: ctx.attrs?.appMonitorId, mono: true, copy: true },
+      { label: "arn", value: ctx.attrs?.appMonitorArn, mono: true, copy: true },
+      { label: "domain", value: ctx.props?.domain },
+    ],
+  },
+);
+
+export const MetricsDestinationUI = UIProvider.succeed<MetricsDestination>(
+  "AWS.RUM.MetricsDestination",
+  {
+    displayName: "RUM Metrics Destination",
+    icon: "chart-line",
+    color: COLOR,
+    category: "observability",
+    summary: (ctx) => ctx.attrs?.destination,
+    facts: (ctx) => [
+      { label: "app monitor", value: ctx.attrs?.appMonitorName, copy: true },
+      { label: "destination", value: ctx.attrs?.destination },
+      {
+        label: "destination arn",
+        value: ctx.attrs?.destinationArn,
+        mono: true,
+      },
+      { label: "iam role", value: ctx.attrs?.iamRoleArn, mono: true },
+    ],
+  },
+);
+
+export const ResourcePolicyUI = UIProvider.succeed<ResourcePolicy>(
+  "AWS.RUM.ResourcePolicy",
+  {
+    displayName: "RUM Resource Policy",
+    icon: "lock",
+    color: COLOR,
+    category: "observability",
+    summary: (ctx) => ctx.attrs?.appMonitorName,
+    facts: (ctx) => [
+      { label: "app monitor", value: ctx.attrs?.appMonitorName, copy: true },
+      { label: "revision", value: ctx.attrs?.policyRevisionId, mono: true },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(AppMonitorUI, MetricsDestinationUI, ResourcePolicyUI);

--- a/packages/alchemy/src/AWS/Rbin/ui.ts
+++ b/packages/alchemy/src/AWS/Rbin/ui.ts
@@ -1,0 +1,27 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Rule } from "./Rule.ts";
+
+/**
+ * Dashboard UI providers for AWS Rbin (Recycle Bin) resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+export const RuleUI = UIProvider.succeed<Rule>("AWS.Rbin.Rule", {
+  displayName: "Recycle Bin Rule",
+  icon: "trash-2",
+  color: "#7AA116",
+  category: "storage",
+  summary: (ctx) => ctx.attrs?.resourceType,
+  facts: (ctx) => [
+    { label: "id", value: ctx.attrs?.identifier, mono: true, copy: true },
+    { label: "arn", value: ctx.attrs?.ruleArn, mono: true, copy: true },
+    { label: "resource type", value: ctx.attrs?.resourceType },
+    { label: "status", value: ctx.attrs?.status },
+    { label: "lock", value: ctx.attrs?.lockState },
+  ],
+});
+
+export const ui = () => Layer.mergeAll(RuleUI);

--- a/packages/alchemy/src/AWS/RePostSpace/ui.ts
+++ b/packages/alchemy/src/AWS/RePostSpace/ui.ts
@@ -1,0 +1,37 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Space } from "./Space.ts";
+
+/**
+ * Dashboard UI providers for AWS re:Post Private resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+export const SpaceUI = UIProvider.succeed<Space>("AWS.RePostSpace.Space", {
+  displayName: "re:Post Private Space",
+  icon: "book-open",
+  color: "#E7157B",
+  category: "other",
+  summary: (ctx) => ctx.attrs?.name,
+  link: (ctx) =>
+    ctx.attrs?.vanityDomain === undefined
+      ? undefined
+      : `https://${ctx.attrs.vanityDomain}`,
+  facts: (ctx) => [
+    { label: "space", value: ctx.attrs?.name, copy: true },
+    { label: "id", value: ctx.attrs?.spaceId, mono: true, copy: true },
+    { label: "arn", value: ctx.attrs?.spaceArn, mono: true, copy: true },
+    { label: "status", value: ctx.attrs?.status },
+    { label: "tier", value: ctx.attrs?.tier },
+    {
+      label: "domain",
+      value: ctx.attrs?.vanityDomain,
+      mono: true,
+      copy: true,
+    },
+  ],
+});
+
+export const ui = () => Layer.mergeAll(SpaceUI);

--- a/packages/alchemy/src/AWS/Redshift/ui.ts
+++ b/packages/alchemy/src/AWS/Redshift/ui.ts
@@ -1,0 +1,141 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Cluster } from "./Cluster.ts";
+import type { ClusterParameterGroup } from "./ClusterParameterGroup.ts";
+import type { ClusterSubnetGroup } from "./ClusterSubnetGroup.ts";
+import type { EventSubscription } from "./EventSubscription.ts";
+
+/**
+ * Dashboard UI providers for AWS Redshift resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** AWS Analytics brand purple. */
+const COLOR = "#8C4FFF";
+
+const regionOf = (arn: string | undefined): string | undefined =>
+  arn?.split(":")[3] || undefined;
+
+export const ClusterUI = UIProvider.succeed<Cluster>("AWS.Redshift.Cluster", {
+  displayName: "Redshift Cluster",
+  icon: "database",
+  color: COLOR,
+  category: "database",
+  summary: (ctx) => ctx.attrs?.clusterIdentifier,
+  consoleUrl: (ctx) => {
+    const region = regionOf(ctx.attrs?.clusterArn);
+    return region === undefined || ctx.attrs?.clusterIdentifier === undefined
+      ? undefined
+      : `https://${region}.console.aws.amazon.com/redshiftv2/home?region=${region}#cluster-details?cluster=${ctx.attrs.clusterIdentifier}`;
+  },
+  facts: (ctx) => [
+    { label: "cluster", value: ctx.attrs?.clusterIdentifier, copy: true },
+    { label: "arn", value: ctx.attrs?.clusterArn, mono: true, copy: true },
+    { label: "status", value: ctx.attrs?.clusterStatus },
+    { label: "node type", value: ctx.attrs?.nodeType },
+    { label: "nodes", value: ctx.attrs?.numberOfNodes },
+    {
+      label: "endpoint",
+      value: ctx.attrs?.endpointAddress
+        ? `${ctx.attrs.endpointAddress}:${ctx.attrs.endpointPort ?? ""}`
+        : undefined,
+      mono: true,
+      copy: true,
+    },
+    { label: "database", value: ctx.attrs?.dbName },
+  ],
+});
+
+export const ClusterParameterGroupUI =
+  UIProvider.succeed<ClusterParameterGroup>(
+    "AWS.Redshift.ClusterParameterGroup",
+    {
+      displayName: "Redshift Cluster Parameter Group",
+      icon: "settings",
+      color: COLOR,
+      category: "config",
+      summary: (ctx) => ctx.attrs?.clusterParameterGroupName,
+      facts: (ctx) => [
+        {
+          label: "group",
+          value: ctx.attrs?.clusterParameterGroupName,
+          copy: true,
+        },
+        {
+          label: "arn",
+          value: ctx.attrs?.clusterParameterGroupArn,
+          mono: true,
+          copy: true,
+        },
+        { label: "family", value: ctx.attrs?.family },
+        { label: "description", value: ctx.attrs?.description },
+      ],
+    },
+  );
+
+export const ClusterSubnetGroupUI = UIProvider.succeed<ClusterSubnetGroup>(
+  "AWS.Redshift.ClusterSubnetGroup",
+  {
+    displayName: "Redshift Cluster Subnet Group",
+    icon: "network",
+    color: COLOR,
+    category: "network",
+    summary: (ctx) => ctx.attrs?.clusterSubnetGroupName,
+    facts: (ctx) => [
+      {
+        label: "group",
+        value: ctx.attrs?.clusterSubnetGroupName,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.clusterSubnetGroupArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "vpc", value: ctx.attrs?.vpcId, mono: true },
+      {
+        label: "subnets",
+        value: ctx.attrs?.subnetIds?.length
+          ? ctx.attrs.subnetIds.join(", ")
+          : undefined,
+        mono: true,
+      },
+      { label: "status", value: ctx.attrs?.subnetGroupStatus },
+    ],
+  },
+);
+
+export const EventSubscriptionUI = UIProvider.succeed<EventSubscription>(
+  "AWS.Redshift.EventSubscription",
+  {
+    displayName: "Redshift Event Subscription",
+    icon: "bell",
+    color: COLOR,
+    category: "eventing",
+    summary: (ctx) => ctx.attrs?.subscriptionName,
+    facts: (ctx) => [
+      { label: "subscription", value: ctx.attrs?.subscriptionName, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.eventSubscriptionArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "topic", value: ctx.attrs?.snsTopicArn, mono: true },
+      { label: "status", value: ctx.attrs?.status },
+      { label: "source type", value: ctx.attrs?.sourceType },
+      { label: "enabled", value: ctx.attrs?.enabled },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(
+    ClusterUI,
+    ClusterParameterGroupUI,
+    ClusterSubnetGroupUI,
+    EventSubscriptionUI,
+  );

--- a/packages/alchemy/src/AWS/RedshiftServerless/ui.ts
+++ b/packages/alchemy/src/AWS/RedshiftServerless/ui.ts
@@ -1,0 +1,79 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Namespace } from "./Namespace.ts";
+import type { Workgroup } from "./Workgroup.ts";
+
+/**
+ * Dashboard UI providers for AWS RedshiftServerless resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+const COLOR = "#C925D1";
+
+export const NamespaceUI = UIProvider.succeed<Namespace>(
+  "AWS.RedshiftServerless.Namespace",
+  {
+    displayName: "Redshift Serverless Namespace",
+    icon: "database",
+    color: COLOR,
+    category: "database",
+    summary: (ctx) => ctx.attrs?.namespaceName,
+    facts: (ctx) => [
+      { label: "namespace", value: ctx.attrs?.namespaceName, copy: true },
+      {
+        label: "id",
+        value: ctx.attrs?.namespaceId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.namespaceArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "db name", value: ctx.attrs?.dbName },
+      { label: "status", value: ctx.attrs?.status },
+      {
+        label: "admin secret",
+        value: ctx.attrs?.adminPasswordSecretArn,
+        mono: true,
+        copy: true,
+      },
+    ],
+  },
+);
+
+export const WorkgroupUI = UIProvider.succeed<Workgroup>(
+  "AWS.RedshiftServerless.Workgroup",
+  {
+    displayName: "Redshift Serverless Workgroup",
+    icon: "cpu",
+    color: COLOR,
+    category: "database",
+    summary: (ctx) => ctx.attrs?.workgroupName,
+    facts: (ctx) => [
+      { label: "workgroup", value: ctx.attrs?.workgroupName, copy: true },
+      {
+        label: "id",
+        value: ctx.attrs?.workgroupId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.workgroupArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "namespace", value: ctx.attrs?.namespaceName, mono: true },
+      { label: "status", value: ctx.attrs?.status },
+      { label: "endpoint", value: ctx.attrs?.endpointAddress, mono: true },
+      { label: "port", value: ctx.attrs?.endpointPort },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(NamespaceUI, WorkgroupUI);

--- a/packages/alchemy/src/AWS/ResourceExplorer/ui.ts
+++ b/packages/alchemy/src/AWS/ResourceExplorer/ui.ts
@@ -1,0 +1,42 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Index } from "./ExplorerIndex.ts";
+import type { View } from "./View.ts";
+
+/**
+ * Dashboard UI providers for AWS Resource Explorer resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** AWS Management & Governance brand pink. */
+const COLOR = "#E7157B";
+
+export const IndexUI = UIProvider.succeed<Index>("AWS.ResourceExplorer.Index", {
+  displayName: "Resource Explorer Index",
+  icon: "database",
+  color: COLOR,
+  category: "config",
+  summary: (ctx) => ctx.attrs?.indexType,
+  facts: (ctx) => [
+    { label: "arn", value: ctx.attrs?.indexArn, mono: true, copy: true },
+    { label: "type", value: ctx.attrs?.indexType },
+    { label: "state", value: ctx.attrs?.indexState },
+  ],
+});
+
+export const ViewUI = UIProvider.succeed<View>("AWS.ResourceExplorer.View", {
+  displayName: "Resource Explorer View",
+  icon: "search",
+  color: COLOR,
+  category: "config",
+  summary: (ctx) => ctx.attrs?.viewName,
+  facts: (ctx) => [
+    { label: "view", value: ctx.attrs?.viewName, copy: true },
+    { label: "arn", value: ctx.attrs?.viewArn, mono: true, copy: true },
+    { label: "scope", value: ctx.attrs?.scope, mono: true },
+  ],
+});
+
+export const ui = () => Layer.mergeAll(IndexUI, ViewUI);

--- a/packages/alchemy/src/AWS/ResourceGroups/ui.ts
+++ b/packages/alchemy/src/AWS/ResourceGroups/ui.ts
@@ -1,0 +1,26 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Group } from "./Group.ts";
+
+/**
+ * Dashboard UI providers for AWS ResourceGroups resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+export const GroupUI = UIProvider.succeed<Group>("AWS.ResourceGroups.Group", {
+  displayName: "Resource Group",
+  icon: "boxes",
+  color: "#E7157B",
+  category: "config",
+  summary: (ctx) => ctx.attrs?.groupName,
+  facts: (ctx) => [
+    { label: "group", value: ctx.attrs?.groupName, copy: true },
+    { label: "arn", value: ctx.attrs?.groupArn, mono: true, copy: true },
+    { label: "description", value: ctx.props?.description },
+    { label: "query type", value: ctx.props?.resourceQuery?.type },
+  ],
+});
+
+export const ui = () => Layer.mergeAll(GroupUI);

--- a/packages/alchemy/src/AWS/RolesAnywhere/ui.ts
+++ b/packages/alchemy/src/AWS/RolesAnywhere/ui.ts
@@ -1,0 +1,95 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Crl } from "./Crl.ts";
+import type { Profile } from "./Profile.ts";
+import type { TrustAnchor } from "./TrustAnchor.ts";
+
+/**
+ * Dashboard UI providers for AWS RolesAnywhere resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+const COLOR = "#DD344C";
+
+export const TrustAnchorUI = UIProvider.succeed<TrustAnchor>(
+  "AWS.RolesAnywhere.TrustAnchor",
+  {
+    displayName: "Roles Anywhere Trust Anchor",
+    icon: "shield-check",
+    color: COLOR,
+    category: "auth",
+    summary: (ctx) => ctx.attrs?.trustAnchorName,
+    facts: (ctx) => [
+      {
+        label: "trust anchor",
+        value: ctx.attrs?.trustAnchorName,
+        copy: true,
+      },
+      {
+        label: "id",
+        value: ctx.attrs?.trustAnchorId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.trustAnchorArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "enabled", value: ctx.attrs?.enabled },
+    ],
+  },
+);
+
+export const ProfileUI = UIProvider.succeed<Profile>(
+  "AWS.RolesAnywhere.Profile",
+  {
+    displayName: "Roles Anywhere Profile",
+    icon: "user",
+    color: COLOR,
+    category: "auth",
+    summary: (ctx) => ctx.attrs?.profileName,
+    facts: (ctx) => [
+      { label: "profile", value: ctx.attrs?.profileName, copy: true },
+      { label: "id", value: ctx.attrs?.profileId, mono: true, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.profileArn,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "roles",
+        value: ctx.attrs?.roleArns?.length
+          ? ctx.attrs.roleArns.join(", ")
+          : undefined,
+        mono: true,
+      },
+      { label: "enabled", value: ctx.attrs?.enabled },
+    ],
+  },
+);
+
+export const CrlUI = UIProvider.succeed<Crl>("AWS.RolesAnywhere.Crl", {
+  displayName: "Roles Anywhere CRL",
+  icon: "shield",
+  color: COLOR,
+  category: "security",
+  summary: (ctx) => ctx.attrs?.crlName,
+  facts: (ctx) => [
+    { label: "crl", value: ctx.attrs?.crlName, copy: true },
+    { label: "id", value: ctx.attrs?.crlId, mono: true, copy: true },
+    { label: "arn", value: ctx.attrs?.crlArn, mono: true, copy: true },
+    {
+      label: "trust anchor",
+      value: ctx.attrs?.trustAnchorArn,
+      mono: true,
+    },
+    { label: "enabled", value: ctx.attrs?.enabled },
+  ],
+});
+
+export const ui = () => Layer.mergeAll(TrustAnchorUI, ProfileUI, CrlUI);

--- a/packages/alchemy/src/AWS/Route53/ui.ts
+++ b/packages/alchemy/src/AWS/Route53/ui.ts
@@ -1,0 +1,260 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { HealthCheck } from "./HealthCheck.ts";
+import type { HostedZone } from "./HostedZone.ts";
+import type { QueryLoggingConfig } from "./QueryLoggingConfig.ts";
+import type { Record } from "./Record.ts";
+import type { Records } from "./Records.ts";
+import type { VpcAssociationAuthorization } from "./VpcAssociationAuthorization.ts";
+import type { ZoneVpcAssociation } from "./ZoneVpcAssociation.ts";
+
+/**
+ * Dashboard UI providers for AWS Route 53 resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** AWS Networking & Content Delivery brand purple. */
+const COLOR = "#8C4FFF";
+
+export const HostedZoneUI = UIProvider.succeed<HostedZone>(
+  "AWS.Route53.HostedZone",
+  {
+    displayName: "Route 53 Hosted Zone",
+    icon: "globe",
+    color: COLOR,
+    category: "dns",
+    summary: (ctx) => ctx.attrs?.name,
+    consoleUrl: (ctx) =>
+      ctx.attrs?.id === undefined
+        ? undefined
+        : `https://console.aws.amazon.com/route53/v2/hostedzones#ListRecordSets/${ctx.attrs.id}`,
+    facts: (ctx) => [
+      { label: "zone", value: ctx.attrs?.name, copy: true },
+      { label: "zone id", value: ctx.attrs?.id, mono: true, copy: true },
+      {
+        label: "name servers",
+        value: ctx.attrs?.nameServers?.join(", "),
+        mono: true,
+        copy: true,
+      },
+      { label: "comment", value: ctx.attrs?.comment },
+    ],
+  },
+);
+
+export const RecordUI = UIProvider.succeed<Record>("AWS.Route53.Record", {
+  displayName: "Route 53 Record",
+  icon: "list",
+  color: COLOR,
+  category: "dns",
+  summary: (ctx) =>
+    ctx.attrs?.name === undefined
+      ? undefined
+      : `${ctx.attrs.name} ${ctx.attrs.type ?? ""}`.trim(),
+  consoleUrl: (ctx) =>
+    ctx.attrs?.hostedZoneId === undefined
+      ? undefined
+      : `https://console.aws.amazon.com/route53/v2/hostedzones#ListRecordSets/${ctx.attrs.hostedZoneId}`,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.name, mono: true, copy: true },
+    { label: "type", value: ctx.attrs?.type, mono: true },
+    { label: "ttl", value: ctx.attrs?.ttl },
+    {
+      label: "values",
+      value: ctx.attrs?.records?.join(", "),
+      mono: true,
+      copy: true,
+    },
+    {
+      label: "alias target",
+      value: ctx.attrs?.aliasTarget?.dnsName,
+      mono: true,
+    },
+    {
+      label: "zone id",
+      value: ctx.attrs?.hostedZoneId,
+      mono: true,
+      copy: true,
+    },
+    { label: "set identifier", value: ctx.attrs?.setIdentifier, mono: true },
+    {
+      label: "routing",
+      value:
+        ctx.attrs?.weight !== undefined
+          ? `weighted (${ctx.attrs.weight})`
+          : ctx.attrs?.failover !== undefined
+            ? `failover (${ctx.attrs.failover})`
+            : ctx.attrs?.region !== undefined
+              ? `latency (${ctx.attrs.region})`
+              : ctx.attrs?.multiValueAnswer
+                ? "multivalue"
+                : ctx.attrs?.geoLocation !== undefined
+                  ? "geolocation"
+                  : ctx.attrs?.geoProximityLocation !== undefined
+                    ? "geoproximity"
+                    : ctx.attrs?.cidrRoutingConfig !== undefined
+                      ? "ip-based"
+                      : undefined,
+    },
+  ],
+});
+
+export const RecordsUI = UIProvider.succeed<Records>("AWS.Route53.Records", {
+  displayName: "Route 53 Records",
+  icon: "list",
+  color: COLOR,
+  category: "dns",
+  summary: (ctx) =>
+    ctx.attrs?.names === undefined || ctx.attrs.names.length === 0
+      ? ctx.attrs?.type
+      : `${ctx.attrs.names[0]}${ctx.attrs.names.length > 1 ? ` +${ctx.attrs.names.length - 1}` : ""} ${ctx.attrs.type ?? ""}`.trim(),
+  consoleUrl: (ctx) =>
+    ctx.attrs?.hostedZoneId === undefined
+      ? undefined
+      : `https://console.aws.amazon.com/route53/v2/hostedzones#ListRecordSets/${ctx.attrs.hostedZoneId}`,
+  facts: (ctx) => [
+    {
+      label: "names",
+      value: ctx.attrs?.names?.join(", "),
+      mono: true,
+      copy: true,
+    },
+    { label: "type", value: ctx.attrs?.type, mono: true },
+    { label: "ttl", value: ctx.attrs?.ttl },
+    {
+      label: "values",
+      value: ctx.attrs?.records?.join(", "),
+      mono: true,
+      copy: true,
+    },
+    {
+      label: "alias target",
+      value: ctx.attrs?.aliasTarget?.dnsName,
+      mono: true,
+    },
+    {
+      label: "zone id",
+      value: ctx.attrs?.hostedZoneId,
+      mono: true,
+      copy: true,
+    },
+  ],
+});
+
+export const HealthCheckUI = UIProvider.succeed<HealthCheck>(
+  "AWS.Route53.HealthCheck",
+  {
+    displayName: "Route 53 Health Check",
+    icon: "heart-pulse",
+    color: COLOR,
+    category: "dns",
+    summary: (ctx) => ctx.attrs?.id,
+    facts: (ctx) => [
+      {
+        label: "health check id",
+        value: ctx.attrs?.healthCheckId,
+        mono: true,
+        copy: true,
+      },
+      { label: "type", value: ctx.attrs?.type },
+      {
+        label: "endpoint",
+        value:
+          (ctx.props?.fullyQualifiedDomainName ?? ctx.props?.ipAddress)
+            ? `${ctx.props?.fullyQualifiedDomainName ?? ctx.props?.ipAddress}${ctx.props?.port ? `:${ctx.props.port}` : ""}`
+            : undefined,
+        mono: true,
+      },
+      { label: "path", value: ctx.props?.resourcePath, mono: true },
+    ],
+  },
+);
+
+export const QueryLoggingConfigUI = UIProvider.succeed<QueryLoggingConfig>(
+  "AWS.Route53.QueryLoggingConfig",
+  {
+    displayName: "Route 53 Query Logging Config",
+    icon: "scroll-text",
+    color: COLOR,
+    category: "dns",
+    summary: (ctx) => ctx.attrs?.hostedZoneId,
+    consoleUrl: (ctx) =>
+      ctx.attrs?.hostedZoneId === undefined
+        ? undefined
+        : `https://console.aws.amazon.com/route53/v2/hostedzones#ListRecordSets/${ctx.attrs.hostedZoneId}`,
+    facts: (ctx) => [
+      { label: "id", value: ctx.attrs?.id, mono: true, copy: true },
+      {
+        label: "zone id",
+        value: ctx.attrs?.hostedZoneId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "log group",
+        value: ctx.attrs?.cloudWatchLogsLogGroupArn,
+        mono: true,
+      },
+    ],
+  },
+);
+
+export const VpcAssociationAuthorizationUI =
+  UIProvider.succeed<VpcAssociationAuthorization>(
+    "AWS.Route53.VpcAssociationAuthorization",
+    {
+      displayName: "Route 53 VPC Association Authorization",
+      icon: "key-round",
+      color: COLOR,
+      category: "auth",
+      summary: (ctx) => ctx.attrs?.vpcId,
+      facts: (ctx) => [
+        {
+          label: "zone id",
+          value: ctx.attrs?.hostedZoneId,
+          mono: true,
+          copy: true,
+        },
+        { label: "vpc", value: ctx.attrs?.vpcId, mono: true, copy: true },
+        { label: "region", value: ctx.attrs?.vpcRegion },
+      ],
+    },
+  );
+
+export const ZoneVpcAssociationUI = UIProvider.succeed<ZoneVpcAssociation>(
+  "AWS.Route53.ZoneVpcAssociation",
+  {
+    displayName: "Route 53 Zone VPC Association",
+    icon: "link",
+    color: COLOR,
+    category: "dns",
+    summary: (ctx) => ctx.attrs?.vpcId,
+    consoleUrl: (ctx) =>
+      ctx.attrs?.hostedZoneId === undefined
+        ? undefined
+        : `https://console.aws.amazon.com/route53/v2/hostedzones#ListRecordSets/${ctx.attrs.hostedZoneId}`,
+    facts: (ctx) => [
+      {
+        label: "zone id",
+        value: ctx.attrs?.hostedZoneId,
+        mono: true,
+        copy: true,
+      },
+      { label: "vpc", value: ctx.attrs?.vpcId, mono: true, copy: true },
+      { label: "region", value: ctx.attrs?.vpcRegion },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(
+    HostedZoneUI,
+    RecordUI,
+    RecordsUI,
+    HealthCheckUI,
+    QueryLoggingConfigUI,
+    VpcAssociationAuthorizationUI,
+    ZoneVpcAssociationUI,
+  );

--- a/packages/alchemy/src/AWS/Route53Profiles/ui.ts
+++ b/packages/alchemy/src/AWS/Route53Profiles/ui.ts
@@ -1,0 +1,87 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Profile } from "./Profile.ts";
+import type { ProfileAssociation } from "./ProfileAssociation.ts";
+import type { ProfileResourceAssociation } from "./ProfileResourceAssociation.ts";
+
+/**
+ * Dashboard UI providers for AWS Route 53 Profiles resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** Route 53 brand color (AWS Networking & Content Delivery purple). */
+const ROUTE53_PROFILES_COLOR = "#8C4FFF";
+
+export const ProfileUI = UIProvider.succeed<Profile>(
+  "AWS.Route53Profiles.Profile",
+  {
+    displayName: "Route 53 Profile",
+    icon: "route",
+    color: ROUTE53_PROFILES_COLOR,
+    category: "dns",
+    summary: (ctx) => ctx.attrs?.profileName,
+    facts: (ctx) => [
+      { label: "profile", value: ctx.attrs?.profileName, copy: true },
+      { label: "id", value: ctx.attrs?.profileId, mono: true, copy: true },
+      { label: "arn", value: ctx.attrs?.profileArn, mono: true, copy: true },
+    ],
+  },
+);
+
+export const ProfileAssociationUI = UIProvider.succeed<ProfileAssociation>(
+  "AWS.Route53Profiles.ProfileAssociation",
+  {
+    displayName: "Route 53 Profile Association",
+    icon: "link",
+    color: ROUTE53_PROFILES_COLOR,
+    category: "dns",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      {
+        label: "association",
+        value: ctx.attrs?.profileAssociationId,
+        mono: true,
+        copy: true,
+      },
+      { label: "profile", value: ctx.attrs?.profileId, mono: true },
+      { label: "vpc", value: ctx.attrs?.resourceId, mono: true, copy: true },
+      { label: "name", value: ctx.attrs?.name },
+      { label: "status", value: ctx.attrs?.status },
+    ],
+  },
+);
+
+export const ProfileResourceAssociationUI =
+  UIProvider.succeed<ProfileResourceAssociation>(
+    "AWS.Route53Profiles.ProfileResourceAssociation",
+    {
+      displayName: "Route 53 Profile Resource Association",
+      icon: "cable",
+      color: ROUTE53_PROFILES_COLOR,
+      category: "dns",
+      summary: (ctx) => ctx.attrs?.name,
+      facts: (ctx) => [
+        {
+          label: "association",
+          value: ctx.attrs?.profileResourceAssociationId,
+          mono: true,
+          copy: true,
+        },
+        { label: "profile", value: ctx.attrs?.profileId, mono: true },
+        {
+          label: "resource arn",
+          value: ctx.attrs?.resourceArn,
+          mono: true,
+          copy: true,
+        },
+        { label: "resource type", value: ctx.attrs?.resourceType },
+        { label: "name", value: ctx.attrs?.name },
+        { label: "status", value: ctx.attrs?.status },
+      ],
+    },
+  );
+
+export const ui = () =>
+  Layer.mergeAll(ProfileUI, ProfileAssociationUI, ProfileResourceAssociationUI);

--- a/packages/alchemy/src/AWS/Route53Resolver/ui.ts
+++ b/packages/alchemy/src/AWS/Route53Resolver/ui.ts
@@ -1,0 +1,96 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { ResolverEndpoint } from "./ResolverEndpoint.ts";
+import type { ResolverRule } from "./ResolverRule.ts";
+import type { ResolverRuleAssociation } from "./ResolverRuleAssociation.ts";
+
+/**
+ * Dashboard UI providers for AWS Route53Resolver resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** AWS Networking & Content Delivery brand purple. */
+const COLOR = "#8C4FFF";
+
+export const ResolverEndpointUI = UIProvider.succeed<ResolverEndpoint>(
+  "AWS.Route53Resolver.ResolverEndpoint",
+  {
+    displayName: "Resolver Endpoint",
+    icon: "route",
+    color: COLOR,
+    category: "dns",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      {
+        label: "endpoint id",
+        value: ctx.attrs?.resolverEndpointId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.resolverEndpointArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "direction", value: ctx.attrs?.direction },
+      { label: "vpc", value: ctx.attrs?.hostVpcId, mono: true },
+    ],
+  },
+);
+
+export const ResolverRuleUI = UIProvider.succeed<ResolverRule>(
+  "AWS.Route53Resolver.ResolverRule",
+  {
+    displayName: "Resolver Rule",
+    icon: "filter",
+    color: COLOR,
+    category: "dns",
+    summary: (ctx) => ctx.attrs?.domainName ?? ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      { label: "domain", value: ctx.attrs?.domainName, mono: true },
+      {
+        label: "rule id",
+        value: ctx.attrs?.resolverRuleId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.resolverRuleArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "type", value: ctx.props?.ruleType },
+    ],
+  },
+);
+
+export const ResolverRuleAssociationUI =
+  UIProvider.succeed<ResolverRuleAssociation>(
+    "AWS.Route53Resolver.ResolverRuleAssociation",
+    {
+      displayName: "Resolver Rule Association",
+      icon: "link-2",
+      color: COLOR,
+      category: "dns",
+      summary: (ctx) => ctx.attrs?.resolverRuleAssociationId,
+      facts: (ctx) => [
+        {
+          label: "association id",
+          value: ctx.attrs?.resolverRuleAssociationId,
+          mono: true,
+          copy: true,
+        },
+        { label: "rule", value: ctx.attrs?.resolverRuleId, mono: true },
+        { label: "vpc", value: ctx.attrs?.vpcId, mono: true },
+      ],
+    },
+  );
+
+export const ui = () =>
+  Layer.mergeAll(ResolverEndpointUI, ResolverRuleUI, ResolverRuleAssociationUI);

--- a/packages/alchemy/src/AWS/S3/ui.ts
+++ b/packages/alchemy/src/AWS/S3/ui.ts
@@ -1,0 +1,36 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Bucket } from "./Bucket.ts";
+
+/**
+ * Dashboard UI providers for AWS S3 resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+export const BucketUI = UIProvider.succeed<Bucket>("AWS.S3.Bucket", {
+  displayName: "S3 Bucket",
+  icon: "cylinder",
+  color: "#7AA116",
+  category: "storage",
+  summary: (ctx) => ctx.attrs?.bucketName,
+  consoleUrl: (ctx) =>
+    ctx.attrs?.bucketName === undefined
+      ? undefined
+      : `https://console.aws.amazon.com/s3/buckets/${ctx.attrs.bucketName}${ctx.attrs.region ? `?region=${ctx.attrs.region}` : ""}`,
+  facts: (ctx) => [
+    { label: "bucket", value: ctx.attrs?.bucketName, copy: true },
+    { label: "arn", value: ctx.attrs?.bucketArn, mono: true, copy: true },
+    { label: "region", value: ctx.attrs?.region },
+    {
+      label: "domain",
+      value: ctx.attrs?.bucketDomainName,
+      href:
+        ctx.attrs?.bucketDomainName === undefined
+          ? undefined
+          : `https://${ctx.attrs.bucketDomainName}`,
+    },
+  ],
+});
+
+export const ui = () => Layer.mergeAll(BucketUI);

--- a/packages/alchemy/src/AWS/S3Control/ui.ts
+++ b/packages/alchemy/src/AWS/S3Control/ui.ts
@@ -1,0 +1,141 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { AccessPoint } from "./AccessPoint.ts";
+import type { AccessPointPolicy } from "./AccessPointPolicy.ts";
+import type { MultiRegionAccessPoint } from "./MultiRegionAccessPoint.ts";
+import type { ObjectLambdaAccessPoint } from "./ObjectLambdaAccessPoint.ts";
+import type { StorageLensConfiguration } from "./StorageLensConfiguration.ts";
+
+/**
+ * Dashboard UI providers for AWS S3Control resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** AWS Storage brand green. */
+const COLOR = "#7AA116";
+
+export const AccessPointUI = UIProvider.succeed<AccessPoint>(
+  "AWS.S3Control.AccessPoint",
+  {
+    displayName: "S3 Access Point",
+    icon: "plug",
+    color: COLOR,
+    category: "storage",
+    summary: (ctx) => ctx.attrs?.accessPointName,
+    facts: (ctx) => [
+      { label: "access point", value: ctx.attrs?.accessPointName, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.accessPointArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "alias", value: ctx.attrs?.alias, mono: true },
+      { label: "bucket", value: ctx.attrs?.bucket },
+      { label: "network origin", value: ctx.attrs?.networkOrigin },
+    ],
+  },
+);
+
+export const AccessPointPolicyUI = UIProvider.succeed<AccessPointPolicy>(
+  "AWS.S3Control.AccessPointPolicy",
+  {
+    displayName: "S3 Access Point Policy",
+    icon: "shield",
+    color: COLOR,
+    category: "storage",
+    summary: (ctx) => ctx.attrs?.accessPointName,
+    facts: (ctx) => [
+      {
+        label: "access point",
+        value: ctx.attrs?.accessPointName,
+        copy: true,
+      },
+    ],
+  },
+);
+
+export const MultiRegionAccessPointUI =
+  UIProvider.succeed<MultiRegionAccessPoint>(
+    "AWS.S3Control.MultiRegionAccessPoint",
+    {
+      displayName: "S3 Multi-Region Access Point",
+      icon: "globe",
+      color: COLOR,
+      category: "storage",
+      summary: (ctx) => ctx.attrs?.multiRegionAccessPointName,
+      facts: (ctx) => [
+        {
+          label: "access point",
+          value: ctx.attrs?.multiRegionAccessPointName,
+          copy: true,
+        },
+        {
+          label: "arn",
+          value: ctx.attrs?.multiRegionAccessPointArn,
+          mono: true,
+          copy: true,
+        },
+        { label: "alias", value: ctx.attrs?.alias, mono: true, copy: true },
+        { label: "status", value: ctx.attrs?.status },
+      ],
+    },
+  );
+
+export const ObjectLambdaAccessPointUI =
+  UIProvider.succeed<ObjectLambdaAccessPoint>(
+    "AWS.S3Control.ObjectLambdaAccessPoint",
+    {
+      displayName: "S3 Object Lambda Access Point",
+      icon: "zap",
+      color: COLOR,
+      category: "storage",
+      summary: (ctx) => ctx.attrs?.objectLambdaAccessPointName,
+      facts: (ctx) => [
+        {
+          label: "access point",
+          value: ctx.attrs?.objectLambdaAccessPointName,
+          copy: true,
+        },
+        {
+          label: "arn",
+          value: ctx.attrs?.objectLambdaAccessPointArn,
+          mono: true,
+          copy: true,
+        },
+        { label: "alias", value: ctx.attrs?.alias, mono: true },
+      ],
+    },
+  );
+
+export const StorageLensConfigurationUI =
+  UIProvider.succeed<StorageLensConfiguration>(
+    "AWS.S3Control.StorageLensConfiguration",
+    {
+      displayName: "S3 Storage Lens Configuration",
+      icon: "chart-bar",
+      color: COLOR,
+      category: "observability",
+      summary: (ctx) => ctx.attrs?.configId,
+      facts: (ctx) => [
+        { label: "configuration", value: ctx.attrs?.configId, copy: true },
+        {
+          label: "arn",
+          value: ctx.attrs?.storageLensArn,
+          mono: true,
+          copy: true,
+        },
+      ],
+    },
+  );
+
+export const ui = () =>
+  Layer.mergeAll(
+    AccessPointUI,
+    AccessPointPolicyUI,
+    MultiRegionAccessPointUI,
+    ObjectLambdaAccessPointUI,
+    StorageLensConfigurationUI,
+  );

--- a/packages/alchemy/src/AWS/S3Files/ui.ts
+++ b/packages/alchemy/src/AWS/S3Files/ui.ts
@@ -1,0 +1,67 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { AccessPoint } from "./AccessPoint.ts";
+import type { FileSystem } from "./FileSystem.ts";
+
+/**
+ * Dashboard UI providers for AWS S3 Files resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** S3 Files brand color (AWS Storage green). */
+const S3FILES_COLOR = "#7AA116";
+
+export const FileSystemUI = UIProvider.succeed<FileSystem>(
+  "AWS.S3Files.FileSystem",
+  {
+    displayName: "S3 File System",
+    icon: "hard-drive",
+    color: S3FILES_COLOR,
+    category: "storage",
+    summary: (ctx) => ctx.attrs?.fileSystemId,
+    facts: (ctx) => [
+      { label: "id", value: ctx.attrs?.fileSystemId, mono: true, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.fileSystemArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "bucket", value: ctx.attrs?.bucket, copy: true },
+      { label: "role", value: ctx.attrs?.roleArn, mono: true },
+      { label: "status", value: ctx.attrs?.status },
+      { label: "prefix", value: ctx.attrs?.prefix, mono: true },
+    ],
+  },
+);
+
+export const AccessPointUI = UIProvider.succeed<AccessPoint>(
+  "AWS.S3Files.AccessPoint",
+  {
+    displayName: "S3 Files Access Point",
+    icon: "key-round",
+    color: S3FILES_COLOR,
+    category: "storage",
+    summary: (ctx) => ctx.attrs?.accessPointId,
+    facts: (ctx) => [
+      {
+        label: "id",
+        value: ctx.attrs?.accessPointId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.accessPointArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "file system", value: ctx.attrs?.fileSystemId, mono: true },
+      { label: "status", value: ctx.attrs?.status },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(FileSystemUI, AccessPointUI);

--- a/packages/alchemy/src/AWS/S3Tables/ui.ts
+++ b/packages/alchemy/src/AWS/S3Tables/ui.ts
@@ -1,0 +1,81 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Namespace } from "./Namespace.ts";
+import type { Table } from "./Table.ts";
+import type { TableBucket } from "./TableBucket.ts";
+
+/**
+ * Dashboard UI providers for AWS S3Tables resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** AWS Storage (S3 Tables) brand green. */
+const COLOR = "#7AA116";
+
+export const TableBucketUI = UIProvider.succeed<TableBucket>(
+  "AWS.S3Tables.TableBucket",
+  {
+    displayName: "S3 Table Bucket",
+    icon: "cylinder",
+    color: COLOR,
+    category: "storage",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.tableBucketArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "owner", value: ctx.attrs?.ownerAccountId, mono: true },
+      { label: "type", value: ctx.attrs?.type },
+    ],
+  },
+);
+
+export const NamespaceUI = UIProvider.succeed<Namespace>(
+  "AWS.S3Tables.Namespace",
+  {
+    displayName: "S3 Tables Namespace",
+    icon: "folder",
+    color: COLOR,
+    category: "storage",
+    summary: (ctx) => ctx.attrs?.namespace,
+    facts: (ctx) => [
+      { label: "namespace", value: ctx.attrs?.namespace, copy: true },
+      {
+        label: "table bucket",
+        value: ctx.attrs?.tableBucketArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "id", value: ctx.attrs?.namespaceId, mono: true },
+      { label: "owner", value: ctx.attrs?.ownerAccountId, mono: true },
+    ],
+  },
+);
+
+export const TableUI = UIProvider.succeed<Table>("AWS.S3Tables.Table", {
+  displayName: "S3 Tables Table",
+  icon: "table",
+  color: COLOR,
+  category: "database",
+  summary: (ctx) => ctx.attrs?.name,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.name, copy: true },
+    { label: "namespace", value: ctx.attrs?.namespace, mono: true },
+    { label: "arn", value: ctx.attrs?.tableArn, mono: true, copy: true },
+    { label: "format", value: ctx.attrs?.format },
+    { label: "type", value: ctx.attrs?.type },
+    {
+      label: "warehouse location",
+      value: ctx.attrs?.warehouseLocation,
+      mono: true,
+    },
+  ],
+});
+
+export const ui = () => Layer.mergeAll(TableBucketUI, NamespaceUI, TableUI);

--- a/packages/alchemy/src/AWS/S3Vectors/ui.ts
+++ b/packages/alchemy/src/AWS/S3Vectors/ui.ts
@@ -1,0 +1,52 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Index } from "./VectorIndex.ts";
+import type { VectorBucket } from "./VectorBucket.ts";
+
+/**
+ * Dashboard UI providers for AWS S3Vectors resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** AWS Storage brand green. */
+const COLOR = "#7AA116";
+
+export const VectorBucketUI = UIProvider.succeed<VectorBucket>(
+  "AWS.S3Vectors.VectorBucket",
+  {
+    displayName: "S3 Vector Bucket",
+    icon: "cylinder",
+    color: COLOR,
+    category: "storage",
+    summary: (ctx) => ctx.attrs?.vectorBucketName,
+    facts: (ctx) => [
+      { label: "bucket", value: ctx.attrs?.vectorBucketName, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.vectorBucketArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "sse type", value: ctx.props?.encryption?.sseType },
+    ],
+  },
+);
+
+export const IndexUI = UIProvider.succeed<Index>("AWS.S3Vectors.Index", {
+  displayName: "S3 Vector Index",
+  icon: "search",
+  color: COLOR,
+  category: "storage",
+  summary: (ctx) => ctx.attrs?.indexName,
+  facts: (ctx) => [
+    { label: "index", value: ctx.attrs?.indexName, copy: true },
+    { label: "arn", value: ctx.attrs?.indexArn, mono: true, copy: true },
+    { label: "bucket", value: ctx.attrs?.vectorBucketName, mono: true },
+    { label: "dimension", value: ctx.props?.dimension },
+    { label: "distance metric", value: ctx.props?.distanceMetric },
+  ],
+});
+
+export const ui = () => Layer.mergeAll(VectorBucketUI, IndexUI);

--- a/packages/alchemy/src/AWS/SES/ui.ts
+++ b/packages/alchemy/src/AWS/SES/ui.ts
@@ -1,0 +1,394 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { AccountSettings } from "./AccountSettings.ts";
+import type { ActiveReceiptRuleSet } from "./ActiveReceiptRuleSet.ts";
+import type { ConfigurationSet } from "./ConfigurationSet.ts";
+import type { ConfigurationSetEventDestination } from "./ConfigurationSetEventDestination.ts";
+import type { Contact } from "./Contact.ts";
+import type { ContactList } from "./ContactList.ts";
+import type { CustomVerificationEmailTemplate } from "./CustomVerificationEmailTemplate.ts";
+import type { DedicatedIpPool } from "./DedicatedIpPool.ts";
+import type { EmailIdentity } from "./EmailIdentity.ts";
+import type { EmailIdentityPolicy } from "./EmailIdentityPolicy.ts";
+import type { EmailTemplate } from "./EmailTemplate.ts";
+import type { MultiRegionEndpoint } from "./MultiRegionEndpoint.ts";
+import type { ReceiptFilter } from "./ReceiptFilter.ts";
+import type { ReceiptRule } from "./ReceiptRule.ts";
+import type { ReceiptRuleSet } from "./ReceiptRuleSet.ts";
+import type { Tenant } from "./Tenant.ts";
+import type { TenantResourceAssociation } from "./TenantResourceAssociation.ts";
+
+/**
+ * Dashboard UI providers for AWS SES resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+const regionOf = (arn: string | undefined) => arn?.split(":")[3];
+
+export const AccountSettingsUI = UIProvider.succeed<AccountSettings>(
+  "AWS.SES.AccountSettings",
+  {
+    displayName: "SES Account Settings",
+    icon: "sliders-horizontal",
+    color: "#E7157B",
+    category: "email",
+    summary: (ctx) =>
+      ctx.attrs === undefined
+        ? undefined
+        : ctx.attrs.sendingEnabled
+          ? "sending enabled"
+          : "sending paused",
+    facts: (ctx) => [
+      { label: "sending enabled", value: ctx.attrs?.sendingEnabled },
+      { label: "vdm", value: ctx.attrs?.vdmEnabled },
+      {
+        label: "suppressed reasons",
+        value: ctx.attrs?.suppressedReasons?.length
+          ? ctx.attrs.suppressedReasons.join(", ")
+          : undefined,
+      },
+    ],
+  },
+);
+
+export const ActiveReceiptRuleSetUI = UIProvider.succeed<ActiveReceiptRuleSet>(
+  "AWS.SES.ActiveReceiptRuleSet",
+  {
+    displayName: "SES Active Receipt Rule Set",
+    icon: "flag",
+    color: "#E7157B",
+    category: "email",
+    summary: (ctx) => ctx.attrs?.ruleSetName,
+    facts: (ctx) => [
+      { label: "rule set", value: ctx.attrs?.ruleSetName, copy: true },
+    ],
+  },
+);
+
+export const ConfigurationSetUI = UIProvider.succeed<ConfigurationSet>(
+  "AWS.SES.ConfigurationSet",
+  {
+    displayName: "SES Configuration Set",
+    icon: "settings",
+    color: "#E7157B",
+    category: "email",
+    summary: (ctx) => ctx.attrs?.configurationSetName,
+    consoleUrl: (ctx) => {
+      const region = regionOf(ctx.attrs?.configurationSetArn);
+      return ctx.attrs?.configurationSetName === undefined ||
+        region === undefined
+        ? undefined
+        : `https://${region}.console.aws.amazon.com/ses/home?region=${region}#/configuration-sets/${encodeURIComponent(ctx.attrs.configurationSetName)}`;
+    },
+    facts: (ctx) => [
+      {
+        label: "configuration set",
+        value: ctx.attrs?.configurationSetName,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.configurationSetArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "sending enabled", value: ctx.props?.sendingEnabled },
+      { label: "tls policy", value: ctx.props?.tlsPolicy },
+    ],
+  },
+);
+
+export const ConfigurationSetEventDestinationUI =
+  UIProvider.succeed<ConfigurationSetEventDestination>(
+    "AWS.SES.ConfigurationSetEventDestination",
+    {
+      displayName: "SES Event Destination",
+      icon: "webhook",
+      color: "#E7157B",
+      category: "eventing",
+      summary: (ctx) => ctx.attrs?.eventDestinationName,
+      facts: (ctx) => [
+        {
+          label: "destination",
+          value: ctx.attrs?.eventDestinationName,
+          copy: true,
+        },
+        {
+          label: "configuration set",
+          value: ctx.attrs?.configurationSetName,
+          copy: true,
+        },
+        { label: "enabled", value: ctx.props?.enabled },
+        {
+          label: "event types",
+          value: ctx.props?.matchingEventTypes?.join(", "),
+        },
+      ],
+    },
+  );
+
+export const ContactUI = UIProvider.succeed<Contact>("AWS.SES.Contact", {
+  displayName: "SES Contact",
+  icon: "user-round",
+  color: "#E7157B",
+  category: "email",
+  summary: (ctx) => ctx.attrs?.emailAddress,
+  facts: (ctx) => [
+    { label: "email", value: ctx.attrs?.emailAddress, copy: true },
+    { label: "contact list", value: ctx.attrs?.contactListName, copy: true },
+    { label: "unsubscribed from all", value: ctx.props?.unsubscribeAll },
+    { label: "topic preferences", value: ctx.props?.topicPreferences?.length },
+  ],
+});
+
+export const ContactListUI = UIProvider.succeed<ContactList>(
+  "AWS.SES.ContactList",
+  {
+    displayName: "SES Contact List",
+    icon: "users-round",
+    color: "#E7157B",
+    category: "email",
+    summary: (ctx) => ctx.attrs?.contactListName,
+    consoleUrl: (ctx) => {
+      const region = regionOf(ctx.attrs?.contactListArn);
+      return ctx.attrs?.contactListName === undefined || region === undefined
+        ? undefined
+        : `https://${region}.console.aws.amazon.com/ses/home?region=${region}#/contact-lists/${encodeURIComponent(ctx.attrs.contactListName)}`;
+    },
+    facts: (ctx) => [
+      { label: "contact list", value: ctx.attrs?.contactListName, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.contactListArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "description", value: ctx.props?.description },
+      { label: "topics", value: ctx.props?.topics?.length },
+    ],
+  },
+);
+
+export const CustomVerificationEmailTemplateUI =
+  UIProvider.succeed<CustomVerificationEmailTemplate>(
+    "AWS.SES.CustomVerificationEmailTemplate",
+    {
+      displayName: "SES Verification Template",
+      icon: "mail-check",
+      color: "#E7157B",
+      category: "email",
+      summary: (ctx) => ctx.attrs?.templateName,
+      facts: (ctx) => [
+        { label: "template", value: ctx.attrs?.templateName, copy: true },
+        { label: "from", value: ctx.props?.fromEmailAddress, copy: true },
+        { label: "subject", value: ctx.props?.templateSubject },
+        {
+          label: "on success",
+          value: ctx.props?.successRedirectionURL,
+          href: ctx.props?.successRedirectionURL,
+        },
+        {
+          label: "on failure",
+          value: ctx.props?.failureRedirectionURL,
+          href: ctx.props?.failureRedirectionURL,
+        },
+      ],
+    },
+  );
+
+export const DedicatedIpPoolUI = UIProvider.succeed<DedicatedIpPool>(
+  "AWS.SES.DedicatedIpPool",
+  {
+    displayName: "SES Dedicated IP Pool",
+    icon: "server",
+    color: "#E7157B",
+    category: "network",
+    summary: (ctx) => ctx.attrs?.poolName,
+    facts: (ctx) => [
+      { label: "pool", value: ctx.attrs?.poolName, copy: true },
+      { label: "scaling mode", value: ctx.attrs?.scalingMode },
+    ],
+  },
+);
+
+export const EmailIdentityUI = UIProvider.succeed<EmailIdentity>(
+  "AWS.SES.EmailIdentity",
+  {
+    displayName: "SES Email Identity",
+    icon: "mail",
+    color: "#E7157B",
+    category: "email",
+    summary: (ctx) => ctx.attrs?.emailIdentity,
+    consoleUrl: (ctx) => {
+      const region = regionOf(ctx.attrs?.identityArn);
+      return ctx.attrs?.emailIdentity === undefined || region === undefined
+        ? undefined
+        : `https://${region}.console.aws.amazon.com/ses/home?region=${region}#/verified-identities/${encodeURIComponent(ctx.attrs.emailIdentity)}`;
+    },
+    facts: (ctx) => [
+      { label: "identity", value: ctx.attrs?.emailIdentity, copy: true },
+      { label: "arn", value: ctx.attrs?.identityArn, mono: true, copy: true },
+      { label: "type", value: ctx.attrs?.identityType },
+      { label: "verification", value: ctx.attrs?.verificationStatus },
+      {
+        label: "verified for sending",
+        value: ctx.attrs?.verifiedForSendingStatus,
+      },
+      { label: "dkim status", value: ctx.attrs?.dkimStatus },
+    ],
+  },
+);
+
+export const EmailIdentityPolicyUI = UIProvider.succeed<EmailIdentityPolicy>(
+  "AWS.SES.EmailIdentityPolicy",
+  {
+    displayName: "SES Identity Policy",
+    icon: "shield-check",
+    color: "#E7157B",
+    category: "security",
+    summary: (ctx) => ctx.attrs?.policyName,
+    facts: (ctx) => [
+      { label: "policy", value: ctx.attrs?.policyName, copy: true },
+      { label: "identity", value: ctx.attrs?.emailIdentity, copy: true },
+      { label: "statements", value: ctx.props?.policy?.Statement?.length },
+    ],
+  },
+);
+
+export const EmailTemplateUI = UIProvider.succeed<EmailTemplate>(
+  "AWS.SES.EmailTemplate",
+  {
+    displayName: "SES Email Template",
+    icon: "file-text",
+    color: "#E7157B",
+    category: "email",
+    summary: (ctx) => ctx.attrs?.templateName,
+    facts: (ctx) => [
+      { label: "template", value: ctx.attrs?.templateName, copy: true },
+      { label: "arn", value: ctx.attrs?.templateArn, mono: true, copy: true },
+      { label: "subject", value: ctx.props?.subject },
+    ],
+  },
+);
+
+export const MultiRegionEndpointUI = UIProvider.succeed<MultiRegionEndpoint>(
+  "AWS.SES.MultiRegionEndpoint",
+  {
+    displayName: "SES Multi-Region Endpoint",
+    icon: "globe",
+    color: "#E7157B",
+    category: "network",
+    summary: (ctx) => ctx.attrs?.endpointName,
+    facts: (ctx) => [
+      { label: "endpoint", value: ctx.attrs?.endpointName, copy: true },
+      { label: "id", value: ctx.attrs?.endpointId, mono: true, copy: true },
+      { label: "status", value: ctx.attrs?.status },
+      { label: "regions", value: ctx.props?.regions?.join(", ") },
+    ],
+  },
+);
+
+export const ReceiptFilterUI = UIProvider.succeed<ReceiptFilter>(
+  "AWS.SES.ReceiptFilter",
+  {
+    displayName: "SES Receipt Filter",
+    icon: "filter",
+    color: "#E7157B",
+    category: "email",
+    summary: (ctx) => ctx.attrs?.filterName,
+    facts: (ctx) => [
+      { label: "filter", value: ctx.attrs?.filterName, copy: true },
+      { label: "policy", value: ctx.props?.ipFilter?.policy },
+      { label: "cidr", value: ctx.props?.ipFilter?.cidr, mono: true },
+    ],
+  },
+);
+
+export const ReceiptRuleUI = UIProvider.succeed<ReceiptRule>(
+  "AWS.SES.ReceiptRule",
+  {
+    displayName: "SES Receipt Rule",
+    icon: "route",
+    color: "#E7157B",
+    category: "email",
+    summary: (ctx) => ctx.attrs?.ruleName,
+    facts: (ctx) => [
+      { label: "rule", value: ctx.attrs?.ruleName, copy: true },
+      { label: "rule set", value: ctx.attrs?.ruleSetName, copy: true },
+      { label: "enabled", value: ctx.props?.enabled },
+      { label: "recipients", value: ctx.props?.recipients?.length },
+      { label: "actions", value: ctx.props?.actions?.length },
+    ],
+  },
+);
+
+export const ReceiptRuleSetUI = UIProvider.succeed<ReceiptRuleSet>(
+  "AWS.SES.ReceiptRuleSet",
+  {
+    displayName: "SES Receipt Rule Set",
+    icon: "list-ordered",
+    color: "#E7157B",
+    category: "email",
+    summary: (ctx) => ctx.attrs?.ruleSetName,
+    facts: (ctx) => [
+      { label: "rule set", value: ctx.attrs?.ruleSetName, copy: true },
+    ],
+  },
+);
+
+export const TenantUI = UIProvider.succeed<Tenant>("AWS.SES.Tenant", {
+  displayName: "SES Tenant",
+  icon: "building-2",
+  color: "#E7157B",
+  category: "email",
+  summary: (ctx) => ctx.attrs?.tenantName,
+  facts: (ctx) => [
+    { label: "tenant", value: ctx.attrs?.tenantName, copy: true },
+    { label: "id", value: ctx.attrs?.tenantId, mono: true, copy: true },
+    { label: "arn", value: ctx.attrs?.tenantArn, mono: true, copy: true },
+  ],
+});
+
+export const TenantResourceAssociationUI =
+  UIProvider.succeed<TenantResourceAssociation>(
+    "AWS.SES.TenantResourceAssociation",
+    {
+      displayName: "SES Tenant Association",
+      icon: "link",
+      color: "#E7157B",
+      category: "email",
+      summary: (ctx) => ctx.attrs?.tenantName,
+      facts: (ctx) => [
+        { label: "tenant", value: ctx.attrs?.tenantName, copy: true },
+        {
+          label: "resource",
+          value: ctx.attrs?.resourceArn,
+          mono: true,
+          copy: true,
+        },
+      ],
+    },
+  );
+
+export const ui = () =>
+  Layer.mergeAll(
+    AccountSettingsUI,
+    ActiveReceiptRuleSetUI,
+    ConfigurationSetUI,
+    ConfigurationSetEventDestinationUI,
+    ContactUI,
+    ContactListUI,
+    CustomVerificationEmailTemplateUI,
+    DedicatedIpPoolUI,
+    EmailIdentityUI,
+    EmailIdentityPolicyUI,
+    EmailTemplateUI,
+    MultiRegionEndpointUI,
+    ReceiptFilterUI,
+    ReceiptRuleUI,
+    ReceiptRuleSetUI,
+    TenantUI,
+    TenantResourceAssociationUI,
+  );

--- a/packages/alchemy/src/AWS/SNS/ui.ts
+++ b/packages/alchemy/src/AWS/SNS/ui.ts
@@ -1,0 +1,91 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { PlatformApplication } from "./PlatformApplication.ts";
+import type { Subscription } from "./Subscription.ts";
+import type { Topic } from "./Topic.ts";
+
+/**
+ * Dashboard UI providers for AWS SNS resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+const regionOf = (arn: string | undefined) => arn?.split(":")[3];
+
+export const TopicUI = UIProvider.succeed<Topic>("AWS.SNS.Topic", {
+  displayName: "SNS Topic",
+  icon: "megaphone",
+  color: "#E7157B",
+  category: "eventing",
+  summary: (ctx) => ctx.attrs?.topicName,
+  consoleUrl: (ctx) => {
+    const region = regionOf(ctx.attrs?.topicArn);
+    return ctx.attrs?.topicArn === undefined || region === undefined
+      ? undefined
+      : `https://${region}.console.aws.amazon.com/sns/v3/home?region=${region}#/topic/${encodeURIComponent(ctx.attrs.topicArn)}`;
+  },
+  facts: (ctx) => [
+    { label: "topic", value: ctx.attrs?.topicName, copy: true },
+    { label: "arn", value: ctx.attrs?.topicArn, mono: true, copy: true },
+    { label: "fifo", value: ctx.attrs?.fifo },
+  ],
+});
+
+export const SubscriptionUI = UIProvider.succeed<Subscription>(
+  "AWS.SNS.Subscription",
+  {
+    displayName: "SNS Subscription",
+    icon: "inbox",
+    color: "#E7157B",
+    category: "eventing",
+    summary: (ctx) =>
+      ctx.attrs?.endpoint
+        ? `${ctx.attrs?.protocol ?? ""}:${ctx.attrs.endpoint}`
+        : ctx.attrs?.subscriptionArn,
+    consoleUrl: (ctx) => {
+      const region = regionOf(ctx.attrs?.subscriptionArn);
+      return ctx.attrs?.subscriptionArn === undefined || region === undefined
+        ? undefined
+        : `https://${region}.console.aws.amazon.com/sns/v3/home?region=${region}#/subscriptions/${encodeURIComponent(ctx.attrs.subscriptionArn)}`;
+    },
+    facts: (ctx) => [
+      {
+        label: "arn",
+        value: ctx.attrs?.subscriptionArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "topic", value: ctx.attrs?.topicArn, mono: true, copy: true },
+      { label: "protocol", value: ctx.attrs?.protocol },
+      { label: "endpoint", value: ctx.attrs?.endpoint, mono: true },
+      { label: "pending", value: ctx.attrs?.pendingConfirmation },
+      { label: "owner", value: ctx.attrs?.owner, mono: true },
+    ],
+  },
+);
+
+export const PlatformApplicationUI = UIProvider.succeed<PlatformApplication>(
+  "AWS.SNS.PlatformApplication",
+  {
+    displayName: "SNS Platform Application",
+    icon: "bell",
+    color: "#E7157B",
+    category: "eventing",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.platformApplicationArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "platform", value: ctx.attrs?.platform },
+      { label: "enabled", value: ctx.attrs?.enabled },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(TopicUI, SubscriptionUI, PlatformApplicationUI);

--- a/packages/alchemy/src/AWS/SQS/ui.ts
+++ b/packages/alchemy/src/AWS/SQS/ui.ts
@@ -1,0 +1,36 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Queue } from "./Queue.ts";
+
+/**
+ * Dashboard UI providers for AWS SQS resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+const regionOf = (arn: string | undefined) => arn?.split(":")[3];
+
+export const QueueUI = UIProvider.succeed<Queue>("AWS.SQS.Queue", {
+  displayName: "SQS Queue",
+  icon: "list-ordered",
+  color: "#E7157B",
+  category: "queue",
+  summary: (ctx) => ctx.attrs?.queueName,
+  consoleUrl: (ctx) => {
+    const region = regionOf(ctx.attrs?.queueArn);
+    return ctx.attrs?.queueUrl === undefined || region === undefined
+      ? undefined
+      : `https://${region}.console.aws.amazon.com/sqs/v3/home?region=${region}#/queues/${encodeURIComponent(ctx.attrs.queueUrl)}`;
+  },
+  facts: (ctx) => [
+    { label: "queue", value: ctx.attrs?.queueName, copy: true },
+    { label: "arn", value: ctx.attrs?.queueArn, mono: true, copy: true },
+    { label: "url", value: ctx.attrs?.queueUrl, mono: true, copy: true },
+    { label: "fifo", value: ctx.props?.fifo },
+    { label: "visibility timeout", value: ctx.props?.visibilityTimeout },
+    { label: "retention", value: ctx.props?.messageRetentionPeriod },
+  ],
+});
+
+export const ui = () => Layer.mergeAll(QueueUI);

--- a/packages/alchemy/src/AWS/SSM/ui.ts
+++ b/packages/alchemy/src/AWS/SSM/ui.ts
@@ -1,0 +1,35 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Parameter } from "./Parameter.ts";
+
+/**
+ * Dashboard UI providers for AWS SSM resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+const regionOf = (arn: string | undefined) => arn?.split(":")[3];
+
+export const ParameterUI = UIProvider.succeed<Parameter>("AWS.SSM.Parameter", {
+  displayName: "SSM Parameter",
+  icon: "settings",
+  color: "#E7157B",
+  category: "config",
+  summary: (ctx) => ctx.attrs?.parameterName,
+  consoleUrl: (ctx) => {
+    const region = regionOf(ctx.attrs?.parameterArn);
+    return ctx.attrs?.parameterName === undefined || region === undefined
+      ? undefined
+      : `https://${region}.console.aws.amazon.com/systems-manager/parameters${encodeURIComponent(ctx.attrs.parameterName)}/description?region=${region}`;
+  },
+  facts: (ctx) => [
+    { label: "parameter", value: ctx.attrs?.parameterName, copy: true },
+    { label: "arn", value: ctx.attrs?.parameterArn, mono: true, copy: true },
+    { label: "type", value: ctx.attrs?.type },
+    { label: "version", value: ctx.attrs?.version },
+    { label: "kms key", value: ctx.attrs?.keyArn, mono: true },
+  ],
+});
+
+export const ui = () => Layer.mergeAll(ParameterUI);

--- a/packages/alchemy/src/AWS/SSMContacts/ui.ts
+++ b/packages/alchemy/src/AWS/SSMContacts/ui.ts
@@ -1,0 +1,89 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Contact } from "./Contact.ts";
+import type { ContactChannel } from "./ContactChannel.ts";
+import type { Plan } from "./Plan.ts";
+import type { Rotation } from "./Rotation.ts";
+
+/**
+ * Dashboard UI providers for AWS SSM Contacts resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** SSM Contacts brand color (AWS Management & Governance pink). */
+const SSM_CONTACTS_COLOR = "#E7157B";
+
+export const ContactUI = UIProvider.succeed<Contact>(
+  "AWS.SSMContacts.Contact",
+  {
+    displayName: "Incident Manager Contact",
+    icon: "phone",
+    color: SSM_CONTACTS_COLOR,
+    category: "observability",
+    summary: (ctx) => ctx.attrs?.displayName ?? ctx.attrs?.alias,
+    facts: (ctx) => [
+      { label: "alias", value: ctx.attrs?.alias, copy: true },
+      { label: "arn", value: ctx.attrs?.contactArn, mono: true, copy: true },
+      { label: "type", value: ctx.attrs?.type },
+      { label: "display name", value: ctx.attrs?.displayName },
+    ],
+  },
+);
+
+export const ContactChannelUI = UIProvider.succeed<ContactChannel>(
+  "AWS.SSMContacts.ContactChannel",
+  {
+    displayName: "Incident Manager Contact Channel",
+    icon: "send",
+    color: SSM_CONTACTS_COLOR,
+    category: "observability",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "channel", value: ctx.attrs?.name, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.contactChannelArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "contact", value: ctx.attrs?.contactArn, mono: true },
+      { label: "type", value: ctx.attrs?.type },
+      { label: "activation", value: ctx.attrs?.activationStatus },
+    ],
+  },
+);
+
+export const PlanUI = UIProvider.succeed<Plan>("AWS.SSMContacts.Plan", {
+  displayName: "Incident Manager Engagement Plan",
+  icon: "list-ordered",
+  color: SSM_CONTACTS_COLOR,
+  category: "observability",
+  summary: (ctx) => ctx.attrs?.contactArn,
+  facts: (ctx) => [
+    { label: "contact", value: ctx.attrs?.contactArn, mono: true, copy: true },
+    { label: "stages", value: ctx.attrs?.stageCount },
+  ],
+});
+
+export const RotationUI = UIProvider.succeed<Rotation>(
+  "AWS.SSMContacts.Rotation",
+  {
+    displayName: "Incident Manager Rotation",
+    icon: "repeat",
+    color: SSM_CONTACTS_COLOR,
+    category: "observability",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "rotation", value: ctx.attrs?.name, copy: true },
+      { label: "arn", value: ctx.attrs?.rotationArn, mono: true, copy: true },
+      { label: "start time", value: ctx.attrs?.startTime },
+      { label: "time zone", value: ctx.props?.timeZoneId },
+      { label: "contacts", value: ctx.props?.contactIds?.length },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(ContactUI, ContactChannelUI, PlanUI, RotationUI);

--- a/packages/alchemy/src/AWS/SSMIncidents/ui.ts
+++ b/packages/alchemy/src/AWS/SSMIncidents/ui.ts
@@ -1,0 +1,56 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { ReplicationSet } from "./ReplicationSet.ts";
+import type { ResponsePlan } from "./ResponsePlan.ts";
+
+/**
+ * Dashboard UI providers for AWS SSMIncidents resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** AWS Management & Governance / Observability (Incident Manager) brand pink. */
+const COLOR = "#E7157B";
+
+export const ReplicationSetUI = UIProvider.succeed<ReplicationSet>(
+  "AWS.SSMIncidents.ReplicationSet",
+  {
+    displayName: "Incident Manager Replication Set",
+    icon: "share-2",
+    color: COLOR,
+    category: "observability",
+    summary: (ctx) => ctx.attrs?.arn,
+    facts: (ctx) => [
+      { label: "arn", value: ctx.attrs?.arn, mono: true, copy: true },
+      { label: "status", value: ctx.attrs?.status },
+      {
+        label: "regions",
+        value: ctx.attrs?.regionNames?.length
+          ? ctx.attrs.regionNames.join(", ")
+          : undefined,
+      },
+      { label: "deletion protected", value: ctx.attrs?.deletionProtected },
+    ],
+  },
+);
+
+export const ResponsePlanUI = UIProvider.succeed<ResponsePlan>(
+  "AWS.SSMIncidents.ResponsePlan",
+  {
+    displayName: "Incident Manager Response Plan",
+    icon: "alert-triangle",
+    color: COLOR,
+    category: "observability",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      { label: "arn", value: ctx.attrs?.arn, mono: true, copy: true },
+      { label: "display name", value: ctx.props?.displayName },
+      { label: "title", value: ctx.props?.incidentTemplate?.title },
+      { label: "impact", value: ctx.props?.incidentTemplate?.impact },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(ReplicationSetUI, ResponsePlanUI);

--- a/packages/alchemy/src/AWS/SageMaker/ui.ts
+++ b/packages/alchemy/src/AWS/SageMaker/ui.ts
@@ -1,0 +1,203 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Cluster } from "./Cluster.ts";
+import type { ClusterSchedulerConfig } from "./ClusterSchedulerConfig.ts";
+import type { ComputeQuota } from "./ComputeQuota.ts";
+import type { Endpoint } from "./Endpoint.ts";
+import type { EndpointConfig } from "./EndpointConfig.ts";
+import type { FeatureGroup } from "./FeatureGroup.ts";
+import type { Model } from "./Model.ts";
+
+/**
+ * Dashboard UI providers for AWS SageMaker resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** AWS machine learning & AI brand teal. */
+const COLOR = "#01A88D";
+
+/** Extract the region segment from an AWS ARN (`arn:aws:sagemaker:REGION:...`). */
+const regionOfArn = (arn: string | undefined): string | undefined =>
+  arn?.split(":")[3] || undefined;
+
+export const ClusterUI = UIProvider.succeed<Cluster>("AWS.SageMaker.Cluster", {
+  displayName: "HyperPod Cluster",
+  icon: "server",
+  color: COLOR,
+  category: "ai",
+  summary: (ctx) => ctx.attrs?.clusterName,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.clusterName, copy: true },
+    { label: "arn", value: ctx.attrs?.clusterArn, mono: true, copy: true },
+    { label: "status", value: ctx.attrs?.clusterStatus },
+    {
+      label: "eks cluster",
+      value: ctx.attrs?.orchestratorEksClusterArn,
+      mono: true,
+    },
+    {
+      label: "instance groups",
+      value: ctx.attrs?.instanceGroups
+        ? Object.keys(ctx.attrs.instanceGroups).join(", ")
+        : undefined,
+    },
+  ],
+});
+
+export const ClusterSchedulerConfigUI =
+  UIProvider.succeed<ClusterSchedulerConfig>(
+    "AWS.SageMaker.ClusterSchedulerConfig",
+    {
+      displayName: "HyperPod Cluster Policy",
+      icon: "list-ordered",
+      color: COLOR,
+      category: "ai",
+      summary: (ctx) => ctx.attrs?.name,
+      facts: (ctx) => [
+        { label: "name", value: ctx.attrs?.name, copy: true },
+        {
+          label: "arn",
+          value: ctx.attrs?.clusterSchedulerConfigArn,
+          mono: true,
+          copy: true,
+        },
+        { label: "cluster", value: ctx.attrs?.clusterArn, mono: true },
+        { label: "version", value: ctx.attrs?.clusterSchedulerConfigVersion },
+      ],
+    },
+  );
+
+export const ComputeQuotaUI = UIProvider.succeed<ComputeQuota>(
+  "AWS.SageMaker.ComputeQuota",
+  {
+    displayName: "HyperPod Compute Quota",
+    icon: "gauge",
+    color: COLOR,
+    category: "ai",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.computeQuotaArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "cluster", value: ctx.attrs?.clusterArn, mono: true },
+      { label: "team", value: ctx.attrs?.teamName },
+      { label: "version", value: ctx.attrs?.computeQuotaVersion },
+    ],
+  },
+);
+
+export const EndpointUI = UIProvider.succeed<Endpoint>(
+  "AWS.SageMaker.Endpoint",
+  {
+    displayName: "SageMaker Endpoint",
+    icon: "plug-zap",
+    color: COLOR,
+    category: "ai",
+    summary: (ctx) => ctx.attrs?.endpointName,
+    consoleUrl: (ctx) => {
+      const region = regionOfArn(ctx.attrs?.endpointArn);
+      return region === undefined || ctx.attrs?.endpointName === undefined
+        ? undefined
+        : `https://${region}.console.aws.amazon.com/sagemaker/home?region=${region}#/endpoints/${ctx.attrs.endpointName}`;
+    },
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.endpointName, copy: true },
+      { label: "arn", value: ctx.attrs?.endpointArn, mono: true, copy: true },
+      { label: "status", value: ctx.attrs?.endpointStatus },
+      { label: "config", value: ctx.props?.endpointConfigName },
+    ],
+  },
+);
+
+export const EndpointConfigUI = UIProvider.succeed<EndpointConfig>(
+  "AWS.SageMaker.EndpointConfig",
+  {
+    displayName: "SageMaker Endpoint Config",
+    icon: "settings",
+    color: COLOR,
+    category: "ai",
+    summary: (ctx) => ctx.attrs?.endpointConfigName,
+    consoleUrl: (ctx) => {
+      const region = regionOfArn(ctx.attrs?.endpointConfigArn);
+      return region === undefined || ctx.attrs?.endpointConfigName === undefined
+        ? undefined
+        : `https://${region}.console.aws.amazon.com/sagemaker/home?region=${region}#/endpointConfig/${ctx.attrs.endpointConfigName}`;
+    },
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.endpointConfigName, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.endpointConfigArn,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "variants",
+        value: ctx.props?.productionVariants
+          ?.map((v: { VariantName?: string }) => v.VariantName)
+          .join(", "),
+      },
+    ],
+  },
+);
+
+export const FeatureGroupUI = UIProvider.succeed<FeatureGroup>(
+  "AWS.SageMaker.FeatureGroup",
+  {
+    displayName: "Feature Group",
+    icon: "table",
+    color: COLOR,
+    category: "ai",
+    summary: (ctx) => ctx.attrs?.featureGroupName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.featureGroupName, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.featureGroupArn,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "record identifier",
+        value: ctx.attrs?.recordIdentifierFeatureName,
+      },
+      { label: "event time", value: ctx.attrs?.eventTimeFeatureName },
+    ],
+  },
+);
+
+export const ModelUI = UIProvider.succeed<Model>("AWS.SageMaker.Model", {
+  displayName: "SageMaker Model",
+  icon: "brain",
+  color: COLOR,
+  category: "ai",
+  summary: (ctx) => ctx.attrs?.modelName,
+  consoleUrl: (ctx) => {
+    const region = regionOfArn(ctx.attrs?.modelArn);
+    return region === undefined || ctx.attrs?.modelName === undefined
+      ? undefined
+      : `https://${region}.console.aws.amazon.com/sagemaker/home?region=${region}#/models/${ctx.attrs.modelName}`;
+  },
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.modelName, copy: true },
+    { label: "arn", value: ctx.attrs?.modelArn, mono: true, copy: true },
+    { label: "execution role", value: ctx.props?.executionRoleArn, mono: true },
+  ],
+});
+
+export const ui = () =>
+  Layer.mergeAll(
+    ClusterUI,
+    ClusterSchedulerConfigUI,
+    ComputeQuotaUI,
+    EndpointUI,
+    EndpointConfigUI,
+    FeatureGroupUI,
+    ModelUI,
+  );

--- a/packages/alchemy/src/AWS/Scheduler/ui.ts
+++ b/packages/alchemy/src/AWS/Scheduler/ui.ts
@@ -1,0 +1,63 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Schedule } from "./Schedule.ts";
+import type { ScheduleGroup } from "./ScheduleGroup.ts";
+
+/**
+ * Dashboard UI providers for AWS EventBridge Scheduler resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+const regionOf = (arn: string | undefined) => arn?.split(":")[3];
+
+export const ScheduleUI = UIProvider.succeed<Schedule>(
+  "AWS.Scheduler.Schedule",
+  {
+    displayName: "Scheduler Schedule",
+    icon: "timer",
+    color: "#E7157B",
+    category: "eventing",
+    summary: (ctx) => ctx.attrs?.scheduleName,
+    consoleUrl: (ctx) => {
+      const region = regionOf(ctx.attrs?.scheduleArn);
+      return ctx.attrs?.scheduleName === undefined ||
+        ctx.attrs?.groupName === undefined ||
+        region === undefined
+        ? undefined
+        : `https://${region}.console.aws.amazon.com/scheduler/home?region=${region}#schedules/${encodeURIComponent(ctx.attrs.groupName)}/${encodeURIComponent(ctx.attrs.scheduleName)}`;
+    },
+    facts: (ctx) => [
+      { label: "schedule", value: ctx.attrs?.scheduleName, copy: true },
+      { label: "arn", value: ctx.attrs?.scheduleArn, mono: true, copy: true },
+      { label: "group", value: ctx.attrs?.groupName },
+      { label: "expression", value: ctx.props?.scheduleExpression, mono: true },
+      { label: "timezone", value: ctx.props?.scheduleExpressionTimezone },
+      { label: "state", value: ctx.attrs?.state },
+    ],
+  },
+);
+
+export const ScheduleGroupUI = UIProvider.succeed<ScheduleGroup>(
+  "AWS.Scheduler.ScheduleGroup",
+  {
+    displayName: "Scheduler Schedule Group",
+    icon: "folder-clock",
+    color: "#E7157B",
+    category: "eventing",
+    summary: (ctx) => ctx.attrs?.scheduleGroupName,
+    facts: (ctx) => [
+      { label: "group", value: ctx.attrs?.scheduleGroupName, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.scheduleGroupArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "state", value: ctx.attrs?.state },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(ScheduleUI, ScheduleGroupUI);

--- a/packages/alchemy/src/AWS/Schemas/ui.ts
+++ b/packages/alchemy/src/AWS/Schemas/ui.ts
@@ -1,0 +1,71 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Discoverer } from "./Discoverer.ts";
+import type { Registry } from "./Registry.ts";
+import type { Schema } from "./Schema.ts";
+
+/**
+ * Dashboard UI providers for AWS Schemas resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+const SCHEMAS_COLOR = "#E7157B";
+
+export const DiscovererUI = UIProvider.succeed<Discoverer>(
+  "AWS.Schemas.Discoverer",
+  {
+    displayName: "Schemas Discoverer",
+    icon: "search",
+    color: SCHEMAS_COLOR,
+    category: "eventing",
+    summary: (ctx) => ctx.attrs?.discovererId,
+    facts: (ctx) => [
+      {
+        label: "discoverer",
+        value: ctx.attrs?.discovererId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.discovererArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "source", value: ctx.attrs?.sourceArn, mono: true },
+      { label: "state", value: ctx.attrs?.state },
+    ],
+  },
+);
+
+export const RegistryUI = UIProvider.succeed<Registry>("AWS.Schemas.Registry", {
+  displayName: "Schemas Registry",
+  icon: "book-open",
+  color: SCHEMAS_COLOR,
+  category: "eventing",
+  summary: (ctx) => ctx.attrs?.registryName,
+  facts: (ctx) => [
+    { label: "registry", value: ctx.attrs?.registryName, copy: true },
+    { label: "arn", value: ctx.attrs?.registryArn, mono: true, copy: true },
+    { label: "description", value: ctx.props?.description },
+  ],
+});
+
+export const SchemaUI = UIProvider.succeed<Schema>("AWS.Schemas.Schema", {
+  displayName: "Schemas Schema",
+  icon: "file-text",
+  color: SCHEMAS_COLOR,
+  category: "eventing",
+  summary: (ctx) => ctx.attrs?.schemaName,
+  facts: (ctx) => [
+    { label: "schema", value: ctx.attrs?.schemaName, copy: true },
+    { label: "arn", value: ctx.attrs?.schemaArn, mono: true, copy: true },
+    { label: "registry", value: ctx.attrs?.registryName, mono: true },
+    { label: "version", value: ctx.attrs?.schemaVersion },
+    { label: "type", value: ctx.attrs?.type },
+  ],
+});
+
+export const ui = () => Layer.mergeAll(DiscovererUI, RegistryUI, SchemaUI);

--- a/packages/alchemy/src/AWS/SecretsManager/ui.ts
+++ b/packages/alchemy/src/AWS/SecretsManager/ui.ts
@@ -1,0 +1,64 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { RotationSchedule } from "./RotationSchedule.ts";
+import type { Secret } from "./Secret.ts";
+
+/**
+ * Dashboard UI providers for AWS Secrets Manager resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+export const SecretUI = UIProvider.succeed<Secret>(
+  "AWS.SecretsManager.Secret",
+  {
+    displayName: "Secret",
+    icon: "file-lock-2",
+    color: "#DD344C",
+    category: "security",
+    summary: (ctx) => ctx.attrs?.secretName,
+    consoleUrl: (ctx) =>
+      ctx.attrs?.secretName === undefined
+        ? undefined
+        : `https://console.aws.amazon.com/secretsmanager/secret?name=${encodeURIComponent(ctx.attrs.secretName)}`,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.secretName, copy: true },
+      { label: "arn", value: ctx.attrs?.secretArn, mono: true, copy: true },
+      { label: "version", value: ctx.attrs?.versionId, mono: true },
+      { label: "kms key", value: ctx.attrs?.kmsKeyId, mono: true },
+      { label: "description", value: ctx.attrs?.description },
+    ],
+  },
+);
+
+export const RotationScheduleUI = UIProvider.succeed<RotationSchedule>(
+  "AWS.SecretsManager.RotationSchedule",
+  {
+    displayName: "Secret Rotation Schedule",
+    icon: "rotate-ccw",
+    color: "#DD344C",
+    category: "security",
+    summary: (ctx) => ctx.attrs?.secretName,
+    consoleUrl: (ctx) =>
+      ctx.attrs?.secretName === undefined
+        ? undefined
+        : `https://console.aws.amazon.com/secretsmanager/secret?name=${encodeURIComponent(ctx.attrs.secretName)}`,
+    facts: (ctx) => [
+      { label: "secret", value: ctx.attrs?.secretName, copy: true },
+      {
+        label: "secret arn",
+        value: ctx.attrs?.secretArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "enabled", value: ctx.attrs?.rotationEnabled },
+      {
+        label: "rotation lambda",
+        value: ctx.attrs?.rotationLambdaArn,
+        mono: true,
+      },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(SecretUI, RotationScheduleUI);

--- a/packages/alchemy/src/AWS/SecurityHub/ui.ts
+++ b/packages/alchemy/src/AWS/SecurityHub/ui.ts
@@ -1,0 +1,121 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { ActionTarget } from "./ActionTarget.ts";
+import type { AutomationRule } from "./AutomationRule.ts";
+import type { FindingAggregator } from "./FindingAggregator.ts";
+import type { Hub } from "./Hub.ts";
+import type { Insight } from "./Insight.ts";
+
+/**
+ * Dashboard UI providers for AWS SecurityHub resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** Security Hub brand color (AWS Security, Identity & Compliance red). */
+const SECURITYHUB_COLOR = "#DD344C";
+
+export const HubUI = UIProvider.succeed<Hub>("AWS.SecurityHub.Hub", {
+  displayName: "Security Hub",
+  icon: "shield-check",
+  color: SECURITYHUB_COLOR,
+  category: "security",
+  summary: (ctx) => ctx.attrs?.hubArn,
+  facts: (ctx) => [
+    { label: "arn", value: ctx.attrs?.hubArn, mono: true, copy: true },
+    { label: "subscribed at", value: ctx.attrs?.subscribedAt },
+    { label: "auto-enable controls", value: ctx.attrs?.autoEnableControls },
+    {
+      label: "control finding generator",
+      value: ctx.attrs?.controlFindingGenerator,
+    },
+  ],
+});
+
+export const ActionTargetUI = UIProvider.succeed<ActionTarget>(
+  "AWS.SecurityHub.ActionTarget",
+  {
+    displayName: "Security Hub Action Target",
+    icon: "flag",
+    color: SECURITYHUB_COLOR,
+    category: "security",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.actionTargetArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "id", value: ctx.attrs?.id, mono: true },
+      { label: "description", value: ctx.attrs?.description },
+    ],
+  },
+);
+
+export const AutomationRuleUI = UIProvider.succeed<AutomationRule>(
+  "AWS.SecurityHub.AutomationRule",
+  {
+    displayName: "Security Hub Automation Rule",
+    icon: "filter",
+    color: SECURITYHUB_COLOR,
+    category: "security",
+    summary: (ctx) => ctx.attrs?.ruleName,
+    facts: (ctx) => [
+      { label: "rule", value: ctx.attrs?.ruleName, copy: true },
+      { label: "arn", value: ctx.attrs?.ruleArn, mono: true, copy: true },
+      { label: "order", value: ctx.attrs?.ruleOrder },
+      { label: "status", value: ctx.attrs?.ruleStatus },
+      { label: "terminal", value: ctx.attrs?.isTerminal },
+    ],
+  },
+);
+
+export const FindingAggregatorUI = UIProvider.succeed<FindingAggregator>(
+  "AWS.SecurityHub.FindingAggregator",
+  {
+    displayName: "Security Hub Finding Aggregator",
+    icon: "merge",
+    color: SECURITYHUB_COLOR,
+    category: "security",
+    summary: (ctx) => ctx.attrs?.findingAggregatorArn,
+    facts: (ctx) => [
+      {
+        label: "arn",
+        value: ctx.attrs?.findingAggregatorArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "home region", value: ctx.attrs?.findingAggregationRegion },
+      { label: "linking mode", value: ctx.attrs?.regionLinkingMode },
+      { label: "regions", value: ctx.attrs?.regions?.join(", ") },
+    ],
+  },
+);
+
+export const InsightUI = UIProvider.succeed<Insight>(
+  "AWS.SecurityHub.Insight",
+  {
+    displayName: "Security Hub Insight",
+    icon: "search",
+    color: SECURITYHUB_COLOR,
+    category: "security",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "insight", value: ctx.attrs?.name, copy: true },
+      { label: "arn", value: ctx.attrs?.insightArn, mono: true, copy: true },
+      { label: "group by", value: ctx.attrs?.groupByAttribute },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(
+    HubUI,
+    ActionTargetUI,
+    AutomationRuleUI,
+    FindingAggregatorUI,
+    InsightUI,
+  );

--- a/packages/alchemy/src/AWS/SecurityLake/ui.ts
+++ b/packages/alchemy/src/AWS/SecurityLake/ui.ts
@@ -1,0 +1,162 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { AwsLogSource } from "./AwsLogSource.ts";
+import type { CustomLogSource } from "./CustomLogSource.ts";
+import type { DataLake } from "./DataLake.ts";
+import type { ExceptionSubscription } from "./ExceptionSubscription.ts";
+import type { Subscriber } from "./Subscriber.ts";
+import type { SubscriberNotification } from "./SubscriberNotification.ts";
+
+/**
+ * Dashboard UI providers for AWS SecurityLake resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+export const AwsLogSourceUI = UIProvider.succeed<AwsLogSource>(
+  "AWS.SecurityLake.AwsLogSource",
+  {
+    displayName: "Security Lake AWS Log Source",
+    icon: "cloud",
+    color: "#DD344C",
+    category: "security",
+    summary: (ctx) => ctx.attrs?.sourceName,
+    facts: (ctx) => [
+      { label: "source", value: ctx.attrs?.sourceName, copy: true },
+      { label: "version", value: ctx.attrs?.sourceVersion },
+      { label: "regions", value: ctx.attrs?.regions?.join(", ") },
+      { label: "accounts", value: ctx.attrs?.accounts?.length },
+    ],
+  },
+);
+
+export const CustomLogSourceUI = UIProvider.succeed<CustomLogSource>(
+  "AWS.SecurityLake.CustomLogSource",
+  {
+    displayName: "Security Lake Custom Log Source",
+    icon: "plug",
+    color: "#DD344C",
+    category: "security",
+    summary: (ctx) => ctx.attrs?.sourceName,
+    facts: (ctx) => [
+      { label: "source", value: ctx.attrs?.sourceName, copy: true },
+      { label: "version", value: ctx.attrs?.sourceVersion },
+      { label: "crawler", value: ctx.attrs?.crawlerArn, mono: true },
+      { label: "database", value: ctx.attrs?.databaseArn, mono: true },
+      { label: "table", value: ctx.attrs?.tableArn, mono: true },
+      { label: "provider role", value: ctx.attrs?.providerRoleArn, mono: true },
+    ],
+  },
+);
+
+export const DataLakeUI = UIProvider.succeed<DataLake>(
+  "AWS.SecurityLake.DataLake",
+  {
+    displayName: "Security Lake Data Lake",
+    icon: "database",
+    color: "#DD344C",
+    category: "security",
+    summary: (ctx) => ctx.attrs?.regions?.join(", "),
+    facts: (ctx) => [
+      { label: "arn", value: ctx.attrs?.dataLakeArn, mono: true, copy: true },
+      { label: "regions", value: ctx.attrs?.regions?.join(", ") },
+      {
+        label: "status",
+        value: ctx.attrs?.dataLakes?.[0]?.createStatus,
+      },
+      {
+        label: "metastore role",
+        value: ctx.props?.metaStoreManagerRoleArn,
+        mono: true,
+      },
+    ],
+  },
+);
+
+export const ExceptionSubscriptionUI =
+  UIProvider.succeed<ExceptionSubscription>(
+    "AWS.SecurityLake.ExceptionSubscription",
+    {
+      displayName: "Security Lake Exception Subscription",
+      icon: "alert-triangle",
+      color: "#DD344C",
+      category: "security",
+      summary: (ctx) => ctx.attrs?.notificationEndpoint,
+      facts: (ctx) => [
+        { label: "protocol", value: ctx.attrs?.subscriptionProtocol },
+        {
+          label: "endpoint",
+          value: ctx.attrs?.notificationEndpoint,
+          copy: true,
+        },
+        { label: "ttl (days)", value: ctx.attrs?.exceptionTimeToLive },
+      ],
+    },
+  );
+
+export const SubscriberUI = UIProvider.succeed<Subscriber>(
+  "AWS.SecurityLake.Subscriber",
+  {
+    displayName: "Security Lake Subscriber",
+    icon: "user",
+    color: "#DD344C",
+    category: "security",
+    summary: (ctx) => ctx.attrs?.subscriberName,
+    facts: (ctx) => [
+      { label: "subscriber", value: ctx.attrs?.subscriberName, copy: true },
+      {
+        label: "id",
+        value: ctx.attrs?.subscriberId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.subscriberArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "status", value: ctx.attrs?.subscriberStatus },
+      { label: "role", value: ctx.attrs?.roleArn, mono: true },
+      { label: "endpoint", value: ctx.attrs?.subscriberEndpoint, mono: true },
+    ],
+  },
+);
+
+export const SubscriberNotificationUI =
+  UIProvider.succeed<SubscriberNotification>(
+    "AWS.SecurityLake.SubscriberNotification",
+    {
+      displayName: "Security Lake Subscriber Notification",
+      icon: "bell",
+      color: "#DD344C",
+      category: "security",
+      summary: (ctx) =>
+        ctx.attrs?.subscriberEndpoint ?? ctx.attrs?.subscriberId,
+      facts: (ctx) => [
+        {
+          label: "subscriber",
+          value: ctx.attrs?.subscriberId,
+          mono: true,
+          copy: true,
+        },
+        {
+          label: "endpoint",
+          value: ctx.attrs?.subscriberEndpoint,
+          mono: true,
+          copy: true,
+        },
+      ],
+    },
+  );
+
+export const ui = () =>
+  Layer.mergeAll(
+    AwsLogSourceUI,
+    CustomLogSourceUI,
+    DataLakeUI,
+    ExceptionSubscriptionUI,
+    SubscriberUI,
+    SubscriberNotificationUI,
+  );

--- a/packages/alchemy/src/AWS/ServiceCatalog/ui.ts
+++ b/packages/alchemy/src/AWS/ServiceCatalog/ui.ts
@@ -1,0 +1,122 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Portfolio } from "./Portfolio.ts";
+import type { PortfolioProductAssociation } from "./PortfolioProductAssociation.ts";
+import type { PrincipalPortfolioAssociation } from "./PrincipalPortfolioAssociation.ts";
+import type { Product } from "./Product.ts";
+
+/**
+ * Dashboard UI providers for AWS ServiceCatalog resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** AWS Management & Governance brand pink. */
+const COLOR = "#E7157B";
+
+export const PortfolioUI = UIProvider.succeed<Portfolio>(
+  "AWS.ServiceCatalog.Portfolio",
+  {
+    displayName: "Service Catalog Portfolio",
+    icon: "briefcase",
+    color: COLOR,
+    category: "config",
+    summary: (ctx) => ctx.attrs?.portfolioName,
+    facts: (ctx) => [
+      { label: "portfolio", value: ctx.attrs?.portfolioName, copy: true },
+      {
+        label: "id",
+        value: ctx.attrs?.portfolioId,
+        mono: true,
+        copy: true,
+      },
+      { label: "arn", value: ctx.attrs?.portfolioArn, mono: true, copy: true },
+      { label: "owner", value: ctx.props?.providerName },
+    ],
+  },
+);
+
+export const PortfolioProductAssociationUI =
+  UIProvider.succeed<PortfolioProductAssociation>(
+    "AWS.ServiceCatalog.PortfolioProductAssociation",
+    {
+      displayName: "Portfolio Product Association",
+      icon: "link",
+      color: COLOR,
+      category: "config",
+      summary: (ctx) => ctx.attrs?.productId,
+      facts: (ctx) => [
+        {
+          label: "portfolio",
+          value: ctx.attrs?.portfolioId,
+          mono: true,
+          copy: true,
+        },
+        {
+          label: "product",
+          value: ctx.attrs?.productId,
+          mono: true,
+          copy: true,
+        },
+      ],
+    },
+  );
+
+export const PrincipalPortfolioAssociationUI =
+  UIProvider.succeed<PrincipalPortfolioAssociation>(
+    "AWS.ServiceCatalog.PrincipalPortfolioAssociation",
+    {
+      displayName: "Principal Portfolio Association",
+      icon: "users",
+      color: COLOR,
+      category: "config",
+      summary: (ctx) => ctx.attrs?.principalArn,
+      facts: (ctx) => [
+        {
+          label: "portfolio",
+          value: ctx.attrs?.portfolioId,
+          mono: true,
+          copy: true,
+        },
+        {
+          label: "principal",
+          value: ctx.attrs?.principalArn,
+          mono: true,
+          copy: true,
+        },
+        { label: "type", value: ctx.attrs?.principalType },
+      ],
+    },
+  );
+
+export const ProductUI = UIProvider.succeed<Product>(
+  "AWS.ServiceCatalog.Product",
+  {
+    displayName: "Service Catalog Product",
+    icon: "package",
+    color: COLOR,
+    category: "config",
+    summary: (ctx) => ctx.attrs?.productName,
+    facts: (ctx) => [
+      { label: "product", value: ctx.attrs?.productName, copy: true },
+      { label: "id", value: ctx.attrs?.productId, mono: true, copy: true },
+      { label: "arn", value: ctx.attrs?.productArn, mono: true, copy: true },
+      {
+        label: "provisioning artifact",
+        value: ctx.attrs?.provisioningArtifactId,
+        mono: true,
+      },
+      { label: "owner", value: ctx.props?.owner },
+      { label: "type", value: ctx.props?.productType },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(
+    PortfolioUI,
+    PortfolioProductAssociationUI,
+    PrincipalPortfolioAssociationUI,
+    ProductUI,
+  );

--- a/packages/alchemy/src/AWS/ServiceQuotas/ui.ts
+++ b/packages/alchemy/src/AWS/ServiceQuotas/ui.ts
@@ -1,0 +1,33 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { ServiceQuotaIncreaseRequest } from "./ServiceQuotaIncreaseRequest.ts";
+
+/**
+ * Dashboard UI providers for AWS ServiceQuotas resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+export const ServiceQuotaIncreaseRequestUI =
+  UIProvider.succeed<ServiceQuotaIncreaseRequest>(
+    "AWS.ServiceQuotas.ServiceQuotaIncreaseRequest",
+    {
+      displayName: "Service Quota Increase Request",
+      icon: "gauge",
+      color: "#E7157B",
+      category: "config",
+      summary: (ctx) => ctx.attrs?.quotaName ?? ctx.attrs?.quotaCode,
+      facts: (ctx) => [
+        { label: "service", value: ctx.attrs?.serviceName, copy: true },
+        { label: "quota", value: ctx.attrs?.quotaName },
+        { label: "status", value: ctx.attrs?.status },
+        { label: "desired", value: ctx.attrs?.desiredValue },
+        { label: "applied", value: ctx.attrs?.appliedValue },
+        { label: "request id", value: ctx.attrs?.requestId, mono: true },
+        { label: "case id", value: ctx.attrs?.caseId, mono: true },
+      ],
+    },
+  );
+
+export const ui = () => Layer.mergeAll(ServiceQuotaIncreaseRequestUI);

--- a/packages/alchemy/src/AWS/Shield/ui.ts
+++ b/packages/alchemy/src/AWS/Shield/ui.ts
@@ -1,0 +1,92 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Protection } from "./Protection.ts";
+import type { ProtectionGroup } from "./ProtectionGroup.ts";
+import type { Subscription } from "./Subscription.ts";
+
+/**
+ * Dashboard UI providers for AWS Shield resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+const COLOR = "#DD344C";
+
+export const ProtectionUI = UIProvider.succeed<Protection>(
+  "AWS.Shield.Protection",
+  {
+    displayName: "Shield Protection",
+    icon: "shield",
+    color: COLOR,
+    category: "security",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      { label: "id", value: ctx.attrs?.protectionId, mono: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.protectionArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "resource", value: ctx.attrs?.resourceArn, mono: true },
+      {
+        label: "layer 7 mitigation",
+        value: ctx.attrs?.applicationLayerAutomaticResponse,
+      },
+    ],
+  },
+);
+
+export const ProtectionGroupUI = UIProvider.succeed<ProtectionGroup>(
+  "AWS.Shield.ProtectionGroup",
+  {
+    displayName: "Shield Protection Group",
+    icon: "layers",
+    color: COLOR,
+    category: "security",
+    summary: (ctx) => ctx.attrs?.protectionGroupId,
+    facts: (ctx) => [
+      { label: "id", value: ctx.attrs?.protectionGroupId, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.protectionGroupArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "aggregation", value: ctx.attrs?.aggregation },
+      { label: "pattern", value: ctx.attrs?.pattern },
+      { label: "resource type", value: ctx.attrs?.resourceType },
+    ],
+  },
+);
+
+export const SubscriptionUI = UIProvider.succeed<Subscription>(
+  "AWS.Shield.Subscription",
+  {
+    displayName: "Shield Subscription",
+    icon: "credit-card",
+    color: COLOR,
+    category: "security",
+    summary: (ctx) => ctx.attrs?.subscriptionArn?.split("/").pop(),
+    facts: (ctx) => [
+      {
+        label: "arn",
+        value: ctx.attrs?.subscriptionArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "auto renew", value: ctx.attrs?.autoRenew },
+      { label: "start", value: ctx.attrs?.startTime },
+      { label: "end", value: ctx.attrs?.endTime },
+      {
+        label: "proactive engagement",
+        value: ctx.attrs?.proactiveEngagementStatus,
+      },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(ProtectionUI, ProtectionGroupUI, SubscriptionUI);

--- a/packages/alchemy/src/AWS/Signer/ui.ts
+++ b/packages/alchemy/src/AWS/Signer/ui.ts
@@ -1,0 +1,55 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { ProfilePermission } from "./ProfilePermission.ts";
+import type { SigningProfile } from "./SigningProfile.ts";
+
+/**
+ * Dashboard UI providers for AWS Signer resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+const SIGNER_COLOR = "#DD344C";
+
+export const ProfilePermissionUI = UIProvider.succeed<ProfilePermission>(
+  "AWS.Signer.ProfilePermission",
+  {
+    displayName: "Signer Profile Permission",
+    icon: "key-round",
+    color: SIGNER_COLOR,
+    category: "security",
+    summary: (ctx) => ctx.attrs?.statementId,
+    facts: (ctx) => [
+      {
+        label: "statement",
+        value: ctx.attrs?.statementId,
+        mono: true,
+        copy: true,
+      },
+      { label: "profile", value: ctx.attrs?.profileName, mono: true },
+      { label: "action", value: ctx.props?.action, mono: true },
+      { label: "principal", value: ctx.props?.principal, mono: true },
+    ],
+  },
+);
+
+export const SigningProfileUI = UIProvider.succeed<SigningProfile>(
+  "AWS.Signer.SigningProfile",
+  {
+    displayName: "Signer Signing Profile",
+    icon: "key",
+    color: SIGNER_COLOR,
+    category: "security",
+    summary: (ctx) => ctx.attrs?.profileName,
+    facts: (ctx) => [
+      { label: "profile", value: ctx.attrs?.profileName, copy: true },
+      { label: "arn", value: ctx.attrs?.arn, mono: true, copy: true },
+      { label: "version", value: ctx.attrs?.profileVersion, mono: true },
+      { label: "platform", value: ctx.attrs?.platformId },
+      { label: "status", value: ctx.attrs?.status },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(ProfilePermissionUI, SigningProfileUI);

--- a/packages/alchemy/src/AWS/SimpleDB/ui.ts
+++ b/packages/alchemy/src/AWS/SimpleDB/ui.ts
@@ -1,0 +1,24 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Domain } from "./Domain.ts";
+
+/**
+ * Dashboard UI providers for AWS SimpleDB resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+export const DomainUI = UIProvider.succeed<Domain>("AWS.SimpleDB.Domain", {
+  displayName: "SimpleDB Domain",
+  icon: "table",
+  color: "#C925D1",
+  category: "database",
+  summary: (ctx) => ctx.attrs?.domainName,
+  facts: (ctx) => [
+    { label: "domain", value: ctx.attrs?.domainName, copy: true },
+    { label: "arn", value: ctx.attrs?.domainArn, mono: true, copy: true },
+  ],
+});
+
+export const ui = () => Layer.mergeAll(DomainUI);

--- a/packages/alchemy/src/AWS/SocialMessaging/ui.ts
+++ b/packages/alchemy/src/AWS/SocialMessaging/ui.ts
@@ -1,0 +1,35 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { LinkedWhatsAppBusinessAccount } from "./LinkedWhatsAppBusinessAccount.ts";
+
+/**
+ * Dashboard UI providers for AWS SocialMessaging resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** AWS App Integration (End User Messaging Social) brand pink. */
+const COLOR = "#E7157B";
+
+export const LinkedWhatsAppBusinessAccountUI =
+  UIProvider.succeed<LinkedWhatsAppBusinessAccount>(
+    "AWS.SocialMessaging.LinkedWhatsAppBusinessAccount",
+    {
+      displayName: "Linked WhatsApp Business Account",
+      icon: "phone",
+      color: COLOR,
+      category: "eventing",
+      summary: (ctx) => ctx.attrs?.wabaName,
+      facts: (ctx) => [
+        { label: "waba name", value: ctx.attrs?.wabaName, copy: true },
+        { label: "id", value: ctx.attrs?.id, mono: true, copy: true },
+        { label: "arn", value: ctx.attrs?.arn, mono: true, copy: true },
+        { label: "waba id", value: ctx.attrs?.wabaId, mono: true },
+        { label: "registration", value: ctx.attrs?.registrationStatus },
+        { label: "phone numbers", value: ctx.attrs?.phoneNumbers?.length },
+      ],
+    },
+  );
+
+export const ui = () => Layer.mergeAll(LinkedWhatsAppBusinessAccountUI);

--- a/packages/alchemy/src/AWS/StepFunctions/ui.ts
+++ b/packages/alchemy/src/AWS/StepFunctions/ui.ts
@@ -1,0 +1,67 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Activity } from "./Activity.ts";
+import type { StateMachine } from "./StateMachine.ts";
+
+/**
+ * Dashboard UI providers for AWS Step Functions resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+const COLOR = "#E7157B";
+
+const regionOf = (arn: string | undefined): string | undefined =>
+  arn?.split(":")[3] || undefined;
+
+export const ActivityUI = UIProvider.succeed<Activity>(
+  "AWS.StepFunctions.Activity",
+  {
+    displayName: "Step Functions Activity",
+    icon: "inbox",
+    color: COLOR,
+    category: "eventing",
+    summary: (ctx) => ctx.attrs?.activityName,
+    consoleUrl: (ctx) => {
+      const region = regionOf(ctx.attrs?.activityArn);
+      return ctx.attrs?.activityArn === undefined || region === undefined
+        ? undefined
+        : `https://${region}.console.aws.amazon.com/states/home?region=${region}#/activities/details/${encodeURIComponent(ctx.attrs.activityArn)}`;
+    },
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.activityName, copy: true },
+      { label: "arn", value: ctx.attrs?.activityArn, mono: true, copy: true },
+    ],
+  },
+);
+
+export const StateMachineUI = UIProvider.succeed<StateMachine>(
+  "AWS.StepFunctions.StateMachine",
+  {
+    displayName: "Step Functions State Machine",
+    icon: "workflow",
+    color: COLOR,
+    category: "eventing",
+    summary: (ctx) => ctx.attrs?.stateMachineName,
+    consoleUrl: (ctx) => {
+      const region = regionOf(ctx.attrs?.stateMachineArn);
+      return ctx.attrs?.stateMachineArn === undefined || region === undefined
+        ? undefined
+        : `https://${region}.console.aws.amazon.com/states/home?region=${region}#/statemachines/view/${encodeURIComponent(ctx.attrs.stateMachineArn)}`;
+    },
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.stateMachineName, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.stateMachineArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "type", value: ctx.attrs?.type },
+      { label: "role", value: ctx.attrs?.roleArn, mono: true },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(ActivityUI, StateMachineUI);

--- a/packages/alchemy/src/AWS/Synthetics/ui.ts
+++ b/packages/alchemy/src/AWS/Synthetics/ui.ts
@@ -1,0 +1,50 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Canary } from "./Canary.ts";
+import type { Group } from "./Group.ts";
+
+/**
+ * Dashboard UI providers for AWS Synthetics resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+export const CanaryUI = UIProvider.succeed<Canary>("AWS.Synthetics.Canary", {
+  displayName: "Synthetics Canary",
+  icon: "test-tube",
+  color: "#E7157B",
+  category: "observability",
+  summary: (ctx) => ctx.attrs?.canaryName,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.canaryName, copy: true },
+    { label: "id", value: ctx.attrs?.canaryId, mono: true, copy: true },
+    { label: "arn", value: ctx.attrs?.canaryArn, mono: true, copy: true },
+    { label: "runtime", value: ctx.attrs?.runtimeVersion },
+    {
+      label: "artifacts",
+      value: ctx.attrs?.artifactS3Location,
+      mono: true,
+    },
+    { label: "role", value: ctx.attrs?.executionRoleArn, mono: true },
+  ],
+});
+
+export const GroupUI = UIProvider.succeed<Group>("AWS.Synthetics.Group", {
+  displayName: "Synthetics Group",
+  icon: "boxes",
+  color: "#E7157B",
+  category: "observability",
+  summary: (ctx) => ctx.attrs?.groupName,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.groupName, copy: true },
+    { label: "id", value: ctx.attrs?.groupId, mono: true, copy: true },
+    { label: "arn", value: ctx.attrs?.groupArn, mono: true, copy: true },
+    {
+      label: "members",
+      value: ctx.props?.members?.length,
+    },
+  ],
+});
+
+export const ui = () => Layer.mergeAll(CanaryUI, GroupUI);

--- a/packages/alchemy/src/AWS/Textract/ui.ts
+++ b/packages/alchemy/src/AWS/Textract/ui.ts
@@ -1,0 +1,32 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Adapter } from "./Adapter.ts";
+
+/**
+ * Dashboard UI providers for AWS Textract resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+export const AdapterUI = UIProvider.succeed<Adapter>("AWS.Textract.Adapter", {
+  displayName: "Textract Adapter",
+  icon: "file-text",
+  color: "#01A88D",
+  category: "ai",
+  summary: (ctx) => ctx.attrs?.adapterName,
+  facts: (ctx) => [
+    { label: "adapter", value: ctx.attrs?.adapterName, copy: true },
+    { label: "id", value: ctx.attrs?.adapterId, mono: true, copy: true },
+    { label: "arn", value: ctx.attrs?.adapterArn, mono: true, copy: true },
+    {
+      label: "feature types",
+      value: ctx.attrs?.featureTypes?.length
+        ? ctx.attrs.featureTypes.join(", ")
+        : undefined,
+    },
+    { label: "auto update", value: ctx.attrs?.autoUpdate },
+  ],
+});
+
+export const ui = () => Layer.mergeAll(AdapterUI);

--- a/packages/alchemy/src/AWS/Timestream/ui.ts
+++ b/packages/alchemy/src/AWS/Timestream/ui.ts
@@ -1,0 +1,101 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Database } from "./Database.ts";
+import type { DbInstance } from "./DbInstance.ts";
+import type { ScheduledQuery } from "./ScheduledQuery.ts";
+import type { Table } from "./Table.ts";
+
+/**
+ * Dashboard UI providers for AWS Timestream resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** AWS Database (Timestream) brand purple. */
+const COLOR = "#C925D1";
+
+export const DatabaseUI = UIProvider.succeed<Database>(
+  "AWS.Timestream.Database",
+  {
+    displayName: "Timestream Database",
+    icon: "database",
+    color: COLOR,
+    category: "database",
+    summary: (ctx) => ctx.attrs?.databaseName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.databaseName, copy: true },
+      { label: "arn", value: ctx.attrs?.databaseArn, mono: true, copy: true },
+      { label: "kms key", value: ctx.attrs?.kmsKeyId, mono: true },
+      { label: "tables", value: ctx.attrs?.tableCount },
+    ],
+  },
+);
+
+export const DbInstanceUI = UIProvider.succeed<DbInstance>(
+  "AWS.Timestream.DbInstance",
+  {
+    displayName: "Timestream InfluxDB Instance",
+    icon: "server",
+    color: COLOR,
+    category: "database",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      { label: "id", value: ctx.attrs?.id, mono: true, copy: true },
+      { label: "arn", value: ctx.attrs?.arn, mono: true, copy: true },
+      { label: "status", value: ctx.attrs?.status },
+      {
+        label: "endpoint",
+        value: ctx.attrs?.endpoint,
+        mono: true,
+        copy: true,
+      },
+      { label: "instance type", value: ctx.attrs?.dbInstanceType },
+    ],
+  },
+);
+
+export const ScheduledQueryUI = UIProvider.succeed<ScheduledQuery>(
+  "AWS.Timestream.ScheduledQuery",
+  {
+    displayName: "Timestream Scheduled Query",
+    icon: "clock",
+    color: COLOR,
+    category: "database",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.scheduledQueryArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "state", value: ctx.attrs?.state },
+      { label: "schedule", value: ctx.props?.scheduleExpression, mono: true },
+    ],
+  },
+);
+
+export const TableUI = UIProvider.succeed<Table>("AWS.Timestream.Table", {
+  displayName: "Timestream Table",
+  icon: "table",
+  color: COLOR,
+  category: "database",
+  summary: (ctx) => ctx.attrs?.tableName,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.tableName, copy: true },
+    {
+      label: "database",
+      value: ctx.attrs?.databaseName,
+      mono: true,
+      copy: true,
+    },
+    { label: "arn", value: ctx.attrs?.tableArn, mono: true, copy: true },
+    { label: "status", value: ctx.attrs?.tableStatus },
+  ],
+});
+
+export const ui = () =>
+  Layer.mergeAll(DatabaseUI, DbInstanceUI, ScheduledQueryUI, TableUI);

--- a/packages/alchemy/src/AWS/Transfer/ui.ts
+++ b/packages/alchemy/src/AWS/Transfer/ui.ts
@@ -1,0 +1,61 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Server } from "./Server.ts";
+import type { User } from "./User.ts";
+
+/**
+ * Dashboard UI providers for AWS Transfer resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+const regionOf = (arn: string | undefined) => arn?.split(":")[3];
+
+export const ServerUI = UIProvider.succeed<Server>("AWS.Transfer.Server", {
+  displayName: "Transfer Family Server",
+  icon: "server",
+  color: "#7AA116",
+  category: "storage",
+  summary: (ctx) => ctx.attrs?.serverId,
+  consoleUrl: (ctx) => {
+    const region = regionOf(ctx.attrs?.arn);
+    return ctx.attrs?.serverId === undefined || region === undefined
+      ? undefined
+      : `https://${region}.console.aws.amazon.com/transfer/home?region=${region}#/servers/${ctx.attrs.serverId}`;
+  },
+  facts: (ctx) => [
+    { label: "server", value: ctx.attrs?.serverId, mono: true, copy: true },
+    { label: "arn", value: ctx.attrs?.arn, mono: true, copy: true },
+    { label: "endpoint type", value: ctx.attrs?.endpointType },
+    { label: "domain", value: ctx.attrs?.domain },
+    { label: "identity provider", value: ctx.attrs?.identityProviderType },
+    { label: "protocols", value: ctx.attrs?.protocols?.join(", ") },
+    { label: "state", value: ctx.attrs?.state },
+  ],
+});
+
+export const UserUI = UIProvider.succeed<User>("AWS.Transfer.User", {
+  displayName: "Transfer Family User",
+  icon: "user",
+  color: "#7AA116",
+  category: "auth",
+  summary: (ctx) => ctx.attrs?.userName,
+  consoleUrl: (ctx) => {
+    const region = regionOf(ctx.attrs?.arn);
+    return ctx.attrs?.serverId === undefined ||
+      ctx.attrs?.userName === undefined ||
+      region === undefined
+      ? undefined
+      : `https://${region}.console.aws.amazon.com/transfer/home?region=${region}#/servers/${ctx.attrs.serverId}/users/${ctx.attrs.userName}`;
+  },
+  facts: (ctx) => [
+    { label: "user", value: ctx.attrs?.userName, copy: true },
+    { label: "server", value: ctx.attrs?.serverId, mono: true, copy: true },
+    { label: "arn", value: ctx.attrs?.arn, mono: true, copy: true },
+    { label: "role", value: ctx.attrs?.role, mono: true },
+    { label: "home directory", value: ctx.attrs?.homeDirectory, mono: true },
+  ],
+});
+
+export const ui = () => Layer.mergeAll(ServerUI, UserUI);

--- a/packages/alchemy/src/AWS/Translate/ui.ts
+++ b/packages/alchemy/src/AWS/Translate/ui.ts
@@ -1,0 +1,70 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { ParallelData } from "./ParallelData.ts";
+import type { Terminology } from "./Terminology.ts";
+
+/**
+ * Dashboard UI providers for AWS Translate resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** AWS Machine Learning & AI (Translate) brand teal. */
+const COLOR = "#01A88D";
+
+export const ParallelDataUI = UIProvider.succeed<ParallelData>(
+  "AWS.Translate.ParallelData",
+  {
+    displayName: "Translate Parallel Data",
+    icon: "languages",
+    color: COLOR,
+    category: "ai",
+    summary: (ctx) => ctx.attrs?.parallelDataName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.parallelDataName, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.parallelDataArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "status", value: ctx.attrs?.status },
+      { label: "source language", value: ctx.attrs?.sourceLanguageCode },
+      {
+        label: "target languages",
+        value: ctx.attrs?.targetLanguageCodes?.join(", "),
+      },
+      { label: "imported records", value: ctx.attrs?.importedRecordCount },
+    ],
+  },
+);
+
+export const TerminologyUI = UIProvider.succeed<Terminology>(
+  "AWS.Translate.Terminology",
+  {
+    displayName: "Translate Terminology",
+    icon: "book-open",
+    color: COLOR,
+    category: "ai",
+    summary: (ctx) => ctx.attrs?.terminologyName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.terminologyName, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.terminologyArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "source language", value: ctx.attrs?.sourceLanguageCode },
+      {
+        label: "target languages",
+        value: ctx.attrs?.targetLanguageCodes?.join(", "),
+      },
+      { label: "term count", value: ctx.attrs?.termCount },
+      { label: "directionality", value: ctx.attrs?.directionality },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(ParallelDataUI, TerminologyUI);

--- a/packages/alchemy/src/AWS/UI.ts
+++ b/packages/alchemy/src/AWS/UI.ts
@@ -1,0 +1,410 @@
+import * as Layer from "effect/Layer";
+import * as ACMUI from "./ACM/ui.ts";
+import * as ACMPCAUI from "./ACMPCA/ui.ts";
+import * as AIOpsUI from "./AIOps/ui.ts";
+import * as AMPUI from "./AMP/ui.ts";
+import * as AccessAnalyzerUI from "./AccessAnalyzer/ui.ts";
+import * as AccountUI from "./Account/ui.ts";
+import * as AmplifyUI from "./Amplify/ui.ts";
+import * as ApiGatewayUI from "./ApiGateway/ui.ts";
+import * as ApiGatewayV2UI from "./ApiGatewayV2/ui.ts";
+import * as AppConfigUI from "./AppConfig/ui.ts";
+import * as AppFlowUI from "./AppFlow/ui.ts";
+import * as AppIntegrationsUI from "./AppIntegrations/ui.ts";
+import * as AppRegistryUI from "./AppRegistry/ui.ts";
+import * as AppRunnerUI from "./AppRunner/ui.ts";
+import * as AppSyncUI from "./AppSync/ui.ts";
+import * as ApplicationAutoScalingUI from "./ApplicationAutoScaling/ui.ts";
+import * as ApplicationSignalsUI from "./ApplicationSignals/ui.ts";
+import * as AthenaUI from "./Athena/ui.ts";
+import * as AuditManagerUI from "./AuditManager/ui.ts";
+import * as AutoScalingUI from "./AutoScaling/ui.ts";
+import * as B2BIUI from "./B2BI/ui.ts";
+import * as BCMDataExportsUI from "./BCMDataExports/ui.ts";
+import * as BackupUI from "./Backup/ui.ts";
+import * as BackupSearchUI from "./BackupSearch/ui.ts";
+import * as BatchUI from "./Batch/ui.ts";
+import * as BedrockUI from "./Bedrock/ui.ts";
+import * as BedrockAgentCoreUI from "./BedrockAgentCore/ui.ts";
+import * as BedrockDataAutomationUI from "./BedrockDataAutomation/ui.ts";
+import * as BudgetsUI from "./Budgets/ui.ts";
+import * as ChatbotUI from "./Chatbot/ui.ts";
+import * as CloudFormationUI from "./CloudFormation/ui.ts";
+import * as CloudFrontUI from "./CloudFront/ui.ts";
+import * as CloudHSMV2UI from "./CloudHSMV2/ui.ts";
+import * as CloudMapUI from "./CloudMap/ui.ts";
+import * as CloudTrailUI from "./CloudTrail/ui.ts";
+import * as CloudWatchUI from "./CloudWatch/ui.ts";
+import * as CodeArtifactUI from "./CodeArtifact/ui.ts";
+import * as CodeBuildUI from "./CodeBuild/ui.ts";
+import * as CodeConnectionsUI from "./CodeConnections/ui.ts";
+import * as CodeDeployUI from "./CodeDeploy/ui.ts";
+import * as CodePipelineUI from "./CodePipeline/ui.ts";
+import * as CognitoUI from "./Cognito/ui.ts";
+import * as ConfigUI from "./Config/ui.ts";
+import * as ControlTowerUI from "./ControlTower/ui.ts";
+import * as CostAndUsageReportUI from "./CostAndUsageReport/ui.ts";
+import * as CostExplorerUI from "./CostExplorer/ui.ts";
+import * as DAXUI from "./DAX/ui.ts";
+import * as DLMUI from "./DLM/ui.ts";
+import * as DMSUI from "./DMS/ui.ts";
+import * as DSQLUI from "./DSQL/ui.ts";
+import * as DataBrewUI from "./DataBrew/ui.ts";
+import * as DataExchangeUI from "./DataExchange/ui.ts";
+import * as DataSyncUI from "./DataSync/ui.ts";
+import * as DataZoneUI from "./DataZone/ui.ts";
+import * as DeadlineUI from "./Deadline/ui.ts";
+import * as DetectiveUI from "./Detective/ui.ts";
+import * as DevOpsGuruUI from "./DevOpsGuru/ui.ts";
+import * as DirectoryServiceUI from "./DirectoryService/ui.ts";
+import * as DocDBUI from "./DocDB/ui.ts";
+import * as DocDBElasticUI from "./DocDBElastic/ui.ts";
+import * as DynamoDBUI from "./DynamoDB/ui.ts";
+import * as EC2UI from "./EC2/ui.ts";
+import * as ECRUI from "./ECR/ui.ts";
+import * as ECRPublicUI from "./ECRPublic/ui.ts";
+import * as ECSUI from "./ECS/ui.ts";
+import * as EFSUI from "./EFS/ui.ts";
+import * as EKSUI from "./EKS/ui.ts";
+import * as ELBv2UI from "./ELBv2/ui.ts";
+import * as EMRUI from "./EMR/ui.ts";
+import * as EMRContainersUI from "./EMRContainers/ui.ts";
+import * as EMRServerlessUI from "./EMRServerless/ui.ts";
+import * as ElastiCacheUI from "./ElastiCache/ui.ts";
+import * as EntityResolutionUI from "./EntityResolution/ui.ts";
+import * as EventBridgeUI from "./EventBridge/ui.ts";
+import * as FISUI from "./FIS/ui.ts";
+import * as FMSUI from "./FMS/ui.ts";
+import * as FSxUI from "./FSx/ui.ts";
+import * as FinSpaceUI from "./FinSpace/ui.ts";
+import * as FirehoseUI from "./Firehose/ui.ts";
+import * as ForecastUI from "./Forecast/ui.ts";
+import * as FraudDetectorUI from "./FraudDetector/ui.ts";
+import * as GlacierUI from "./Glacier/ui.ts";
+import * as GlobalAcceleratorUI from "./GlobalAccelerator/ui.ts";
+import * as GlueUI from "./Glue/ui.ts";
+import * as GrafanaUI from "./Grafana/ui.ts";
+import * as GreengrassV2UI from "./GreengrassV2/ui.ts";
+import * as GuardDutyUI from "./GuardDuty/ui.ts";
+import * as HealthLakeUI from "./HealthLake/ui.ts";
+import * as IAMUI from "./IAM/ui.ts";
+import * as IVSUI from "./IVS/ui.ts";
+import * as IVSChatUI from "./IVSChat/ui.ts";
+import * as IVSRealtimeUI from "./IVSRealtime/ui.ts";
+import * as IdentityCenterUI from "./IdentityCenter/ui.ts";
+import * as ImageBuilderUI from "./ImageBuilder/ui.ts";
+import * as Inspector2UI from "./Inspector2/ui.ts";
+import * as InternetMonitorUI from "./InternetMonitor/ui.ts";
+import * as IoTUI from "./IoT/ui.ts";
+import * as IoTFleetWiseUI from "./IoTFleetWise/ui.ts";
+import * as IoTManagedIntegrationsUI from "./IoTManagedIntegrations/ui.ts";
+import * as IoTSiteWiseUI from "./IoTSiteWise/ui.ts";
+import * as IoTWirelessUI from "./IoTWireless/ui.ts";
+import * as KMSUI from "./KMS/ui.ts";
+import * as KafkaUI from "./Kafka/ui.ts";
+import * as KendraUI from "./Kendra/ui.ts";
+import * as KeyspacesUI from "./Keyspaces/ui.ts";
+import * as KinesisUI from "./Kinesis/ui.ts";
+import * as KinesisAnalyticsV2UI from "./KinesisAnalyticsV2/ui.ts";
+import * as KinesisVideoUI from "./KinesisVideo/ui.ts";
+import * as LakeFormationUI from "./LakeFormation/ui.ts";
+import * as LambdaUI from "./Lambda/ui.ts";
+import * as LexV2UI from "./LexV2/ui.ts";
+import * as LicenseManagerUI from "./LicenseManager/ui.ts";
+import * as LocationUI from "./Location/ui.ts";
+import * as LogsUI from "./Logs/ui.ts";
+import * as MQUI from "./MQ/ui.ts";
+import * as MWAAUI from "./MWAA/ui.ts";
+import * as MWAAServerlessUI from "./MWAAServerless/ui.ts";
+import * as Macie2UI from "./Macie2/ui.ts";
+import * as MailManagerUI from "./MailManager/ui.ts";
+import * as MediaConnectUI from "./MediaConnect/ui.ts";
+import * as MediaConvertUI from "./MediaConvert/ui.ts";
+import * as MediaLiveUI from "./MediaLive/ui.ts";
+import * as MediaPackageV2UI from "./MediaPackageV2/ui.ts";
+import * as MediaTailorUI from "./MediaTailor/ui.ts";
+import * as MedicalImagingUI from "./MedicalImaging/ui.ts";
+import * as MemoryDBUI from "./MemoryDB/ui.ts";
+import * as NeptuneUI from "./Neptune/ui.ts";
+import * as NeptuneGraphUI from "./NeptuneGraph/ui.ts";
+import * as NetworkFirewallUI from "./NetworkFirewall/ui.ts";
+import * as NotificationsUI from "./Notifications/ui.ts";
+import * as NotificationsContactsUI from "./NotificationsContacts/ui.ts";
+import * as OAMUI from "./OAM/ui.ts";
+import * as OSISUI from "./OSIS/ui.ts";
+import * as ObservabilityAdminUI from "./ObservabilityAdmin/ui.ts";
+import * as OmicsUI from "./Omics/ui.ts";
+import * as OpenSearchUI from "./OpenSearch/ui.ts";
+import * as OpenSearchServerlessUI from "./OpenSearchServerless/ui.ts";
+import * as OrganizationsUI from "./Organizations/ui.ts";
+import * as PaymentCryptographyUI from "./PaymentCryptography/ui.ts";
+import * as PersonalizeUI from "./Personalize/ui.ts";
+import * as PinpointSMSVoiceV2UI from "./PinpointSMSVoiceV2/ui.ts";
+import * as PipesUI from "./Pipes/ui.ts";
+import * as PollyUI from "./Polly/ui.ts";
+import * as QAppsUI from "./QApps/ui.ts";
+import * as QBusinessUI from "./QBusiness/ui.ts";
+import * as QuickSightUI from "./QuickSight/ui.ts";
+import * as RAMUI from "./RAM/ui.ts";
+import * as RDSUI from "./RDS/ui.ts";
+import * as RUMUI from "./RUM/ui.ts";
+import * as RbinUI from "./Rbin/ui.ts";
+import * as RePostSpaceUI from "./RePostSpace/ui.ts";
+import * as RedshiftUI from "./Redshift/ui.ts";
+import * as RedshiftServerlessUI from "./RedshiftServerless/ui.ts";
+import * as ResourceExplorerUI from "./ResourceExplorer/ui.ts";
+import * as ResourceGroupsUI from "./ResourceGroups/ui.ts";
+import * as RolesAnywhereUI from "./RolesAnywhere/ui.ts";
+import * as Route53UI from "./Route53/ui.ts";
+import * as Route53ProfilesUI from "./Route53Profiles/ui.ts";
+import * as Route53ResolverUI from "./Route53Resolver/ui.ts";
+import * as S3UI from "./S3/ui.ts";
+import * as S3ControlUI from "./S3Control/ui.ts";
+import * as S3FilesUI from "./S3Files/ui.ts";
+import * as S3TablesUI from "./S3Tables/ui.ts";
+import * as S3VectorsUI from "./S3Vectors/ui.ts";
+import * as SESUI from "./SES/ui.ts";
+import * as SNSUI from "./SNS/ui.ts";
+import * as SQSUI from "./SQS/ui.ts";
+import * as SSMUI from "./SSM/ui.ts";
+import * as SSMContactsUI from "./SSMContacts/ui.ts";
+import * as SSMIncidentsUI from "./SSMIncidents/ui.ts";
+import * as SageMakerUI from "./SageMaker/ui.ts";
+import * as SchedulerUI from "./Scheduler/ui.ts";
+import * as SchemasUI from "./Schemas/ui.ts";
+import * as SecretsManagerUI from "./SecretsManager/ui.ts";
+import * as SecurityHubUI from "./SecurityHub/ui.ts";
+import * as SecurityLakeUI from "./SecurityLake/ui.ts";
+import * as ServiceCatalogUI from "./ServiceCatalog/ui.ts";
+import * as ServiceQuotasUI from "./ServiceQuotas/ui.ts";
+import * as ShieldUI from "./Shield/ui.ts";
+import * as SignerUI from "./Signer/ui.ts";
+import * as SimpleDBUI from "./SimpleDB/ui.ts";
+import * as SocialMessagingUI from "./SocialMessaging/ui.ts";
+import * as StepFunctionsUI from "./StepFunctions/ui.ts";
+import * as SyntheticsUI from "./Synthetics/ui.ts";
+import * as TextractUI from "./Textract/ui.ts";
+import * as TimestreamUI from "./Timestream/ui.ts";
+import * as TransferUI from "./Transfer/ui.ts";
+import * as TranslateUI from "./Translate/ui.ts";
+import * as VerifiedPermissionsUI from "./VerifiedPermissions/ui.ts";
+import * as VpcLatticeUI from "./VpcLattice/ui.ts";
+import * as WAFv2UI from "./WAFv2/ui.ts";
+import * as WebsiteUI from "./Website/ui.ts";
+import * as XRayUI from "./XRay/ui.ts";
+
+/**
+ * Aggregated dashboard UI providers for every AWS service.
+ *
+ * Generated by scripts (see processes/Dashboard.md). Per-service providers
+ * live in `AWS/{Service}/ui.ts`; keep merge groups nested (≤ 35
+ * entries) to stay under tsc's variadic-inference ceiling.
+ */
+export const ui = () =>
+  Layer.mergeAll(
+    Layer.mergeAll(
+      ACMUI.ui(),
+      ACMPCAUI.ui(),
+      AIOpsUI.ui(),
+      AMPUI.ui(),
+      AccessAnalyzerUI.ui(),
+      AccountUI.ui(),
+      AmplifyUI.ui(),
+      ApiGatewayUI.ui(),
+      ApiGatewayV2UI.ui(),
+      AppConfigUI.ui(),
+      AppFlowUI.ui(),
+      AppIntegrationsUI.ui(),
+      AppRegistryUI.ui(),
+      AppRunnerUI.ui(),
+      AppSyncUI.ui(),
+      ApplicationAutoScalingUI.ui(),
+      ApplicationSignalsUI.ui(),
+      AthenaUI.ui(),
+      AuditManagerUI.ui(),
+      AutoScalingUI.ui(),
+      B2BIUI.ui(),
+      BCMDataExportsUI.ui(),
+      BackupUI.ui(),
+      BackupSearchUI.ui(),
+      BatchUI.ui(),
+      BedrockUI.ui(),
+      BedrockAgentCoreUI.ui(),
+      BedrockDataAutomationUI.ui(),
+      BudgetsUI.ui(),
+      ChatbotUI.ui(),
+      CloudFormationUI.ui(),
+      CloudFrontUI.ui(),
+      CloudHSMV2UI.ui(),
+      CloudMapUI.ui(),
+      CloudTrailUI.ui(),
+    ),
+    Layer.mergeAll(
+      CloudWatchUI.ui(),
+      CodeArtifactUI.ui(),
+      CodeBuildUI.ui(),
+      CodeConnectionsUI.ui(),
+      CodeDeployUI.ui(),
+      CodePipelineUI.ui(),
+      CognitoUI.ui(),
+      ConfigUI.ui(),
+      ControlTowerUI.ui(),
+      CostAndUsageReportUI.ui(),
+      CostExplorerUI.ui(),
+      DAXUI.ui(),
+      DLMUI.ui(),
+      DMSUI.ui(),
+      DSQLUI.ui(),
+      DataBrewUI.ui(),
+      DataExchangeUI.ui(),
+      DataSyncUI.ui(),
+      DataZoneUI.ui(),
+      DeadlineUI.ui(),
+      DetectiveUI.ui(),
+      DevOpsGuruUI.ui(),
+      DirectoryServiceUI.ui(),
+      DocDBUI.ui(),
+      DocDBElasticUI.ui(),
+      DynamoDBUI.ui(),
+      EC2UI.ui(),
+      ECRUI.ui(),
+      ECRPublicUI.ui(),
+      ECSUI.ui(),
+      EFSUI.ui(),
+      EKSUI.ui(),
+      ELBv2UI.ui(),
+      EMRUI.ui(),
+      EMRContainersUI.ui(),
+    ),
+    Layer.mergeAll(
+      EMRServerlessUI.ui(),
+      ElastiCacheUI.ui(),
+      EntityResolutionUI.ui(),
+      EventBridgeUI.ui(),
+      FISUI.ui(),
+      FMSUI.ui(),
+      FSxUI.ui(),
+      FinSpaceUI.ui(),
+      FirehoseUI.ui(),
+      ForecastUI.ui(),
+      FraudDetectorUI.ui(),
+      GlacierUI.ui(),
+      GlobalAcceleratorUI.ui(),
+      GlueUI.ui(),
+      GrafanaUI.ui(),
+      GreengrassV2UI.ui(),
+      GuardDutyUI.ui(),
+      HealthLakeUI.ui(),
+      IAMUI.ui(),
+      IVSUI.ui(),
+      IVSChatUI.ui(),
+      IVSRealtimeUI.ui(),
+      IdentityCenterUI.ui(),
+      ImageBuilderUI.ui(),
+      Inspector2UI.ui(),
+      InternetMonitorUI.ui(),
+      IoTUI.ui(),
+      IoTFleetWiseUI.ui(),
+      IoTManagedIntegrationsUI.ui(),
+      IoTSiteWiseUI.ui(),
+      IoTWirelessUI.ui(),
+      KMSUI.ui(),
+      KafkaUI.ui(),
+      KendraUI.ui(),
+      KeyspacesUI.ui(),
+    ),
+    Layer.mergeAll(
+      KinesisUI.ui(),
+      KinesisAnalyticsV2UI.ui(),
+      KinesisVideoUI.ui(),
+      LakeFormationUI.ui(),
+      LambdaUI.ui(),
+      LexV2UI.ui(),
+      LicenseManagerUI.ui(),
+      LocationUI.ui(),
+      LogsUI.ui(),
+      MQUI.ui(),
+      MWAAUI.ui(),
+      MWAAServerlessUI.ui(),
+      Macie2UI.ui(),
+      MailManagerUI.ui(),
+      MediaConnectUI.ui(),
+      MediaConvertUI.ui(),
+      MediaLiveUI.ui(),
+      MediaPackageV2UI.ui(),
+      MediaTailorUI.ui(),
+      MedicalImagingUI.ui(),
+      MemoryDBUI.ui(),
+      NeptuneUI.ui(),
+      NeptuneGraphUI.ui(),
+      NetworkFirewallUI.ui(),
+      NotificationsUI.ui(),
+      NotificationsContactsUI.ui(),
+      OAMUI.ui(),
+      OSISUI.ui(),
+      ObservabilityAdminUI.ui(),
+      OmicsUI.ui(),
+      OpenSearchUI.ui(),
+      OpenSearchServerlessUI.ui(),
+      OrganizationsUI.ui(),
+      PaymentCryptographyUI.ui(),
+      PersonalizeUI.ui(),
+    ),
+    Layer.mergeAll(
+      PinpointSMSVoiceV2UI.ui(),
+      PipesUI.ui(),
+      PollyUI.ui(),
+      QAppsUI.ui(),
+      QBusinessUI.ui(),
+      QuickSightUI.ui(),
+      RAMUI.ui(),
+      RDSUI.ui(),
+      RUMUI.ui(),
+      RbinUI.ui(),
+      RePostSpaceUI.ui(),
+      RedshiftUI.ui(),
+      RedshiftServerlessUI.ui(),
+      ResourceExplorerUI.ui(),
+      ResourceGroupsUI.ui(),
+      RolesAnywhereUI.ui(),
+      Route53UI.ui(),
+      Route53ProfilesUI.ui(),
+      Route53ResolverUI.ui(),
+      S3UI.ui(),
+      S3ControlUI.ui(),
+      S3FilesUI.ui(),
+      S3TablesUI.ui(),
+      S3VectorsUI.ui(),
+      SESUI.ui(),
+      SNSUI.ui(),
+      SQSUI.ui(),
+      SSMUI.ui(),
+      SSMContactsUI.ui(),
+      SSMIncidentsUI.ui(),
+      SageMakerUI.ui(),
+      SchedulerUI.ui(),
+      SchemasUI.ui(),
+      SecretsManagerUI.ui(),
+      SecurityHubUI.ui(),
+    ),
+    Layer.mergeAll(
+      SecurityLakeUI.ui(),
+      ServiceCatalogUI.ui(),
+      ServiceQuotasUI.ui(),
+      ShieldUI.ui(),
+      SignerUI.ui(),
+      SimpleDBUI.ui(),
+      SocialMessagingUI.ui(),
+      StepFunctionsUI.ui(),
+      SyntheticsUI.ui(),
+      TextractUI.ui(),
+      TimestreamUI.ui(),
+      TransferUI.ui(),
+      TranslateUI.ui(),
+      VerifiedPermissionsUI.ui(),
+      VpcLatticeUI.ui(),
+      WAFv2UI.ui(),
+      WebsiteUI.ui(),
+      XRayUI.ui(),
+    ),
+  );

--- a/packages/alchemy/src/AWS/VerifiedPermissions/ui.ts
+++ b/packages/alchemy/src/AWS/VerifiedPermissions/ui.ts
@@ -1,0 +1,143 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { IdentitySource } from "./IdentitySource.ts";
+import type { Policy } from "./Policy.ts";
+import type { PolicyStore } from "./PolicyStore.ts";
+import type { PolicyStoreAlias } from "./PolicyStoreAlias.ts";
+import type { PolicyTemplate } from "./PolicyTemplate.ts";
+import type { Schema } from "./Schema.ts";
+
+/**
+ * Dashboard UI providers for AWS Verified Permissions resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** AWS Security, Identity & Compliance brand red. */
+const COLOR = "#DD344C";
+
+export const PolicyStoreUI = UIProvider.succeed<PolicyStore>(
+  "AWS.VerifiedPermissions.PolicyStore",
+  {
+    displayName: "Verified Permissions Policy Store",
+    icon: "shield",
+    color: COLOR,
+    category: "security",
+    summary: (ctx) => ctx.attrs?.policyStoreId,
+    facts: (ctx) => [
+      {
+        label: "store",
+        value: ctx.attrs?.policyStoreId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.policyStoreArn,
+        mono: true,
+        copy: true,
+      },
+    ],
+  },
+);
+
+export const PolicyUI = UIProvider.succeed<Policy>(
+  "AWS.VerifiedPermissions.Policy",
+  {
+    displayName: "Verified Permissions Policy",
+    icon: "scroll-text",
+    color: COLOR,
+    category: "security",
+    summary: (ctx) => ctx.attrs?.policyId,
+    facts: (ctx) => [
+      { label: "policy", value: ctx.attrs?.policyId, mono: true, copy: true },
+      { label: "store", value: ctx.attrs?.policyStoreId, mono: true },
+    ],
+  },
+);
+
+export const PolicyStoreAliasUI = UIProvider.succeed<PolicyStoreAlias>(
+  "AWS.VerifiedPermissions.PolicyStoreAlias",
+  {
+    displayName: "Verified Permissions Policy Store Alias",
+    icon: "tag",
+    color: COLOR,
+    category: "security",
+    summary: (ctx) => ctx.attrs?.aliasName,
+    facts: (ctx) => [
+      { label: "alias", value: ctx.attrs?.aliasName, copy: true },
+      { label: "arn", value: ctx.attrs?.aliasArn, mono: true, copy: true },
+      { label: "store", value: ctx.attrs?.policyStoreId, mono: true },
+    ],
+  },
+);
+
+export const PolicyTemplateUI = UIProvider.succeed<PolicyTemplate>(
+  "AWS.VerifiedPermissions.PolicyTemplate",
+  {
+    displayName: "Verified Permissions Policy Template",
+    icon: "file-text",
+    color: COLOR,
+    category: "security",
+    summary: (ctx) => ctx.attrs?.policyTemplateId,
+    facts: (ctx) => [
+      {
+        label: "template",
+        value: ctx.attrs?.policyTemplateId,
+        mono: true,
+        copy: true,
+      },
+      { label: "store", value: ctx.attrs?.policyStoreId, mono: true },
+    ],
+  },
+);
+
+export const SchemaUI = UIProvider.succeed<Schema>(
+  "AWS.VerifiedPermissions.Schema",
+  {
+    displayName: "Verified Permissions Schema",
+    icon: "code",
+    color: COLOR,
+    category: "security",
+    summary: (ctx) => ctx.attrs?.policyStoreId,
+    facts: (ctx) => [
+      {
+        label: "store",
+        value: ctx.attrs?.policyStoreId,
+        mono: true,
+        copy: true,
+      },
+    ],
+  },
+);
+
+export const IdentitySourceUI = UIProvider.succeed<IdentitySource>(
+  "AWS.VerifiedPermissions.IdentitySource",
+  {
+    displayName: "Verified Permissions Identity Source",
+    icon: "share-2",
+    color: COLOR,
+    category: "auth",
+    summary: (ctx) => ctx.attrs?.identitySourceId,
+    facts: (ctx) => [
+      {
+        label: "identity source",
+        value: ctx.attrs?.identitySourceId,
+        mono: true,
+        copy: true,
+      },
+      { label: "store", value: ctx.attrs?.policyStoreId, mono: true },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(
+    PolicyStoreUI,
+    PolicyUI,
+    PolicyStoreAliasUI,
+    PolicyTemplateUI,
+    SchemaUI,
+    IdentitySourceUI,
+  );

--- a/packages/alchemy/src/AWS/VpcLattice/ui.ts
+++ b/packages/alchemy/src/AWS/VpcLattice/ui.ts
@@ -1,0 +1,292 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { AccessLogSubscription } from "./AccessLogSubscription.ts";
+import type { AuthPolicy } from "./AuthPolicy.ts";
+import type { Listener } from "./Listener.ts";
+import type { ResourcePolicy } from "./ResourcePolicy.ts";
+import type { Rule } from "./Rule.ts";
+import type { Service } from "./Service.ts";
+import type { ServiceNetwork } from "./ServiceNetwork.ts";
+import type { ServiceNetworkServiceAssociation } from "./ServiceNetworkServiceAssociation.ts";
+import type { ServiceNetworkVpcAssociation } from "./ServiceNetworkVpcAssociation.ts";
+import type { TargetGroup } from "./TargetGroup.ts";
+
+/**
+ * Dashboard UI providers for AWS VpcLattice resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+const COLOR = "#8C4FFF";
+
+export const ServiceNetworkUI = UIProvider.succeed<ServiceNetwork>(
+  "AWS.VpcLattice.ServiceNetwork",
+  {
+    displayName: "VPC Lattice Service Network",
+    icon: "network",
+    color: COLOR,
+    category: "network",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "network", value: ctx.attrs?.name, copy: true },
+      {
+        label: "id",
+        value: ctx.attrs?.serviceNetworkId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.serviceNetworkArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "auth type", value: ctx.attrs?.authType },
+    ],
+  },
+);
+
+export const ServiceUI = UIProvider.succeed<Service>("AWS.VpcLattice.Service", {
+  displayName: "VPC Lattice Service",
+  icon: "share-2",
+  color: COLOR,
+  category: "network",
+  summary: (ctx) => ctx.attrs?.name,
+  facts: (ctx) => [
+    { label: "service", value: ctx.attrs?.name, copy: true },
+    { label: "id", value: ctx.attrs?.serviceId, mono: true, copy: true },
+    { label: "arn", value: ctx.attrs?.serviceArn, mono: true, copy: true },
+    { label: "status", value: ctx.attrs?.status },
+    { label: "dns name", value: ctx.attrs?.dnsName, mono: true, copy: true },
+    { label: "auth type", value: ctx.attrs?.authType },
+  ],
+});
+
+export const ListenerUI = UIProvider.succeed<Listener>(
+  "AWS.VpcLattice.Listener",
+  {
+    displayName: "VPC Lattice Listener",
+    icon: "plug",
+    color: COLOR,
+    category: "network",
+    summary: (ctx) =>
+      ctx.attrs?.protocol === undefined
+        ? ctx.attrs?.name
+        : `${ctx.attrs.protocol}${ctx.attrs.port ? `:${ctx.attrs.port}` : ""}`,
+    facts: (ctx) => [
+      { label: "listener", value: ctx.attrs?.name, copy: true },
+      { label: "id", value: ctx.attrs?.listenerId, mono: true, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.listenerArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "protocol", value: ctx.attrs?.protocol },
+      { label: "port", value: ctx.attrs?.port },
+      { label: "service", value: ctx.attrs?.serviceId, mono: true },
+    ],
+  },
+);
+
+export const RuleUI = UIProvider.succeed<Rule>("AWS.VpcLattice.Rule", {
+  displayName: "VPC Lattice Rule",
+  icon: "filter",
+  color: COLOR,
+  category: "network",
+  summary: (ctx) => ctx.attrs?.name,
+  facts: (ctx) => [
+    { label: "rule", value: ctx.attrs?.name, copy: true },
+    { label: "id", value: ctx.attrs?.ruleId, mono: true, copy: true },
+    { label: "arn", value: ctx.attrs?.ruleArn, mono: true, copy: true },
+    { label: "priority", value: ctx.attrs?.priority },
+    { label: "listener", value: ctx.attrs?.listenerIdentifier, mono: true },
+  ],
+});
+
+export const TargetGroupUI = UIProvider.succeed<TargetGroup>(
+  "AWS.VpcLattice.TargetGroup",
+  {
+    displayName: "VPC Lattice Target Group",
+    icon: "boxes",
+    color: COLOR,
+    category: "network",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "target group", value: ctx.attrs?.name, copy: true },
+      {
+        label: "id",
+        value: ctx.attrs?.targetGroupId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.targetGroupArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "type", value: ctx.attrs?.type },
+      { label: "status", value: ctx.attrs?.status },
+      {
+        label: "targets",
+        value: ctx.props?.targets?.length,
+      },
+    ],
+  },
+);
+
+export const AccessLogSubscriptionUI =
+  UIProvider.succeed<AccessLogSubscription>(
+    "AWS.VpcLattice.AccessLogSubscription",
+    {
+      displayName: "VPC Lattice Access Log Subscription",
+      icon: "scroll-text",
+      color: COLOR,
+      category: "observability",
+      summary: (ctx) => ctx.attrs?.destinationArn,
+      facts: (ctx) => [
+        {
+          label: "id",
+          value: ctx.attrs?.accessLogSubscriptionId,
+          mono: true,
+          copy: true,
+        },
+        {
+          label: "arn",
+          value: ctx.attrs?.accessLogSubscriptionArn,
+          mono: true,
+          copy: true,
+        },
+        { label: "resource", value: ctx.attrs?.resourceId, mono: true },
+        {
+          label: "destination",
+          value: ctx.attrs?.destinationArn,
+          mono: true,
+          copy: true,
+        },
+      ],
+    },
+  );
+
+export const AuthPolicyUI = UIProvider.succeed<AuthPolicy>(
+  "AWS.VpcLattice.AuthPolicy",
+  {
+    displayName: "VPC Lattice Auth Policy",
+    icon: "shield",
+    color: COLOR,
+    category: "security",
+    summary: (ctx) => ctx.attrs?.resourceIdentifier,
+    facts: (ctx) => [
+      {
+        label: "resource",
+        value: ctx.attrs?.resourceIdentifier,
+        mono: true,
+        copy: true,
+      },
+      { label: "state", value: ctx.attrs?.state },
+      { label: "policy", value: ctx.attrs?.policy, mono: true, copy: true },
+    ],
+  },
+);
+
+export const ResourcePolicyUI = UIProvider.succeed<ResourcePolicy>(
+  "AWS.VpcLattice.ResourcePolicy",
+  {
+    displayName: "VPC Lattice Resource Policy",
+    icon: "shield",
+    color: COLOR,
+    category: "security",
+    summary: (ctx) => ctx.attrs?.resourceArn,
+    facts: (ctx) => [
+      {
+        label: "resource",
+        value: ctx.attrs?.resourceArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "policy", value: ctx.attrs?.policy, mono: true, copy: true },
+    ],
+  },
+);
+
+export const ServiceNetworkServiceAssociationUI =
+  UIProvider.succeed<ServiceNetworkServiceAssociation>(
+    "AWS.VpcLattice.ServiceNetworkServiceAssociation",
+    {
+      displayName: "Service Network / Service Association",
+      icon: "link",
+      color: COLOR,
+      category: "network",
+      summary: (ctx) => ctx.attrs?.dnsName ?? ctx.attrs?.associationId,
+      facts: (ctx) => [
+        {
+          label: "id",
+          value: ctx.attrs?.associationId,
+          mono: true,
+          copy: true,
+        },
+        {
+          label: "arn",
+          value: ctx.attrs?.associationArn,
+          mono: true,
+          copy: true,
+        },
+        {
+          label: "service network",
+          value: ctx.attrs?.serviceNetworkId,
+          mono: true,
+        },
+        { label: "service", value: ctx.attrs?.serviceId, mono: true },
+        { label: "status", value: ctx.attrs?.status },
+      ],
+    },
+  );
+
+export const ServiceNetworkVpcAssociationUI =
+  UIProvider.succeed<ServiceNetworkVpcAssociation>(
+    "AWS.VpcLattice.ServiceNetworkVpcAssociation",
+    {
+      displayName: "Service Network / VPC Association",
+      icon: "link",
+      color: COLOR,
+      category: "network",
+      summary: (ctx) => ctx.attrs?.vpcId ?? ctx.attrs?.associationId,
+      facts: (ctx) => [
+        {
+          label: "id",
+          value: ctx.attrs?.associationId,
+          mono: true,
+          copy: true,
+        },
+        {
+          label: "arn",
+          value: ctx.attrs?.associationArn,
+          mono: true,
+          copy: true,
+        },
+        {
+          label: "service network",
+          value: ctx.attrs?.serviceNetworkId,
+          mono: true,
+        },
+        { label: "vpc", value: ctx.attrs?.vpcId, mono: true },
+        { label: "status", value: ctx.attrs?.status },
+      ],
+    },
+  );
+
+export const ui = () =>
+  Layer.mergeAll(
+    ServiceNetworkUI,
+    ServiceUI,
+    ListenerUI,
+    RuleUI,
+    TargetGroupUI,
+    AccessLogSubscriptionUI,
+    AuthPolicyUI,
+    ResourcePolicyUI,
+    ServiceNetworkServiceAssociationUI,
+    ServiceNetworkVpcAssociationUI,
+  );

--- a/packages/alchemy/src/AWS/WAFv2/ui.ts
+++ b/packages/alchemy/src/AWS/WAFv2/ui.ts
@@ -1,0 +1,158 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { IPSet } from "./IPSet.ts";
+import type { LoggingConfiguration } from "./LoggingConfiguration.ts";
+import type { RegexPatternSet } from "./RegexPatternSet.ts";
+import type { RuleGroup } from "./RuleGroup.ts";
+import type { WebACL } from "./WebACL.ts";
+import type { WebACLAssociation } from "./WebACLAssociation.ts";
+
+/**
+ * Dashboard UI providers for AWS WAFv2 resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+/** WAFv2 brand color (AWS Security, Identity & Compliance red). */
+const WAFV2_COLOR = "#DD344C";
+
+export const WebACLUI = UIProvider.succeed<WebACL>("AWS.WAFv2.WebACL", {
+  displayName: "WAF Web ACL",
+  icon: "shield",
+  color: WAFV2_COLOR,
+  category: "security",
+  summary: (ctx) => ctx.attrs?.webAclName,
+  facts: (ctx) => [
+    { label: "web acl", value: ctx.attrs?.webAclName, copy: true },
+    { label: "id", value: ctx.attrs?.webAclId, mono: true, copy: true },
+    { label: "arn", value: ctx.attrs?.webAclArn, mono: true, copy: true },
+    { label: "scope", value: ctx.attrs?.scope },
+  ],
+});
+
+export const IPSetUI = UIProvider.succeed<IPSet>("AWS.WAFv2.IPSet", {
+  displayName: "WAF IP Set",
+  icon: "network",
+  color: WAFV2_COLOR,
+  category: "security",
+  summary: (ctx) => ctx.attrs?.ipSetName,
+  facts: (ctx) => [
+    { label: "ip set", value: ctx.attrs?.ipSetName, copy: true },
+    { label: "id", value: ctx.attrs?.ipSetId, mono: true, copy: true },
+    { label: "arn", value: ctx.attrs?.ipSetArn, mono: true, copy: true },
+    { label: "scope", value: ctx.attrs?.scope },
+    { label: "ip version", value: ctx.attrs?.ipAddressVersion },
+    { label: "addresses", value: ctx.attrs?.addresses?.length },
+  ],
+});
+
+export const RegexPatternSetUI = UIProvider.succeed<RegexPatternSet>(
+  "AWS.WAFv2.RegexPatternSet",
+  {
+    displayName: "WAF Regex Pattern Set",
+    icon: "code",
+    color: WAFV2_COLOR,
+    category: "security",
+    summary: (ctx) => ctx.attrs?.regexPatternSetName,
+    facts: (ctx) => [
+      {
+        label: "pattern set",
+        value: ctx.attrs?.regexPatternSetName,
+        copy: true,
+      },
+      {
+        label: "id",
+        value: ctx.attrs?.regexPatternSetId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "arn",
+        value: ctx.attrs?.regexPatternSetArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "scope", value: ctx.attrs?.scope },
+      { label: "expressions", value: ctx.attrs?.regularExpressions?.length },
+    ],
+  },
+);
+
+export const RuleGroupUI = UIProvider.succeed<RuleGroup>(
+  "AWS.WAFv2.RuleGroup",
+  {
+    displayName: "WAF Rule Group",
+    icon: "list-ordered",
+    color: WAFV2_COLOR,
+    category: "security",
+    summary: (ctx) => ctx.attrs?.ruleGroupName,
+    facts: (ctx) => [
+      { label: "rule group", value: ctx.attrs?.ruleGroupName, copy: true },
+      { label: "id", value: ctx.attrs?.ruleGroupId, mono: true, copy: true },
+      {
+        label: "arn",
+        value: ctx.attrs?.ruleGroupArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "scope", value: ctx.attrs?.scope },
+      { label: "capacity", value: ctx.attrs?.capacity },
+    ],
+  },
+);
+
+export const LoggingConfigurationUI = UIProvider.succeed<LoggingConfiguration>(
+  "AWS.WAFv2.LoggingConfiguration",
+  {
+    displayName: "WAF Logging Configuration",
+    icon: "scroll-text",
+    color: WAFV2_COLOR,
+    category: "security",
+    summary: (ctx) => ctx.attrs?.resourceArn,
+    facts: (ctx) => [
+      {
+        label: "resource",
+        value: ctx.attrs?.resourceArn,
+        mono: true,
+        copy: true,
+      },
+      { label: "scope", value: ctx.attrs?.scope },
+      {
+        label: "destinations",
+        value: ctx.attrs?.logDestinationConfigs?.join(", "),
+        mono: true,
+      },
+    ],
+  },
+);
+
+export const WebACLAssociationUI = UIProvider.succeed<WebACLAssociation>(
+  "AWS.WAFv2.WebACLAssociation",
+  {
+    displayName: "WAF Web ACL Association",
+    icon: "link",
+    color: WAFV2_COLOR,
+    category: "security",
+    summary: (ctx) => ctx.attrs?.resourceArn,
+    facts: (ctx) => [
+      { label: "web acl", value: ctx.attrs?.webAclArn, mono: true, copy: true },
+      {
+        label: "resource",
+        value: ctx.attrs?.resourceArn,
+        mono: true,
+        copy: true,
+      },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(
+    WebACLUI,
+    IPSetUI,
+    RegexPatternSetUI,
+    RuleGroupUI,
+    LoggingConfigurationUI,
+    WebACLAssociationUI,
+  );

--- a/packages/alchemy/src/AWS/Website/ui.ts
+++ b/packages/alchemy/src/AWS/Website/ui.ts
@@ -1,0 +1,37 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { AssetDeployment } from "./AssetDeployment.ts";
+
+/**
+ * Dashboard UI providers for AWS Website resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+export const AssetDeploymentUI = UIProvider.succeed<AssetDeployment>(
+  "AWS.Website.AssetDeployment",
+  {
+    displayName: "Website Asset Deployment",
+    icon: "upload",
+    color: "#FF9900",
+    category: "storage",
+    summary: (ctx) =>
+      ctx.attrs?.bucketName === undefined
+        ? undefined
+        : ctx.attrs?.prefix
+          ? `${ctx.attrs.bucketName}/${ctx.attrs.prefix}`
+          : ctx.attrs.bucketName,
+    consoleUrl: (ctx) =>
+      ctx.attrs?.bucketName === undefined
+        ? undefined
+        : `https://console.aws.amazon.com/s3/buckets/${ctx.attrs.bucketName}${ctx.attrs.prefix ? `?prefix=${ctx.attrs.prefix}/` : ""}`,
+    facts: (ctx) => [
+      { label: "bucket", value: ctx.attrs?.bucketName, copy: true },
+      { label: "prefix", value: ctx.attrs?.prefix, mono: true },
+      { label: "version", value: ctx.attrs?.version, mono: true, copy: true },
+      { label: "files", value: ctx.attrs?.fileCount },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(AssetDeploymentUI);

--- a/packages/alchemy/src/AWS/XRay/ui.ts
+++ b/packages/alchemy/src/AWS/XRay/ui.ts
@@ -1,0 +1,66 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Group } from "./Group.ts";
+import type { ResourcePolicy } from "./ResourcePolicy.ts";
+import type { SamplingRule } from "./SamplingRule.ts";
+
+/**
+ * Dashboard UI providers for AWS XRay resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no AWS SDK code reaches the dashboard bundle.
+ */
+
+export const GroupUI = UIProvider.succeed<Group>("AWS.XRay.Group", {
+  displayName: "X-Ray Group",
+  icon: "search",
+  color: "#E7157B",
+  category: "observability",
+  summary: (ctx) => ctx.attrs?.groupName,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.groupName, copy: true },
+    { label: "arn", value: ctx.attrs?.groupArn, mono: true, copy: true },
+    { label: "filter", value: ctx.props?.filterExpression, mono: true },
+    { label: "insights", value: ctx.props?.insightsEnabled },
+  ],
+});
+
+export const ResourcePolicyUI = UIProvider.succeed<ResourcePolicy>(
+  "AWS.XRay.ResourcePolicy",
+  {
+    displayName: "X-Ray Resource Policy",
+    icon: "lock",
+    color: "#E7157B",
+    category: "security",
+    summary: (ctx) => ctx.attrs?.policyName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.policyName, copy: true },
+      {
+        label: "revision",
+        value: ctx.attrs?.policyRevisionId,
+        mono: true,
+      },
+    ],
+  },
+);
+
+export const SamplingRuleUI = UIProvider.succeed<SamplingRule>(
+  "AWS.XRay.SamplingRule",
+  {
+    displayName: "X-Ray Sampling Rule",
+    icon: "filter",
+    color: "#E7157B",
+    category: "observability",
+    summary: (ctx) => ctx.attrs?.ruleName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.ruleName, copy: true },
+      { label: "arn", value: ctx.attrs?.ruleArn, mono: true, copy: true },
+      { label: "priority", value: ctx.props?.priority },
+      { label: "fixed rate", value: ctx.props?.fixedRate },
+      { label: "reservoir size", value: ctx.props?.reservoirSize },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(GroupUI, ResourcePolicyUI, SamplingRuleUI);

--- a/packages/alchemy/src/Axiom/UI.ts
+++ b/packages/alchemy/src/Axiom/UI.ts
@@ -1,0 +1,242 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../UI/UIProvider.ts";
+import type { Annotation } from "./Annotation.ts";
+import type { ApiToken } from "./ApiToken.ts";
+import type { Dashboard } from "./Dashboard.ts";
+import type { Dataset } from "./Dataset.ts";
+import type { Monitor } from "./Monitor.ts";
+import type { Notifier } from "./Notifier.ts";
+import type { View } from "./View.ts";
+import type { VirtualField } from "./VirtualField.ts";
+
+/**
+ * Dashboard UI providers for Axiom resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Axiom SDK code reaches the dashboard bundle.
+ */
+
+const AXIOM_BLUE = "#3b82f6";
+
+export const DatasetUI = UIProvider.succeed<Dataset>("Axiom.Dataset", {
+  displayName: "Axiom Dataset",
+  icon: "database",
+  color: AXIOM_BLUE,
+  category: "observability",
+  summary: (ctx) => ctx.attrs?.name ?? ctx.props?.name,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.name ?? ctx.props?.name, copy: true },
+    { label: "id", value: ctx.attrs?.id, mono: true, copy: true },
+    { label: "kind", value: ctx.attrs?.kind ?? ctx.props?.kind },
+    {
+      label: "retention",
+      value:
+        ctx.props?.retentionDays === undefined
+          ? undefined
+          : `${ctx.props.retentionDays}d`,
+    },
+    {
+      label: "otel endpoint",
+      value: ctx.attrs?.otelEndpoint,
+      mono: true,
+      copy: true,
+    },
+    { label: "created", value: ctx.attrs?.created },
+    { label: "description", value: ctx.attrs?.description },
+  ],
+});
+
+export const DashboardUI = UIProvider.succeed<Dashboard>("Axiom.Dashboard", {
+  displayName: "Axiom Dashboard",
+  icon: "layout-dashboard",
+  color: AXIOM_BLUE,
+  category: "observability",
+  summary: (ctx) =>
+    ctx.attrs?.dashboard?.name ?? ctx.props?.dashboard?.name ?? ctx.attrs?.uid,
+  facts: (ctx) => [
+    {
+      label: "name",
+      value: ctx.attrs?.dashboard?.name ?? ctx.props?.dashboard?.name,
+    },
+    { label: "uid", value: ctx.attrs?.uid, mono: true, copy: true },
+    {
+      label: "charts",
+      value: ctx.props?.dashboard?.charts?.length,
+    },
+    {
+      label: "refresh",
+      value:
+        ctx.props?.dashboard?.refreshTime === undefined
+          ? undefined
+          : `${ctx.props.dashboard.refreshTime}s`,
+    },
+    {
+      label: "window",
+      value:
+        ctx.props?.dashboard?.timeWindowStart === undefined
+          ? undefined
+          : `${ctx.props.dashboard.timeWindowStart} → ${ctx.props.dashboard.timeWindowEnd ?? ""}`,
+    },
+    { label: "updated", value: ctx.attrs?.updatedAt },
+  ],
+});
+
+export const MonitorUI = UIProvider.succeed<Monitor>("Axiom.Monitor", {
+  displayName: "Axiom Monitor",
+  icon: "activity",
+  color: AXIOM_BLUE,
+  category: "observability",
+  summary: (ctx) => ctx.attrs?.name ?? ctx.props?.name,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.name ?? ctx.props?.name },
+    { label: "id", value: ctx.attrs?.id, mono: true, copy: true },
+    { label: "type", value: ctx.attrs?.type ?? ctx.props?.type },
+    {
+      label: "interval",
+      value:
+        (ctx.attrs?.intervalMinutes ?? ctx.props?.intervalMinutes) === undefined
+          ? undefined
+          : `${ctx.attrs?.intervalMinutes ?? ctx.props?.intervalMinutes}m`,
+    },
+    {
+      label: "threshold",
+      value:
+        ctx.attrs?.threshold === undefined
+          ? undefined
+          : `${ctx.attrs?.operator ?? ""} ${ctx.attrs.threshold}`.trim(),
+    },
+    {
+      label: "notifiers",
+      value: (ctx.attrs?.notifierIds ?? ctx.props?.notifierIds)?.length,
+    },
+    { label: "disabled", value: ctx.attrs?.disabled },
+  ],
+});
+
+export const NotifierUI = UIProvider.succeed<Notifier>("Axiom.Notifier", {
+  displayName: "Axiom Notifier",
+  icon: "bell-ring",
+  color: AXIOM_BLUE,
+  category: "observability",
+  summary: (ctx) => ctx.attrs?.name ?? ctx.props?.name,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.name ?? ctx.props?.name },
+    { label: "id", value: ctx.attrs?.id, mono: true, copy: true },
+    {
+      label: "channel",
+      value: Object.keys(
+        ctx.attrs?.properties ?? ctx.props?.properties ?? {},
+      )[0],
+    },
+    { label: "created", value: ctx.attrs?.createdAt },
+    { label: "updated", value: ctx.attrs?.updatedAt },
+  ],
+});
+
+export const ApiTokenUI = UIProvider.succeed<ApiToken>("Axiom.ApiToken", {
+  displayName: "Axiom API Token",
+  icon: "key-round",
+  color: AXIOM_BLUE,
+  category: "auth",
+  summary: (ctx) => ctx.attrs?.name ?? ctx.props?.name,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.name ?? ctx.props?.name },
+    { label: "id", value: ctx.attrs?.id, mono: true, copy: true },
+    {
+      label: "datasets",
+      value:
+        ctx.attrs?.datasetCapabilities === undefined
+          ? undefined
+          : Object.keys(ctx.attrs.datasetCapabilities).join(", "),
+    },
+    { label: "expires", value: ctx.attrs?.expiresAt ?? undefined },
+    { label: "description", value: ctx.attrs?.description },
+  ],
+});
+
+export const ViewUI = UIProvider.succeed<View>("Axiom.View", {
+  displayName: "Axiom View",
+  icon: "bookmark",
+  color: AXIOM_BLUE,
+  category: "observability",
+  summary: (ctx) => ctx.attrs?.name ?? ctx.props?.name,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.name ?? ctx.props?.name, copy: true },
+    {
+      label: "datasets",
+      value: (ctx.attrs?.datasets ?? ctx.props?.datasets)?.join(", "),
+    },
+    {
+      label: "query",
+      value: ctx.attrs?.aplQuery ?? ctx.props?.aplQuery,
+      mono: true,
+      copy: true,
+    },
+    { label: "description", value: ctx.attrs?.description },
+  ],
+});
+
+export const VirtualFieldUI = UIProvider.succeed<VirtualField>(
+  "Axiom.VirtualField",
+  {
+    displayName: "Axiom Virtual Field",
+    icon: "sigma",
+    color: AXIOM_BLUE,
+    category: "observability",
+    summary: (ctx) => ctx.attrs?.name ?? ctx.props?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name ?? ctx.props?.name },
+      { label: "id", value: ctx.attrs?.id, mono: true, copy: true },
+      { label: "dataset", value: ctx.attrs?.dataset ?? ctx.props?.dataset },
+      {
+        label: "expression",
+        value: ctx.attrs?.expression ?? ctx.props?.expression,
+        mono: true,
+        copy: true,
+      },
+      { label: "type", value: ctx.attrs?.type ?? ctx.props?.type },
+      { label: "unit", value: ctx.attrs?.unit ?? ctx.props?.unit },
+    ],
+  },
+);
+
+export const AnnotationUI = UIProvider.succeed<Annotation>("Axiom.Annotation", {
+  displayName: "Axiom Annotation",
+  icon: "flag",
+  color: AXIOM_BLUE,
+  category: "observability",
+  summary: (ctx) =>
+    ctx.attrs?.title ?? ctx.props?.title ?? ctx.attrs?.type ?? ctx.props?.type,
+  link: (ctx) => ctx.attrs?.url ?? ctx.props?.url,
+  facts: (ctx) => [
+    { label: "title", value: ctx.attrs?.title ?? ctx.props?.title },
+    { label: "id", value: ctx.attrs?.id, mono: true, copy: true },
+    { label: "type", value: ctx.attrs?.type ?? ctx.props?.type },
+    {
+      label: "datasets",
+      value: (ctx.attrs?.datasets ?? ctx.props?.datasets)?.join(", "),
+    },
+    { label: "time", value: ctx.attrs?.time ?? ctx.props?.time },
+    {
+      label: "end",
+      value: (ctx.attrs?.endTime ?? ctx.props?.endTime) || undefined,
+    },
+    {
+      label: "url",
+      value: ctx.attrs?.url ?? ctx.props?.url,
+      href: ctx.attrs?.url ?? ctx.props?.url,
+    },
+  ],
+});
+
+export const ui = () =>
+  Layer.mergeAll(
+    DatasetUI,
+    DashboardUI,
+    MonitorUI,
+    NotifierUI,
+    ApiTokenUI,
+    ViewUI,
+    VirtualFieldUI,
+    AnnotationUI,
+  );

--- a/packages/alchemy/src/Cloudflare/AI/ui.ts
+++ b/packages/alchemy/src/Cloudflare/AI/ui.ts
@@ -1,0 +1,248 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { CustomTopics } from "./CustomTopics.ts";
+import type { Dataset } from "./Dataset.ts";
+import type { Evaluation } from "./Evaluation.ts";
+import type { Gateway } from "./Gateway.ts";
+import type { GatewayDynamicRouting } from "./GatewayDynamicRouting.ts";
+import type { GatewayProvider } from "./GatewayProvider.ts";
+import type { SearchInstance } from "./SearchInstance.ts";
+import type { SearchNamespace } from "./SearchNamespace.ts";
+import type { SearchToken } from "./SearchToken.ts";
+import type { SecuritySettings } from "./SecuritySettings.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare AI resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const GatewayUI = UIProvider.succeed<Gateway>("Cloudflare.AI.Gateway", {
+  displayName: "AI Gateway",
+  icon: "waypoints",
+  color: "#F6821F",
+  category: "ai",
+  summary: (ctx) => ctx.attrs?.gatewayId,
+  consoleUrl: (ctx) =>
+    ctx.attrs?.accountId === undefined || ctx.attrs?.gatewayId === undefined
+      ? undefined
+      : `https://dash.cloudflare.com/${ctx.attrs.accountId}/ai/ai-gateway/gateways/${ctx.attrs.gatewayId}`,
+  facts: (ctx) => [
+    { label: "gateway", value: ctx.attrs?.gatewayId, mono: true, copy: true },
+    { label: "account", value: ctx.attrs?.accountId, mono: true, copy: true },
+    { label: "logs", value: ctx.attrs?.collectLogs },
+    { label: "authentication", value: ctx.attrs?.authentication },
+    {
+      label: "cache ttl",
+      value: ctx.attrs?.cacheTtl === null ? undefined : ctx.attrs?.cacheTtl,
+    },
+    {
+      label: "rate limit",
+      value:
+        ctx.attrs?.rateLimitingLimit === null ||
+        ctx.attrs?.rateLimitingLimit === undefined
+          ? undefined
+          : `${ctx.attrs.rateLimitingLimit} / ${ctx.attrs.rateLimitingInterval ?? "?"}s (${ctx.attrs.rateLimitingTechnique ?? ""})`,
+    },
+    { label: "zdr", value: ctx.attrs?.zdr },
+  ],
+});
+
+export const GatewayProviderUI = UIProvider.succeed<GatewayProvider>(
+  "Cloudflare.AI.GatewayProvider",
+  {
+    displayName: "AI Gateway Provider",
+    icon: "key-round",
+    color: "#F6821F",
+    category: "ai",
+    summary: (ctx) =>
+      ctx.attrs?.providerSlug === undefined
+        ? ctx.attrs?.alias
+        : `${ctx.attrs.providerSlug}${ctx.attrs.alias ? ` (${ctx.attrs.alias})` : ""}`,
+    facts: (ctx) => [
+      { label: "provider", value: ctx.attrs?.providerSlug },
+      { label: "alias", value: ctx.attrs?.alias },
+      { label: "gateway", value: ctx.attrs?.gatewayId, mono: true, copy: true },
+      {
+        label: "config id",
+        value: ctx.attrs?.providerConfigId,
+        mono: true,
+        copy: true,
+      },
+      { label: "secret", value: ctx.attrs?.secretPreview, mono: true },
+      { label: "default", value: ctx.attrs?.defaultConfig },
+    ],
+  },
+);
+
+export const GatewayDynamicRoutingUI =
+  UIProvider.succeed<GatewayDynamicRouting>("Cloudflare.AI.DynamicRouting", {
+    displayName: "AI Gateway Dynamic Route",
+    icon: "route",
+    color: "#F6821F",
+    category: "ai",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      { label: "gateway", value: ctx.attrs?.gatewayId, mono: true, copy: true },
+      { label: "route id", value: ctx.attrs?.routeId, mono: true, copy: true },
+      { label: "version", value: ctx.attrs?.versionId, mono: true },
+      { label: "deployment", value: ctx.attrs?.deploymentId, mono: true },
+      { label: "elements", value: ctx.attrs?.elements?.length },
+    ],
+  });
+
+export const DatasetUI = UIProvider.succeed<Dataset>("Cloudflare.AI.Dataset", {
+  displayName: "AI Gateway Dataset",
+  icon: "database",
+  color: "#F6821F",
+  category: "ai",
+  summary: (ctx) => ctx.attrs?.name,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.name, copy: true },
+    {
+      label: "dataset id",
+      value: ctx.attrs?.datasetId,
+      mono: true,
+      copy: true,
+    },
+    { label: "gateway", value: ctx.attrs?.gatewayId, mono: true, copy: true },
+    { label: "enabled", value: ctx.attrs?.enable },
+    { label: "filters", value: ctx.attrs?.filters?.length },
+  ],
+});
+
+export const EvaluationUI = UIProvider.succeed<Evaluation>(
+  "Cloudflare.AI.Evaluation",
+  {
+    displayName: "AI Gateway Evaluation",
+    icon: "clipboard-check",
+    color: "#F6821F",
+    category: "ai",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      {
+        label: "evaluation id",
+        value: ctx.attrs?.evaluationId,
+        mono: true,
+        copy: true,
+      },
+      { label: "gateway", value: ctx.attrs?.gatewayId, mono: true, copy: true },
+      { label: "datasets", value: ctx.attrs?.datasetIds?.length },
+      { label: "processed", value: ctx.attrs?.processed },
+      { label: "total logs", value: ctx.attrs?.totalLogs },
+    ],
+  },
+);
+
+export const SearchInstanceUI = UIProvider.succeed<SearchInstance>(
+  "Cloudflare.AI.Search",
+  {
+    displayName: "AI Search",
+    icon: "search",
+    color: "#F6821F",
+    category: "ai",
+    summary: (ctx) => ctx.attrs?.instanceId,
+    facts: (ctx) => [
+      {
+        label: "instance",
+        value: ctx.attrs?.instanceId,
+        mono: true,
+        copy: true,
+      },
+      { label: "namespace", value: ctx.attrs?.namespace },
+      { label: "type", value: ctx.attrs?.type },
+      { label: "source", value: ctx.attrs?.source, mono: true },
+      { label: "embedding model", value: ctx.attrs?.embeddingModel },
+      { label: "search model", value: ctx.attrs?.aiSearchModel },
+      { label: "status", value: ctx.attrs?.status },
+      { label: "paused", value: ctx.attrs?.paused },
+    ],
+  },
+);
+
+export const SearchNamespaceUI = UIProvider.succeed<SearchNamespace>(
+  "Cloudflare.AI.SearchNamespace",
+  {
+    displayName: "AI Search Namespace",
+    icon: "folder-tree",
+    color: "#F6821F",
+    category: "ai",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      { label: "account", value: ctx.attrs?.accountId, mono: true, copy: true },
+      { label: "description", value: ctx.attrs?.description },
+      { label: "created", value: ctx.attrs?.createdAt },
+    ],
+  },
+);
+
+export const SearchTokenUI = UIProvider.succeed<SearchToken>(
+  "Cloudflare.AI.SearchToken",
+  {
+    displayName: "AI Search Token",
+    icon: "key-round",
+    color: "#F6821F",
+    category: "auth",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      { label: "token id", value: ctx.attrs?.id, mono: true, copy: true },
+      { label: "api token", value: ctx.attrs?.cfApiId, mono: true, copy: true },
+      { label: "enabled", value: ctx.attrs?.enabled },
+      { label: "legacy", value: ctx.attrs?.legacy },
+    ],
+  },
+);
+
+export const SecuritySettingsUI = UIProvider.succeed<SecuritySettings>(
+  "Cloudflare.AI.SecuritySettings",
+  {
+    displayName: "AI Security Settings",
+    icon: "shield-check",
+    color: "#F6821F",
+    category: "security",
+    summary: (ctx) =>
+      ctx.attrs?.enabled === undefined
+        ? ctx.attrs?.zoneId
+        : ctx.attrs.enabled
+          ? "enabled"
+          : "disabled",
+    facts: (ctx) => [
+      { label: "zone", value: ctx.attrs?.zoneId, mono: true, copy: true },
+      { label: "enabled", value: ctx.attrs?.enabled },
+      { label: "initial", value: ctx.attrs?.initialEnabled },
+    ],
+  },
+);
+
+export const CustomTopicsUI = UIProvider.succeed<CustomTopics>(
+  "Cloudflare.AI.Security.CustomTopics",
+  {
+    displayName: "AI Security Custom Topics",
+    icon: "shield",
+    color: "#F6821F",
+    category: "security",
+    summary: (ctx) => ctx.attrs?.zoneId,
+    facts: (ctx) => [
+      { label: "zone", value: ctx.attrs?.zoneId, mono: true, copy: true },
+      { label: "topics", value: ctx.attrs?.topics?.length },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(
+    GatewayUI,
+    GatewayProviderUI,
+    GatewayDynamicRoutingUI,
+    DatasetUI,
+    EvaluationUI,
+    SearchInstanceUI,
+    SearchNamespaceUI,
+    SearchTokenUI,
+    SecuritySettingsUI,
+    CustomTopicsUI,
+  );

--- a/packages/alchemy/src/Cloudflare/Access/ui.ts
+++ b/packages/alchemy/src/Cloudflare/Access/ui.ts
@@ -1,0 +1,336 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Application } from "./Application.ts";
+import type { Bookmark } from "./Bookmark.ts";
+import type { Certificate } from "./Certificate.ts";
+import type { CustomPage } from "./CustomPage.ts";
+import type { Group } from "./Group.ts";
+import type { IdentityProvider } from "./IdentityProvider.ts";
+import type { InfrastructureTarget } from "./InfrastructureTarget.ts";
+import type { KeyConfiguration } from "./KeyConfiguration.ts";
+import type { McpPortal } from "./McpPortal.ts";
+import type { Organization } from "./Organization.ts";
+import type { Policy } from "./Policy.ts";
+import type { ServiceToken } from "./ServiceToken.ts";
+import type { Tag } from "./Tag.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare Access (Zero Trust) resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const ApplicationUI = UIProvider.succeed<Application>(
+  "Cloudflare.Access.Application",
+  {
+    displayName: "Access Application",
+    icon: "shield-check",
+    color: "#F6821F",
+    category: "auth",
+    summary: (ctx) => ctx.attrs?.name,
+    link: (ctx) =>
+      ctx.attrs?.domain ? `https://${ctx.attrs.domain}` : undefined,
+    consoleUrl: (ctx) =>
+      ctx.attrs?.accountId === undefined
+        ? undefined
+        : `https://one.dash.cloudflare.com/${ctx.attrs.accountId}/access/apps`,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      { label: "id", value: ctx.attrs?.applicationId, mono: true, copy: true },
+      { label: "type", value: ctx.attrs?.type },
+      {
+        label: "domain",
+        value: ctx.attrs?.domain,
+        href: ctx.attrs?.domain ? `https://${ctx.attrs.domain}` : undefined,
+      },
+      { label: "aud", value: ctx.attrs?.aud, mono: true, copy: true },
+      { label: "created", value: ctx.attrs?.createdAt },
+    ],
+  },
+);
+
+export const BookmarkUI = UIProvider.succeed<Bookmark>(
+  "Cloudflare.Access.Bookmark",
+  {
+    displayName: "Access Bookmark",
+    icon: "bookmark",
+    color: "#F6821F",
+    category: "auth",
+    summary: (ctx) => ctx.attrs?.name,
+    link: (ctx) =>
+      ctx.attrs?.domain ? `https://${ctx.attrs.domain}` : undefined,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      { label: "id", value: ctx.attrs?.bookmarkId, mono: true, copy: true },
+      {
+        label: "domain",
+        value: ctx.attrs?.domain,
+        href: ctx.attrs?.domain ? `https://${ctx.attrs.domain}` : undefined,
+      },
+      { label: "app launcher", value: ctx.attrs?.appLauncherVisible },
+    ],
+  },
+);
+
+export const CertificateUI = UIProvider.succeed<Certificate>(
+  "Cloudflare.Access.Certificate",
+  {
+    displayName: "Access mTLS Certificate",
+    icon: "file-lock-2",
+    color: "#F6821F",
+    category: "security",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      { label: "id", value: ctx.attrs?.certificateId, mono: true, copy: true },
+      { label: "fingerprint", value: ctx.attrs?.fingerprint, mono: true },
+      {
+        label: "hostnames",
+        value: ctx.attrs?.associatedHostnames?.length
+          ? ctx.attrs.associatedHostnames.join(", ")
+          : undefined,
+      },
+      { label: "expires", value: ctx.attrs?.expiresOn },
+    ],
+  },
+);
+
+export const CustomPageUI = UIProvider.succeed<CustomPage>(
+  "Cloudflare.Access.CustomPage",
+  {
+    displayName: "Access Custom Page",
+    icon: "file-text",
+    color: "#F6821F",
+    category: "auth",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      { label: "id", value: ctx.attrs?.customPageId, mono: true, copy: true },
+      { label: "type", value: ctx.attrs?.type },
+      { label: "account", value: ctx.attrs?.accountId, mono: true },
+    ],
+  },
+);
+
+export const GroupUI = UIProvider.succeed<Group>("Cloudflare.Access.Group", {
+  displayName: "Access Group",
+  icon: "users",
+  color: "#F6821F",
+  category: "auth",
+  summary: (ctx) => ctx.attrs?.name,
+  consoleUrl: (ctx) =>
+    ctx.attrs?.accountId === undefined
+      ? undefined
+      : `https://one.dash.cloudflare.com/${ctx.attrs.accountId}/access/groups`,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.name, copy: true },
+    { label: "id", value: ctx.attrs?.groupId, mono: true, copy: true },
+    { label: "default", value: ctx.attrs?.isDefault },
+    { label: "account", value: ctx.attrs?.accountId, mono: true },
+  ],
+});
+
+export const IdentityProviderUI = UIProvider.succeed<IdentityProvider>(
+  "Cloudflare.Access.IdentityProvider",
+  {
+    displayName: "Access Identity Provider",
+    icon: "key-round",
+    color: "#F6821F",
+    category: "auth",
+    summary: (ctx) => ctx.attrs?.name,
+    consoleUrl: (ctx) =>
+      ctx.attrs?.accountId === undefined
+        ? undefined
+        : `https://one.dash.cloudflare.com/${ctx.attrs.accountId}/settings/authentication`,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      {
+        label: "id",
+        value: ctx.attrs?.identityProviderId,
+        mono: true,
+        copy: true,
+      },
+      { label: "type", value: ctx.attrs?.type },
+      { label: "scim", value: ctx.attrs?.scimEnabled },
+      {
+        label: "scim url",
+        value: ctx.attrs?.scimBaseUrl,
+        mono: true,
+        copy: true,
+      },
+    ],
+  },
+);
+
+export const InfrastructureTargetUI = UIProvider.succeed<InfrastructureTarget>(
+  "Cloudflare.Access.InfrastructureTarget",
+  {
+    displayName: "Access Infrastructure Target",
+    icon: "server",
+    color: "#F6821F",
+    category: "security",
+    summary: (ctx) => ctx.attrs?.hostname,
+    facts: (ctx) => [
+      { label: "hostname", value: ctx.attrs?.hostname, copy: true },
+      { label: "id", value: ctx.attrs?.targetId, mono: true, copy: true },
+      { label: "ipv4", value: ctx.attrs?.ip?.ipv4?.ipAddr, mono: true },
+      { label: "ipv6", value: ctx.attrs?.ip?.ipv6?.ipAddr, mono: true },
+      { label: "created", value: ctx.attrs?.createdAt },
+    ],
+  },
+);
+
+export const KeyConfigurationUI = UIProvider.succeed<KeyConfiguration>(
+  "Cloudflare.Access.KeyConfiguration",
+  {
+    displayName: "Access Key Configuration",
+    icon: "key-square",
+    color: "#F6821F",
+    category: "security",
+    summary: (ctx) =>
+      ctx.attrs?.keyRotationIntervalDays === undefined
+        ? undefined
+        : `rotate every ${ctx.attrs.keyRotationIntervalDays}d`,
+    facts: (ctx) => [
+      {
+        label: "rotation interval (days)",
+        value: ctx.attrs?.keyRotationIntervalDays,
+      },
+      {
+        label: "days until next rotation",
+        value: ctx.attrs?.daysUntilNextRotation,
+      },
+      { label: "last rotation", value: ctx.attrs?.lastKeyRotationAt },
+      { label: "account", value: ctx.attrs?.accountId, mono: true },
+    ],
+  },
+);
+
+export const McpPortalUI = UIProvider.succeed<McpPortal>(
+  "Cloudflare.Access.McpPortal",
+  {
+    displayName: "Access MCP Portal",
+    icon: "panels-top-left",
+    color: "#F6821F",
+    category: "auth",
+    summary: (ctx) => ctx.attrs?.name ?? ctx.attrs?.hostname,
+    link: (ctx) =>
+      ctx.attrs?.hostname ? `https://${ctx.attrs.hostname}` : undefined,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      { label: "id", value: ctx.attrs?.portalId, mono: true, copy: true },
+      {
+        label: "hostname",
+        value: ctx.attrs?.hostname,
+        href: ctx.attrs?.hostname ? `https://${ctx.attrs.hostname}` : undefined,
+      },
+      { label: "code mode", value: ctx.attrs?.allowCodeMode },
+      { label: "secure web gateway", value: ctx.attrs?.secureWebGateway },
+    ],
+  },
+);
+
+export const OrganizationUI = UIProvider.succeed<Organization>(
+  "Cloudflare.Access.Organization",
+  {
+    displayName: "Zero Trust Organization",
+    icon: "building-2",
+    color: "#F6821F",
+    category: "auth",
+    summary: (ctx) => ctx.attrs?.authDomain ?? ctx.attrs?.name,
+    link: (ctx) =>
+      ctx.attrs?.authDomain ? `https://${ctx.attrs.authDomain}` : undefined,
+    consoleUrl: (ctx) =>
+      ctx.attrs?.accountId === undefined
+        ? undefined
+        : `https://one.dash.cloudflare.com/${ctx.attrs.accountId}/settings/general`,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      {
+        label: "team domain",
+        value: ctx.attrs?.authDomain,
+        mono: true,
+        copy: true,
+      },
+      { label: "session duration", value: ctx.attrs?.sessionDuration },
+      {
+        label: "auto redirect to IdP",
+        value: ctx.attrs?.autoRedirectToIdentity,
+      },
+      { label: "warp auth", value: ctx.attrs?.allowAuthenticateViaWarp },
+      { label: "account", value: ctx.attrs?.accountId, mono: true },
+    ],
+  },
+);
+
+export const PolicyUI = UIProvider.succeed<Policy>("Cloudflare.Access.Policy", {
+  displayName: "Access Policy",
+  icon: "shield",
+  color: "#F6821F",
+  category: "auth",
+  summary: (ctx) => ctx.attrs?.name,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.name, copy: true },
+    { label: "id", value: ctx.attrs?.policyId, mono: true, copy: true },
+    { label: "decision", value: ctx.attrs?.decision },
+    { label: "created", value: ctx.attrs?.createdAt },
+    { label: "updated", value: ctx.attrs?.updatedAt },
+  ],
+});
+
+export const ServiceTokenUI = UIProvider.succeed<ServiceToken>(
+  "Cloudflare.Access.ServiceToken",
+  {
+    displayName: "Access Service Token",
+    icon: "key",
+    color: "#F6821F",
+    category: "auth",
+    summary: (ctx) => ctx.attrs?.name,
+    consoleUrl: (ctx) =>
+      ctx.attrs?.accountId === undefined
+        ? undefined
+        : `https://one.dash.cloudflare.com/${ctx.attrs.accountId}/access/service-auth`,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      { label: "id", value: ctx.attrs?.serviceTokenId, mono: true, copy: true },
+      {
+        label: "client id",
+        value: ctx.attrs?.clientId,
+        mono: true,
+        copy: true,
+      },
+      { label: "duration", value: ctx.attrs?.duration },
+      { label: "expires", value: ctx.attrs?.expiresAt },
+      { label: "secret version", value: ctx.attrs?.clientSecretVersion },
+    ],
+  },
+);
+
+export const TagUI = UIProvider.succeed<Tag>("Cloudflare.Access.Tag", {
+  displayName: "Access Tag",
+  icon: "tag",
+  color: "#F6821F",
+  category: "auth",
+  summary: (ctx) => ctx.attrs?.name,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.name, copy: true },
+    { label: "account", value: ctx.attrs?.accountId, mono: true },
+  ],
+});
+
+export const ui = () =>
+  Layer.mergeAll(
+    ApplicationUI,
+    BookmarkUI,
+    CertificateUI,
+    CustomPageUI,
+    GroupUI,
+    IdentityProviderUI,
+    InfrastructureTargetUI,
+    KeyConfigurationUI,
+    McpPortalUI,
+    OrganizationUI,
+    PolicyUI,
+    ServiceTokenUI,
+    TagUI,
+  );

--- a/packages/alchemy/src/Cloudflare/Account/ui.ts
+++ b/packages/alchemy/src/Cloudflare/Account/ui.ts
@@ -1,0 +1,73 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Account } from "./Account.ts";
+import type { Member } from "./Member.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare Account resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const AccountUI = UIProvider.succeed<Account>(
+  "Cloudflare.Account.Account",
+  {
+    displayName: "Cloudflare Account",
+    icon: "building-2",
+    color: "#F6821F",
+    category: "config",
+    summary: (ctx) => ctx.attrs?.name,
+    consoleUrl: (ctx) =>
+      ctx.attrs?.accountId === undefined
+        ? undefined
+        : `https://dash.cloudflare.com/${ctx.attrs.accountId}`,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      {
+        label: "account id",
+        value: ctx.attrs?.accountId,
+        mono: true,
+        copy: true,
+      },
+      { label: "type", value: ctx.attrs?.type },
+      { label: "parent org", value: ctx.attrs?.parentOrgName },
+      { label: "2FA enforced", value: ctx.attrs?.enforceTwofactor },
+      { label: "created", value: ctx.attrs?.createdOn },
+    ],
+  },
+);
+
+export const MemberUI = UIProvider.succeed<Member>(
+  "Cloudflare.Account.Member",
+  {
+    displayName: "Account Member",
+    icon: "user-round",
+    color: "#F6821F",
+    category: "auth",
+    summary: (ctx) => ctx.attrs?.email,
+    consoleUrl: (ctx) =>
+      ctx.attrs?.accountId === undefined
+        ? undefined
+        : `https://dash.cloudflare.com/${ctx.attrs.accountId}/members`,
+    facts: (ctx) => [
+      { label: "email", value: ctx.attrs?.email, copy: true },
+      {
+        label: "member id",
+        value: ctx.attrs?.memberId,
+        mono: true,
+        copy: true,
+      },
+      { label: "account", value: ctx.attrs?.accountId, mono: true },
+      { label: "status", value: ctx.attrs?.status },
+      {
+        label: "roles",
+        value: ctx.attrs?.roles?.length
+          ? ctx.attrs.roles.map((r) => r.name).join(", ")
+          : undefined,
+      },
+      { label: "policies", value: ctx.attrs?.policies?.length },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(AccountUI, MemberUI);

--- a/packages/alchemy/src/Cloudflare/Acm/ui.ts
+++ b/packages/alchemy/src/Cloudflare/Acm/ui.ts
@@ -1,0 +1,55 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { CustomTrustStore } from "./CustomTrustStore.ts";
+import type { TotalTls } from "./TotalTls.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare Advanced Certificate Manager
+ * resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const TotalTlsUI = UIProvider.succeed<TotalTls>(
+  "Cloudflare.Acm.TotalTls",
+  {
+    displayName: "Total TLS",
+    icon: "shield-check",
+    color: "#F6821F",
+    category: "security",
+    summary: (ctx) =>
+      ctx.attrs?.enabled === undefined
+        ? undefined
+        : ctx.attrs.enabled
+          ? "enabled"
+          : "disabled",
+    facts: (ctx) => [
+      { label: "zone", value: ctx.attrs?.zoneId, mono: true, copy: true },
+      { label: "enabled", value: ctx.attrs?.enabled },
+      { label: "CA", value: ctx.attrs?.certificateAuthority },
+      { label: "validity (days)", value: ctx.attrs?.validityPeriod },
+      { label: "initially enabled", value: ctx.attrs?.initialEnabled },
+    ],
+  },
+);
+
+export const CustomTrustStoreUI = UIProvider.succeed<CustomTrustStore>(
+  "Cloudflare.Acm.CustomTrustStore",
+  {
+    displayName: "Custom Trust Store",
+    icon: "file-lock-2",
+    color: "#F6821F",
+    category: "security",
+    summary: (ctx) => ctx.attrs?.issuer ?? ctx.attrs?.id,
+    facts: (ctx) => [
+      { label: "id", value: ctx.attrs?.id, mono: true, copy: true },
+      { label: "zone", value: ctx.attrs?.zoneId, mono: true, copy: true },
+      { label: "issuer", value: ctx.attrs?.issuer },
+      { label: "status", value: ctx.attrs?.status },
+      { label: "expires", value: ctx.attrs?.expiresOn },
+      { label: "uploaded", value: ctx.attrs?.uploadedOn },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(TotalTlsUI, CustomTrustStoreUI);

--- a/packages/alchemy/src/Cloudflare/Addressing/ui.ts
+++ b/packages/alchemy/src/Cloudflare/Addressing/ui.ts
@@ -1,0 +1,165 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { AddressMap } from "./AddressMap.ts";
+import type { BgpPrefix } from "./BgpPrefix.ts";
+import type { Prefix } from "./Prefix.ts";
+import type { PrefixDelegation } from "./PrefixDelegation.ts";
+import type { ServiceBinding } from "./ServiceBinding.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare Addressing resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const AddressMapUI = UIProvider.succeed<AddressMap>(
+  "Cloudflare.Addressing.AddressMap",
+  {
+    displayName: "Address Map",
+    icon: "map",
+    color: "#F6821F",
+    category: "network",
+    summary: (ctx) =>
+      ctx.attrs?.defaultSni ??
+      ctx.attrs?.description ??
+      ctx.attrs?.addressMapId,
+    facts: (ctx) => [
+      {
+        label: "address map id",
+        value: ctx.attrs?.addressMapId,
+        mono: true,
+        copy: true,
+      },
+      { label: "enabled", value: ctx.attrs?.enabled },
+      { label: "default SNI", value: ctx.attrs?.defaultSni, mono: true },
+      {
+        label: "ips",
+        value: ctx.attrs?.ips?.length ? ctx.attrs.ips.join(", ") : undefined,
+        mono: true,
+      },
+      { label: "memberships", value: ctx.attrs?.memberships?.length },
+      { label: "description", value: ctx.attrs?.description },
+      { label: "account", value: ctx.attrs?.accountId, mono: true },
+    ],
+  },
+);
+
+export const PrefixUI = UIProvider.succeed<Prefix>(
+  "Cloudflare.Addressing.Prefix",
+  {
+    displayName: "IP Prefix",
+    icon: "binary",
+    color: "#F6821F",
+    category: "network",
+    summary: (ctx) => ctx.attrs?.cidr ?? ctx.props?.cidr,
+    facts: (ctx) => [
+      { label: "cidr", value: ctx.attrs?.cidr, mono: true, copy: true },
+      {
+        label: "prefix id",
+        value: ctx.attrs?.prefixId,
+        mono: true,
+        copy: true,
+      },
+      { label: "asn", value: ctx.attrs?.asn, mono: true },
+      { label: "approved", value: ctx.attrs?.approved },
+      {
+        label: "ownership validation",
+        value: ctx.attrs?.ownershipValidationState,
+      },
+      { label: "rpki validation", value: ctx.attrs?.rpkiValidationState },
+      { label: "description", value: ctx.attrs?.description },
+      { label: "account", value: ctx.attrs?.accountId, mono: true },
+    ],
+  },
+);
+
+export const BgpPrefixUI = UIProvider.succeed<BgpPrefix>(
+  "Cloudflare.Addressing.BgpPrefix",
+  {
+    displayName: "BGP Prefix",
+    icon: "git-branch",
+    color: "#F6821F",
+    category: "network",
+    summary: (ctx) => ctx.attrs?.cidr,
+    facts: (ctx) => [
+      { label: "cidr", value: ctx.attrs?.cidr, mono: true, copy: true },
+      {
+        label: "bgp prefix id",
+        value: ctx.attrs?.bgpPrefixId,
+        mono: true,
+        copy: true,
+      },
+      { label: "prefix id", value: ctx.attrs?.prefixId, mono: true },
+      { label: "asn", value: ctx.attrs?.asn, mono: true },
+      { label: "advertised", value: ctx.attrs?.onDemand?.advertised },
+      {
+        label: "on-demand enabled",
+        value: ctx.attrs?.onDemand?.onDemandEnabled,
+      },
+      { label: "account", value: ctx.attrs?.accountId, mono: true },
+    ],
+  },
+);
+
+export const PrefixDelegationUI = UIProvider.succeed<PrefixDelegation>(
+  "Cloudflare.Addressing.PrefixDelegation",
+  {
+    displayName: "Prefix Delegation",
+    icon: "share-2",
+    color: "#F6821F",
+    category: "network",
+    summary: (ctx) => ctx.attrs?.cidr ?? ctx.props?.cidr,
+    facts: (ctx) => [
+      { label: "cidr", value: ctx.attrs?.cidr, mono: true, copy: true },
+      {
+        label: "delegation id",
+        value: ctx.attrs?.delegationId,
+        mono: true,
+        copy: true,
+      },
+      { label: "prefix id", value: ctx.attrs?.prefixId, mono: true },
+      {
+        label: "delegated account",
+        value: ctx.attrs?.delegatedAccountId,
+        mono: true,
+        copy: true,
+      },
+      { label: "account", value: ctx.attrs?.accountId, mono: true },
+      { label: "created", value: ctx.attrs?.createdAt },
+    ],
+  },
+);
+
+export const ServiceBindingUI = UIProvider.succeed<ServiceBinding>(
+  "Cloudflare.Addressing.ServiceBinding",
+  {
+    displayName: "Address Service Binding",
+    icon: "link-2",
+    color: "#F6821F",
+    category: "network",
+    summary: (ctx) => ctx.attrs?.serviceName ?? ctx.attrs?.cidr,
+    facts: (ctx) => [
+      { label: "service", value: ctx.attrs?.serviceName },
+      {
+        label: "binding id",
+        value: ctx.attrs?.bindingId,
+        mono: true,
+        copy: true,
+      },
+      { label: "cidr", value: ctx.attrs?.cidr, mono: true, copy: true },
+      { label: "service id", value: ctx.attrs?.serviceId, mono: true },
+      { label: "prefix id", value: ctx.attrs?.prefixId, mono: true },
+      { label: "provisioning", value: ctx.attrs?.provisioning?.state },
+      { label: "account", value: ctx.attrs?.accountId, mono: true },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(
+    AddressMapUI,
+    PrefixUI,
+    BgpPrefixUI,
+    PrefixDelegationUI,
+    ServiceBindingUI,
+  );

--- a/packages/alchemy/src/Cloudflare/Alerting/ui.ts
+++ b/packages/alchemy/src/Cloudflare/Alerting/ui.ts
@@ -1,0 +1,89 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { NotificationPolicy } from "./NotificationPolicy.ts";
+import type { Silence } from "./Silence.ts";
+import type { NotificationWebhook } from "./Webhook.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare Alerting resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const NotificationPolicyUI = UIProvider.succeed<NotificationPolicy>(
+  "Cloudflare.Alerting.NotificationPolicy",
+  {
+    displayName: "Notification Policy",
+    icon: "bell",
+    color: "#F6821F",
+    category: "observability",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      {
+        label: "policy id",
+        value: ctx.attrs?.policyId,
+        mono: true,
+        copy: true,
+      },
+      { label: "alert type", value: ctx.attrs?.alertType, mono: true },
+      { label: "enabled", value: ctx.attrs?.enabled },
+      { label: "created", value: ctx.attrs?.created },
+      { label: "modified", value: ctx.attrs?.modified },
+    ],
+  },
+);
+
+export const SilenceUI = UIProvider.succeed<Silence>(
+  "Cloudflare.Alerting.Silence",
+  {
+    displayName: "Alert Silence",
+    icon: "bell-off",
+    color: "#F6821F",
+    category: "observability",
+    summary: (ctx) => ctx.attrs?.silenceId,
+    facts: (ctx) => [
+      {
+        label: "silence id",
+        value: ctx.attrs?.silenceId,
+        mono: true,
+        copy: true,
+      },
+      { label: "policy", value: ctx.attrs?.policyId, mono: true, copy: true },
+      { label: "start", value: ctx.attrs?.startTime },
+      { label: "end", value: ctx.attrs?.endTime },
+    ],
+  },
+);
+
+export const NotificationWebhookUI = UIProvider.succeed<NotificationWebhook>(
+  "Cloudflare.Alerting.Webhook",
+  {
+    displayName: "Notification Webhook",
+    icon: "webhook",
+    color: "#F6821F",
+    category: "eventing",
+    summary: (ctx) => ctx.attrs?.name,
+    link: (ctx) => ctx.attrs?.url,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      {
+        label: "url",
+        value: ctx.attrs?.url,
+        href: ctx.attrs?.url,
+        copy: true,
+      },
+      {
+        label: "webhook id",
+        value: ctx.attrs?.webhookId,
+        mono: true,
+        copy: true,
+      },
+      { label: "type", value: ctx.attrs?.type },
+      { label: "created", value: ctx.attrs?.createdAt },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(NotificationPolicyUI, SilenceUI, NotificationWebhookUI);

--- a/packages/alchemy/src/Cloudflare/ApiShield/ui.ts
+++ b/packages/alchemy/src/Cloudflare/ApiShield/ui.ts
@@ -1,0 +1,96 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Label } from "./Label.ts";
+import type { Operation } from "./Operation.ts";
+import type { UserSchema } from "./UserSchema.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare ApiShield resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const OperationUI = UIProvider.succeed<Operation>(
+  "Cloudflare.ApiShield.Operation",
+  {
+    displayName: "API Shield Operation",
+    icon: "route",
+    color: "#F6821F",
+    category: "security",
+    summary: (ctx) =>
+      ctx.attrs?.method !== undefined && ctx.attrs?.endpoint !== undefined
+        ? `${ctx.attrs.method} ${ctx.attrs.host ?? ""}${ctx.attrs.endpoint}`
+        : ctx.props?.endpoint,
+    facts: (ctx) => [
+      {
+        label: "operation id",
+        value: ctx.attrs?.operationId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "method",
+        value: ctx.attrs?.method ?? ctx.props?.method,
+        mono: true,
+      },
+      { label: "host", value: ctx.attrs?.host ?? ctx.props?.host, copy: true },
+      {
+        label: "endpoint",
+        value: ctx.attrs?.endpoint ?? ctx.props?.endpoint,
+        mono: true,
+        copy: true,
+      },
+      { label: "zone", value: ctx.attrs?.zoneId, mono: true, copy: true },
+      { label: "last updated", value: ctx.attrs?.lastUpdated },
+    ],
+  },
+);
+
+export const LabelUI = UIProvider.succeed<Label>("Cloudflare.ApiShield.Label", {
+  displayName: "API Shield Label",
+  icon: "tag",
+  color: "#F6821F",
+  category: "security",
+  summary: (ctx) => ctx.attrs?.name ?? ctx.props?.name,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.name, copy: true },
+    { label: "description", value: ctx.attrs?.description },
+    { label: "source", value: ctx.attrs?.source },
+    { label: "zone", value: ctx.attrs?.zoneId, mono: true, copy: true },
+    { label: "created", value: ctx.attrs?.createdAt },
+  ],
+});
+
+export const UserSchemaUI = UIProvider.succeed<UserSchema>(
+  "Cloudflare.ApiShield.UserSchema",
+  {
+    displayName: "API Shield User Schema",
+    icon: "file-code",
+    color: "#F6821F",
+    category: "security",
+    summary: (ctx) => ctx.attrs?.name ?? ctx.props?.name,
+    facts: (ctx) => [
+      {
+        label: "schema id",
+        value: ctx.attrs?.schemaId,
+        mono: true,
+        copy: true,
+      },
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      { label: "kind", value: ctx.attrs?.kind },
+      {
+        label: "validation",
+        value:
+          ctx.attrs?.validationEnabled === undefined
+            ? undefined
+            : ctx.attrs.validationEnabled
+              ? "enabled"
+              : "disabled",
+      },
+      { label: "zone", value: ctx.attrs?.zoneId, mono: true, copy: true },
+      { label: "created", value: ctx.attrs?.createdAt },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(OperationUI, LabelUI, UserSchemaUI);

--- a/packages/alchemy/src/Cloudflare/ApiToken/ui.ts
+++ b/packages/alchemy/src/Cloudflare/ApiToken/ui.ts
@@ -1,0 +1,55 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { AccountApiToken } from "./AccountApiToken.ts";
+import type { UserApiToken } from "./UserApiToken.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare ApiToken resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const UserApiTokenUI = UIProvider.succeed<UserApiToken>(
+  "Cloudflare.ApiToken.UserApiToken",
+  {
+    displayName: "User API Token",
+    icon: "key-round",
+    color: "#F6821F",
+    category: "auth",
+    summary: (ctx) => ctx.attrs?.name ?? ctx.props?.name,
+    consoleUrl: () => "https://dash.cloudflare.com/profile/api-tokens",
+    facts: (ctx) => [
+      { label: "token id", value: ctx.attrs?.tokenId, mono: true, copy: true },
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      { label: "status", value: ctx.attrs?.status },
+    ],
+  },
+);
+
+export const AccountApiTokenUI = UIProvider.succeed<AccountApiToken>(
+  "Cloudflare.ApiToken.AccountApiToken",
+  {
+    displayName: "Account API Token",
+    icon: "key-round",
+    color: "#F6821F",
+    category: "auth",
+    summary: (ctx) => ctx.attrs?.name ?? ctx.props?.name,
+    consoleUrl: (ctx) =>
+      ctx.attrs?.accountId === undefined
+        ? undefined
+        : `https://dash.cloudflare.com/${ctx.attrs.accountId}/api-tokens`,
+    facts: (ctx) => [
+      { label: "token id", value: ctx.attrs?.tokenId, mono: true, copy: true },
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      { label: "status", value: ctx.attrs?.status },
+      {
+        label: "account",
+        value: ctx.attrs?.accountId,
+        mono: true,
+        copy: true,
+      },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(UserApiTokenUI, AccountApiTokenUI);

--- a/packages/alchemy/src/Cloudflare/Argo/ui.ts
+++ b/packages/alchemy/src/Cloudflare/Argo/ui.ts
@@ -1,0 +1,54 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { SmartRouting } from "./SmartRouting.ts";
+import type { TieredCaching } from "./TieredCaching.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare Argo resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const SmartRoutingUI = UIProvider.succeed<SmartRouting>(
+  "Cloudflare.Argo.SmartRouting",
+  {
+    displayName: "Argo Smart Routing",
+    icon: "route",
+    color: "#F6821F",
+    category: "network",
+    summary: (ctx) =>
+      ctx.attrs?.value === undefined
+        ? ctx.attrs?.zoneId
+        : `smart routing ${ctx.attrs.value}`,
+    facts: (ctx) => [
+      { label: "zone", value: ctx.attrs?.zoneId, mono: true, copy: true },
+      { label: "value", value: ctx.attrs?.value },
+      { label: "editable", value: ctx.attrs?.editable },
+      { label: "initial value", value: ctx.attrs?.initialValue },
+      { label: "modified", value: ctx.attrs?.modifiedOn, mono: true },
+    ],
+  },
+);
+
+export const TieredCachingUI = UIProvider.succeed<TieredCaching>(
+  "Cloudflare.Argo.TieredCaching",
+  {
+    displayName: "Argo Tiered Caching",
+    icon: "layers",
+    color: "#F6821F",
+    category: "cdn",
+    summary: (ctx) =>
+      ctx.attrs?.value === undefined
+        ? ctx.attrs?.zoneId
+        : `tiered caching ${ctx.attrs.value}`,
+    facts: (ctx) => [
+      { label: "zone", value: ctx.attrs?.zoneId, mono: true, copy: true },
+      { label: "value", value: ctx.attrs?.value },
+      { label: "editable", value: ctx.attrs?.editable },
+      { label: "initial value", value: ctx.attrs?.initialValue },
+      { label: "modified", value: ctx.attrs?.modifiedOn, mono: true },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(SmartRoutingUI, TieredCachingUI);

--- a/packages/alchemy/src/Cloudflare/BotManagement/ui.ts
+++ b/packages/alchemy/src/Cloudflare/BotManagement/ui.ts
@@ -1,0 +1,35 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { BotManagement } from "./BotManagement.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare Bot Management resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const BotManagementUI = UIProvider.succeed<BotManagement>(
+  "Cloudflare.BotManagement.BotManagement",
+  {
+    displayName: "Bot Management",
+    icon: "bot",
+    color: "#F6821F",
+    category: "security",
+    summary: (ctx) => ctx.attrs?.zoneId ?? ctx.props?.zoneId,
+    consoleUrl: (ctx) =>
+      ctx.attrs?.zoneId === undefined
+        ? undefined
+        : `https://dash.cloudflare.com/?to=/:account/${ctx.attrs.zoneId}/security/bots`,
+    facts: (ctx) => [
+      { label: "zone", value: ctx.attrs?.zoneId, mono: true, copy: true },
+      { label: "fight mode", value: ctx.attrs?.fightMode },
+      { label: "ai bots protection", value: ctx.attrs?.aiBotsProtection },
+      { label: "crawler protection", value: ctx.attrs?.crawlerProtection },
+      { label: "enable js", value: ctx.attrs?.enableJs },
+      { label: "auto-update model", value: ctx.attrs?.autoUpdateModel },
+      { label: "latest model", value: ctx.attrs?.usingLatestModel },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(BotManagementUI);

--- a/packages/alchemy/src/Cloudflare/Cache/ui.ts
+++ b/packages/alchemy/src/Cloudflare/Cache/ui.ts
@@ -1,0 +1,135 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { OriginCloudRegion } from "./OriginCloudRegion.ts";
+import type { RegionalTieredCache } from "./RegionalTieredCache.ts";
+import type { Reserve } from "./Reserve.ts";
+import type { SmartTieredCache } from "./SmartTieredCache.ts";
+import type { Variants } from "./Variants.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare Cache resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const ReserveUI = UIProvider.succeed<Reserve>(
+  "Cloudflare.Cache.Reserve",
+  {
+    displayName: "Cache Reserve",
+    icon: "hard-drive",
+    color: "#F6821F",
+    category: "cdn",
+    summary: (ctx) =>
+      ctx.attrs?.value === undefined
+        ? ctx.attrs?.zoneId
+        : `cache reserve ${ctx.attrs.value}`,
+    facts: (ctx) => [
+      { label: "zone", value: ctx.attrs?.zoneId, mono: true, copy: true },
+      { label: "value", value: ctx.attrs?.value },
+      { label: "editable", value: ctx.attrs?.editable },
+      { label: "initial value", value: ctx.attrs?.initialValue },
+      { label: "modified", value: ctx.attrs?.modifiedOn, mono: true },
+      { label: "clear on delete", value: ctx.props?.clearOnDelete },
+    ],
+  },
+);
+
+export const SmartTieredCacheUI = UIProvider.succeed<SmartTieredCache>(
+  "Cloudflare.Cache.SmartTieredCache",
+  {
+    displayName: "Smart Tiered Cache",
+    icon: "layers",
+    color: "#F6821F",
+    category: "cdn",
+    summary: (ctx) =>
+      ctx.attrs?.value === undefined
+        ? ctx.attrs?.zoneId
+        : `smart tiered cache ${ctx.attrs.value}`,
+    facts: (ctx) => [
+      { label: "zone", value: ctx.attrs?.zoneId, mono: true, copy: true },
+      { label: "value", value: ctx.attrs?.value },
+      { label: "editable", value: ctx.attrs?.editable },
+      { label: "initial value", value: ctx.attrs?.initialValue },
+      { label: "modified", value: ctx.attrs?.modifiedOn, mono: true },
+    ],
+  },
+);
+
+export const RegionalTieredCacheUI = UIProvider.succeed<RegionalTieredCache>(
+  "Cloudflare.Cache.RegionalTieredCache",
+  {
+    displayName: "Regional Tiered Cache",
+    icon: "map",
+    color: "#F6821F",
+    category: "cdn",
+    summary: (ctx) =>
+      ctx.attrs?.value === undefined
+        ? ctx.attrs?.zoneId
+        : `regional tiered cache ${ctx.attrs.value}`,
+    facts: (ctx) => [
+      { label: "zone", value: ctx.attrs?.zoneId, mono: true, copy: true },
+      { label: "value", value: ctx.attrs?.value },
+      { label: "editable", value: ctx.attrs?.editable },
+      { label: "initial value", value: ctx.attrs?.initialValue },
+      { label: "modified", value: ctx.attrs?.modifiedOn, mono: true },
+    ],
+  },
+);
+
+export const VariantsUI = UIProvider.succeed<Variants>(
+  "Cloudflare.Cache.Variants",
+  {
+    displayName: "Cache Variants",
+    icon: "images",
+    color: "#F6821F",
+    category: "cdn",
+    summary: (ctx) => ctx.attrs?.zoneId,
+    facts: (ctx) => [
+      { label: "zone", value: ctx.attrs?.zoneId, mono: true, copy: true },
+      {
+        label: "extensions",
+        value: ctx.attrs?.value
+          ? Object.keys(ctx.attrs.value).join(", ")
+          : undefined,
+        mono: true,
+      },
+      { label: "editable", value: ctx.attrs?.editable },
+      { label: "modified", value: ctx.attrs?.modifiedOn, mono: true },
+    ],
+  },
+);
+
+export const OriginCloudRegionUI = UIProvider.succeed<OriginCloudRegion>(
+  "Cloudflare.Cache.OriginCloudRegion",
+  {
+    displayName: "Origin Cloud Region",
+    icon: "cloud",
+    color: "#F6821F",
+    category: "cdn",
+    summary: (ctx) =>
+      ctx.attrs?.vendor === undefined || ctx.attrs.region === undefined
+        ? ctx.attrs?.originIp
+        : `${ctx.attrs.vendor} ${ctx.attrs.region}`,
+    facts: (ctx) => [
+      { label: "zone", value: ctx.attrs?.zoneId, mono: true, copy: true },
+      {
+        label: "origin ip",
+        value: ctx.attrs?.originIp,
+        mono: true,
+        copy: true,
+      },
+      { label: "vendor", value: ctx.attrs?.vendor },
+      { label: "region", value: ctx.attrs?.region },
+      { label: "modified", value: ctx.attrs?.modifiedOn, mono: true },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(
+    ReserveUI,
+    SmartTieredCacheUI,
+    RegionalTieredCacheUI,
+    VariantsUI,
+    OriginCloudRegionUI,
+  );

--- a/packages/alchemy/src/Cloudflare/Calls/ui.ts
+++ b/packages/alchemy/src/Cloudflare/Calls/ui.ts
@@ -1,0 +1,53 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { App } from "./App.ts";
+import type { TurnKey } from "./TurnKey.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare Calls (Realtime SFU) resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const AppUI = UIProvider.succeed<App>("Cloudflare.Calls.App", {
+  displayName: "Calls App",
+  icon: "video",
+  color: "#F6821F",
+  category: "media",
+  summary: (ctx) => ctx.attrs?.name ?? ctx.attrs?.appId,
+  consoleUrl: (ctx) =>
+    ctx.attrs?.accountId === undefined
+      ? undefined
+      : `https://dash.cloudflare.com/${ctx.attrs.accountId}/calls`,
+  facts: (ctx) => [
+    { label: "app id", value: ctx.attrs?.appId, mono: true, copy: true },
+    { label: "name", value: ctx.attrs?.name },
+    { label: "account", value: ctx.attrs?.accountId, mono: true },
+    { label: "created", value: ctx.attrs?.created },
+    { label: "modified", value: ctx.attrs?.modified },
+  ],
+});
+
+export const TurnKeyUI = UIProvider.succeed<TurnKey>(
+  "Cloudflare.Calls.TurnKey",
+  {
+    displayName: "Calls TURN Key",
+    icon: "key-round",
+    color: "#F6821F",
+    category: "security",
+    summary: (ctx) => ctx.attrs?.name ?? ctx.attrs?.keyId,
+    consoleUrl: (ctx) =>
+      ctx.attrs?.accountId === undefined
+        ? undefined
+        : `https://dash.cloudflare.com/${ctx.attrs.accountId}/calls`,
+    facts: (ctx) => [
+      { label: "key id", value: ctx.attrs?.keyId, mono: true, copy: true },
+      { label: "name", value: ctx.attrs?.name },
+      { label: "account", value: ctx.attrs?.accountId, mono: true },
+      { label: "created", value: ctx.attrs?.created },
+      { label: "modified", value: ctx.attrs?.modified },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(AppUI, TurnKeyUI);

--- a/packages/alchemy/src/Cloudflare/CertificateAuthorities/ui.ts
+++ b/packages/alchemy/src/Cloudflare/CertificateAuthorities/ui.ts
@@ -1,0 +1,33 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { HostnameAssociation } from "./HostnameAssociation.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare Certificate Authorities resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const HostnameAssociationUI = UIProvider.succeed<HostnameAssociation>(
+  "Cloudflare.CertificateAuthorities.HostnameAssociation",
+  {
+    displayName: "CA Hostname Association",
+    icon: "link-2",
+    color: "#F6821F",
+    category: "security",
+    summary: (ctx) => ctx.attrs?.hostnames?.join(", "),
+    facts: (ctx) => [
+      { label: "zone", value: ctx.attrs?.zoneId, mono: true, copy: true },
+      {
+        label: "mTLS certificate",
+        value: ctx.attrs?.mtlsCertificateId ?? "Cloudflare Managed CA",
+        mono: ctx.attrs?.mtlsCertificateId !== undefined,
+        copy: ctx.attrs?.mtlsCertificateId !== undefined,
+      },
+      { label: "hostnames", value: ctx.attrs?.hostnames?.join(", ") },
+      { label: "hostname count", value: ctx.attrs?.hostnames?.length },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(HostnameAssociationUI);

--- a/packages/alchemy/src/Cloudflare/ClientCertificate/ui.ts
+++ b/packages/alchemy/src/Cloudflare/ClientCertificate/ui.ts
@@ -1,0 +1,42 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { ClientCertificate } from "./ClientCertificate.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare Client Certificate resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const ClientCertificateUI = UIProvider.succeed<ClientCertificate>(
+  "Cloudflare.ClientCertificate.ClientCertificate",
+  {
+    displayName: "Client Certificate",
+    icon: "file-key-2",
+    color: "#F6821F",
+    category: "security",
+    summary: (ctx) => ctx.attrs?.commonName ?? ctx.attrs?.clientCertificateId,
+    facts: (ctx) => [
+      {
+        label: "certificate id",
+        value: ctx.attrs?.clientCertificateId,
+        mono: true,
+        copy: true,
+      },
+      { label: "zone", value: ctx.attrs?.zoneId, mono: true, copy: true },
+      { label: "common name", value: ctx.attrs?.commonName },
+      { label: "status", value: ctx.attrs?.status },
+      { label: "issued", value: ctx.attrs?.issuedOn },
+      { label: "expires", value: ctx.attrs?.expiresOn },
+      {
+        label: "serial",
+        value: ctx.attrs?.serialNumber,
+        mono: true,
+        copy: true,
+      },
+      { label: "issuing CA", value: ctx.attrs?.certificateAuthorityName },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(ClientCertificateUI);

--- a/packages/alchemy/src/Cloudflare/CloudConnector/ui.ts
+++ b/packages/alchemy/src/Cloudflare/CloudConnector/ui.ts
@@ -1,0 +1,43 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Rules } from "./Rules.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare CloudConnector resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const RulesUI = UIProvider.succeed<Rules>(
+  "Cloudflare.CloudConnector.Rules",
+  {
+    displayName: "Cloud Connector Rules",
+    icon: "cable",
+    color: "#F6821F",
+    category: "network",
+    summary: (ctx) =>
+      ctx.attrs?.rules?.length !== undefined
+        ? `${ctx.attrs.rules.length} rule${ctx.attrs.rules.length === 1 ? "" : "s"}`
+        : ctx.props?.zoneId,
+    facts: (ctx) => [
+      { label: "zone id", value: ctx.attrs?.zoneId, mono: true, copy: true },
+      { label: "rules", value: ctx.attrs?.rules?.length },
+      {
+        label: "providers",
+        value: ctx.attrs?.rules?.length
+          ? [...new Set(ctx.attrs.rules.map((r) => r?.provider))].join(", ")
+          : undefined,
+        mono: true,
+      },
+      {
+        label: "hosts",
+        value: ctx.attrs?.rules?.length
+          ? ctx.attrs.rules.map((r) => r?.host).join(", ")
+          : undefined,
+        mono: true,
+      },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(RulesUI);

--- a/packages/alchemy/src/Cloudflare/CloudforceOne/ui.ts
+++ b/packages/alchemy/src/Cloudflare/CloudforceOne/ui.ts
@@ -1,0 +1,39 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { ScanConfig } from "./ScanConfig.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare Cloudforce One resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const ScanConfigUI = UIProvider.succeed<ScanConfig>(
+  "Cloudflare.CloudforceOne.ScanConfig",
+  {
+    displayName: "Attack Surface Scan Config",
+    icon: "radar",
+    color: "#F6821F",
+    category: "security",
+    summary: (ctx) => ctx.attrs?.ips?.join(", "),
+    facts: (ctx) => [
+      {
+        label: "config id",
+        value: ctx.attrs?.configId,
+        mono: true,
+        copy: true,
+      },
+      { label: "ips", value: ctx.attrs?.ips?.join(", "), mono: true },
+      { label: "ports", value: ctx.attrs?.ports?.join(", "), mono: true },
+      {
+        label: "frequency",
+        value:
+          ctx.attrs?.frequency === undefined
+            ? undefined
+            : `every ${ctx.attrs.frequency} day(s)`,
+      },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(ScanConfigUI);

--- a/packages/alchemy/src/Cloudflare/Connectivity/ui.ts
+++ b/packages/alchemy/src/Cloudflare/Connectivity/ui.ts
@@ -1,0 +1,48 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { DirectoryService } from "./DirectoryService.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare Connectivity resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+
+const hostLabel = (
+  host: DirectoryService.HostAttributes | undefined,
+): string | undefined => {
+  if (host === undefined) return undefined;
+  if ("hostname" in host) return host.hostname;
+  const ipv4 = "ipv4" in host ? host.ipv4 : undefined;
+  const ipv6 = "ipv6" in host ? host.ipv6 : undefined;
+  return [ipv4, ipv6].filter((ip) => ip !== undefined).join(" / ");
+};
+
+export const DirectoryServiceUI = UIProvider.succeed<DirectoryService>(
+  "Cloudflare.Connectivity.DirectoryService",
+  {
+    displayName: "Directory Service",
+    icon: "folder-tree",
+    color: "#F6821F",
+    category: "network",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      {
+        label: "service id",
+        value: ctx.attrs?.serviceId,
+        mono: true,
+        copy: true,
+      },
+      { label: "type", value: ctx.attrs?.type },
+      { label: "host", value: hostLabel(ctx.attrs?.host), mono: true },
+      { label: "tcp port", value: ctx.attrs?.tcpPort },
+      { label: "http port", value: ctx.attrs?.httpPort },
+      { label: "https port", value: ctx.attrs?.httpsPort },
+      { label: "account", value: ctx.attrs?.accountId, mono: true },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(DirectoryServiceUI);

--- a/packages/alchemy/src/Cloudflare/ContentScanning/ui.ts
+++ b/packages/alchemy/src/Cloudflare/ContentScanning/ui.ts
@@ -1,0 +1,49 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { ContentScanning } from "./ContentScanning.ts";
+import type { Expression } from "./Expression.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare Content Scanning resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const ContentScanningUI = UIProvider.succeed<ContentScanning>(
+  "Cloudflare.ContentScanning.ContentScanning",
+  {
+    displayName: "Content Scanning",
+    icon: "scan-search",
+    color: "#F6821F",
+    category: "security",
+    summary: (ctx) =>
+      ctx.attrs?.enabled === undefined
+        ? (ctx.attrs?.zoneId ?? ctx.props?.zoneId)
+        : ctx.attrs.enabled
+          ? "enabled"
+          : "disabled",
+    facts: (ctx) => [
+      { label: "zone", value: ctx.attrs?.zoneId, mono: true, copy: true },
+      { label: "enabled", value: ctx.attrs?.enabled },
+      { label: "modified", value: ctx.attrs?.modified },
+    ],
+  },
+);
+
+export const ExpressionUI = UIProvider.succeed<Expression>(
+  "Cloudflare.ContentScanning.Expression",
+  {
+    displayName: "Content Scanning Expression",
+    icon: "file-search",
+    color: "#F6821F",
+    category: "security",
+    summary: (ctx) => ctx.attrs?.payload ?? ctx.props?.payload,
+    facts: (ctx) => [
+      { label: "payload", value: ctx.attrs?.payload, mono: true },
+      { label: "id", value: ctx.attrs?.expressionId, mono: true, copy: true },
+      { label: "zone", value: ctx.attrs?.zoneId, mono: true, copy: true },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(ContentScanningUI, ExpressionUI);

--- a/packages/alchemy/src/Cloudflare/CustomCertificate/ui.ts
+++ b/packages/alchemy/src/Cloudflare/CustomCertificate/ui.ts
@@ -1,0 +1,37 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { CustomCertificate } from "./CustomCertificate.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare Custom Certificate resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const CustomCertificateUI = UIProvider.succeed<CustomCertificate>(
+  "Cloudflare.CustomCertificate.CustomCertificate",
+  {
+    displayName: "Custom Certificate",
+    icon: "file-badge",
+    color: "#F6821F",
+    category: "security",
+    summary: (ctx) => ctx.attrs?.hosts?.join(", ") ?? ctx.attrs?.certificateId,
+    facts: (ctx) => [
+      {
+        label: "certificate id",
+        value: ctx.attrs?.certificateId,
+        mono: true,
+        copy: true,
+      },
+      { label: "zone", value: ctx.attrs?.zoneId, mono: true, copy: true },
+      { label: "hosts", value: ctx.attrs?.hosts?.join(", ") },
+      { label: "issuer", value: ctx.attrs?.issuer },
+      { label: "status", value: ctx.attrs?.status },
+      { label: "type", value: ctx.attrs?.type },
+      { label: "bundle method", value: ctx.attrs?.bundleMethod },
+      { label: "expires", value: ctx.attrs?.expiresOn },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(CustomCertificateUI);

--- a/packages/alchemy/src/Cloudflare/CustomHostname/ui.ts
+++ b/packages/alchemy/src/Cloudflare/CustomHostname/ui.ts
@@ -1,0 +1,61 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { CustomHostname } from "./CustomHostname.ts";
+import type { FallbackOrigin } from "./FallbackOrigin.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare for SaaS Custom Hostname resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const CustomHostnameUI = UIProvider.succeed<CustomHostname>(
+  "Cloudflare.CustomHostname.CustomHostname",
+  {
+    displayName: "Custom Hostname",
+    icon: "globe-lock",
+    color: "#F6821F",
+    category: "dns",
+    summary: (ctx) => ctx.attrs?.hostname,
+    link: (ctx) =>
+      ctx.attrs?.hostname === undefined || ctx.attrs?.status !== "active"
+        ? undefined
+        : `https://${ctx.attrs.hostname}`,
+    facts: (ctx) => [
+      { label: "hostname", value: ctx.attrs?.hostname, copy: true },
+      {
+        label: "hostname id",
+        value: ctx.attrs?.customHostnameId,
+        mono: true,
+        copy: true,
+      },
+      { label: "zone", value: ctx.attrs?.zoneId, mono: true, copy: true },
+      { label: "status", value: ctx.attrs?.status },
+      { label: "ssl status", value: ctx.attrs?.sslStatus },
+      {
+        label: "ownership TXT",
+        value: ctx.attrs?.ownershipVerification?.name,
+        mono: true,
+        copy: true,
+      },
+    ],
+  },
+);
+
+export const FallbackOriginUI = UIProvider.succeed<FallbackOrigin>(
+  "Cloudflare.CustomHostname.FallbackOrigin",
+  {
+    displayName: "Fallback Origin",
+    icon: "server",
+    color: "#F6821F",
+    category: "network",
+    summary: (ctx) => ctx.attrs?.origin,
+    facts: (ctx) => [
+      { label: "origin", value: ctx.attrs?.origin, mono: true, copy: true },
+      { label: "zone", value: ctx.attrs?.zoneId, mono: true, copy: true },
+      { label: "status", value: ctx.attrs?.status },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(CustomHostnameUI, FallbackOriginUI);

--- a/packages/alchemy/src/Cloudflare/CustomNameserver/ui.ts
+++ b/packages/alchemy/src/Cloudflare/CustomNameserver/ui.ts
@@ -1,0 +1,43 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { CustomNameserver } from "./CustomNameserver.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare Custom Nameserver resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const CustomNameserverUI = UIProvider.succeed<CustomNameserver>(
+  "Cloudflare.CustomNameserver.CustomNameserver",
+  {
+    displayName: "Custom Nameserver",
+    icon: "server",
+    color: "#F6821F",
+    category: "dns",
+    summary: (ctx) => ctx.attrs?.nsName,
+    facts: (ctx) => [
+      { label: "ns name", value: ctx.attrs?.nsName, mono: true, copy: true },
+      { label: "status", value: ctx.attrs?.status },
+      { label: "ns set", value: ctx.attrs?.nsSet },
+      { label: "zone tag", value: ctx.attrs?.zoneTag, mono: true, copy: true },
+      {
+        label: "dns records",
+        value: ctx.attrs?.dnsRecords?.length
+          ? ctx.attrs.dnsRecords
+              .map((r) => `${r?.type ?? "?"} ${r?.value ?? "?"}`)
+              .join(", ")
+          : undefined,
+        mono: true,
+      },
+      {
+        label: "account id",
+        value: ctx.attrs?.accountId,
+        mono: true,
+        copy: true,
+      },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(CustomNameserverUI);

--- a/packages/alchemy/src/Cloudflare/D1/ui.ts
+++ b/packages/alchemy/src/Cloudflare/D1/ui.ts
@@ -1,0 +1,47 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Database } from "./Database.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare D1 resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const DatabaseUI = UIProvider.succeed<Database>(
+  "Cloudflare.D1Database",
+  {
+    displayName: "D1 Database",
+    icon: "database",
+    color: "#F6821F",
+    category: "database",
+    summary: (ctx) => ctx.attrs?.databaseName,
+    consoleUrl: (ctx) =>
+      ctx.attrs?.accountId === undefined || ctx.attrs.databaseId === undefined
+        ? undefined
+        : `https://dash.cloudflare.com/${ctx.attrs.accountId}/workers/d1/databases/${ctx.attrs.databaseId}`,
+    facts: (ctx) => [
+      { label: "database", value: ctx.attrs?.databaseName, copy: true },
+      {
+        label: "database id",
+        value: ctx.attrs?.databaseId,
+        mono: true,
+        copy: true,
+      },
+      { label: "jurisdiction", value: ctx.attrs?.jurisdiction },
+      {
+        label: "read replication",
+        value: ctx.attrs?.readReplication?.mode,
+      },
+      { label: "migrations dir", value: ctx.attrs?.migrationsDir, mono: true },
+      {
+        label: "migrations table",
+        value: ctx.attrs?.migrationsTable,
+        mono: true,
+      },
+      { label: "account", value: ctx.attrs?.accountId, mono: true, copy: true },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(DatabaseUI);

--- a/packages/alchemy/src/Cloudflare/DNS/ui.ts
+++ b/packages/alchemy/src/Cloudflare/DNS/ui.ts
@@ -1,0 +1,312 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { AccountDnsSettings } from "./AccountSettings.ts";
+import type { Dnssec } from "./Dnssec.ts";
+import type { Firewall } from "./Firewall.ts";
+import type { Record } from "./Record.ts";
+import type { View } from "./View.ts";
+import type { ZoneDnsSettings } from "./ZoneSettings.ts";
+import type { ZoneTransferAcl } from "./ZoneTransferAcl.ts";
+import type { ZoneTransferIncoming } from "./ZoneTransferIncoming.ts";
+import type { ZoneTransferOutgoing } from "./ZoneTransferOutgoing.ts";
+import type { ZoneTransferPeer } from "./ZoneTransferPeer.ts";
+import type { ZoneTransferTsig } from "./ZoneTransferTsig.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare DNS resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const RecordUI = UIProvider.succeed<Record>("Cloudflare.DNS.Record", {
+  displayName: "DNS Record",
+  icon: "globe",
+  color: "#F6821F",
+  category: "dns",
+  summary: (ctx) =>
+    ctx.attrs?.name === undefined
+      ? undefined
+      : `${ctx.attrs.type ?? ""} ${ctx.attrs.name}`.trim(),
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.name, copy: true },
+    { label: "type", value: ctx.attrs?.type, mono: true },
+    { label: "content", value: ctx.attrs?.content, mono: true, copy: true },
+    { label: "ttl", value: ctx.attrs?.ttl },
+    { label: "proxied", value: ctx.attrs?.proxied },
+    { label: "record id", value: ctx.attrs?.recordId, mono: true, copy: true },
+    { label: "zone id", value: ctx.attrs?.zoneId, mono: true, copy: true },
+  ],
+});
+
+export const DnssecUI = UIProvider.succeed<Dnssec>("Cloudflare.DNS.Dnssec", {
+  displayName: "DNSSEC",
+  icon: "shield-check",
+  color: "#F6821F",
+  category: "dns",
+  summary: (ctx) => ctx.attrs?.status,
+  facts: (ctx) => [
+    { label: "status", value: ctx.attrs?.status },
+    { label: "zone id", value: ctx.attrs?.zoneId, mono: true, copy: true },
+    { label: "algorithm", value: ctx.attrs?.algorithm, mono: true },
+    { label: "key tag", value: ctx.attrs?.keyTag, mono: true },
+    { label: "digest type", value: ctx.attrs?.digestType, mono: true },
+    { label: "ds", value: ctx.attrs?.ds, mono: true, copy: true },
+    { label: "multi-signer", value: ctx.attrs?.dnssecMultiSigner },
+    { label: "presigned", value: ctx.attrs?.dnssecPresigned },
+  ],
+});
+
+export const FirewallUI = UIProvider.succeed<Firewall>(
+  "Cloudflare.DNS.Firewall",
+  {
+    displayName: "DNS Firewall",
+    icon: "shield",
+    color: "#F6821F",
+    category: "dns",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      {
+        label: "firewall id",
+        value: ctx.attrs?.dnsFirewallId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "firewall ips",
+        value: ctx.attrs?.dnsFirewallIps?.length
+          ? ctx.attrs.dnsFirewallIps.join(", ")
+          : undefined,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "upstream ips",
+        value: ctx.attrs?.upstreamIps?.length
+          ? ctx.attrs.upstreamIps.join(", ")
+          : undefined,
+        mono: true,
+      },
+      { label: "max cache ttl", value: ctx.attrs?.maximumCacheTtl },
+      { label: "retries", value: ctx.attrs?.retries },
+      {
+        label: "account id",
+        value: ctx.attrs?.accountId,
+        mono: true,
+        copy: true,
+      },
+    ],
+  },
+);
+
+export const ViewUI = UIProvider.succeed<View>("Cloudflare.DNS.View", {
+  displayName: "DNS Internal View",
+  icon: "eye",
+  color: "#F6821F",
+  category: "dns",
+  summary: (ctx) => ctx.attrs?.name,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.name, copy: true },
+    { label: "view id", value: ctx.attrs?.viewId, mono: true, copy: true },
+    {
+      label: "zones",
+      value: ctx.attrs?.zones?.length ? ctx.attrs.zones.join(", ") : undefined,
+      mono: true,
+    },
+    {
+      label: "account id",
+      value: ctx.attrs?.accountId,
+      mono: true,
+      copy: true,
+    },
+  ],
+});
+
+export const AccountDnsSettingsUI = UIProvider.succeed<AccountDnsSettings>(
+  "Cloudflare.DNS.AccountSettings",
+  {
+    displayName: "Account DNS Settings",
+    icon: "settings-2",
+    color: "#F6821F",
+    category: "config",
+    summary: (ctx) => ctx.attrs?.accountId,
+    facts: (ctx) => [
+      {
+        label: "account id",
+        value: ctx.attrs?.accountId,
+        mono: true,
+        copy: true,
+      },
+      { label: "enforce dns only", value: ctx.attrs?.enforceDnsOnly },
+      {
+        label: "managed keys",
+        value: ctx.attrs?.managedKeys?.length
+          ? ctx.attrs.managedKeys.join(", ")
+          : undefined,
+        mono: true,
+      },
+    ],
+  },
+);
+
+export const ZoneDnsSettingsUI = UIProvider.succeed<ZoneDnsSettings>(
+  "Cloudflare.DNS.ZoneSettings",
+  {
+    displayName: "Zone DNS Settings",
+    icon: "settings",
+    color: "#F6821F",
+    category: "config",
+    summary: (ctx) => ctx.attrs?.zoneId,
+    facts: (ctx) => [
+      { label: "zone id", value: ctx.attrs?.zoneId, mono: true, copy: true },
+      { label: "zone mode", value: ctx.attrs?.zoneMode },
+      { label: "multi-provider", value: ctx.attrs?.multiProvider },
+      { label: "flatten all cnames", value: ctx.attrs?.flattenAllCnames },
+      { label: "foundation dns", value: ctx.attrs?.foundationDns },
+      { label: "ns ttl", value: ctx.attrs?.nsTtl },
+      {
+        label: "managed keys",
+        value: ctx.attrs?.managedKeys?.length
+          ? ctx.attrs.managedKeys.join(", ")
+          : undefined,
+        mono: true,
+      },
+    ],
+  },
+);
+
+export const ZoneTransferAclUI = UIProvider.succeed<ZoneTransferAcl>(
+  "Cloudflare.DNS.ZoneTransferAcl",
+  {
+    displayName: "Zone Transfer ACL",
+    icon: "list-checks",
+    color: "#F6821F",
+    category: "dns",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      { label: "acl id", value: ctx.attrs?.aclId, mono: true, copy: true },
+      { label: "ip range", value: ctx.attrs?.ipRange, mono: true, copy: true },
+      {
+        label: "account id",
+        value: ctx.attrs?.accountId,
+        mono: true,
+        copy: true,
+      },
+    ],
+  },
+);
+
+export const ZoneTransferIncomingUI = UIProvider.succeed<ZoneTransferIncoming>(
+  "Cloudflare.DNS.ZoneTransferIncoming",
+  {
+    displayName: "Incoming Zone Transfer",
+    icon: "arrow-down-to-line",
+    color: "#F6821F",
+    category: "dns",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      { label: "id", value: ctx.attrs?.id, mono: true, copy: true },
+      { label: "zone id", value: ctx.attrs?.zoneId, mono: true, copy: true },
+      {
+        label: "peers",
+        value: ctx.attrs?.peers?.length
+          ? ctx.attrs.peers.join(", ")
+          : undefined,
+        mono: true,
+      },
+      { label: "auto refresh (s)", value: ctx.attrs?.autoRefreshSeconds },
+      { label: "soa serial", value: ctx.attrs?.soaSerial, mono: true },
+      { label: "last checked", value: ctx.attrs?.checkedTime },
+    ],
+  },
+);
+
+export const ZoneTransferOutgoingUI = UIProvider.succeed<ZoneTransferOutgoing>(
+  "Cloudflare.DNS.ZoneTransferOutgoing",
+  {
+    displayName: "Outgoing Zone Transfer",
+    icon: "arrow-up-from-line",
+    color: "#F6821F",
+    category: "dns",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      { label: "id", value: ctx.attrs?.id, mono: true, copy: true },
+      { label: "zone id", value: ctx.attrs?.zoneId, mono: true, copy: true },
+      {
+        label: "peers",
+        value: ctx.attrs?.peers?.length
+          ? ctx.attrs.peers.join(", ")
+          : undefined,
+        mono: true,
+      },
+      { label: "enabled", value: ctx.attrs?.enabled },
+      { label: "soa serial", value: ctx.attrs?.soaSerial, mono: true },
+      { label: "last transferred", value: ctx.attrs?.lastTransferredTime },
+    ],
+  },
+);
+
+export const ZoneTransferPeerUI = UIProvider.succeed<ZoneTransferPeer>(
+  "Cloudflare.DNS.ZoneTransferPeer",
+  {
+    displayName: "Zone Transfer Peer",
+    icon: "network",
+    color: "#F6821F",
+    category: "dns",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      { label: "peer id", value: ctx.attrs?.peerId, mono: true, copy: true },
+      { label: "ip", value: ctx.attrs?.ip, mono: true, copy: true },
+      { label: "port", value: ctx.attrs?.port, mono: true },
+      { label: "tsig id", value: ctx.attrs?.tsigId, mono: true, copy: true },
+      { label: "ixfr enabled", value: ctx.attrs?.ixfrEnable },
+      {
+        label: "account id",
+        value: ctx.attrs?.accountId,
+        mono: true,
+        copy: true,
+      },
+    ],
+  },
+);
+
+export const ZoneTransferTsigUI = UIProvider.succeed<ZoneTransferTsig>(
+  "Cloudflare.DNS.ZoneTransferTsig",
+  {
+    displayName: "Zone Transfer TSIG",
+    icon: "key-round",
+    color: "#F6821F",
+    category: "security",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      { label: "tsig id", value: ctx.attrs?.tsigId, mono: true, copy: true },
+      { label: "algorithm", value: ctx.attrs?.algo, mono: true },
+      {
+        label: "account id",
+        value: ctx.attrs?.accountId,
+        mono: true,
+        copy: true,
+      },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(
+    RecordUI,
+    DnssecUI,
+    FirewallUI,
+    ViewUI,
+    AccountDnsSettingsUI,
+    ZoneDnsSettingsUI,
+    ZoneTransferAclUI,
+    ZoneTransferIncomingUI,
+    ZoneTransferOutgoingUI,
+    ZoneTransferPeerUI,
+    ZoneTransferTsigUI,
+  );

--- a/packages/alchemy/src/Cloudflare/DdosProtection/ui.ts
+++ b/packages/alchemy/src/Cloudflare/DdosProtection/ui.ts
@@ -1,0 +1,136 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { DdosAllowlistEntry } from "./AllowlistEntry.ts";
+import type { SynProtectionFilter } from "./SynProtectionFilter.ts";
+import type { SynProtectionRule } from "./SynProtectionRule.ts";
+import type { TcpFlowProtectionFilter } from "./TcpFlowProtectionFilter.ts";
+import type { TcpFlowProtectionRule } from "./TcpFlowProtectionRule.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare DDoS Protection resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const DdosAllowlistEntryUI = UIProvider.succeed<DdosAllowlistEntry>(
+  "Cloudflare.DdosProtection.AllowlistEntry",
+  {
+    displayName: "DDoS Allowlist Entry",
+    icon: "shield-check",
+    color: "#F6821F",
+    category: "security",
+    summary: (ctx) => ctx.attrs?.prefix ?? ctx.props?.prefix,
+    facts: (ctx) => [
+      { label: "prefix", value: ctx.attrs?.prefix, mono: true, copy: true },
+      { label: "id", value: ctx.attrs?.allowlistId, mono: true, copy: true },
+      { label: "account", value: ctx.attrs?.accountId, mono: true, copy: true },
+      { label: "enabled", value: ctx.attrs?.enabled },
+      { label: "comment", value: ctx.attrs?.comment },
+      { label: "modified", value: ctx.attrs?.modifiedOn },
+    ],
+  },
+);
+
+export const SynProtectionRuleUI = UIProvider.succeed<SynProtectionRule>(
+  "Cloudflare.DdosProtection.SynProtectionRule",
+  {
+    displayName: "SYN Protection Rule",
+    icon: "shield",
+    color: "#F6821F",
+    category: "security",
+    summary: (ctx) =>
+      ctx.attrs?.name === undefined
+        ? ctx.props?.name
+        : `${ctx.attrs.name} (${ctx.attrs.mode})`,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name },
+      { label: "scope", value: ctx.attrs?.scope },
+      { label: "mode", value: ctx.attrs?.mode },
+      { label: "burst sensitivity", value: ctx.attrs?.burstSensitivity },
+      { label: "rate sensitivity", value: ctx.attrs?.rateSensitivity },
+      { label: "mitigation", value: ctx.attrs?.mitigationType },
+      { label: "id", value: ctx.attrs?.ruleId, mono: true, copy: true },
+      { label: "account", value: ctx.attrs?.accountId, mono: true, copy: true },
+    ],
+  },
+);
+
+export const SynProtectionFilterUI = UIProvider.succeed<SynProtectionFilter>(
+  "Cloudflare.DdosProtection.SynProtectionFilter",
+  {
+    displayName: "SYN Protection Filter",
+    icon: "filter",
+    color: "#F6821F",
+    category: "security",
+    summary: (ctx) => ctx.attrs?.expression ?? ctx.props?.expression,
+    facts: (ctx) => [
+      { label: "expression", value: ctx.attrs?.expression, mono: true },
+      { label: "mode", value: ctx.attrs?.mode },
+      { label: "id", value: ctx.attrs?.filterId, mono: true, copy: true },
+      { label: "account", value: ctx.attrs?.accountId, mono: true, copy: true },
+      { label: "modified", value: ctx.attrs?.modifiedOn },
+    ],
+  },
+);
+
+export const TcpFlowProtectionRuleUI =
+  UIProvider.succeed<TcpFlowProtectionRule>(
+    "Cloudflare.DdosProtection.TcpFlowProtectionRule",
+    {
+      displayName: "TCP Flow Protection Rule",
+      icon: "shield",
+      color: "#F6821F",
+      category: "security",
+      summary: (ctx) =>
+        ctx.attrs?.name === undefined
+          ? ctx.props?.name
+          : `${ctx.attrs.name} (${ctx.attrs.mode})`,
+      facts: (ctx) => [
+        { label: "name", value: ctx.attrs?.name },
+        { label: "scope", value: ctx.attrs?.scope },
+        { label: "mode", value: ctx.attrs?.mode },
+        { label: "burst sensitivity", value: ctx.attrs?.burstSensitivity },
+        { label: "rate sensitivity", value: ctx.attrs?.rateSensitivity },
+        { label: "id", value: ctx.attrs?.ruleId, mono: true, copy: true },
+        {
+          label: "account",
+          value: ctx.attrs?.accountId,
+          mono: true,
+          copy: true,
+        },
+      ],
+    },
+  );
+
+export const TcpFlowProtectionFilterUI =
+  UIProvider.succeed<TcpFlowProtectionFilter>(
+    "Cloudflare.DdosProtection.TcpFlowProtectionFilter",
+    {
+      displayName: "TCP Flow Protection Filter",
+      icon: "filter",
+      color: "#F6821F",
+      category: "security",
+      summary: (ctx) => ctx.attrs?.expression ?? ctx.props?.expression,
+      facts: (ctx) => [
+        { label: "expression", value: ctx.attrs?.expression, mono: true },
+        { label: "mode", value: ctx.attrs?.mode },
+        { label: "id", value: ctx.attrs?.filterId, mono: true, copy: true },
+        {
+          label: "account",
+          value: ctx.attrs?.accountId,
+          mono: true,
+          copy: true,
+        },
+        { label: "modified", value: ctx.attrs?.modifiedOn },
+      ],
+    },
+  );
+
+export const ui = () =>
+  Layer.mergeAll(
+    DdosAllowlistEntryUI,
+    SynProtectionRuleUI,
+    SynProtectionFilterUI,
+    TcpFlowProtectionRuleUI,
+    TcpFlowProtectionFilterUI,
+  );

--- a/packages/alchemy/src/Cloudflare/Devices/ui.ts
+++ b/packages/alchemy/src/Cloudflare/Devices/ui.ts
@@ -1,0 +1,205 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { DeviceCustomProfile } from "./CustomProfile.ts";
+import type { DeviceDefaultProfile } from "./DefaultProfile.ts";
+import type { DeviceDexTest } from "./DexTest.ts";
+import type { DeviceManagedNetwork } from "./ManagedNetwork.ts";
+import type { DevicePostureIntegration } from "./PostureIntegration.ts";
+import type { DevicePostureRule } from "./PostureRule.ts";
+import type { DeviceSettings } from "./Settings.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare Zero Trust Devices (WARP)
+ * resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const DeviceCustomProfileUI = UIProvider.succeed<DeviceCustomProfile>(
+  "Cloudflare.Devices.CustomProfile",
+  {
+    displayName: "Device Custom Profile",
+    icon: "sliders-horizontal",
+    color: "#F6821F",
+    category: "config",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name },
+      { label: "id", value: ctx.attrs?.policyId, mono: true, copy: true },
+      { label: "match", value: ctx.attrs?.match, mono: true },
+      { label: "precedence", value: ctx.attrs?.precedence },
+      { label: "enabled", value: ctx.attrs?.enabled },
+      { label: "tunnel protocol", value: ctx.attrs?.tunnelProtocol },
+      {
+        label: "mode",
+        value: ctx.attrs?.serviceModeV2?.mode,
+      },
+    ],
+  },
+);
+
+export const DeviceDefaultProfileUI = UIProvider.succeed<DeviceDefaultProfile>(
+  "Cloudflare.Devices.DefaultProfile",
+  {
+    displayName: "Device Default Profile",
+    icon: "settings-2",
+    color: "#F6821F",
+    category: "config",
+    summary: (ctx) => ctx.attrs?.accountId,
+    facts: (ctx) => [
+      { label: "account", value: ctx.attrs?.accountId, mono: true, copy: true },
+      { label: "split-tunnel mode", value: ctx.attrs?.mode },
+      {
+        label: "include routes",
+        value: ctx.attrs?.splitTunnelInclude?.length || undefined,
+      },
+      {
+        label: "exclude routes",
+        value: ctx.attrs?.splitTunnelExclude?.length || undefined,
+      },
+      {
+        label: "fallback domains",
+        value: ctx.attrs?.fallbackDomains?.length || undefined,
+      },
+      { label: "captive portal", value: ctx.attrs?.captivePortal },
+      { label: "auto connect", value: ctx.attrs?.autoConnect },
+    ],
+  },
+);
+
+export const DeviceDexTestUI = UIProvider.succeed<DeviceDexTest>(
+  "Cloudflare.Devices.DexTest",
+  {
+    displayName: "Device DEX Test",
+    icon: "activity",
+    color: "#F6821F",
+    category: "observability",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name },
+      { label: "id", value: ctx.attrs?.testId, mono: true, copy: true },
+      { label: "kind", value: ctx.attrs?.data?.kind },
+      { label: "host", value: ctx.attrs?.data?.host, mono: true, copy: true },
+      { label: "interval", value: ctx.attrs?.interval },
+      { label: "enabled", value: ctx.attrs?.enabled },
+    ],
+  },
+);
+
+export const DeviceManagedNetworkUI = UIProvider.succeed<DeviceManagedNetwork>(
+  "Cloudflare.Devices.ManagedNetwork",
+  {
+    displayName: "Device Managed Network",
+    icon: "network",
+    color: "#F6821F",
+    category: "network",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name },
+      { label: "id", value: ctx.attrs?.networkId, mono: true, copy: true },
+      { label: "type", value: ctx.attrs?.type },
+      {
+        label: "tls sockaddr",
+        value: ctx.attrs?.config?.tlsSockaddr,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "sha256",
+        value: ctx.attrs?.config?.sha256,
+        mono: true,
+        copy: true,
+      },
+    ],
+  },
+);
+
+export const DevicePostureIntegrationUI =
+  UIProvider.succeed<DevicePostureIntegration>(
+    "Cloudflare.Devices.PostureIntegration",
+    {
+      displayName: "Device Posture Integration",
+      icon: "plug-zap",
+      color: "#F6821F",
+      category: "security",
+      summary: (ctx) => ctx.attrs?.name,
+      facts: (ctx) => [
+        { label: "name", value: ctx.attrs?.name },
+        {
+          label: "id",
+          value: ctx.attrs?.integrationId,
+          mono: true,
+          copy: true,
+        },
+        { label: "provider", value: ctx.attrs?.type },
+        { label: "interval", value: ctx.attrs?.interval },
+        {
+          label: "api url",
+          value: ctx.attrs?.config?.apiUrl,
+          href: ctx.attrs?.config?.apiUrl,
+          mono: true,
+        },
+        { label: "client id", value: ctx.attrs?.config?.clientId, mono: true },
+      ],
+    },
+  );
+
+export const DevicePostureRuleUI = UIProvider.succeed<DevicePostureRule>(
+  "Cloudflare.Devices.PostureRule",
+  {
+    displayName: "Device Posture Rule",
+    icon: "shield-check",
+    color: "#F6821F",
+    category: "security",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name },
+      { label: "id", value: ctx.attrs?.postureRuleId, mono: true, copy: true },
+      { label: "type", value: ctx.attrs?.type },
+      { label: "schedule", value: ctx.attrs?.schedule },
+      { label: "expiration", value: ctx.attrs?.expiration },
+      {
+        label: "platforms",
+        value: ctx.attrs?.match?.length
+          ? ctx.attrs.match
+              .map((m) => m?.platform)
+              .filter((p) => p !== undefined)
+              .join(", ") || undefined
+          : undefined,
+      },
+    ],
+  },
+);
+
+export const DeviceSettingsUI = UIProvider.succeed<DeviceSettings>(
+  "Cloudflare.Devices.Settings",
+  {
+    displayName: "Device Settings",
+    icon: "settings",
+    color: "#F6821F",
+    category: "config",
+    summary: (ctx) => ctx.attrs?.accountId,
+    facts: (ctx) => [
+      { label: "account", value: ctx.attrs?.accountId, mono: true, copy: true },
+      { label: "gateway tcp proxy", value: ctx.attrs?.gatewayProxyEnabled },
+      { label: "gateway udp proxy", value: ctx.attrs?.gatewayUdpProxyEnabled },
+      {
+        label: "root cert install",
+        value: ctx.attrs?.rootCertificateInstallationEnabled,
+      },
+      { label: "zt virtual ip", value: ctx.attrs?.useZtVirtualIp },
+      { label: "disable for time", value: ctx.attrs?.disableForTime },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(
+    DeviceCustomProfileUI,
+    DeviceDefaultProfileUI,
+    DeviceDexTestUI,
+    DeviceManagedNetworkUI,
+    DevicePostureIntegrationUI,
+    DevicePostureRuleUI,
+    DeviceSettingsUI,
+  );

--- a/packages/alchemy/src/Cloudflare/Diagnostics/ui.ts
+++ b/packages/alchemy/src/Cloudflare/Diagnostics/ui.ts
@@ -1,0 +1,33 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { EndpointHealthcheck } from "./EndpointHealthcheck.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare Diagnostics resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const EndpointHealthcheckUI = UIProvider.succeed<EndpointHealthcheck>(
+  "Cloudflare.Diagnostics.EndpointHealthcheck",
+  {
+    displayName: "Endpoint Healthcheck",
+    icon: "heart-pulse",
+    color: "#F6821F",
+    category: "observability",
+    summary: (ctx) => ctx.attrs?.endpoint ?? ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      { label: "endpoint", value: ctx.attrs?.endpoint, mono: true, copy: true },
+      { label: "check type", value: ctx.attrs?.checkType },
+      {
+        label: "healthcheck id",
+        value: ctx.attrs?.healthcheckId,
+        mono: true,
+        copy: true,
+      },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(EndpointHealthcheckUI);

--- a/packages/alchemy/src/Cloudflare/Dlp/ui.ts
+++ b/packages/alchemy/src/Cloudflare/Dlp/ui.ts
@@ -1,0 +1,56 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Entry } from "./Entry.ts";
+import type { Profile } from "./Profile.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare DLP (Data Loss Prevention) resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const ProfileUI = UIProvider.succeed<Profile>("Cloudflare.Dlp.Profile", {
+  displayName: "DLP Profile",
+  icon: "shield",
+  color: "#F6821F",
+  category: "security",
+  summary: (ctx) => ctx.attrs?.name,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.name, copy: true },
+    {
+      label: "profile id",
+      value: ctx.attrs?.profileId,
+      mono: true,
+      copy: true,
+    },
+    { label: "account", value: ctx.attrs?.accountId, mono: true },
+    { label: "description", value: ctx.attrs?.description },
+    { label: "allowed matches", value: ctx.attrs?.allowedMatchCount },
+    { label: "OCR", value: ctx.attrs?.ocrEnabled },
+    {
+      label: "entries",
+      value: ctx.attrs?.entryIds
+        ? Object.keys(ctx.attrs.entryIds).length
+        : undefined,
+    },
+  ],
+});
+
+export const EntryUI = UIProvider.succeed<Entry>("Cloudflare.Dlp.Entry", {
+  displayName: "DLP Entry",
+  icon: "file-lock-2",
+  color: "#F6821F",
+  category: "security",
+  summary: (ctx) => ctx.attrs?.name,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.name, copy: true },
+    { label: "entry id", value: ctx.attrs?.entryId, mono: true, copy: true },
+    { label: "account", value: ctx.attrs?.accountId, mono: true },
+    { label: "profile", value: ctx.attrs?.profileId, mono: true },
+    { label: "enabled", value: ctx.attrs?.enabled },
+    { label: "regex", value: ctx.attrs?.pattern?.regex, mono: true },
+    { label: "validation", value: ctx.attrs?.pattern?.validation },
+  ],
+});
+
+export const ui = () => Layer.mergeAll(ProfileUI, EntryUI);

--- a/packages/alchemy/src/Cloudflare/Email/ui.ts
+++ b/packages/alchemy/src/Cloudflare/Email/ui.ts
@@ -1,0 +1,251 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Address } from "./Address.ts";
+import type { AllowPolicy } from "./AllowPolicy.ts";
+import type { BlockSender } from "./BlockSender.ts";
+import type { CatchAll } from "./CatchAll.ts";
+import type { Domain } from "./Domain.ts";
+import type { ImpersonationRegistryEntry } from "./ImpersonationRegistryEntry.ts";
+import type { Routing } from "./Routing.ts";
+import type { Rule } from "./Rule.ts";
+import type { SendingSubdomain } from "./SendingSubdomain.ts";
+import type { TrustedDomain } from "./TrustedDomain.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare Email resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no SDK code reaches the dashboard bundle.
+ */
+export const RoutingUI = UIProvider.succeed<Routing>(
+  "Cloudflare.Email.Routing",
+  {
+    displayName: "Email Routing",
+    icon: "mail",
+    color: "#F6821F",
+    category: "email",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name },
+      { label: "enabled", value: ctx.attrs?.enabled },
+      { label: "status", value: ctx.attrs?.status },
+      { label: "zone id", value: ctx.attrs?.zoneId, mono: true, copy: true },
+      {
+        label: "routing id",
+        value: ctx.attrs?.routingId,
+        mono: true,
+        copy: true,
+      },
+    ],
+  },
+);
+
+export const AddressUI = UIProvider.succeed<Address>(
+  "Cloudflare.Email.Address",
+  {
+    displayName: "Email Address",
+    icon: "at-sign",
+    color: "#F6821F",
+    category: "email",
+    summary: (ctx) => ctx.attrs?.email ?? ctx.props?.email,
+    facts: (ctx) => [
+      { label: "email", value: ctx.attrs?.email, copy: true },
+      { label: "verified", value: ctx.attrs?.verified },
+      { label: "verified at", value: ctx.attrs?.verifiedAt },
+      {
+        label: "address id",
+        value: ctx.attrs?.addressId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "account id",
+        value: ctx.attrs?.accountId,
+        mono: true,
+        copy: true,
+      },
+    ],
+  },
+);
+
+export const RuleUI = UIProvider.succeed<Rule>("Cloudflare.Email.Rule", {
+  displayName: "Email Rule",
+  icon: "mail-check",
+  color: "#F6821F",
+  category: "email",
+  summary: (ctx) => ctx.attrs?.name || ctx.attrs?.ruleId,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.name },
+    { label: "enabled", value: ctx.attrs?.enabled },
+    { label: "priority", value: ctx.attrs?.priority },
+    { label: "matchers", value: ctx.attrs?.matchers?.length },
+    { label: "actions", value: ctx.attrs?.actions?.length },
+    { label: "rule id", value: ctx.attrs?.ruleId, mono: true, copy: true },
+    { label: "zone id", value: ctx.attrs?.zoneId, mono: true, copy: true },
+  ],
+});
+
+export const CatchAllUI = UIProvider.succeed<CatchAll>(
+  "Cloudflare.Email.CatchAll",
+  {
+    displayName: "Email Catch-All Rule",
+    icon: "mail-question",
+    color: "#F6821F",
+    category: "email",
+    summary: (ctx) => ctx.attrs?.name || ctx.attrs?.zoneId,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name },
+      { label: "enabled", value: ctx.attrs?.enabled },
+      {
+        label: "actions",
+        value: ctx.attrs?.actions?.map((a) => a.type).join(", "),
+      },
+      { label: "rule id", value: ctx.attrs?.ruleId, mono: true, copy: true },
+      { label: "zone id", value: ctx.attrs?.zoneId, mono: true, copy: true },
+    ],
+  },
+);
+
+export const SendingSubdomainUI = UIProvider.succeed<SendingSubdomain>(
+  "Cloudflare.Email.SendingSubdomain",
+  {
+    displayName: "Email Sending Subdomain",
+    icon: "send",
+    color: "#F6821F",
+    category: "email",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      { label: "enabled", value: ctx.attrs?.enabled },
+      { label: "dkim selector", value: ctx.attrs?.dkimSelector, mono: true },
+      { label: "return path", value: ctx.attrs?.returnPathDomain, mono: true },
+      {
+        label: "subdomain id",
+        value: ctx.attrs?.subdomainId,
+        mono: true,
+        copy: true,
+      },
+      { label: "zone id", value: ctx.attrs?.zoneId, mono: true, copy: true },
+    ],
+  },
+);
+
+export const DomainUI = UIProvider.succeed<Domain>("Cloudflare.Email.Domain", {
+  displayName: "Email Security Domain",
+  icon: "shield-check",
+  color: "#F6821F",
+  category: "email",
+  summary: (ctx) => ctx.attrs?.domain ?? ctx.props?.domain,
+  facts: (ctx) => [
+    { label: "domain", value: ctx.attrs?.domain, copy: true },
+    { label: "transport", value: ctx.attrs?.transport, mono: true },
+    { label: "authorized", value: ctx.attrs?.authorization?.authorized },
+    {
+      label: "delivery modes",
+      value: ctx.attrs?.allowedDeliveryModes?.join(", "),
+    },
+    { label: "domain id", value: ctx.attrs?.domainId, mono: true, copy: true },
+    {
+      label: "account id",
+      value: ctx.attrs?.accountId,
+      mono: true,
+      copy: true,
+    },
+  ],
+});
+
+export const TrustedDomainUI = UIProvider.succeed<TrustedDomain>(
+  "Cloudflare.Email.TrustedDomain",
+  {
+    displayName: "Email Trusted Domain",
+    icon: "shield",
+    color: "#F6821F",
+    category: "email",
+    summary: (ctx) => ctx.attrs?.pattern ?? ctx.props?.pattern,
+    facts: (ctx) => [
+      { label: "pattern", value: ctx.attrs?.pattern, mono: true, copy: true },
+      { label: "regex", value: ctx.attrs?.isRegex },
+      { label: "recent", value: ctx.attrs?.isRecent },
+      { label: "similarity", value: ctx.attrs?.isSimilarity },
+      { label: "comments", value: ctx.attrs?.comments },
+      {
+        label: "id",
+        value: ctx.attrs?.trustedDomainId,
+        mono: true,
+        copy: true,
+      },
+    ],
+  },
+);
+
+export const BlockSenderUI = UIProvider.succeed<BlockSender>(
+  "Cloudflare.Email.BlockSender",
+  {
+    displayName: "Email Blocked Sender",
+    icon: "mail-x",
+    color: "#F6821F",
+    category: "email",
+    summary: (ctx) => ctx.attrs?.pattern ?? ctx.props?.pattern,
+    facts: (ctx) => [
+      { label: "pattern", value: ctx.attrs?.pattern, mono: true, copy: true },
+      { label: "pattern type", value: ctx.attrs?.patternType },
+      { label: "regex", value: ctx.attrs?.isRegex },
+      { label: "comments", value: ctx.attrs?.comments },
+      { label: "id", value: ctx.attrs?.blockSenderId, mono: true, copy: true },
+    ],
+  },
+);
+
+export const AllowPolicyUI = UIProvider.succeed<AllowPolicy>(
+  "Cloudflare.Email.AllowPolicy",
+  {
+    displayName: "Email Allow Policy",
+    icon: "mail-open",
+    color: "#F6821F",
+    category: "email",
+    summary: (ctx) => ctx.attrs?.pattern ?? ctx.props?.pattern,
+    facts: (ctx) => [
+      { label: "pattern", value: ctx.attrs?.pattern, mono: true, copy: true },
+      { label: "pattern type", value: ctx.attrs?.patternType },
+      { label: "acceptable sender", value: ctx.attrs?.isAcceptableSender },
+      { label: "exempt recipient", value: ctx.attrs?.isExemptRecipient },
+      { label: "trusted sender", value: ctx.attrs?.isTrustedSender },
+      { label: "verify sender", value: ctx.attrs?.verifySender },
+      { label: "id", value: ctx.attrs?.policyId, mono: true, copy: true },
+    ],
+  },
+);
+
+export const ImpersonationRegistryEntryUI =
+  UIProvider.succeed<ImpersonationRegistryEntry>(
+    "Cloudflare.Email.ImpersonationRegistryEntry",
+    {
+      displayName: "Impersonation Registry Entry",
+      icon: "user-check",
+      color: "#F6821F",
+      category: "email",
+      summary: (ctx) => ctx.attrs?.email ?? ctx.props?.email,
+      facts: (ctx) => [
+        { label: "name", value: ctx.attrs?.name },
+        { label: "email", value: ctx.attrs?.email, copy: true },
+        { label: "email regex", value: ctx.attrs?.isEmailRegex },
+        { label: "provenance", value: ctx.attrs?.provenance },
+        { label: "comments", value: ctx.attrs?.comments },
+        { label: "id", value: ctx.attrs?.entryId, mono: true, copy: true },
+      ],
+    },
+  );
+
+export const ui = () =>
+  Layer.mergeAll(
+    RoutingUI,
+    AddressUI,
+    RuleUI,
+    CatchAllUI,
+    SendingSubdomainUI,
+    DomainUI,
+    TrustedDomainUI,
+    BlockSenderUI,
+    AllowPolicyUI,
+    ImpersonationRegistryEntryUI,
+  );

--- a/packages/alchemy/src/Cloudflare/Firewall/ui.ts
+++ b/packages/alchemy/src/Cloudflare/Firewall/ui.ts
@@ -1,0 +1,83 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { AccessRule } from "./AccessRule.ts";
+import type { Lockdown } from "./Lockdown.ts";
+import type { UaRule } from "./UaRule.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare Firewall resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const AccessRuleUI = UIProvider.succeed<AccessRule>(
+  "Cloudflare.Firewall.AccessRule",
+  {
+    displayName: "Firewall Access Rule",
+    icon: "shield",
+    color: "#F6821F",
+    category: "security",
+    summary: (ctx) =>
+      ctx.attrs?.configuration?.value === undefined
+        ? ctx.props?.configuration?.value
+        : `${ctx.attrs.mode} ${ctx.attrs.configuration.value}`,
+    facts: (ctx) => [
+      { label: "mode", value: ctx.attrs?.mode },
+      { label: "target", value: ctx.attrs?.configuration?.target },
+      {
+        label: "value",
+        value: ctx.attrs?.configuration?.value,
+        mono: true,
+        copy: true,
+      },
+      { label: "id", value: ctx.attrs?.ruleId, mono: true, copy: true },
+      { label: "zone", value: ctx.attrs?.zoneId, mono: true, copy: true },
+      { label: "account", value: ctx.attrs?.accountId, mono: true, copy: true },
+      { label: "notes", value: ctx.attrs?.notes },
+    ],
+  },
+);
+
+export const LockdownUI = UIProvider.succeed<Lockdown>(
+  "Cloudflare.Firewall.Lockdown",
+  {
+    displayName: "Zone Lockdown",
+    icon: "lock",
+    color: "#F6821F",
+    category: "security",
+    summary: (ctx) => ctx.attrs?.urls?.[0] ?? ctx.props?.urls?.[0],
+    facts: (ctx) => [
+      {
+        label: "urls",
+        value: ctx.attrs?.urls?.length ? ctx.attrs.urls.join(", ") : undefined,
+        mono: true,
+      },
+      { label: "id", value: ctx.attrs?.lockdownId, mono: true, copy: true },
+      { label: "zone", value: ctx.attrs?.zoneId, mono: true, copy: true },
+      { label: "paused", value: ctx.attrs?.paused },
+      { label: "priority", value: ctx.attrs?.priority },
+      { label: "description", value: ctx.attrs?.description },
+    ],
+  },
+);
+
+export const UaRuleUI = UIProvider.succeed<UaRule>(
+  "Cloudflare.Firewall.UaRule",
+  {
+    displayName: "User Agent Rule",
+    icon: "user-x",
+    color: "#F6821F",
+    category: "security",
+    summary: (ctx) => ctx.attrs?.userAgent ?? ctx.props?.userAgent,
+    facts: (ctx) => [
+      { label: "user agent", value: ctx.attrs?.userAgent, mono: true },
+      { label: "mode", value: ctx.attrs?.mode },
+      { label: "id", value: ctx.attrs?.uaRuleId, mono: true, copy: true },
+      { label: "zone", value: ctx.attrs?.zoneId, mono: true, copy: true },
+      { label: "paused", value: ctx.attrs?.paused },
+      { label: "description", value: ctx.attrs?.description },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(AccessRuleUI, LockdownUI, UaRuleUI);

--- a/packages/alchemy/src/Cloudflare/Flagship/ui.ts
+++ b/packages/alchemy/src/Cloudflare/Flagship/ui.ts
@@ -1,0 +1,49 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { App } from "./App.ts";
+import type { Flag } from "./Flag.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare Flagship (feature flags) resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const AppUI = UIProvider.succeed<App>("Cloudflare.Flagship.App", {
+  displayName: "Flagship App",
+  icon: "flag",
+  color: "#F6821F",
+  category: "config",
+  summary: (ctx) => ctx.attrs?.name,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.name, copy: true },
+    { label: "app id", value: ctx.attrs?.appId, mono: true, copy: true },
+    { label: "account", value: ctx.attrs?.accountId, mono: true },
+    { label: "created", value: ctx.attrs?.createdAt },
+    { label: "updated", value: ctx.attrs?.updatedAt },
+  ],
+});
+
+export const FlagUI = UIProvider.succeed<Flag>("Cloudflare.Flagship.Flag", {
+  displayName: "Feature Flag",
+  icon: "toggle-right",
+  color: "#F6821F",
+  category: "config",
+  summary: (ctx) => ctx.attrs?.key,
+  facts: (ctx) => [
+    { label: "key", value: ctx.attrs?.key, mono: true, copy: true },
+    { label: "app", value: ctx.attrs?.appId, mono: true },
+    { label: "enabled", value: ctx.attrs?.enabled },
+    { label: "default variation", value: ctx.attrs?.defaultVariation },
+    {
+      label: "variations",
+      value: ctx.attrs?.variations
+        ? Object.keys(ctx.attrs.variations).join(", ")
+        : undefined,
+    },
+    { label: "rules", value: ctx.attrs?.rules?.length },
+    { label: "type", value: ctx.attrs?.type },
+  ],
+});
+
+export const ui = () => Layer.mergeAll(AppUI, FlagUI);

--- a/packages/alchemy/src/Cloudflare/Fraud/ui.ts
+++ b/packages/alchemy/src/Cloudflare/Fraud/ui.ts
@@ -1,0 +1,40 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { DetectionSettings } from "./DetectionSettings.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare Fraud Detection resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const DetectionSettingsUI = UIProvider.succeed<DetectionSettings>(
+  "Cloudflare.Fraud.DetectionSettings",
+  {
+    displayName: "Fraud Detection Settings",
+    icon: "shield-check",
+    color: "#F6821F",
+    category: "security",
+    summary: (ctx) => ctx.attrs?.zoneId,
+    facts: (ctx) => [
+      { label: "zone", value: ctx.attrs?.zoneId, mono: true, copy: true },
+      { label: "user profiles", value: ctx.attrs?.userProfiles },
+      {
+        label: "username expressions",
+        value: ctx.attrs?.usernameExpressions?.length
+          ? ctx.attrs.usernameExpressions.join(", ")
+          : undefined,
+        mono: true,
+      },
+      {
+        label: "auth settings",
+        value:
+          ctx.attrs?.authenticationSettings === undefined
+            ? undefined
+            : "configured",
+      },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(DetectionSettingsUI);

--- a/packages/alchemy/src/Cloudflare/Gateway/ui.ts
+++ b/packages/alchemy/src/Cloudflare/Gateway/ui.ts
@@ -1,0 +1,196 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Certificate } from "./Certificate.ts";
+import type { Configuration } from "./Configuration.ts";
+import type { List } from "./List.ts";
+import type { Location } from "./Location.ts";
+import type { Logging } from "./Logging.ts";
+import type { ProxyEndpoint } from "./ProxyEndpoint.ts";
+import type { Rule } from "./Rule.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare Zero Trust Gateway resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const CertificateUI = UIProvider.succeed<Certificate>(
+  "Cloudflare.Gateway.Certificate",
+  {
+    displayName: "Gateway Certificate",
+    icon: "file-lock-2",
+    color: "#F6821F",
+    category: "security",
+    summary: (ctx) => ctx.attrs?.certificateId,
+    facts: (ctx) => [
+      { label: "id", value: ctx.attrs?.certificateId, mono: true, copy: true },
+      {
+        label: "fingerprint",
+        value: ctx.attrs?.fingerprint,
+        mono: true,
+        copy: true,
+      },
+      { label: "type", value: ctx.attrs?.certificateType },
+      { label: "binding status", value: ctx.attrs?.bindingStatus },
+      { label: "in use", value: ctx.attrs?.inUse },
+      { label: "issuer", value: ctx.attrs?.issuerOrg },
+      { label: "expires", value: ctx.attrs?.expiresOn },
+    ],
+  },
+);
+
+export const ConfigurationUI = UIProvider.succeed<Configuration>(
+  "Cloudflare.Gateway.Configuration",
+  {
+    displayName: "Gateway Configuration",
+    icon: "settings-2",
+    color: "#F6821F",
+    category: "config",
+    summary: (ctx) => ctx.attrs?.accountId,
+    facts: (ctx) => [
+      { label: "account", value: ctx.attrs?.accountId, mono: true, copy: true },
+      { label: "created", value: ctx.attrs?.createdAt },
+      { label: "updated", value: ctx.attrs?.updatedAt },
+    ],
+  },
+);
+
+export const ListUI = UIProvider.succeed<List>("Cloudflare.Gateway.List", {
+  displayName: "Gateway List",
+  icon: "list-ordered",
+  color: "#F6821F",
+  category: "security",
+  summary: (ctx) => ctx.attrs?.name,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.name },
+    { label: "id", value: ctx.attrs?.listId, mono: true, copy: true },
+    { label: "type", value: ctx.attrs?.type },
+    { label: "items", value: ctx.attrs?.count },
+    { label: "description", value: ctx.attrs?.description || undefined },
+  ],
+});
+
+export const LocationUI = UIProvider.succeed<Location>(
+  "Cloudflare.Gateway.Location",
+  {
+    displayName: "Gateway Location",
+    icon: "map-pin",
+    color: "#F6821F",
+    category: "network",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name },
+      { label: "id", value: ctx.attrs?.locationId, mono: true, copy: true },
+      {
+        label: "doh",
+        value:
+          ctx.attrs?.dohSubdomain === undefined
+            ? undefined
+            : `${ctx.attrs.dohSubdomain}.cloudflare-gateway.com`,
+        mono: true,
+        copy: true,
+      },
+      { label: "ipv6", value: ctx.attrs?.ip, mono: true, copy: true },
+      { label: "dns ipv4", value: ctx.attrs?.ipv4Destination, mono: true },
+      { label: "client default", value: ctx.attrs?.clientDefault },
+      { label: "ecs support", value: ctx.attrs?.ecsSupport },
+    ],
+  },
+);
+
+const logLevel = (settings?: {
+  logAll?: boolean;
+  logBlocks?: boolean;
+}): string | undefined =>
+  settings === undefined
+    ? undefined
+    : settings.logAll
+      ? "log all"
+      : settings.logBlocks
+        ? "log blocks"
+        : "off";
+
+export const LoggingUI = UIProvider.succeed<Logging>(
+  "Cloudflare.Gateway.Logging",
+  {
+    displayName: "Gateway Logging",
+    icon: "scroll-text",
+    color: "#F6821F",
+    category: "observability",
+    summary: (ctx) => ctx.attrs?.accountId,
+    facts: (ctx) => [
+      { label: "account", value: ctx.attrs?.accountId, mono: true, copy: true },
+      { label: "redact PII", value: ctx.attrs?.redactPii },
+      { label: "dns", value: logLevel(ctx.attrs?.dns) },
+      { label: "http", value: logLevel(ctx.attrs?.http) },
+      { label: "l4", value: logLevel(ctx.attrs?.l4) },
+    ],
+  },
+);
+
+export const ProxyEndpointUI = UIProvider.succeed<ProxyEndpoint>(
+  "Cloudflare.Gateway.ProxyEndpoint",
+  {
+    displayName: "Gateway Proxy Endpoint",
+    icon: "waypoints",
+    color: "#F6821F",
+    category: "network",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name },
+      {
+        label: "id",
+        value: ctx.attrs?.proxyEndpointId,
+        mono: true,
+        copy: true,
+      },
+      { label: "kind", value: ctx.attrs?.kind },
+      {
+        label: "proxy host",
+        value:
+          ctx.attrs?.subdomain === undefined
+            ? undefined
+            : `${ctx.attrs.subdomain}.proxy.cloudflare-gateway.com`,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "allowed ips",
+        value: ctx.attrs?.ips?.length ? ctx.attrs.ips.join(", ") : undefined,
+        mono: true,
+      },
+    ],
+  },
+);
+
+export const RuleUI = UIProvider.succeed<Rule>("Cloudflare.Gateway.Rule", {
+  displayName: "Gateway Rule",
+  icon: "shield",
+  color: "#F6821F",
+  category: "security",
+  summary: (ctx) => ctx.attrs?.name,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.name },
+    { label: "id", value: ctx.attrs?.ruleId, mono: true, copy: true },
+    { label: "action", value: ctx.attrs?.action },
+    {
+      label: "filters",
+      value: ctx.attrs?.filters?.length
+        ? ctx.attrs.filters.join(", ")
+        : undefined,
+    },
+    { label: "precedence", value: ctx.attrs?.precedence },
+    { label: "traffic", value: ctx.props?.traffic, mono: true },
+  ],
+});
+
+export const ui = () =>
+  Layer.mergeAll(
+    CertificateUI,
+    ConfigurationUI,
+    ListUI,
+    LocationUI,
+    LoggingUI,
+    ProxyEndpointUI,
+    RuleUI,
+  );

--- a/packages/alchemy/src/Cloudflare/GoogleTagGateway/ui.ts
+++ b/packages/alchemy/src/Cloudflare/GoogleTagGateway/ui.ts
@@ -1,0 +1,34 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { GoogleTagGateway } from "./GoogleTagGateway.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare Google Tag Gateway resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const GoogleTagGatewayUI = UIProvider.succeed<GoogleTagGateway>(
+  "Cloudflare.GoogleTagGateway.GoogleTagGateway",
+  {
+    displayName: "Google Tag Gateway",
+    icon: "tag",
+    color: "#F6821F",
+    category: "observability",
+    summary: (ctx) => ctx.attrs?.measurementId ?? ctx.attrs?.zoneId,
+    facts: (ctx) => [
+      { label: "zone", value: ctx.attrs?.zoneId, mono: true, copy: true },
+      {
+        label: "measurement id",
+        value: ctx.attrs?.measurementId,
+        mono: true,
+        copy: true,
+      },
+      { label: "enabled", value: ctx.attrs?.enabled },
+      { label: "endpoint", value: ctx.attrs?.endpoint, mono: true },
+      { label: "hide origin IP", value: ctx.attrs?.hideOriginalIp },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(GoogleTagGatewayUI);

--- a/packages/alchemy/src/Cloudflare/Healthcheck/ui.ts
+++ b/packages/alchemy/src/Cloudflare/Healthcheck/ui.ts
@@ -1,0 +1,33 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Healthcheck } from "./Healthcheck.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare Healthcheck resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no SDK code reaches the dashboard bundle.
+ */
+export const HealthcheckUI = UIProvider.succeed<Healthcheck>(
+  "Cloudflare.Healthcheck.Healthcheck",
+  {
+    displayName: "Healthcheck",
+    icon: "heart-pulse",
+    color: "#F6821F",
+    category: "observability",
+    summary: (ctx) =>
+      ctx.attrs?.name ?? ctx.attrs?.address ?? ctx.props?.address,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      { label: "id", value: ctx.attrs?.healthcheckId, mono: true, copy: true },
+      { label: "zone", value: ctx.attrs?.zoneId, mono: true, copy: true },
+      { label: "address", value: ctx.attrs?.address, mono: true, copy: true },
+      { label: "type", value: ctx.attrs?.type },
+      { label: "status", value: ctx.attrs?.status },
+      { label: "interval", value: ctx.attrs?.interval },
+      { label: "suspended", value: ctx.attrs?.suspended },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(HealthcheckUI);

--- a/packages/alchemy/src/Cloudflare/HostnameTlsSetting/ui.ts
+++ b/packages/alchemy/src/Cloudflare/HostnameTlsSetting/ui.ts
@@ -1,0 +1,40 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { HostnameTlsSetting } from "./HostnameTlsSetting.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare Hostname TLS Setting resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+const showValue = (value: unknown): string | undefined =>
+  value === undefined
+    ? undefined
+    : Array.isArray(value)
+      ? value.join(", ")
+      : String(value);
+
+export const HostnameTlsSettingUI = UIProvider.succeed<HostnameTlsSetting>(
+  "Cloudflare.HostnameTlsSetting.HostnameTlsSetting",
+  {
+    displayName: "Hostname TLS Setting",
+    icon: "sliders-horizontal",
+    color: "#F6821F",
+    category: "security",
+    summary: (ctx) =>
+      ctx.attrs?.hostname === undefined
+        ? undefined
+        : `${ctx.attrs.hostname} · ${ctx.attrs.settingId ?? ""}`,
+    facts: (ctx) => [
+      { label: "hostname", value: ctx.attrs?.hostname, copy: true },
+      { label: "zone", value: ctx.attrs?.zoneId, mono: true, copy: true },
+      { label: "setting", value: ctx.attrs?.settingId, mono: true },
+      { label: "value", value: showValue(ctx.attrs?.value), mono: true },
+      { label: "status", value: ctx.attrs?.status },
+      { label: "updated", value: ctx.attrs?.updatedAt },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(HostnameTlsSettingUI);

--- a/packages/alchemy/src/Cloudflare/Hyperdrive/ui.ts
+++ b/packages/alchemy/src/Cloudflare/Hyperdrive/ui.ts
@@ -1,0 +1,39 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Connection } from "./Connection.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare Hyperdrive resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const ConnectionUI = UIProvider.succeed<Connection>(
+  "Cloudflare.Hyperdrive",
+  {
+    displayName: "Hyperdrive",
+    icon: "plug-zap",
+    color: "#F6821F",
+    category: "database",
+    summary: (ctx) => ctx.attrs?.name,
+    consoleUrl: (ctx) =>
+      ctx.attrs?.accountId === undefined || ctx.attrs.hyperdriveId === undefined
+        ? undefined
+        : `https://dash.cloudflare.com/${ctx.attrs.accountId}/hyperdrive/configs/${ctx.attrs.hyperdriveId}`,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      {
+        label: "hyperdrive id",
+        value: ctx.attrs?.hyperdriveId,
+        mono: true,
+        copy: true,
+      },
+      { label: "scheme", value: ctx.attrs?.origin?.scheme },
+      { label: "host", value: ctx.attrs?.origin?.host, mono: true },
+      { label: "database", value: ctx.attrs?.origin?.database, mono: true },
+      { label: "account", value: ctx.attrs?.accountId, mono: true, copy: true },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(ConnectionUI);

--- a/packages/alchemy/src/Cloudflare/Iam/ui.ts
+++ b/packages/alchemy/src/Cloudflare/Iam/ui.ts
@@ -1,0 +1,79 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { ResourceGroup } from "./ResourceGroup.ts";
+import type { UserGroup } from "./UserGroup.ts";
+import type { UserGroupMembership } from "./UserGroupMembership.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare IAM resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const ResourceGroupUI = UIProvider.succeed<ResourceGroup>(
+  "Cloudflare.Iam.ResourceGroup",
+  {
+    displayName: "IAM Resource Group",
+    icon: "boxes",
+    color: "#F6821F",
+    category: "auth",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      {
+        label: "id",
+        value: ctx.attrs?.resourceGroupId,
+        mono: true,
+        copy: true,
+      },
+      { label: "account", value: ctx.attrs?.accountId, mono: true, copy: true },
+      { label: "scope key", value: ctx.attrs?.scope?.key, mono: true },
+      { label: "objects", value: ctx.attrs?.scope?.objects?.length },
+    ],
+  },
+);
+
+export const UserGroupUI = UIProvider.succeed<UserGroup>(
+  "Cloudflare.Iam.UserGroup",
+  {
+    displayName: "IAM User Group",
+    icon: "users",
+    color: "#F6821F",
+    category: "auth",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      { label: "id", value: ctx.attrs?.userGroupId, mono: true, copy: true },
+      { label: "account", value: ctx.attrs?.accountId, mono: true, copy: true },
+      { label: "policies", value: ctx.attrs?.policies?.length },
+      { label: "created", value: ctx.attrs?.createdOn },
+      { label: "modified", value: ctx.attrs?.modifiedOn },
+    ],
+  },
+);
+
+export const UserGroupMembershipUI = UIProvider.succeed<UserGroupMembership>(
+  "Cloudflare.Iam.UserGroupMembership",
+  {
+    displayName: "IAM User Group Membership",
+    icon: "user-plus",
+    color: "#F6821F",
+    category: "auth",
+    summary: (ctx) => ctx.attrs?.email ?? ctx.attrs?.memberId,
+    facts: (ctx) => [
+      { label: "email", value: ctx.attrs?.email, copy: true },
+      { label: "member", value: ctx.attrs?.memberId, mono: true, copy: true },
+      {
+        label: "user group",
+        value: ctx.attrs?.userGroupId,
+        mono: true,
+        copy: true,
+      },
+      { label: "account", value: ctx.attrs?.accountId, mono: true },
+      { label: "status", value: ctx.attrs?.status },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(ResourceGroupUI, UserGroupUI, UserGroupMembershipUI);

--- a/packages/alchemy/src/Cloudflare/Images/ui.ts
+++ b/packages/alchemy/src/Cloudflare/Images/ui.ts
@@ -1,0 +1,59 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { SigningKey } from "./SigningKey.ts";
+import type { Variant } from "./Variant.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare Images resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const SigningKeyUI = UIProvider.succeed<SigningKey>(
+  "Cloudflare.Images.SigningKey",
+  {
+    displayName: "Images Signing Key",
+    icon: "key-round",
+    color: "#F6821F",
+    category: "security",
+    summary: (ctx) => ctx.attrs?.keyName,
+    facts: (ctx) => [
+      { label: "key name", value: ctx.attrs?.keyName, mono: true, copy: true },
+      { label: "account", value: ctx.attrs?.accountId, mono: true },
+    ],
+  },
+);
+
+export const VariantUI = UIProvider.succeed<Variant>(
+  "Cloudflare.Images.Variant",
+  {
+    displayName: "Images Variant",
+    icon: "crop",
+    color: "#F6821F",
+    category: "media",
+    summary: (ctx) => ctx.attrs?.variantName,
+    consoleUrl: (ctx) =>
+      ctx.attrs?.accountId === undefined
+        ? undefined
+        : `https://dash.cloudflare.com/${ctx.attrs.accountId}/images/variants`,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.variantName, mono: true, copy: true },
+      { label: "fit", value: ctx.attrs?.fit },
+      {
+        label: "dimensions",
+        value:
+          ctx.attrs?.width === undefined || ctx.attrs?.height === undefined
+            ? undefined
+            : `${ctx.attrs.width}x${ctx.attrs.height}`,
+      },
+      { label: "metadata", value: ctx.attrs?.metadata },
+      {
+        label: "never require signed urls",
+        value: ctx.attrs?.neverRequireSignedURLs,
+      },
+      { label: "account", value: ctx.attrs?.accountId, mono: true },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(SigningKeyUI, VariantUI);

--- a/packages/alchemy/src/Cloudflare/Intel/ui.ts
+++ b/packages/alchemy/src/Cloudflare/Intel/ui.ts
@@ -1,0 +1,60 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { IndicatorFeed } from "./IndicatorFeed.ts";
+import type { IndicatorFeedPermission } from "./IndicatorFeedPermission.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare Intel resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const IndicatorFeedUI = UIProvider.succeed<IndicatorFeed>(
+  "Cloudflare.Intel.IndicatorFeed",
+  {
+    displayName: "Indicator Feed",
+    icon: "rss",
+    color: "#F6821F",
+    category: "security",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      { label: "feed id", value: ctx.attrs?.feedId, mono: true, copy: true },
+      { label: "description", value: ctx.attrs?.description },
+      { label: "public", value: ctx.attrs?.isPublic },
+      { label: "attributable", value: ctx.attrs?.isAttributable },
+      { label: "downloadable", value: ctx.attrs?.isDownloadable },
+      { label: "latest upload", value: ctx.attrs?.latestUploadStatus },
+    ],
+  },
+);
+
+export const IndicatorFeedPermissionUI =
+  UIProvider.succeed<IndicatorFeedPermission>(
+    "Cloudflare.Intel.IndicatorFeedPermission",
+    {
+      displayName: "Indicator Feed Permission",
+      icon: "key-round",
+      color: "#F6821F",
+      category: "security",
+      summary: (ctx) => ctx.attrs?.accountTag,
+      facts: (ctx) => [
+        { label: "feed id", value: ctx.attrs?.feedId, mono: true, copy: true },
+        {
+          label: "consumer account",
+          value: ctx.attrs?.accountTag,
+          mono: true,
+          copy: true,
+        },
+        {
+          label: "owner account",
+          value: ctx.attrs?.accountId,
+          mono: true,
+          copy: true,
+        },
+      ],
+    },
+  );
+
+export const ui = () =>
+  Layer.mergeAll(IndicatorFeedUI, IndicatorFeedPermissionUI);

--- a/packages/alchemy/src/Cloudflare/KV/ui.ts
+++ b/packages/alchemy/src/Cloudflare/KV/ui.ts
@@ -1,0 +1,37 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Namespace } from "./Namespace.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare KV resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const NamespaceUI = UIProvider.succeed<Namespace>(
+  "Cloudflare.KV.Namespace",
+  {
+    displayName: "KV Namespace",
+    icon: "key-round",
+    color: "#F6821F",
+    category: "storage",
+    summary: (ctx) => ctx.attrs?.title,
+    consoleUrl: (ctx) =>
+      ctx.attrs?.accountId === undefined || ctx.attrs.namespaceId === undefined
+        ? undefined
+        : `https://dash.cloudflare.com/${ctx.attrs.accountId}/workers/kv/namespaces/${ctx.attrs.namespaceId}`,
+    facts: (ctx) => [
+      { label: "title", value: ctx.attrs?.title, copy: true },
+      {
+        label: "namespace id",
+        value: ctx.attrs?.namespaceId,
+        mono: true,
+        copy: true,
+      },
+      { label: "url encoding", value: ctx.attrs?.supportsUrlEncoding },
+      { label: "account", value: ctx.attrs?.accountId, mono: true, copy: true },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(NamespaceUI);

--- a/packages/alchemy/src/Cloudflare/KeylessCertificate/ui.ts
+++ b/packages/alchemy/src/Cloudflare/KeylessCertificate/ui.ts
@@ -1,0 +1,43 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { KeylessCertificate } from "./KeylessCertificate.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare Keyless SSL resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const KeylessCertificateUI = UIProvider.succeed<KeylessCertificate>(
+  "Cloudflare.KeylessCertificate.KeylessCertificate",
+  {
+    displayName: "Keyless Certificate",
+    icon: "key-round",
+    color: "#F6821F",
+    category: "security",
+    summary: (ctx) => ctx.attrs?.name ?? ctx.attrs?.keylessCertificateId,
+    facts: (ctx) => [
+      {
+        label: "keyless id",
+        value: ctx.attrs?.keylessCertificateId,
+        mono: true,
+        copy: true,
+      },
+      { label: "zone", value: ctx.attrs?.zoneId, mono: true, copy: true },
+      { label: "name", value: ctx.attrs?.name },
+      {
+        label: "key server",
+        value:
+          ctx.attrs?.host === undefined
+            ? undefined
+            : `${ctx.attrs.host}:${ctx.attrs.port ?? 24008}`,
+        mono: true,
+      },
+      { label: "enabled", value: ctx.attrs?.enabled },
+      { label: "status", value: ctx.attrs?.status },
+      { label: "modified", value: ctx.attrs?.modifiedOn },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(KeylessCertificateUI);

--- a/packages/alchemy/src/Cloudflare/LeakedCredentialCheck/ui.ts
+++ b/packages/alchemy/src/Cloudflare/LeakedCredentialCheck/ui.ts
@@ -1,0 +1,52 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { LeakedCredentialDetection } from "./Detection.ts";
+import type { LeakedCredentialCheck } from "./LeakedCredentialCheck.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare Leaked Credential Check resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const LeakedCredentialCheckUI =
+  UIProvider.succeed<LeakedCredentialCheck>(
+    "Cloudflare.LeakedCredentialCheck.LeakedCredentialCheck",
+    {
+      displayName: "Leaked Credential Check",
+      icon: "key-round",
+      color: "#F6821F",
+      category: "security",
+      summary: (ctx) =>
+        ctx.attrs?.enabled === undefined
+          ? (ctx.attrs?.zoneId ?? ctx.props?.zoneId)
+          : ctx.attrs.enabled
+            ? "enabled"
+            : "disabled",
+      facts: (ctx) => [
+        { label: "zone", value: ctx.attrs?.zoneId, mono: true, copy: true },
+        { label: "enabled", value: ctx.attrs?.enabled },
+      ],
+    },
+  );
+
+export const LeakedCredentialDetectionUI =
+  UIProvider.succeed<LeakedCredentialDetection>(
+    "Cloudflare.LeakedCredentialCheck.Detection",
+    {
+      displayName: "Leaked Credential Detection",
+      icon: "file-lock-2",
+      color: "#F6821F",
+      category: "security",
+      summary: (ctx) => ctx.attrs?.detectionId ?? ctx.attrs?.zoneId,
+      facts: (ctx) => [
+        { label: "id", value: ctx.attrs?.detectionId, mono: true, copy: true },
+        { label: "zone", value: ctx.attrs?.zoneId, mono: true, copy: true },
+        { label: "username expr", value: ctx.attrs?.username, mono: true },
+        { label: "password expr", value: ctx.attrs?.password, mono: true },
+      ],
+    },
+  );
+
+export const ui = () =>
+  Layer.mergeAll(LeakedCredentialCheckUI, LeakedCredentialDetectionUI);

--- a/packages/alchemy/src/Cloudflare/LoadBalancer/ui.ts
+++ b/packages/alchemy/src/Cloudflare/LoadBalancer/ui.ts
@@ -1,0 +1,98 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { LoadBalancer } from "./LoadBalancer.ts";
+import type { Monitor } from "./Monitor.ts";
+import type { MonitorGroup } from "./MonitorGroup.ts";
+import type { Pool } from "./Pool.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare Load Balancing resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no SDK code reaches the dashboard bundle.
+ */
+export const LoadBalancerUI = UIProvider.succeed<LoadBalancer>(
+  "Cloudflare.LoadBalancer.LoadBalancer",
+  {
+    displayName: "Load Balancer",
+    icon: "scale",
+    color: "#F6821F",
+    category: "network",
+    summary: (ctx) => ctx.attrs?.name ?? ctx.props?.name,
+    link: (ctx) =>
+      ctx.attrs?.name === undefined ? undefined : `https://${ctx.attrs.name}`,
+    facts: (ctx) => [
+      { label: "hostname", value: ctx.attrs?.name, copy: true },
+      { label: "id", value: ctx.attrs?.loadBalancerId, mono: true, copy: true },
+      { label: "zone", value: ctx.attrs?.zoneId, mono: true, copy: true },
+      { label: "steering", value: ctx.attrs?.steeringPolicy },
+      { label: "proxied", value: ctx.attrs?.proxied },
+      { label: "enabled", value: ctx.attrs?.enabled },
+      { label: "fallback pool", value: ctx.attrs?.fallbackPool, mono: true },
+      { label: "default pools", value: ctx.attrs?.defaultPools?.length },
+    ],
+  },
+);
+
+export const PoolUI = UIProvider.succeed<Pool>("Cloudflare.LoadBalancer.Pool", {
+  displayName: "LB Pool",
+  icon: "layers",
+  color: "#F6821F",
+  category: "network",
+  summary: (ctx) => ctx.attrs?.name ?? ctx.props?.name,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.name, copy: true },
+    { label: "id", value: ctx.attrs?.poolId, mono: true, copy: true },
+    { label: "account", value: ctx.attrs?.accountId, mono: true, copy: true },
+    { label: "enabled", value: ctx.attrs?.enabled },
+    { label: "monitor", value: ctx.attrs?.monitor, mono: true },
+    { label: "origins", value: ctx.props?.origins?.length },
+    { label: "modified", value: ctx.attrs?.modifiedOn },
+  ],
+});
+
+export const MonitorUI = UIProvider.succeed<Monitor>(
+  "Cloudflare.LoadBalancer.Monitor",
+  {
+    displayName: "LB Monitor",
+    icon: "activity",
+    color: "#F6821F",
+    category: "observability",
+    summary: (ctx) => ctx.attrs?.description ?? ctx.props?.description,
+    facts: (ctx) => [
+      { label: "description", value: ctx.attrs?.description },
+      { label: "id", value: ctx.attrs?.monitorId, mono: true, copy: true },
+      { label: "account", value: ctx.attrs?.accountId, mono: true, copy: true },
+      { label: "type", value: ctx.attrs?.type },
+      { label: "path", value: ctx.props?.path },
+      { label: "interval", value: ctx.props?.interval },
+      { label: "expected codes", value: ctx.props?.expectedCodes },
+    ],
+  },
+);
+
+export const MonitorGroupUI = UIProvider.succeed<MonitorGroup>(
+  "Cloudflare.LoadBalancer.MonitorGroup",
+  {
+    displayName: "LB Monitor Group",
+    icon: "list-checks",
+    color: "#F6821F",
+    category: "observability",
+    summary: (ctx) => ctx.attrs?.description ?? ctx.props?.description,
+    facts: (ctx) => [
+      { label: "description", value: ctx.attrs?.description },
+      {
+        label: "id",
+        value: ctx.attrs?.monitorGroupId,
+        mono: true,
+        copy: true,
+      },
+      { label: "account", value: ctx.attrs?.accountId, mono: true, copy: true },
+      { label: "members", value: ctx.props?.members?.length },
+      { label: "modified", value: ctx.attrs?.modifiedOn },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(LoadBalancerUI, PoolUI, MonitorUI, MonitorGroupUI);

--- a/packages/alchemy/src/Cloudflare/Logpush/ui.ts
+++ b/packages/alchemy/src/Cloudflare/Logpush/ui.ts
@@ -1,0 +1,37 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Job } from "./Job.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare Logpush resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const JobUI = UIProvider.succeed<Job>("Cloudflare.Logpush.Job", {
+  displayName: "Logpush Job",
+  icon: "file-output",
+  color: "#F6821F",
+  category: "observability",
+  summary: (ctx) => ctx.attrs?.name,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.name, copy: true },
+    { label: "job id", value: ctx.attrs?.jobId, mono: true, copy: true },
+    { label: "dataset", value: ctx.attrs?.dataset },
+    { label: "kind", value: ctx.attrs?.kind || undefined },
+    {
+      label: "scope",
+      value:
+        ctx.attrs?.zoneId !== undefined
+          ? `zone ${ctx.attrs.zoneId}`
+          : ctx.attrs?.accountId !== undefined
+            ? "account"
+            : undefined,
+    },
+    { label: "enabled", value: ctx.attrs?.enabled },
+    { label: "destination", value: ctx.props?.destinationConf, mono: true },
+    { label: "last error", value: ctx.attrs?.lastError },
+  ],
+});
+
+export const ui = () => Layer.mergeAll(JobUI);

--- a/packages/alchemy/src/Cloudflare/LogsControl/ui.ts
+++ b/packages/alchemy/src/Cloudflare/LogsControl/ui.ts
@@ -1,0 +1,57 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { CmbConfig } from "./CmbConfig.ts";
+import type { LogsRetentionFlag } from "./RetentionFlag.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare Logs Control resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const CmbConfigUI = UIProvider.succeed<CmbConfig>(
+  "Cloudflare.Logs.CmbConfig",
+  {
+    displayName: "Customer Metadata Boundary",
+    icon: "globe-lock",
+    color: "#F6821F",
+    category: "config",
+    summary: (ctx) => ctx.attrs?.regions,
+    facts: (ctx) => [
+      { label: "regions", value: ctx.attrs?.regions },
+      {
+        label: "out-of-region access",
+        value: ctx.attrs?.allowOutOfRegionAccess,
+      },
+      {
+        label: "account",
+        value: ctx.attrs?.accountId,
+        mono: true,
+        copy: true,
+      },
+    ],
+  },
+);
+
+export const LogsRetentionFlagUI = UIProvider.succeed<LogsRetentionFlag>(
+  "Cloudflare.Logs.RetentionFlag",
+  {
+    displayName: "Logs Retention Flag",
+    icon: "archive",
+    color: "#F6821F",
+    category: "observability",
+    summary: (ctx) =>
+      ctx.attrs?.flag === undefined
+        ? undefined
+        : ctx.attrs.flag
+          ? "retention on"
+          : "retention off",
+    facts: (ctx) => [
+      { label: "retention", value: ctx.attrs?.flag },
+      { label: "initial", value: ctx.attrs?.initialFlag },
+      { label: "zone", value: ctx.attrs?.zoneId, mono: true, copy: true },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(CmbConfigUI, LogsRetentionFlagUI);

--- a/packages/alchemy/src/Cloudflare/MagicCloudNetworking/ui.ts
+++ b/packages/alchemy/src/Cloudflare/MagicCloudNetworking/ui.ts
@@ -1,0 +1,122 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { CatalogSync } from "./CatalogSync.ts";
+import type { CloudIntegration } from "./CloudIntegration.ts";
+import type { OnRamp } from "./OnRamp.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare MagicCloudNetworking resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const CatalogSyncUI = UIProvider.succeed<CatalogSync>(
+  "Cloudflare.MagicCloudNetworking.CatalogSync",
+  {
+    displayName: "Magic Catalog Sync",
+    icon: "refresh-cw",
+    color: "#F6821F",
+    category: "network",
+    summary: (ctx) => ctx.attrs?.name ?? ctx.props?.name,
+    facts: (ctx) => [
+      { label: "sync id", value: ctx.attrs?.syncId, mono: true, copy: true },
+      { label: "name", value: ctx.attrs?.name ?? ctx.props?.name },
+      {
+        label: "destination type",
+        value: ctx.attrs?.destinationType ?? ctx.props?.destinationType,
+      },
+      {
+        label: "destination id",
+        value: ctx.attrs?.destinationId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "update mode",
+        value: ctx.attrs?.updateMode ?? ctx.props?.updateMode,
+      },
+      { label: "policy", value: ctx.attrs?.policy, mono: true },
+      { label: "last update", value: ctx.attrs?.lastUserUpdateAt, mono: true },
+    ],
+  },
+);
+
+export const CloudIntegrationUI = UIProvider.succeed<CloudIntegration>(
+  "Cloudflare.MagicCloudNetworking.CloudIntegration",
+  {
+    displayName: "Cloud Integration",
+    icon: "cloud",
+    color: "#F6821F",
+    category: "network",
+    summary: (ctx) => ctx.attrs?.friendlyName ?? ctx.props?.friendlyName,
+    facts: (ctx) => [
+      {
+        label: "integration id",
+        value: ctx.attrs?.integrationId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "name",
+        value: ctx.attrs?.friendlyName ?? ctx.props?.friendlyName,
+      },
+      {
+        label: "cloud",
+        value: ctx.attrs?.cloudType ?? ctx.props?.cloudType,
+      },
+      { label: "lifecycle", value: ctx.attrs?.lifecycleState },
+      { label: "state", value: ctx.attrs?.state },
+      { label: "aws arn", value: ctx.attrs?.awsArn, mono: true, copy: true },
+      {
+        label: "azure subscription",
+        value: ctx.attrs?.azureSubscriptionId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "gcp project",
+        value: ctx.attrs?.gcpProjectId,
+        mono: true,
+        copy: true,
+      },
+    ],
+  },
+);
+
+export const OnRampUI = UIProvider.succeed<OnRamp>(
+  "Cloudflare.MagicCloudNetworking.OnRamp",
+  {
+    displayName: "Magic On-Ramp",
+    icon: "arrow-up-right",
+    color: "#F6821F",
+    category: "network",
+    summary: (ctx) => ctx.attrs?.name ?? ctx.props?.name,
+    facts: (ctx) => [
+      {
+        label: "on-ramp id",
+        value: ctx.attrs?.onRampId,
+        mono: true,
+        copy: true,
+      },
+      { label: "name", value: ctx.attrs?.name ?? ctx.props?.name },
+      { label: "cloud", value: ctx.attrs?.cloudType ?? ctx.props?.cloudType },
+      { label: "type", value: ctx.attrs?.type ?? ctx.props?.type },
+      { label: "vpc", value: ctx.attrs?.vpc, mono: true, copy: true },
+      { label: "cloud asn", value: ctx.attrs?.cloudAsn, mono: true },
+      {
+        label: "dynamic routing",
+        value: ctx.attrs?.dynamicRouting ?? ctx.props?.dynamicRouting,
+      },
+      {
+        label: "attached vpcs",
+        value: ctx.attrs?.attachedVpcs?.length
+          ? ctx.attrs.attachedVpcs.join(", ")
+          : undefined,
+        mono: true,
+      },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(CatalogSyncUI, CloudIntegrationUI, OnRampUI);

--- a/packages/alchemy/src/Cloudflare/MagicNetworkMonitoring/ui.ts
+++ b/packages/alchemy/src/Cloudflare/MagicNetworkMonitoring/ui.ts
@@ -1,0 +1,81 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Config } from "./Config.ts";
+import type { Rule } from "./Rule.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare MagicNetworkMonitoring resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const ConfigUI = UIProvider.succeed<Config>(
+  "Cloudflare.MagicNetworkMonitoring.Config",
+  {
+    displayName: "Network Monitoring Config",
+    icon: "activity",
+    color: "#F6821F",
+    category: "observability",
+    summary: (ctx) => ctx.attrs?.name ?? ctx.props?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name ?? ctx.props?.name },
+      {
+        label: "default sampling",
+        value: ctx.attrs?.defaultSampling ?? ctx.props?.defaultSampling,
+        mono: true,
+      },
+      {
+        label: "router ips",
+        value: ctx.attrs?.routerIps?.length
+          ? ctx.attrs.routerIps.join(", ")
+          : undefined,
+        mono: true,
+      },
+      {
+        label: "warp devices",
+        value: ctx.attrs?.warpDevices?.length,
+      },
+      { label: "account", value: ctx.attrs?.accountId, mono: true, copy: true },
+    ],
+  },
+);
+
+export const RuleUI = UIProvider.succeed<Rule>(
+  "Cloudflare.MagicNetworkMonitoring.Rule",
+  {
+    displayName: "Network Monitoring Rule",
+    icon: "siren",
+    color: "#F6821F",
+    category: "observability",
+    summary: (ctx) => ctx.attrs?.name ?? ctx.props?.name,
+    facts: (ctx) => [
+      { label: "rule id", value: ctx.attrs?.ruleId, mono: true, copy: true },
+      { label: "name", value: ctx.attrs?.name ?? ctx.props?.name },
+      { label: "type", value: ctx.attrs?.type ?? ctx.props?.type },
+      {
+        label: "prefixes",
+        value: ctx.attrs?.prefixes?.length
+          ? ctx.attrs.prefixes.join(", ")
+          : undefined,
+        mono: true,
+      },
+      {
+        label: "bandwidth threshold",
+        value: ctx.attrs?.bandwidthThreshold,
+        mono: true,
+      },
+      {
+        label: "packet threshold",
+        value: ctx.attrs?.packetThreshold,
+        mono: true,
+      },
+      { label: "duration", value: ctx.attrs?.duration },
+      {
+        label: "auto advertisement",
+        value: ctx.attrs?.automaticAdvertisement,
+      },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(ConfigUI, RuleUI);

--- a/packages/alchemy/src/Cloudflare/MagicTransit/ui.ts
+++ b/packages/alchemy/src/Cloudflare/MagicTransit/ui.ts
@@ -1,0 +1,272 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { MagicApp } from "./App.ts";
+import type { GreTunnel } from "./GreTunnel.ts";
+import type { IpsecTunnel } from "./IpsecTunnel.ts";
+import type { MagicSite } from "./Site.ts";
+import type { MagicSiteAcl } from "./SiteAcl.ts";
+import type { MagicSiteLan } from "./SiteLan.ts";
+import type { MagicSiteWan } from "./SiteWan.ts";
+import type { MagicStaticRoute } from "./StaticRoute.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare MagicTransit resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const MagicAppUI = UIProvider.succeed<MagicApp>(
+  "Cloudflare.MagicTransit.App",
+  {
+    displayName: "Magic App",
+    icon: "app-window",
+    color: "#F6821F",
+    category: "network",
+    summary: (ctx) => ctx.attrs?.name ?? ctx.props?.name,
+    facts: (ctx) => [
+      { label: "app id", value: ctx.attrs?.appId, mono: true, copy: true },
+      { label: "name", value: ctx.attrs?.name ?? ctx.props?.name },
+      { label: "type", value: ctx.attrs?.type ?? ctx.props?.type },
+      {
+        label: "hostnames",
+        value: ctx.attrs?.hostnames?.length
+          ? ctx.attrs.hostnames.join(", ")
+          : undefined,
+        mono: true,
+      },
+      {
+        label: "ip subnets",
+        value: ctx.attrs?.ipSubnets?.length
+          ? ctx.attrs.ipSubnets.join(", ")
+          : undefined,
+        mono: true,
+      },
+      { label: "account", value: ctx.attrs?.accountId, mono: true, copy: true },
+    ],
+  },
+);
+
+export const MagicSiteUI = UIProvider.succeed<MagicSite>(
+  "Cloudflare.MagicTransit.Site",
+  {
+    displayName: "Magic Site",
+    icon: "map-pin",
+    color: "#F6821F",
+    category: "network",
+    summary: (ctx) => ctx.attrs?.name ?? ctx.props?.name,
+    facts: (ctx) => [
+      { label: "site id", value: ctx.attrs?.siteId, mono: true, copy: true },
+      { label: "name", value: ctx.attrs?.name ?? ctx.props?.name },
+      { label: "description", value: ctx.attrs?.description },
+      {
+        label: "connector",
+        value: ctx.attrs?.connectorId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "secondary connector",
+        value: ctx.attrs?.secondaryConnectorId,
+        mono: true,
+        copy: true,
+      },
+      { label: "ha mode", value: ctx.attrs?.haMode },
+      { label: "account", value: ctx.attrs?.accountId, mono: true, copy: true },
+    ],
+  },
+);
+
+export const MagicSiteLanUI = UIProvider.succeed<MagicSiteLan>(
+  "Cloudflare.MagicTransit.SiteLan",
+  {
+    displayName: "Magic Site LAN",
+    icon: "network",
+    color: "#F6821F",
+    category: "network",
+    summary: (ctx) => ctx.attrs?.name ?? ctx.props?.name,
+    facts: (ctx) => [
+      { label: "lan id", value: ctx.attrs?.lanId, mono: true, copy: true },
+      { label: "name", value: ctx.attrs?.name ?? ctx.props?.name },
+      { label: "site", value: ctx.attrs?.siteId, mono: true, copy: true },
+      {
+        label: "physport",
+        value: ctx.attrs?.physport ?? ctx.props?.physport,
+        mono: true,
+      },
+      { label: "vlan tag", value: ctx.attrs?.vlanTag, mono: true },
+      { label: "ha link", value: ctx.attrs?.haLink },
+    ],
+  },
+);
+
+export const MagicSiteWanUI = UIProvider.succeed<MagicSiteWan>(
+  "Cloudflare.MagicTransit.SiteWan",
+  {
+    displayName: "Magic Site WAN",
+    icon: "cable",
+    color: "#F6821F",
+    category: "network",
+    summary: (ctx) => ctx.attrs?.name ?? ctx.props?.name,
+    facts: (ctx) => [
+      { label: "wan id", value: ctx.attrs?.wanId, mono: true, copy: true },
+      { label: "name", value: ctx.attrs?.name ?? ctx.props?.name },
+      { label: "site", value: ctx.attrs?.siteId, mono: true, copy: true },
+      {
+        label: "physport",
+        value: ctx.attrs?.physport ?? ctx.props?.physport,
+        mono: true,
+      },
+      { label: "priority", value: ctx.attrs?.priority },
+      { label: "vlan tag", value: ctx.attrs?.vlanTag, mono: true },
+      { label: "health check rate", value: ctx.attrs?.healthCheckRate },
+    ],
+  },
+);
+
+export const MagicSiteAclUI = UIProvider.succeed<MagicSiteAcl>(
+  "Cloudflare.MagicTransit.SiteAcl",
+  {
+    displayName: "Magic Site ACL",
+    icon: "shield",
+    color: "#F6821F",
+    category: "security",
+    summary: (ctx) => ctx.attrs?.name ?? ctx.props?.name,
+    facts: (ctx) => [
+      { label: "acl id", value: ctx.attrs?.aclId, mono: true, copy: true },
+      { label: "name", value: ctx.attrs?.name ?? ctx.props?.name },
+      { label: "site", value: ctx.attrs?.siteId, mono: true, copy: true },
+      {
+        label: "protocols",
+        value: ctx.attrs?.protocols?.length
+          ? ctx.attrs.protocols.join(", ")
+          : undefined,
+        mono: true,
+      },
+      { label: "forward locally", value: ctx.attrs?.forwardLocally },
+      { label: "unidirectional", value: ctx.attrs?.unidirectional },
+    ],
+  },
+);
+
+export const MagicStaticRouteUI = UIProvider.succeed<MagicStaticRoute>(
+  "Cloudflare.MagicTransit.StaticRoute",
+  {
+    displayName: "Magic Static Route",
+    icon: "route",
+    color: "#F6821F",
+    category: "network",
+    summary: (ctx) =>
+      ctx.attrs?.prefix !== undefined && ctx.attrs?.nexthop !== undefined
+        ? `${ctx.attrs.prefix} → ${ctx.attrs.nexthop}`
+        : (ctx.attrs?.prefix ?? ctx.props?.prefix),
+    facts: (ctx) => [
+      { label: "route id", value: ctx.attrs?.routeId, mono: true, copy: true },
+      {
+        label: "prefix",
+        value: ctx.attrs?.prefix ?? ctx.props?.prefix,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "nexthop",
+        value: ctx.attrs?.nexthop ?? ctx.props?.nexthop,
+        mono: true,
+        copy: true,
+      },
+      { label: "priority", value: ctx.attrs?.priority },
+      { label: "weight", value: ctx.attrs?.weight },
+      { label: "description", value: ctx.attrs?.description },
+    ],
+  },
+);
+
+export const GreTunnelUI = UIProvider.succeed<GreTunnel>(
+  "Cloudflare.MagicTransit.GreTunnel",
+  {
+    displayName: "Magic GRE Tunnel",
+    icon: "waypoints",
+    color: "#F6821F",
+    category: "network",
+    summary: (ctx) => ctx.attrs?.name ?? ctx.props?.name,
+    facts: (ctx) => [
+      {
+        label: "tunnel id",
+        value: ctx.attrs?.tunnelId,
+        mono: true,
+        copy: true,
+      },
+      { label: "name", value: ctx.attrs?.name ?? ctx.props?.name },
+      {
+        label: "cloudflare endpoint",
+        value:
+          ctx.attrs?.cloudflareGreEndpoint ?? ctx.props?.cloudflareGreEndpoint,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "customer endpoint",
+        value: ctx.attrs?.customerGreEndpoint ?? ctx.props?.customerGreEndpoint,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "interface address",
+        value: ctx.attrs?.interfaceAddress ?? ctx.props?.interfaceAddress,
+        mono: true,
+      },
+      { label: "ttl", value: ctx.attrs?.ttl },
+      { label: "mtu", value: ctx.attrs?.mtu },
+    ],
+  },
+);
+
+export const IpsecTunnelUI = UIProvider.succeed<IpsecTunnel>(
+  "Cloudflare.MagicTransit.IpsecTunnel",
+  {
+    displayName: "Magic IPsec Tunnel",
+    icon: "lock",
+    color: "#F6821F",
+    category: "network",
+    summary: (ctx) => ctx.attrs?.name ?? ctx.props?.name,
+    facts: (ctx) => [
+      {
+        label: "tunnel id",
+        value: ctx.attrs?.tunnelId,
+        mono: true,
+        copy: true,
+      },
+      { label: "name", value: ctx.attrs?.name ?? ctx.props?.name },
+      {
+        label: "cloudflare endpoint",
+        value: ctx.attrs?.cloudflareEndpoint ?? ctx.props?.cloudflareEndpoint,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "customer endpoint",
+        value: ctx.attrs?.customerEndpoint ?? ctx.props?.customerEndpoint,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "interface address",
+        value: ctx.attrs?.interfaceAddress ?? ctx.props?.interfaceAddress,
+        mono: true,
+      },
+      { label: "replay protection", value: ctx.attrs?.replayProtection },
+      { label: "null cipher", value: ctx.attrs?.allowNullCipher },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(
+    MagicAppUI,
+    MagicSiteUI,
+    MagicSiteLanUI,
+    MagicSiteWanUI,
+    MagicSiteAclUI,
+    MagicStaticRouteUI,
+    GreTunnelUI,
+    IpsecTunnelUI,
+  );

--- a/packages/alchemy/src/Cloudflare/ManagedTransforms/ui.ts
+++ b/packages/alchemy/src/Cloudflare/ManagedTransforms/ui.ts
@@ -1,0 +1,47 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { ManagedTransforms } from "./ManagedTransforms.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare Managed Transforms resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const ManagedTransformsUI = UIProvider.succeed<ManagedTransforms>(
+  "Cloudflare.ManagedTransforms.ManagedTransforms",
+  {
+    displayName: "Managed Transforms",
+    icon: "replace",
+    color: "#F6821F",
+    category: "config",
+    summary: (ctx) => ctx.attrs?.zoneId,
+    facts: (ctx) => [
+      { label: "zone", value: ctx.attrs?.zoneId, mono: true, copy: true },
+      {
+        label: "request transforms enabled",
+        value: ctx.attrs?.requestHeaders?.filter((t) => t?.enabled).length,
+      },
+      {
+        label: "response transforms enabled",
+        value: ctx.attrs?.responseHeaders?.filter((t) => t?.enabled).length,
+      },
+      {
+        label: "managed request headers",
+        value: ctx.props?.requestHeaders
+          ? Object.keys(ctx.props.requestHeaders).join(", ")
+          : undefined,
+        mono: true,
+      },
+      {
+        label: "managed response headers",
+        value: ctx.props?.responseHeaders
+          ? Object.keys(ctx.props.responseHeaders).join(", ")
+          : undefined,
+        mono: true,
+      },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(ManagedTransformsUI);

--- a/packages/alchemy/src/Cloudflare/MtlsCertificate/ui.ts
+++ b/packages/alchemy/src/Cloudflare/MtlsCertificate/ui.ts
@@ -1,0 +1,54 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { MtlsCertificate } from "./MtlsCertificate.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare mTLS Certificate resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const MtlsCertificateUI = UIProvider.succeed<MtlsCertificate>(
+  "Cloudflare.MtlsCertificate.MtlsCertificate",
+  {
+    displayName: "mTLS Certificate",
+    icon: "shield-check",
+    color: "#F6821F",
+    category: "security",
+    summary: (ctx) => ctx.attrs?.name ?? ctx.attrs?.mtlsCertificateId,
+    consoleUrl: (ctx) =>
+      ctx.attrs?.accountId === undefined
+        ? undefined
+        : `https://dash.cloudflare.com/${ctx.attrs.accountId}/mtls-certificates`,
+    facts: (ctx) => [
+      {
+        label: "certificate id",
+        value: ctx.attrs?.mtlsCertificateId,
+        mono: true,
+        copy: true,
+      },
+      { label: "account", value: ctx.attrs?.accountId, mono: true, copy: true },
+      { label: "name", value: ctx.attrs?.name },
+      {
+        label: "kind",
+        value:
+          ctx.attrs?.ca === undefined
+            ? undefined
+            : ctx.attrs.ca
+              ? "CA"
+              : "leaf",
+      },
+      { label: "issuer", value: ctx.attrs?.issuer },
+      {
+        label: "serial",
+        value: ctx.attrs?.serialNumber,
+        mono: true,
+        copy: true,
+      },
+      { label: "expires", value: ctx.attrs?.expiresOn },
+      { label: "uploaded", value: ctx.attrs?.uploadedOn },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(MtlsCertificateUI);

--- a/packages/alchemy/src/Cloudflare/NetworkInterconnects/ui.ts
+++ b/packages/alchemy/src/Cloudflare/NetworkInterconnects/ui.ts
@@ -1,0 +1,35 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { NetworkInterconnectSettings } from "./Settings.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare Network Interconnects resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const NetworkInterconnectSettingsUI =
+  UIProvider.succeed<NetworkInterconnectSettings>(
+    "Cloudflare.NetworkInterconnects.Settings",
+    {
+      displayName: "Interconnect Settings",
+      icon: "cable",
+      color: "#F6821F",
+      category: "config",
+      summary: (ctx) =>
+        ctx.attrs?.defaultAsn === undefined
+          ? undefined
+          : `ASN ${ctx.attrs.defaultAsn}`,
+      facts: (ctx) => [
+        { label: "default ASN", value: ctx.attrs?.defaultAsn, mono: true },
+        {
+          label: "initial default ASN",
+          value: ctx.attrs?.initialDefaultAsn,
+          mono: true,
+        },
+        { label: "account", value: ctx.attrs?.accountId, mono: true },
+      ],
+    },
+  );
+
+export const ui = () => Layer.mergeAll(NetworkInterconnectSettingsUI);

--- a/packages/alchemy/src/Cloudflare/Organization/ui.ts
+++ b/packages/alchemy/src/Cloudflare/Organization/ui.ts
@@ -1,0 +1,35 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Organization } from "./Organization.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare Organization resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const OrganizationUI = UIProvider.succeed<Organization>(
+  "Cloudflare.Organization.Organization",
+  {
+    displayName: "Organization",
+    icon: "network",
+    color: "#F6821F",
+    category: "config",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      {
+        label: "org id",
+        value: ctx.attrs?.organizationId,
+        mono: true,
+        copy: true,
+      },
+      { label: "parent", value: ctx.attrs?.parent?.name },
+      { label: "parent id", value: ctx.attrs?.parent?.id, mono: true },
+      { label: "managed by", value: ctx.attrs?.managedBy },
+      { label: "created", value: ctx.attrs?.createTime },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(OrganizationUI);

--- a/packages/alchemy/src/Cloudflare/OriginCaCertificate/ui.ts
+++ b/packages/alchemy/src/Cloudflare/OriginCaCertificate/ui.ts
@@ -1,0 +1,35 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { OriginCaCertificate } from "./OriginCaCertificate.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare Origin CA Certificate resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const OriginCaCertificateUI = UIProvider.succeed<OriginCaCertificate>(
+  "Cloudflare.OriginCaCertificate.OriginCaCertificate",
+  {
+    displayName: "Origin CA Certificate",
+    icon: "file-key",
+    color: "#F6821F",
+    category: "security",
+    summary: (ctx) =>
+      ctx.attrs?.hostnames?.join(", ") ?? ctx.attrs?.certificateId,
+    facts: (ctx) => [
+      {
+        label: "certificate id",
+        value: ctx.attrs?.certificateId,
+        mono: true,
+        copy: true,
+      },
+      { label: "hostnames", value: ctx.attrs?.hostnames?.join(", ") },
+      { label: "request type", value: ctx.attrs?.requestType },
+      { label: "validity (days)", value: ctx.attrs?.requestedValidity },
+      { label: "expires", value: ctx.attrs?.expiresOn },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(OriginCaCertificateUI);

--- a/packages/alchemy/src/Cloudflare/OriginPostQuantumEncryption/ui.ts
+++ b/packages/alchemy/src/Cloudflare/OriginPostQuantumEncryption/ui.ts
@@ -1,0 +1,31 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { OriginPostQuantumEncryption } from "./OriginPostQuantumEncryption.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare Origin Post-Quantum Encryption
+ * resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const OriginPostQuantumEncryptionUI =
+  UIProvider.succeed<OriginPostQuantumEncryption>(
+    "Cloudflare.OriginPostQuantumEncryption.OriginPostQuantumEncryption",
+    {
+      displayName: "Origin Post-Quantum Encryption",
+      icon: "atom",
+      color: "#F6821F",
+      category: "security",
+      summary: (ctx) => ctx.attrs?.value,
+      facts: (ctx) => [
+        { label: "zone", value: ctx.attrs?.zoneId, mono: true, copy: true },
+        { label: "value", value: ctx.attrs?.value },
+        { label: "editable", value: ctx.attrs?.editable },
+        { label: "initial value", value: ctx.attrs?.initialValue },
+        { label: "modified", value: ctx.attrs?.modifiedOn },
+      ],
+    },
+  );
+
+export const ui = () => Layer.mergeAll(OriginPostQuantumEncryptionUI);

--- a/packages/alchemy/src/Cloudflare/OriginTlsClientAuth/ui.ts
+++ b/packages/alchemy/src/Cloudflare/OriginTlsClientAuth/ui.ts
@@ -1,0 +1,119 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Certificate } from "./Certificate.ts";
+import type { HostnameAssociation } from "./HostnameAssociation.ts";
+import type { HostnameCertificate } from "./HostnameCertificate.ts";
+import type { Setting } from "./Setting.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare Authenticated Origin Pulls
+ * (Origin TLS Client Auth) resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const CertificateUI = UIProvider.succeed<Certificate>(
+  "Cloudflare.OriginTlsClientAuth.Certificate",
+  {
+    displayName: "AOP Certificate",
+    icon: "file-key",
+    color: "#F6821F",
+    category: "security",
+    summary: (ctx) => ctx.attrs?.certificateId,
+    facts: (ctx) => [
+      {
+        label: "certificate id",
+        value: ctx.attrs?.certificateId,
+        mono: true,
+        copy: true,
+      },
+      { label: "zone", value: ctx.attrs?.zoneId, mono: true, copy: true },
+      { label: "status", value: ctx.attrs?.status },
+      { label: "issuer", value: ctx.attrs?.issuer },
+      { label: "expires", value: ctx.attrs?.expiresOn },
+      { label: "uploaded", value: ctx.attrs?.uploadedOn },
+    ],
+  },
+);
+
+export const HostnameCertificateUI = UIProvider.succeed<HostnameCertificate>(
+  "Cloudflare.OriginTlsClientAuth.HostnameCertificate",
+  {
+    displayName: "AOP Hostname Certificate",
+    icon: "file-key-2",
+    color: "#F6821F",
+    category: "security",
+    summary: (ctx) => ctx.attrs?.certificateId,
+    facts: (ctx) => [
+      {
+        label: "certificate id",
+        value: ctx.attrs?.certificateId,
+        mono: true,
+        copy: true,
+      },
+      { label: "zone", value: ctx.attrs?.zoneId, mono: true, copy: true },
+      { label: "status", value: ctx.attrs?.status },
+      { label: "issuer", value: ctx.attrs?.issuer },
+      {
+        label: "serial",
+        value: ctx.attrs?.serialNumber,
+        mono: true,
+        copy: true,
+      },
+      { label: "expires", value: ctx.attrs?.expiresOn },
+    ],
+  },
+);
+
+export const HostnameAssociationUI = UIProvider.succeed<HostnameAssociation>(
+  "Cloudflare.OriginTlsClientAuth.HostnameAssociation",
+  {
+    displayName: "AOP Hostname Association",
+    icon: "link-2",
+    color: "#F6821F",
+    category: "security",
+    summary: (ctx) => ctx.attrs?.hostname,
+    facts: (ctx) => [
+      { label: "hostname", value: ctx.attrs?.hostname, copy: true },
+      { label: "zone", value: ctx.attrs?.zoneId, mono: true, copy: true },
+      {
+        label: "certificate id",
+        value: ctx.attrs?.certId,
+        mono: true,
+        copy: true,
+      },
+      { label: "enabled", value: ctx.attrs?.enabled },
+      { label: "status", value: ctx.attrs?.status },
+      { label: "certificate status", value: ctx.attrs?.certStatus },
+    ],
+  },
+);
+
+export const SettingUI = UIProvider.succeed<Setting>(
+  "Cloudflare.OriginTlsClientAuth.Setting",
+  {
+    displayName: "AOP Zone Setting",
+    icon: "settings-2",
+    color: "#F6821F",
+    category: "security",
+    summary: (ctx) =>
+      ctx.attrs?.enabled === undefined
+        ? undefined
+        : ctx.attrs.enabled
+          ? "enabled"
+          : "disabled",
+    facts: (ctx) => [
+      { label: "zone", value: ctx.attrs?.zoneId, mono: true, copy: true },
+      { label: "enabled", value: ctx.attrs?.enabled },
+      { label: "initial value", value: ctx.attrs?.initialEnabled },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(
+    CertificateUI,
+    HostnameCertificateUI,
+    HostnameAssociationUI,
+    SettingUI,
+  );

--- a/packages/alchemy/src/Cloudflare/PageRule/ui.ts
+++ b/packages/alchemy/src/Cloudflare/PageRule/ui.ts
@@ -1,0 +1,42 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { PageRule } from "./PageRule.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare PageRule resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const PageRuleUI = UIProvider.succeed<PageRule>(
+  "Cloudflare.PageRule.PageRule",
+  {
+    displayName: "Page Rule",
+    icon: "route",
+    color: "#F6821F",
+    category: "cdn",
+    summary: (ctx) => ctx.attrs?.target ?? ctx.props?.target,
+    facts: (ctx) => [
+      { label: "target", value: ctx.attrs?.target, mono: true, copy: true },
+      {
+        label: "rule id",
+        value: ctx.attrs?.pageRuleId,
+        mono: true,
+        copy: true,
+      },
+      { label: "zone id", value: ctx.attrs?.zoneId, mono: true, copy: true },
+      { label: "status", value: ctx.attrs?.status },
+      { label: "priority", value: ctx.attrs?.priority },
+      {
+        label: "actions",
+        value: ctx.attrs?.actions?.length
+          ? ctx.attrs.actions.map((a) => a?.id).join(", ")
+          : undefined,
+        mono: true,
+      },
+      { label: "modified", value: ctx.attrs?.modifiedOn },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(PageRuleUI);

--- a/packages/alchemy/src/Cloudflare/PageShield/ui.ts
+++ b/packages/alchemy/src/Cloudflare/PageShield/ui.ts
@@ -1,0 +1,61 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Policy } from "./Policy.ts";
+import type { Settings } from "./Settings.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare Page Shield resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const PolicyUI = UIProvider.succeed<Policy>(
+  "Cloudflare.PageShield.Policy",
+  {
+    displayName: "Page Shield Policy",
+    icon: "shield-alert",
+    color: "#F6821F",
+    category: "security",
+    summary: (ctx) => ctx.attrs?.description ?? ctx.attrs?.expression,
+    facts: (ctx) => [
+      { label: "action", value: ctx.attrs?.action },
+      { label: "expression", value: ctx.attrs?.expression, mono: true },
+      { label: "value", value: ctx.attrs?.value, mono: true },
+      { label: "enabled", value: ctx.attrs?.enabled },
+      { label: "id", value: ctx.attrs?.policyId, mono: true, copy: true },
+      { label: "zone", value: ctx.attrs?.zoneId, mono: true, copy: true },
+      { label: "description", value: ctx.attrs?.description },
+    ],
+  },
+);
+
+export const SettingsUI = UIProvider.succeed<Settings>(
+  "Cloudflare.PageShield.Settings",
+  {
+    displayName: "Page Shield Settings",
+    icon: "shield",
+    color: "#F6821F",
+    category: "security",
+    summary: (ctx) =>
+      ctx.attrs?.enabled === undefined
+        ? (ctx.attrs?.zoneId ?? ctx.props?.zoneId)
+        : ctx.attrs.enabled
+          ? "enabled"
+          : "disabled",
+    facts: (ctx) => [
+      { label: "zone", value: ctx.attrs?.zoneId, mono: true, copy: true },
+      { label: "enabled", value: ctx.attrs?.enabled },
+      {
+        label: "cf reporting endpoint",
+        value: ctx.attrs?.useCloudflareReportingEndpoint,
+      },
+      {
+        label: "connection url path",
+        value: ctx.attrs?.useConnectionUrlPath,
+      },
+      { label: "updated", value: ctx.attrs?.updatedAt },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(PolicyUI, SettingsUI);

--- a/packages/alchemy/src/Cloudflare/Pages/ui.ts
+++ b/packages/alchemy/src/Cloudflare/Pages/ui.ts
@@ -1,0 +1,114 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Deployment } from "./Deployment.ts";
+import type { Domain } from "./Domain.ts";
+import type { Project } from "./Project.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare Pages resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const ProjectUI = UIProvider.succeed<Project>(
+  "Cloudflare.Pages.Project",
+  {
+    displayName: "Pages Project",
+    icon: "panels-top-left",
+    color: "#F6821F",
+    category: "cdn",
+    summary: (ctx) => ctx.attrs?.name,
+    link: (ctx) =>
+      ctx.attrs?.subdomain === undefined
+        ? undefined
+        : `https://${ctx.attrs.subdomain}`,
+    consoleUrl: (ctx) =>
+      ctx.attrs?.accountId === undefined || ctx.attrs.name === undefined
+        ? undefined
+        : `https://dash.cloudflare.com/${ctx.attrs.accountId}/pages/view/${ctx.attrs.name}`,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      { label: "id", value: ctx.attrs?.projectId, mono: true, copy: true },
+      {
+        label: "subdomain",
+        value: ctx.attrs?.subdomain,
+        href:
+          ctx.attrs?.subdomain === undefined
+            ? undefined
+            : `https://${ctx.attrs.subdomain}`,
+        copy: true,
+      },
+      { label: "production branch", value: ctx.attrs?.productionBranch },
+      {
+        label: "domains",
+        value: ctx.attrs?.domains?.length
+          ? ctx.attrs.domains.join(", ")
+          : undefined,
+      },
+      { label: "created", value: ctx.attrs?.createdOn },
+    ],
+  },
+);
+
+export const DeploymentUI = UIProvider.succeed<Deployment>(
+  "Cloudflare.Pages.Deployment",
+  {
+    displayName: "Pages Deployment",
+    icon: "rocket",
+    color: "#F6821F",
+    category: "cdn",
+    summary: (ctx) => ctx.attrs?.shortId ?? ctx.props?.projectName,
+    link: (ctx) => ctx.attrs?.url,
+    consoleUrl: (ctx) =>
+      ctx.attrs?.accountId === undefined ||
+      ctx.attrs.projectName === undefined ||
+      ctx.attrs.deploymentId === undefined
+        ? undefined
+        : `https://dash.cloudflare.com/${ctx.attrs.accountId}/pages/view/${ctx.attrs.projectName}/${ctx.attrs.deploymentId}`,
+    facts: (ctx) => [
+      { label: "project", value: ctx.attrs?.projectName },
+      { label: "id", value: ctx.attrs?.deploymentId, mono: true, copy: true },
+      {
+        label: "url",
+        value: ctx.attrs?.url,
+        href: ctx.attrs?.url,
+        copy: true,
+      },
+      { label: "environment", value: ctx.attrs?.environment },
+      { label: "branch", value: ctx.attrs?.branch, mono: true },
+      {
+        label: "stage",
+        value:
+          ctx.attrs?.latestStageName === undefined
+            ? undefined
+            : `${ctx.attrs.latestStageName} (${ctx.attrs.latestStageStatus})`,
+      },
+      { label: "created", value: ctx.attrs?.createdOn },
+    ],
+  },
+);
+
+export const DomainUI = UIProvider.succeed<Domain>("Cloudflare.Pages.Domain", {
+  displayName: "Pages Domain",
+  icon: "globe",
+  color: "#F6821F",
+  category: "dns",
+  summary: (ctx) => ctx.attrs?.name ?? ctx.props?.name,
+  link: (ctx) =>
+    ctx.attrs?.name === undefined ? undefined : `https://${ctx.attrs.name}`,
+  consoleUrl: (ctx) =>
+    ctx.attrs?.accountId === undefined || ctx.attrs.projectName === undefined
+      ? undefined
+      : `https://dash.cloudflare.com/${ctx.attrs.accountId}/pages/view/${ctx.attrs.projectName}/domains`,
+  facts: (ctx) => [
+    { label: "domain", value: ctx.attrs?.name, copy: true },
+    { label: "project", value: ctx.attrs?.projectName },
+    { label: "id", value: ctx.attrs?.domainId, mono: true, copy: true },
+    { label: "status", value: ctx.attrs?.status },
+    { label: "validation", value: ctx.attrs?.validationStatus },
+    { label: "certificate authority", value: ctx.attrs?.certificateAuthority },
+    { label: "zone", value: ctx.attrs?.zoneTag, mono: true },
+  ],
+});
+
+export const ui = () => Layer.mergeAll(ProjectUI, DeploymentUI, DomainUI);

--- a/packages/alchemy/src/Cloudflare/Pipelines/ui.ts
+++ b/packages/alchemy/src/Cloudflare/Pipelines/ui.ts
@@ -1,0 +1,131 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { LegacyPipeline } from "./LegacyPipeline.ts";
+import type { Pipeline } from "./Pipeline.ts";
+import type { Sink } from "./Sink.ts";
+import type { Stream } from "./Stream.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare Pipelines resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const StreamUI = UIProvider.succeed<Stream>(
+  "Cloudflare.Pipelines.Stream",
+  {
+    displayName: "Pipelines Stream",
+    icon: "waves",
+    color: "#F6821F",
+    category: "eventing",
+    summary: (ctx) => ctx.attrs?.name,
+    link: (ctx) => ctx.attrs?.endpoint,
+    facts: (ctx) => [
+      { label: "stream", value: ctx.attrs?.name, mono: true, copy: true },
+      {
+        label: "stream id",
+        value: ctx.attrs?.streamId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "endpoint",
+        value: ctx.attrs?.endpoint,
+        href: ctx.attrs?.endpoint,
+        copy: true,
+      },
+      { label: "http enabled", value: ctx.attrs?.httpEnabled },
+      { label: "http auth", value: ctx.attrs?.httpAuthentication },
+      { label: "worker binding", value: ctx.attrs?.workerBindingEnabled },
+      { label: "version", value: ctx.attrs?.version },
+      {
+        label: "account",
+        value: ctx.attrs?.accountId,
+        mono: true,
+        copy: true,
+      },
+    ],
+  },
+);
+
+export const PipelineUI = UIProvider.succeed<Pipeline>(
+  "Cloudflare.Pipelines.Pipeline",
+  {
+    displayName: "Pipeline",
+    icon: "workflow",
+    color: "#F6821F",
+    category: "eventing",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "pipeline", value: ctx.attrs?.name, mono: true, copy: true },
+      {
+        label: "pipeline id",
+        value: ctx.attrs?.pipelineId,
+        mono: true,
+        copy: true,
+      },
+      { label: "status", value: ctx.attrs?.status },
+      { label: "sql", value: ctx.attrs?.sql, mono: true },
+      {
+        label: "account",
+        value: ctx.attrs?.accountId,
+        mono: true,
+        copy: true,
+      },
+    ],
+  },
+);
+
+export const SinkUI = UIProvider.succeed<Sink>("Cloudflare.Pipelines.Sink", {
+  displayName: "Pipelines Sink",
+  icon: "archive",
+  color: "#F6821F",
+  category: "storage",
+  summary: (ctx) => ctx.attrs?.name,
+  facts: (ctx) => [
+    { label: "sink", value: ctx.attrs?.name, mono: true, copy: true },
+    { label: "sink id", value: ctx.attrs?.sinkId, mono: true, copy: true },
+    { label: "type", value: ctx.attrs?.type },
+    { label: "bucket", value: ctx.attrs?.bucket, mono: true },
+    { label: "path", value: ctx.attrs?.path, mono: true },
+    { label: "account", value: ctx.attrs?.accountId, mono: true, copy: true },
+  ],
+});
+
+export const LegacyPipelineUI = UIProvider.succeed<LegacyPipeline>(
+  "Cloudflare.Pipelines.LegacyPipeline",
+  {
+    displayName: "Legacy Pipeline",
+    icon: "history",
+    color: "#F6821F",
+    category: "eventing",
+    summary: (ctx) => ctx.attrs?.name,
+    link: (ctx) => ctx.attrs?.endpoint,
+    facts: (ctx) => [
+      { label: "pipeline", value: ctx.attrs?.name, mono: true, copy: true },
+      {
+        label: "pipeline id",
+        value: ctx.attrs?.pipelineId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "endpoint",
+        value: ctx.attrs?.endpoint,
+        href: ctx.attrs?.endpoint,
+        copy: true,
+      },
+      { label: "bucket", value: ctx.attrs?.bucket, mono: true },
+      { label: "version", value: ctx.attrs?.version },
+      {
+        label: "account",
+        value: ctx.attrs?.accountId,
+        mono: true,
+        copy: true,
+      },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(StreamUI, PipelineUI, SinkUI, LegacyPipelineUI);

--- a/packages/alchemy/src/Cloudflare/Queues/ui.ts
+++ b/packages/alchemy/src/Cloudflare/Queues/ui.ts
@@ -1,0 +1,96 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Consumer } from "./Consumer.ts";
+import type { Queue } from "./Queue.ts";
+import type { Subscription } from "./Subscription.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare Queues resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const QueueUI = UIProvider.succeed<Queue>("Cloudflare.Queues.Queue", {
+  displayName: "Queue",
+  icon: "list-ordered",
+  color: "#F6821F",
+  category: "queue",
+  summary: (ctx) => ctx.attrs?.queueName,
+  consoleUrl: (ctx) =>
+    ctx.attrs?.accountId === undefined || ctx.attrs.queueId === undefined
+      ? undefined
+      : `https://dash.cloudflare.com/${ctx.attrs.accountId}/workers/queues/queue/${ctx.attrs.queueId}`,
+  facts: (ctx) => [
+    { label: "queue", value: ctx.attrs?.queueName, copy: true },
+    { label: "queue id", value: ctx.attrs?.queueId, mono: true, copy: true },
+    { label: "account", value: ctx.attrs?.accountId, mono: true, copy: true },
+  ],
+});
+
+export const ConsumerUI = UIProvider.succeed<Consumer>(
+  "Cloudflare.Queues.Consumer",
+  {
+    displayName: "Queue Consumer",
+    icon: "inbox",
+    color: "#F6821F",
+    category: "queue",
+    summary: (ctx) => ctx.attrs?.scriptName ?? ctx.props?.scriptName,
+    facts: (ctx) => [
+      { label: "script", value: ctx.attrs?.scriptName, mono: true },
+      {
+        label: "consumer id",
+        value: ctx.attrs?.consumerId,
+        mono: true,
+        copy: true,
+      },
+      { label: "queue id", value: ctx.attrs?.queueId, mono: true, copy: true },
+      { label: "dead letter queue", value: ctx.attrs?.deadLetterQueue },
+      { label: "batch size", value: ctx.attrs?.settings?.batchSize },
+      { label: "max retries", value: ctx.attrs?.settings?.maxRetries },
+      {
+        label: "account",
+        value: ctx.attrs?.accountId,
+        mono: true,
+        copy: true,
+      },
+    ],
+  },
+);
+
+export const SubscriptionUI = UIProvider.succeed<Subscription>(
+  "Cloudflare.Queues.Subscription",
+  {
+    displayName: "Queue Subscription",
+    icon: "rss",
+    color: "#F6821F",
+    category: "eventing",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      {
+        label: "subscription id",
+        value: ctx.attrs?.subscriptionId,
+        mono: true,
+        copy: true,
+      },
+      { label: "source", value: ctx.attrs?.source?.type },
+      {
+        label: "events",
+        value: ctx.attrs?.events?.length
+          ? ctx.attrs.events.join(", ")
+          : undefined,
+        mono: true,
+      },
+      { label: "queue id", value: ctx.attrs?.queueId, mono: true, copy: true },
+      { label: "enabled", value: ctx.attrs?.enabled },
+      {
+        label: "account",
+        value: ctx.attrs?.accountId,
+        mono: true,
+        copy: true,
+      },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(QueueUI, ConsumerUI, SubscriptionUI);

--- a/packages/alchemy/src/Cloudflare/R2/ui.ts
+++ b/packages/alchemy/src/Cloudflare/R2/ui.ts
@@ -1,0 +1,134 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Bucket } from "./Bucket.ts";
+import type { BucketEventNotification } from "./BucketEventNotification.ts";
+import type { BucketSippy } from "./BucketSippy.ts";
+import type { DataCatalog } from "./DataCatalog.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare R2 resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const BucketUI = UIProvider.succeed<Bucket>("Cloudflare.R2.Bucket", {
+  displayName: "R2 Bucket",
+  icon: "hard-drive",
+  color: "#F6821F",
+  category: "storage",
+  summary: (ctx) => ctx.attrs?.bucketName,
+  consoleUrl: (ctx) =>
+    ctx.attrs?.accountId === undefined || ctx.attrs.bucketName === undefined
+      ? undefined
+      : `https://dash.cloudflare.com/${ctx.attrs.accountId}/r2/default/buckets/${ctx.attrs.bucketName}`,
+  facts: (ctx) => [
+    { label: "bucket", value: ctx.attrs?.bucketName, mono: true, copy: true },
+    { label: "storage class", value: ctx.attrs?.storageClass },
+    { label: "jurisdiction", value: ctx.attrs?.jurisdiction },
+    { label: "location", value: ctx.attrs?.location },
+    {
+      label: "domains",
+      value: ctx.attrs?.domains?.length
+        ? ctx.attrs.domains.map((d) => d.domain).join(", ")
+        : undefined,
+    },
+    {
+      label: "lifecycle rules",
+      value: ctx.attrs?.lifecycleRules?.length || undefined,
+    },
+    { label: "account", value: ctx.attrs?.accountId, mono: true, copy: true },
+  ],
+});
+
+export const BucketSippyUI = UIProvider.succeed<BucketSippy>(
+  "Cloudflare.R2.BucketSippy",
+  {
+    displayName: "R2 Sippy",
+    icon: "arrow-right-left",
+    color: "#F6821F",
+    category: "storage",
+    summary: (ctx) => ctx.attrs?.bucketName,
+    facts: (ctx) => [
+      { label: "bucket", value: ctx.attrs?.bucketName, mono: true, copy: true },
+      { label: "enabled", value: ctx.attrs?.enabled },
+      { label: "source provider", value: ctx.attrs?.source?.provider },
+      { label: "source bucket", value: ctx.attrs?.source?.bucket, mono: true },
+      { label: "source region", value: ctx.attrs?.source?.region },
+      { label: "jurisdiction", value: ctx.attrs?.jurisdiction },
+      { label: "account", value: ctx.attrs?.accountId, mono: true, copy: true },
+    ],
+  },
+);
+
+export const BucketEventNotificationUI =
+  UIProvider.succeed<BucketEventNotification>(
+    "Cloudflare.R2.BucketEventNotification",
+    {
+      displayName: "R2 Event Notification",
+      icon: "bell",
+      color: "#F6821F",
+      category: "eventing",
+      summary: (ctx) => ctx.attrs?.bucketName,
+      facts: (ctx) => [
+        {
+          label: "bucket",
+          value: ctx.attrs?.bucketName,
+          mono: true,
+          copy: true,
+        },
+        { label: "queue", value: ctx.attrs?.queueName },
+        {
+          label: "queue id",
+          value: ctx.attrs?.queueId,
+          mono: true,
+          copy: true,
+        },
+        { label: "rules", value: ctx.attrs?.rules?.length },
+        { label: "jurisdiction", value: ctx.attrs?.jurisdiction },
+        {
+          label: "account",
+          value: ctx.attrs?.accountId,
+          mono: true,
+          copy: true,
+        },
+      ],
+    },
+  );
+
+export const DataCatalogUI = UIProvider.succeed<DataCatalog>(
+  "Cloudflare.R2.DataCatalog",
+  {
+    displayName: "R2 Data Catalog",
+    icon: "table",
+    color: "#F6821F",
+    category: "database",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "warehouse", value: ctx.attrs?.name, mono: true, copy: true },
+      {
+        label: "catalog id",
+        value: ctx.attrs?.catalogId,
+        mono: true,
+        copy: true,
+      },
+      { label: "bucket", value: ctx.attrs?.bucketName, mono: true },
+      { label: "status", value: ctx.attrs?.status },
+      {
+        label: "catalog uri",
+        value: ctx.attrs?.catalogUri,
+        mono: true,
+        copy: true,
+      },
+      { label: "credential", value: ctx.attrs?.credentialStatus },
+      { label: "account", value: ctx.attrs?.accountId, mono: true, copy: true },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(
+    BucketUI,
+    BucketSippyUI,
+    BucketEventNotificationUI,
+    DataCatalogUI,
+  );

--- a/packages/alchemy/src/Cloudflare/RealtimeKit/ui.ts
+++ b/packages/alchemy/src/Cloudflare/RealtimeKit/ui.ts
@@ -1,0 +1,84 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { App } from "./App.ts";
+import type { Preset } from "./Preset.ts";
+import type { Webhook } from "./Webhook.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare RealtimeKit resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const AppUI = UIProvider.succeed<App>("Cloudflare.RealtimeKit.App", {
+  displayName: "RealtimeKit App",
+  icon: "video",
+  color: "#F6821F",
+  category: "media",
+  summary: (ctx) => ctx.attrs?.name ?? ctx.attrs?.appId,
+  facts: (ctx) => [
+    { label: "app id", value: ctx.attrs?.appId, mono: true, copy: true },
+    { label: "name", value: ctx.attrs?.name },
+    { label: "account", value: ctx.attrs?.accountId, mono: true },
+    { label: "created", value: ctx.attrs?.createdAt },
+  ],
+});
+
+export const PresetUI = UIProvider.succeed<Preset>(
+  "Cloudflare.RealtimeKit.Preset",
+  {
+    displayName: "RealtimeKit Preset",
+    icon: "sliders-horizontal",
+    color: "#F6821F",
+    category: "config",
+    summary: (ctx) => ctx.attrs?.name ?? ctx.attrs?.presetId,
+    facts: (ctx) => [
+      {
+        label: "preset id",
+        value: ctx.attrs?.presetId,
+        mono: true,
+        copy: true,
+      },
+      { label: "name", value: ctx.attrs?.name },
+      { label: "app id", value: ctx.attrs?.appId, mono: true, copy: true },
+      { label: "account", value: ctx.attrs?.accountId, mono: true },
+    ],
+  },
+);
+
+export const WebhookUI = UIProvider.succeed<Webhook>(
+  "Cloudflare.RealtimeKit.Webhook",
+  {
+    displayName: "RealtimeKit Webhook",
+    icon: "webhook",
+    color: "#F6821F",
+    category: "eventing",
+    summary: (ctx) => ctx.attrs?.name ?? ctx.attrs?.url,
+    facts: (ctx) => [
+      {
+        label: "webhook id",
+        value: ctx.attrs?.webhookId,
+        mono: true,
+        copy: true,
+      },
+      { label: "name", value: ctx.attrs?.name },
+      {
+        label: "url",
+        value: ctx.attrs?.url,
+        href: ctx.attrs?.url,
+        copy: true,
+      },
+      {
+        label: "events",
+        value: ctx.attrs?.events?.length
+          ? ctx.attrs.events.join(", ")
+          : undefined,
+        mono: true,
+      },
+      { label: "enabled", value: ctx.attrs?.enabled },
+      { label: "app id", value: ctx.attrs?.appId, mono: true, copy: true },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(AppUI, PresetUI, WebhookUI);

--- a/packages/alchemy/src/Cloudflare/RegionalHostname/ui.ts
+++ b/packages/alchemy/src/Cloudflare/RegionalHostname/ui.ts
@@ -1,0 +1,32 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { RegionalHostname } from "./RegionalHostname.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare Regional Hostname resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const RegionalHostnameUI = UIProvider.succeed<RegionalHostname>(
+  "Cloudflare.RegionalHostname.RegionalHostname",
+  {
+    displayName: "Regional Hostname",
+    icon: "map-pin",
+    color: "#F6821F",
+    category: "dns",
+    summary: (ctx) =>
+      ctx.attrs?.hostname === undefined
+        ? undefined
+        : `${ctx.attrs.hostname} (${ctx.attrs.regionKey ?? "?"})`,
+    facts: (ctx) => [
+      { label: "hostname", value: ctx.attrs?.hostname, mono: true, copy: true },
+      { label: "region", value: ctx.attrs?.regionKey, mono: true },
+      { label: "routing", value: ctx.attrs?.routing },
+      { label: "zone id", value: ctx.attrs?.zoneId, mono: true, copy: true },
+      { label: "created", value: ctx.attrs?.createdOn },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(RegionalHostnameUI);

--- a/packages/alchemy/src/Cloudflare/Registrar/ui.ts
+++ b/packages/alchemy/src/Cloudflare/Registrar/ui.ts
@@ -1,0 +1,38 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Domain } from "./Domain.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare Registrar resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const DomainUI = UIProvider.succeed<Domain>(
+  "Cloudflare.Registrar.Domain",
+  {
+    displayName: "Registrar Domain",
+    icon: "globe-lock",
+    color: "#F6821F",
+    category: "dns",
+    summary: (ctx) => ctx.attrs?.domainName ?? ctx.props?.domainName,
+    link: (ctx) =>
+      ctx.attrs?.domainName ? `https://${ctx.attrs.domainName}` : undefined,
+    facts: (ctx) => [
+      { label: "domain", value: ctx.attrs?.domainName, copy: true },
+      { label: "account", value: ctx.attrs?.accountId, mono: true, copy: true },
+      { label: "registrar", value: ctx.attrs?.currentRegistrar },
+      { label: "expires", value: ctx.attrs?.expiresAt },
+      { label: "auto renew", value: ctx.attrs?.autoRenew },
+      { label: "locked", value: ctx.attrs?.locked },
+      { label: "privacy", value: ctx.attrs?.privacy },
+      {
+        label: "registry statuses",
+        value: ctx.attrs?.registryStatuses,
+        mono: true,
+      },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(DomainUI);

--- a/packages/alchemy/src/Cloudflare/ResourceSharing/ui.ts
+++ b/packages/alchemy/src/Cloudflare/ResourceSharing/ui.ts
@@ -1,0 +1,97 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Share } from "./Share.ts";
+import type { ShareRecipient } from "./ShareRecipient.ts";
+import type { ShareResource } from "./ShareResource.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare Resource Sharing resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const ShareUI = UIProvider.succeed<Share>(
+  "Cloudflare.ResourceSharing.Share",
+  {
+    displayName: "Resource Share",
+    icon: "share-2",
+    color: "#F6821F",
+    category: "config",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      { label: "share id", value: ctx.attrs?.shareId, mono: true, copy: true },
+      { label: "account", value: ctx.attrs?.accountId, mono: true },
+      { label: "status", value: ctx.attrs?.status },
+      { label: "target", value: ctx.attrs?.targetType },
+      { label: "kind", value: ctx.attrs?.kind },
+      { label: "org", value: ctx.attrs?.organizationId, mono: true },
+    ],
+  },
+);
+
+export const ShareRecipientUI = UIProvider.succeed<ShareRecipient>(
+  "Cloudflare.ResourceSharing.ShareRecipient",
+  {
+    displayName: "Share Recipient",
+    icon: "user-check",
+    color: "#F6821F",
+    category: "config",
+    summary: (ctx) => ctx.attrs?.recipientAccountId ?? ctx.attrs?.recipientId,
+    facts: (ctx) => [
+      {
+        label: "recipient id",
+        value: ctx.attrs?.recipientId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "recipient account",
+        value: ctx.attrs?.recipientAccountId,
+        mono: true,
+        copy: true,
+      },
+      { label: "share", value: ctx.attrs?.shareId, mono: true },
+      { label: "account", value: ctx.attrs?.accountId, mono: true },
+      { label: "association", value: ctx.attrs?.associationStatus },
+      { label: "created", value: ctx.attrs?.created },
+    ],
+  },
+);
+
+export const ShareResourceUI = UIProvider.succeed<ShareResource>(
+  "Cloudflare.ResourceSharing.ShareResource",
+  {
+    displayName: "Share Resource",
+    icon: "package",
+    color: "#F6821F",
+    category: "config",
+    summary: (ctx) => ctx.attrs?.resourceId,
+    facts: (ctx) => [
+      {
+        label: "id",
+        value: ctx.attrs?.shareResourceId,
+        mono: true,
+        copy: true,
+      },
+      { label: "resource type", value: ctx.attrs?.resourceType },
+      {
+        label: "resource id",
+        value: ctx.attrs?.resourceId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "resource account",
+        value: ctx.attrs?.resourceAccountId,
+        mono: true,
+      },
+      { label: "share", value: ctx.attrs?.shareId, mono: true },
+      { label: "status", value: ctx.attrs?.status },
+      { label: "version", value: ctx.attrs?.resourceVersion },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(ShareUI, ShareRecipientUI, ShareResourceUI);

--- a/packages/alchemy/src/Cloudflare/RiskScoring/ui.ts
+++ b/packages/alchemy/src/Cloudflare/RiskScoring/ui.ts
@@ -1,0 +1,45 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Integration } from "./Integration.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare Zero Trust Risk Scoring resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const IntegrationUI = UIProvider.succeed<Integration>(
+  "Cloudflare.RiskScoring.Integration",
+  {
+    displayName: "Risk Scoring Integration",
+    icon: "shield-alert",
+    color: "#F6821F",
+    category: "security",
+    summary: (ctx) => ctx.attrs?.tenantUrl,
+    facts: (ctx) => [
+      { label: "type", value: ctx.attrs?.integrationType },
+      {
+        label: "tenant url",
+        value: ctx.attrs?.tenantUrl,
+        href: ctx.attrs?.tenantUrl,
+        copy: true,
+      },
+      {
+        label: "integration id",
+        value: ctx.attrs?.integrationId,
+        mono: true,
+        copy: true,
+      },
+      { label: "reference id", value: ctx.attrs?.referenceId, mono: true },
+      { label: "active", value: ctx.attrs?.active },
+      {
+        label: "well-known url",
+        value: ctx.attrs?.wellKnownUrl,
+        href: ctx.attrs?.wellKnownUrl,
+        mono: true,
+      },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(IntegrationUI);

--- a/packages/alchemy/src/Cloudflare/Rules/ui.ts
+++ b/packages/alchemy/src/Cloudflare/Rules/ui.ts
@@ -1,0 +1,28 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { List } from "./List.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare Rules resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const ListUI = UIProvider.succeed<List>("Cloudflare.Rules.List", {
+  displayName: "Rules List",
+  icon: "list-ordered",
+  color: "#F6821F",
+  category: "security",
+  summary: (ctx) => ctx.attrs?.name,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.name, mono: true, copy: true },
+    { label: "list id", value: ctx.attrs?.listId, mono: true, copy: true },
+    { label: "account", value: ctx.attrs?.accountId, mono: true, copy: true },
+    { label: "kind", value: ctx.attrs?.kind },
+    { label: "items", value: ctx.attrs?.numItems },
+    { label: "referencing filters", value: ctx.attrs?.numReferencingFilters },
+    { label: "description", value: ctx.attrs?.description },
+  ],
+});
+
+export const ui = () => Layer.mergeAll(ListUI);

--- a/packages/alchemy/src/Cloudflare/Ruleset/ui.ts
+++ b/packages/alchemy/src/Cloudflare/Ruleset/ui.ts
@@ -1,0 +1,88 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { AccountEntrypoint } from "./AccountEntrypoint.ts";
+import type { CustomRuleset } from "./CustomRuleset.ts";
+import type { Ruleset } from "./Ruleset.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare Ruleset resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const RulesetUI = UIProvider.succeed<Ruleset>(
+  "Cloudflare.Ruleset.Ruleset",
+  {
+    displayName: "Ruleset",
+    icon: "shield",
+    color: "#F6821F",
+    category: "security",
+    summary: (ctx) => ctx.attrs?.phase ?? ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name },
+      { label: "phase", value: ctx.attrs?.phase, mono: true },
+      {
+        label: "ruleset id",
+        value: ctx.attrs?.rulesetId,
+        mono: true,
+        copy: true,
+      },
+      { label: "zone id", value: ctx.attrs?.zoneId, mono: true, copy: true },
+      { label: "kind", value: ctx.attrs?.kind },
+      { label: "rules", value: ctx.attrs?.rules?.length },
+      { label: "version", value: ctx.attrs?.version, mono: true },
+    ],
+  },
+);
+
+export const CustomRulesetUI = UIProvider.succeed<CustomRuleset>(
+  "Cloudflare.Rulesets.CustomRuleset",
+  {
+    displayName: "Custom Ruleset",
+    icon: "shield-plus",
+    color: "#F6821F",
+    category: "security",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name },
+      { label: "phase", value: ctx.attrs?.phase, mono: true },
+      {
+        label: "ruleset id",
+        value: ctx.attrs?.rulesetId,
+        mono: true,
+        copy: true,
+      },
+      { label: "account", value: ctx.attrs?.accountId, mono: true, copy: true },
+      { label: "kind", value: ctx.attrs?.kind },
+      { label: "rules", value: ctx.attrs?.rules?.length },
+      { label: "version", value: ctx.attrs?.version, mono: true },
+    ],
+  },
+);
+
+export const AccountEntrypointUI = UIProvider.succeed<AccountEntrypoint>(
+  "Cloudflare.Rulesets.AccountEntrypoint",
+  {
+    displayName: "Account Ruleset Entrypoint",
+    icon: "shield-check",
+    color: "#F6821F",
+    category: "security",
+    summary: (ctx) => ctx.attrs?.phase ?? ctx.props?.phase,
+    facts: (ctx) => [
+      { label: "phase", value: ctx.attrs?.phase, mono: true },
+      {
+        label: "ruleset id",
+        value: ctx.attrs?.rulesetId,
+        mono: true,
+        copy: true,
+      },
+      { label: "account", value: ctx.attrs?.accountId, mono: true, copy: true },
+      { label: "name", value: ctx.attrs?.name },
+      { label: "rules", value: ctx.attrs?.rules?.length },
+      { label: "version", value: ctx.attrs?.version, mono: true },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(RulesetUI, CustomRulesetUI, AccountEntrypointUI);

--- a/packages/alchemy/src/Cloudflare/Rum/ui.ts
+++ b/packages/alchemy/src/Cloudflare/Rum/ui.ts
@@ -1,0 +1,63 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Rule } from "./Rule.ts";
+import type { Site } from "./Site.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare Web Analytics (RUM) resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const SiteUI = UIProvider.succeed<Site>("Cloudflare.Rum.Site", {
+  displayName: "Web Analytics Site",
+  icon: "chart-line",
+  color: "#F6821F",
+  category: "observability",
+  summary: (ctx) => ctx.attrs?.host ?? ctx.attrs?.siteTag,
+  facts: (ctx) => [
+    { label: "host", value: ctx.attrs?.host },
+    { label: "site tag", value: ctx.attrs?.siteTag, mono: true, copy: true },
+    {
+      label: "site token",
+      value: ctx.attrs?.siteToken,
+      mono: true,
+      copy: true,
+    },
+    { label: "zone", value: ctx.attrs?.zoneTag, mono: true },
+    { label: "ruleset", value: ctx.attrs?.rulesetId, mono: true, copy: true },
+    { label: "auto install", value: ctx.attrs?.autoInstall },
+    { label: "created", value: ctx.attrs?.created },
+  ],
+});
+
+export const RuleUI = UIProvider.succeed<Rule>("Cloudflare.Rum.Rule", {
+  displayName: "Web Analytics Rule",
+  icon: "filter",
+  color: "#F6821F",
+  category: "observability",
+  summary: (ctx) =>
+    ctx.attrs?.host !== undefined || ctx.attrs?.paths?.length
+      ? [ctx.attrs?.host, ctx.attrs?.paths?.join(", ")]
+          .filter(Boolean)
+          .join(" ")
+      : ctx.attrs?.id,
+  facts: (ctx) => [
+    { label: "rule id", value: ctx.attrs?.id, mono: true, copy: true },
+    { label: "ruleset", value: ctx.attrs?.rulesetId, mono: true, copy: true },
+    { label: "host", value: ctx.attrs?.host },
+    { label: "paths", value: ctx.attrs?.paths?.join(", "), mono: true },
+    {
+      label: "mode",
+      value:
+        ctx.attrs?.inclusive === undefined
+          ? undefined
+          : ctx.attrs.inclusive
+            ? "include"
+            : "exclude",
+    },
+    { label: "paused", value: ctx.attrs?.isPaused },
+  ],
+});
+
+export const ui = () => Layer.mergeAll(SiteUI, RuleUI);

--- a/packages/alchemy/src/Cloudflare/SchemaValidation/ui.ts
+++ b/packages/alchemy/src/Cloudflare/SchemaValidation/ui.ts
@@ -1,0 +1,92 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { OperationSetting } from "./OperationSetting.ts";
+import type { SchemaValidationSchema } from "./Schema.ts";
+import type { Settings } from "./Settings.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare SchemaValidation resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const SchemaUI = UIProvider.succeed<SchemaValidationSchema>(
+  "Cloudflare.SchemaValidation.Schema",
+  {
+    displayName: "Schema Validation Schema",
+    icon: "file-check",
+    color: "#F6821F",
+    category: "security",
+    summary: (ctx) => ctx.attrs?.name ?? ctx.props?.name,
+    facts: (ctx) => [
+      {
+        label: "schema id",
+        value: ctx.attrs?.schemaId,
+        mono: true,
+        copy: true,
+      },
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      { label: "kind", value: ctx.attrs?.kind },
+      {
+        label: "validation",
+        value:
+          ctx.attrs?.validationEnabled === undefined
+            ? undefined
+            : ctx.attrs.validationEnabled
+              ? "enabled"
+              : "disabled",
+      },
+      { label: "zone", value: ctx.attrs?.zoneId, mono: true, copy: true },
+      { label: "created", value: ctx.attrs?.createdAt },
+    ],
+  },
+);
+
+export const SettingsUI = UIProvider.succeed<Settings>(
+  "Cloudflare.SchemaValidation.Settings",
+  {
+    displayName: "Schema Validation Settings",
+    icon: "settings-2",
+    color: "#F6821F",
+    category: "security",
+    summary: (ctx) =>
+      ctx.attrs?.validationDefaultMitigationAction ??
+      ctx.props?.validationDefaultMitigationAction,
+    facts: (ctx) => [
+      { label: "zone", value: ctx.attrs?.zoneId, mono: true, copy: true },
+      {
+        label: "default action",
+        value: ctx.attrs?.validationDefaultMitigationAction,
+      },
+      {
+        label: "override action",
+        value: ctx.attrs?.validationOverrideMitigationAction ?? undefined,
+      },
+    ],
+  },
+);
+
+export const OperationSettingUI = UIProvider.succeed<OperationSetting>(
+  "Cloudflare.SchemaValidation.OperationSetting",
+  {
+    displayName: "Schema Validation Operation Setting",
+    icon: "sliders-horizontal",
+    color: "#F6821F",
+    category: "security",
+    summary: (ctx) =>
+      ctx.attrs?.mitigationAction ?? ctx.props?.mitigationAction,
+    facts: (ctx) => [
+      {
+        label: "operation id",
+        value: ctx.attrs?.operationId,
+        mono: true,
+        copy: true,
+      },
+      { label: "mitigation action", value: ctx.attrs?.mitigationAction },
+      { label: "zone", value: ctx.attrs?.zoneId, mono: true, copy: true },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(SchemaUI, SettingsUI, OperationSettingUI);

--- a/packages/alchemy/src/Cloudflare/SecretsStore/ui.ts
+++ b/packages/alchemy/src/Cloudflare/SecretsStore/ui.ts
@@ -1,0 +1,59 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Secret } from "./Secret.ts";
+import type { Store } from "./SecretsStore.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare Secrets Store resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const StoreUI = UIProvider.succeed<Store>("Cloudflare.SecretsStore", {
+  displayName: "Secrets Store",
+  icon: "vault",
+  color: "#F6821F",
+  category: "security",
+  summary: (ctx) => ctx.attrs?.storeName,
+  consoleUrl: (ctx) =>
+    ctx.attrs?.accountId === undefined
+      ? undefined
+      : `https://dash.cloudflare.com/${ctx.attrs.accountId}/secrets-store`,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.storeName, copy: true },
+    { label: "store id", value: ctx.attrs?.storeId, mono: true, copy: true },
+    { label: "account", value: ctx.attrs?.accountId, mono: true, copy: true },
+  ],
+});
+
+export const SecretUI = UIProvider.succeed<Secret>(
+  "Cloudflare.SecretsStore.Secret",
+  {
+    displayName: "Store Secret",
+    icon: "key-round",
+    color: "#F6821F",
+    category: "security",
+    summary: (ctx) => ctx.attrs?.secretName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.secretName, copy: true },
+      {
+        label: "secret id",
+        value: ctx.attrs?.secretId,
+        mono: true,
+        copy: true,
+      },
+      { label: "store", value: ctx.attrs?.storeId, mono: true },
+      { label: "account", value: ctx.attrs?.accountId, mono: true },
+      { label: "status", value: ctx.attrs?.status },
+      {
+        label: "scopes",
+        value: ctx.attrs?.scopes?.length
+          ? ctx.attrs.scopes.join(", ")
+          : undefined,
+      },
+      { label: "comment", value: ctx.attrs?.comment },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(StoreUI, SecretUI);

--- a/packages/alchemy/src/Cloudflare/SecurityTxt/ui.ts
+++ b/packages/alchemy/src/Cloudflare/SecurityTxt/ui.ts
@@ -1,0 +1,58 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { SecurityTxt } from "./SecurityTxt.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare SecurityTxt resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const SecurityTxtUI = UIProvider.succeed<SecurityTxt>(
+  "Cloudflare.SecurityTxt.SecurityTxt",
+  {
+    displayName: "security.txt",
+    icon: "file-lock-2",
+    color: "#F6821F",
+    category: "security",
+    summary: (ctx) =>
+      ctx.attrs?.contact?.length
+        ? ctx.attrs.contact[0]
+        : ctx.props?.contact?.[0],
+    facts: (ctx) => [
+      { label: "zone", value: ctx.attrs?.zoneId, mono: true, copy: true },
+      {
+        label: "enabled",
+        value:
+          ctx.attrs?.enabled === undefined
+            ? undefined
+            : ctx.attrs.enabled
+              ? "yes"
+              : "no",
+      },
+      {
+        label: "contact",
+        value: ctx.attrs?.contact?.length
+          ? ctx.attrs.contact.join(", ")
+          : undefined,
+        copy: true,
+      },
+      { label: "expires", value: ctx.attrs?.expires },
+      {
+        label: "canonical",
+        value: ctx.attrs?.canonical?.length
+          ? ctx.attrs.canonical.join(", ")
+          : undefined,
+      },
+      {
+        label: "policy",
+        value: ctx.attrs?.policy?.length
+          ? ctx.attrs.policy.join(", ")
+          : undefined,
+      },
+      { label: "languages", value: ctx.attrs?.preferredLanguages },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(SecurityTxtUI);

--- a/packages/alchemy/src/Cloudflare/Snippets/ui.ts
+++ b/packages/alchemy/src/Cloudflare/Snippets/ui.ts
@@ -1,0 +1,60 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Snippet } from "./Snippet.ts";
+import type { SnippetRules } from "./SnippetRules.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare Snippets resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const SnippetUI = UIProvider.succeed<Snippet>(
+  "Cloudflare.Snippets.Snippet",
+  {
+    displayName: "Snippet",
+    icon: "code",
+    color: "#F6821F",
+    category: "compute",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, mono: true, copy: true },
+      { label: "zone", value: ctx.attrs?.zoneId, mono: true, copy: true },
+      { label: "main module", value: ctx.attrs?.mainModule, mono: true },
+      { label: "created", value: ctx.attrs?.createdOn, mono: true },
+      { label: "modified", value: ctx.attrs?.modifiedOn, mono: true },
+    ],
+  },
+);
+
+export const SnippetRulesUI = UIProvider.succeed<SnippetRules>(
+  "Cloudflare.Snippets.Rules",
+  {
+    displayName: "Snippet Rules",
+    icon: "list-ordered",
+    color: "#F6821F",
+    category: "network",
+    summary: (ctx) =>
+      ctx.attrs?.rules === undefined
+        ? ctx.attrs?.zoneId
+        : `${ctx.attrs.rules.length} rule${ctx.attrs.rules.length === 1 ? "" : "s"}`,
+    facts: (ctx) => [
+      { label: "zone", value: ctx.attrs?.zoneId, mono: true, copy: true },
+      { label: "rules", value: ctx.attrs?.rules?.length },
+      {
+        label: "snippets",
+        value: ctx.attrs?.rules
+          ?.map((r) => r?.snippetName)
+          .filter((n) => n !== undefined)
+          .join(", "),
+        mono: true,
+      },
+      {
+        label: "enabled rules",
+        value: ctx.attrs?.rules?.filter((r) => r?.enabled).length,
+      },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(SnippetUI, SnippetRulesUI);

--- a/packages/alchemy/src/Cloudflare/Spectrum/ui.ts
+++ b/packages/alchemy/src/Cloudflare/Spectrum/ui.ts
@@ -1,0 +1,37 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Application } from "./Application.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare Spectrum resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no SDK code reaches the dashboard bundle.
+ */
+export const ApplicationUI = UIProvider.succeed<Application>(
+  "Cloudflare.Spectrum.Application",
+  {
+    displayName: "Spectrum App",
+    icon: "network",
+    color: "#F6821F",
+    category: "network",
+    summary: (ctx) => ctx.attrs?.dnsName ?? ctx.props?.dns?.name,
+    facts: (ctx) => [
+      { label: "hostname", value: ctx.attrs?.dnsName, copy: true },
+      { label: "id", value: ctx.attrs?.appId, mono: true, copy: true },
+      { label: "zone", value: ctx.attrs?.zoneId, mono: true, copy: true },
+      { label: "protocol", value: ctx.attrs?.protocol, mono: true },
+      { label: "traffic type", value: ctx.attrs?.trafficType },
+      {
+        label: "origin",
+        value:
+          ctx.attrs?.originDirect?.join(", ") ?? ctx.attrs?.originDns?.name,
+        mono: true,
+      },
+      { label: "proxy protocol", value: ctx.attrs?.proxyProtocol },
+      { label: "argo smart routing", value: ctx.attrs?.argoSmartRouting },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(ApplicationUI);

--- a/packages/alchemy/src/Cloudflare/Speed/ui.ts
+++ b/packages/alchemy/src/Cloudflare/Speed/ui.ts
@@ -1,0 +1,30 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { TestSchedule } from "./TestSchedule.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare Speed resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const TestScheduleUI = UIProvider.succeed<TestSchedule>(
+  "Cloudflare.Speed.TestSchedule",
+  {
+    displayName: "Speed Test Schedule",
+    icon: "gauge",
+    color: "#F6821F",
+    category: "observability",
+    summary: (ctx) => ctx.attrs?.url,
+    link: (ctx) =>
+      ctx.attrs?.url === undefined ? undefined : `https://${ctx.attrs.url}`,
+    facts: (ctx) => [
+      { label: "url", value: ctx.attrs?.url, mono: true, copy: true },
+      { label: "zone", value: ctx.attrs?.zoneId, mono: true, copy: true },
+      { label: "region", value: ctx.attrs?.region },
+      { label: "frequency", value: ctx.attrs?.frequency },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(TestScheduleUI);

--- a/packages/alchemy/src/Cloudflare/Ssl/ui.ts
+++ b/packages/alchemy/src/Cloudflare/Ssl/ui.ts
@@ -1,0 +1,59 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { CertificatePack } from "./CertificatePack.ts";
+import type { UniversalSsl } from "./UniversalSsl.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare SSL resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const CertificatePackUI = UIProvider.succeed<CertificatePack>(
+  "Cloudflare.Ssl.CertificatePack",
+  {
+    displayName: "Certificate Pack",
+    icon: "file-badge",
+    color: "#F6821F",
+    category: "security",
+    summary: (ctx) =>
+      ctx.attrs?.hosts?.join(", ") ?? ctx.attrs?.certificatePackId,
+    facts: (ctx) => [
+      {
+        label: "pack id",
+        value: ctx.attrs?.certificatePackId,
+        mono: true,
+        copy: true,
+      },
+      { label: "zone", value: ctx.attrs?.zoneId, mono: true, copy: true },
+      { label: "hosts", value: ctx.attrs?.hosts?.join(", ") },
+      { label: "CA", value: ctx.attrs?.certificateAuthority },
+      { label: "status", value: ctx.attrs?.status },
+      { label: "validation", value: ctx.attrs?.validationMethod },
+      { label: "validity (days)", value: ctx.attrs?.validityDays },
+    ],
+  },
+);
+
+export const UniversalSslUI = UIProvider.succeed<UniversalSsl>(
+  "Cloudflare.Ssl.UniversalSsl",
+  {
+    displayName: "Universal SSL",
+    icon: "lock",
+    color: "#F6821F",
+    category: "security",
+    summary: (ctx) =>
+      ctx.attrs?.enabled === undefined
+        ? undefined
+        : ctx.attrs.enabled
+          ? "enabled"
+          : "disabled",
+    facts: (ctx) => [
+      { label: "zone", value: ctx.attrs?.zoneId, mono: true, copy: true },
+      { label: "enabled", value: ctx.attrs?.enabled },
+      { label: "initial value", value: ctx.attrs?.initialEnabled },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(CertificatePackUI, UniversalSslUI);

--- a/packages/alchemy/src/Cloudflare/Stream/ui.ts
+++ b/packages/alchemy/src/Cloudflare/Stream/ui.ts
@@ -1,0 +1,137 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { LiveInput } from "./LiveInput.ts";
+import type { LiveInputOutput } from "./LiveInputOutput.ts";
+import type { SigningKey } from "./SigningKey.ts";
+import type { Watermark } from "./Watermark.ts";
+import type { Webhook } from "./Webhook.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare Stream resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const LiveInputUI = UIProvider.succeed<LiveInput>(
+  "Cloudflare.Stream.LiveInput",
+  {
+    displayName: "Stream Live Input",
+    icon: "radio",
+    color: "#F6821F",
+    category: "media",
+    summary: (ctx) =>
+      (ctx.attrs?.meta?.name as string | undefined) ?? ctx.attrs?.liveInputId,
+    consoleUrl: (ctx) =>
+      ctx.attrs?.accountId === undefined || ctx.attrs.liveInputId === undefined
+        ? undefined
+        : `https://dash.cloudflare.com/${ctx.attrs.accountId}/stream/inputs/${ctx.attrs.liveInputId}`,
+    facts: (ctx) => [
+      { label: "id", value: ctx.attrs?.liveInputId, mono: true, copy: true },
+      { label: "name", value: ctx.attrs?.meta?.name as string | undefined },
+      { label: "enabled", value: ctx.attrs?.enabled },
+      { label: "recording", value: ctx.props?.recording?.mode },
+      {
+        label: "delete recordings after",
+        value:
+          ctx.attrs?.deleteRecordingAfterDays === undefined
+            ? undefined
+            : `${ctx.attrs.deleteRecordingAfterDays} days`,
+      },
+      { label: "created", value: ctx.attrs?.created },
+    ],
+  },
+);
+
+export const LiveInputOutputUI = UIProvider.succeed<LiveInputOutput>(
+  "Cloudflare.Stream.LiveInputOutput",
+  {
+    displayName: "Stream Live Output",
+    icon: "cast",
+    color: "#F6821F",
+    category: "media",
+    summary: (ctx) => ctx.attrs?.url ?? ctx.attrs?.outputId,
+    facts: (ctx) => [
+      { label: "id", value: ctx.attrs?.outputId, mono: true, copy: true },
+      {
+        label: "live input",
+        value: ctx.attrs?.liveInputId,
+        mono: true,
+        copy: true,
+      },
+      { label: "url", value: ctx.attrs?.url, mono: true, copy: true },
+      { label: "enabled", value: ctx.attrs?.enabled },
+    ],
+  },
+);
+
+export const SigningKeyUI = UIProvider.succeed<SigningKey>(
+  "Cloudflare.Stream.SigningKey",
+  {
+    displayName: "Stream Signing Key",
+    icon: "key-round",
+    color: "#F6821F",
+    category: "security",
+    summary: (ctx) => ctx.attrs?.keyId,
+    facts: (ctx) => [
+      { label: "key id", value: ctx.attrs?.keyId, mono: true, copy: true },
+      { label: "account", value: ctx.attrs?.accountId, mono: true },
+      { label: "created", value: ctx.attrs?.created },
+    ],
+  },
+);
+
+export const WatermarkUI = UIProvider.succeed<Watermark>(
+  "Cloudflare.Stream.Watermark",
+  {
+    displayName: "Stream Watermark",
+    icon: "stamp",
+    color: "#F6821F",
+    category: "media",
+    summary: (ctx) => ctx.attrs?.name ?? ctx.attrs?.watermarkId,
+    facts: (ctx) => [
+      { label: "id", value: ctx.attrs?.watermarkId, mono: true, copy: true },
+      { label: "name", value: ctx.attrs?.name },
+      { label: "position", value: ctx.attrs?.position },
+      { label: "opacity", value: ctx.attrs?.opacity },
+      { label: "scale", value: ctx.attrs?.scale },
+      {
+        label: "dimensions",
+        value:
+          ctx.attrs?.width === undefined || ctx.attrs?.height === undefined
+            ? undefined
+            : `${ctx.attrs.width}x${ctx.attrs.height}`,
+      },
+      { label: "created", value: ctx.attrs?.created },
+    ],
+  },
+);
+
+export const WebhookUI = UIProvider.succeed<Webhook>(
+  "Cloudflare.Stream.Webhook",
+  {
+    displayName: "Stream Webhook",
+    icon: "webhook",
+    color: "#F6821F",
+    category: "eventing",
+    summary: (ctx) => ctx.attrs?.notificationUrl,
+    facts: (ctx) => [
+      {
+        label: "notification url",
+        value: ctx.attrs?.notificationUrl,
+        href: ctx.attrs?.notificationUrl,
+        copy: true,
+      },
+      { label: "account", value: ctx.attrs?.accountId, mono: true },
+      { label: "modified", value: ctx.attrs?.modified },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(
+    LiveInputUI,
+    LiveInputOutputUI,
+    SigningKeyUI,
+    WatermarkUI,
+    WebhookUI,
+  );

--- a/packages/alchemy/src/Cloudflare/Tags/ui.ts
+++ b/packages/alchemy/src/Cloudflare/Tags/ui.ts
@@ -1,0 +1,87 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { AccountResourceTags } from "./AccountResourceTags.ts";
+import type { ZoneResourceTags } from "./ZoneResourceTags.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare resource tagging resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const AccountResourceTagsUI = UIProvider.succeed<AccountResourceTags>(
+  "Cloudflare.Tags.AccountResourceTags",
+  {
+    displayName: "Account Resource Tags",
+    icon: "tags",
+    color: "#F6821F",
+    category: "config",
+    summary: (ctx) =>
+      ctx.attrs?.resourceType === undefined
+        ? ctx.attrs?.resourceId
+        : `${ctx.attrs.resourceType}/${ctx.attrs.resourceId ?? ""}`,
+    facts: (ctx) => [
+      { label: "resource type", value: ctx.attrs?.resourceType },
+      {
+        label: "resource id",
+        value: ctx.attrs?.resourceId,
+        mono: true,
+        copy: true,
+      },
+      { label: "account", value: ctx.attrs?.accountId, mono: true },
+      { label: "worker", value: ctx.attrs?.workerId, mono: true },
+      {
+        label: "tags",
+        value: ctx.attrs?.tags
+          ? Object.entries(ctx.attrs.tags)
+              .map(([k, v]) => `${k}=${v}`)
+              .join(", ")
+          : undefined,
+        mono: true,
+      },
+      { label: "etag", value: ctx.attrs?.etag, mono: true },
+    ],
+  },
+);
+
+export const ZoneResourceTagsUI = UIProvider.succeed<ZoneResourceTags>(
+  "Cloudflare.Tags.ZoneResourceTags",
+  {
+    displayName: "Zone Resource Tags",
+    icon: "tag",
+    color: "#F6821F",
+    category: "config",
+    summary: (ctx) =>
+      ctx.attrs?.resourceType === undefined
+        ? ctx.attrs?.resourceId
+        : `${ctx.attrs.resourceType}/${ctx.attrs.resourceId ?? ""}`,
+    facts: (ctx) => [
+      { label: "resource type", value: ctx.attrs?.resourceType },
+      {
+        label: "resource id",
+        value: ctx.attrs?.resourceId,
+        mono: true,
+        copy: true,
+      },
+      { label: "zone", value: ctx.attrs?.zoneId, mono: true, copy: true },
+      {
+        label: "access app",
+        value: ctx.attrs?.accessApplicationId,
+        mono: true,
+      },
+      {
+        label: "tags",
+        value: ctx.attrs?.tags
+          ? Object.entries(ctx.attrs.tags)
+              .map(([k, v]) => `${k}=${v}`)
+              .join(", ")
+          : undefined,
+        mono: true,
+      },
+      { label: "etag", value: ctx.attrs?.etag, mono: true },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(AccountResourceTagsUI, ZoneResourceTagsUI);

--- a/packages/alchemy/src/Cloudflare/TokenValidation/ui.ts
+++ b/packages/alchemy/src/Cloudflare/TokenValidation/ui.ts
@@ -1,0 +1,44 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Rule } from "./Rule.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare TokenValidation resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const RuleUI = UIProvider.succeed<Rule>(
+  "Cloudflare.TokenValidation.Rule",
+  {
+    displayName: "Token Validation Rule",
+    icon: "shield-check",
+    color: "#F6821F",
+    category: "security",
+    summary: (ctx) => ctx.attrs?.title ?? ctx.props?.title,
+    facts: (ctx) => [
+      { label: "rule id", value: ctx.attrs?.ruleId, mono: true, copy: true },
+      { label: "title", value: ctx.attrs?.title, copy: true },
+      { label: "action", value: ctx.attrs?.action ?? ctx.props?.action },
+      {
+        label: "enabled",
+        value:
+          ctx.attrs?.enabled === undefined
+            ? undefined
+            : ctx.attrs.enabled
+              ? "yes"
+              : "no",
+      },
+      {
+        label: "expression",
+        value: ctx.attrs?.expression ?? ctx.props?.expression,
+        mono: true,
+        copy: true,
+      },
+      { label: "zone", value: ctx.attrs?.zoneId, mono: true, copy: true },
+      { label: "last updated", value: ctx.attrs?.lastUpdated },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(RuleUI);

--- a/packages/alchemy/src/Cloudflare/Tunnel/ui.ts
+++ b/packages/alchemy/src/Cloudflare/Tunnel/ui.ts
@@ -1,0 +1,154 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Configuration } from "./Configuration.ts";
+import type { HostnameRoute } from "./HostnameRoute.ts";
+import type { Route } from "./Route.ts";
+import type { Tunnel } from "./Tunnel.ts";
+import type { VirtualNetwork } from "./VirtualNetwork.ts";
+import type { WarpConnector } from "./WarpConnector.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare Tunnel resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const TunnelUI = UIProvider.succeed<Tunnel>("Cloudflare.Tunnel.Tunnel", {
+  displayName: "Tunnel",
+  icon: "waypoints",
+  color: "#F6821F",
+  category: "network",
+  summary: (ctx) => ctx.attrs?.tunnelName,
+  consoleUrl: (ctx) =>
+    ctx.attrs?.accountId === undefined
+      ? undefined
+      : `https://one.dash.cloudflare.com/${ctx.attrs.accountId}/networks/tunnels`,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.tunnelName, copy: true },
+    { label: "tunnel id", value: ctx.attrs?.tunnelId, mono: true, copy: true },
+    { label: "account", value: ctx.attrs?.accountId, mono: true },
+    { label: "config source", value: ctx.attrs?.configSrc },
+    { label: "created", value: ctx.attrs?.createdAt },
+  ],
+});
+
+export const RouteUI = UIProvider.succeed<Route>("Cloudflare.Tunnel.Route", {
+  displayName: "Tunnel Route",
+  icon: "route",
+  color: "#F6821F",
+  category: "network",
+  summary: (ctx) => ctx.attrs?.network ?? ctx.props?.network,
+  facts: (ctx) => [
+    { label: "network", value: ctx.attrs?.network, mono: true, copy: true },
+    { label: "route id", value: ctx.attrs?.routeId, mono: true, copy: true },
+    { label: "tunnel id", value: ctx.attrs?.tunnelId, mono: true },
+    {
+      label: "virtual network",
+      value: ctx.attrs?.virtualNetworkId,
+      mono: true,
+    },
+    { label: "comment", value: ctx.attrs?.comment },
+    { label: "created", value: ctx.attrs?.createdAt },
+  ],
+});
+
+export const HostnameRouteUI = UIProvider.succeed<HostnameRoute>(
+  "Cloudflare.Tunnel.HostnameRoute",
+  {
+    displayName: "Tunnel Hostname Route",
+    icon: "signpost",
+    color: "#F6821F",
+    category: "dns",
+    summary: (ctx) => ctx.attrs?.hostname ?? ctx.props?.hostname,
+    facts: (ctx) => [
+      { label: "hostname", value: ctx.attrs?.hostname, copy: true },
+      {
+        label: "route id",
+        value: ctx.attrs?.hostnameRouteId,
+        mono: true,
+        copy: true,
+      },
+      { label: "tunnel id", value: ctx.attrs?.tunnelId, mono: true },
+      { label: "comment", value: ctx.attrs?.comment },
+      { label: "created", value: ctx.attrs?.createdAt },
+    ],
+  },
+);
+
+export const VirtualNetworkUI = UIProvider.succeed<VirtualNetwork>(
+  "Cloudflare.Tunnel.VirtualNetwork",
+  {
+    displayName: "Tunnel Virtual Network",
+    icon: "network",
+    color: "#F6821F",
+    category: "network",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      {
+        label: "virtual network id",
+        value: ctx.attrs?.virtualNetworkId,
+        mono: true,
+        copy: true,
+      },
+      { label: "account", value: ctx.attrs?.accountId, mono: true },
+      { label: "default network", value: ctx.attrs?.isDefaultNetwork },
+      { label: "comment", value: ctx.attrs?.comment },
+      { label: "created", value: ctx.attrs?.createdAt },
+    ],
+  },
+);
+
+export const WarpConnectorUI = UIProvider.succeed<WarpConnector>(
+  "Cloudflare.Tunnel.WarpConnector",
+  {
+    displayName: "WARP Connector",
+    icon: "plug-zap",
+    color: "#F6821F",
+    category: "network",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      {
+        label: "tunnel id",
+        value: ctx.attrs?.tunnelId,
+        mono: true,
+        copy: true,
+      },
+      { label: "account", value: ctx.attrs?.accountId, mono: true },
+      { label: "status", value: ctx.attrs?.status },
+      { label: "created", value: ctx.attrs?.createdAt },
+    ],
+  },
+);
+
+export const ConfigurationUI = UIProvider.succeed<Configuration>(
+  "Cloudflare.Tunnel.Configuration",
+  {
+    displayName: "Tunnel Configuration",
+    icon: "settings-2",
+    color: "#F6821F",
+    category: "config",
+    summary: (ctx) => ctx.attrs?.tunnelId,
+    facts: (ctx) => [
+      {
+        label: "tunnel id",
+        value: ctx.attrs?.tunnelId,
+        mono: true,
+        copy: true,
+      },
+      { label: "account", value: ctx.attrs?.accountId, mono: true },
+      { label: "version", value: ctx.attrs?.version },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(
+    TunnelUI,
+    RouteUI,
+    HostnameRouteUI,
+    VirtualNetworkUI,
+    WarpConnectorUI,
+    ConfigurationUI,
+  );

--- a/packages/alchemy/src/Cloudflare/Turnstile/ui.ts
+++ b/packages/alchemy/src/Cloudflare/Turnstile/ui.ts
@@ -1,0 +1,54 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Widget } from "./Widget.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare Turnstile resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const WidgetUI = UIProvider.succeed<Widget>(
+  "Cloudflare.Turnstile.Widget",
+  {
+    displayName: "Turnstile Widget",
+    icon: "shield-check",
+    color: "#F6821F",
+    category: "security",
+    summary: (ctx) => ctx.attrs?.name ?? ctx.props?.name,
+    consoleUrl: (ctx) =>
+      ctx.attrs?.accountId === undefined
+        ? undefined
+        : `https://dash.cloudflare.com/${ctx.attrs.accountId}/turnstile`,
+    facts: (ctx) => [
+      { label: "sitekey", value: ctx.attrs?.sitekey, mono: true, copy: true },
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      { label: "mode", value: ctx.attrs?.mode ?? ctx.props?.mode },
+      {
+        label: "domains",
+        value: ctx.attrs?.domains?.length
+          ? ctx.attrs.domains.join(", ")
+          : undefined,
+      },
+      { label: "region", value: ctx.attrs?.region },
+      { label: "clearance level", value: ctx.attrs?.clearanceLevel },
+      {
+        label: "bot fight mode",
+        value:
+          ctx.attrs?.botFightMode === undefined
+            ? undefined
+            : ctx.attrs.botFightMode
+              ? "on"
+              : "off",
+      },
+      {
+        label: "account",
+        value: ctx.attrs?.accountId,
+        mono: true,
+        copy: true,
+      },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(WidgetUI);

--- a/packages/alchemy/src/Cloudflare/UI.ts
+++ b/packages/alchemy/src/Cloudflare/UI.ts
@@ -1,0 +1,202 @@
+import * as Layer from "effect/Layer";
+import * as AIUI from "./AI/ui.ts";
+import * as AccessUI from "./Access/ui.ts";
+import * as AccountUI from "./Account/ui.ts";
+import * as AcmUI from "./Acm/ui.ts";
+import * as AddressingUI from "./Addressing/ui.ts";
+import * as AlertingUI from "./Alerting/ui.ts";
+import * as ApiShieldUI from "./ApiShield/ui.ts";
+import * as ApiTokenUI from "./ApiToken/ui.ts";
+import * as ArgoUI from "./Argo/ui.ts";
+import * as BotManagementUI from "./BotManagement/ui.ts";
+import * as CacheUI from "./Cache/ui.ts";
+import * as CallsUI from "./Calls/ui.ts";
+import * as CertificateAuthoritiesUI from "./CertificateAuthorities/ui.ts";
+import * as ClientCertificateUI from "./ClientCertificate/ui.ts";
+import * as CloudConnectorUI from "./CloudConnector/ui.ts";
+import * as CloudforceOneUI from "./CloudforceOne/ui.ts";
+import * as ConnectivityUI from "./Connectivity/ui.ts";
+import * as ContentScanningUI from "./ContentScanning/ui.ts";
+import * as CustomCertificateUI from "./CustomCertificate/ui.ts";
+import * as CustomHostnameUI from "./CustomHostname/ui.ts";
+import * as CustomNameserverUI from "./CustomNameserver/ui.ts";
+import * as D1UI from "./D1/ui.ts";
+import * as DNSUI from "./DNS/ui.ts";
+import * as DdosProtectionUI from "./DdosProtection/ui.ts";
+import * as DevicesUI from "./Devices/ui.ts";
+import * as DiagnosticsUI from "./Diagnostics/ui.ts";
+import * as DlpUI from "./Dlp/ui.ts";
+import * as EmailUI from "./Email/ui.ts";
+import * as FirewallUI from "./Firewall/ui.ts";
+import * as FlagshipUI from "./Flagship/ui.ts";
+import * as FraudUI from "./Fraud/ui.ts";
+import * as GatewayUI from "./Gateway/ui.ts";
+import * as GoogleTagGatewayUI from "./GoogleTagGateway/ui.ts";
+import * as HealthcheckUI from "./Healthcheck/ui.ts";
+import * as HostnameTlsSettingUI from "./HostnameTlsSetting/ui.ts";
+import * as HyperdriveUI from "./Hyperdrive/ui.ts";
+import * as IamUI from "./Iam/ui.ts";
+import * as ImagesUI from "./Images/ui.ts";
+import * as IntelUI from "./Intel/ui.ts";
+import * as KVUI from "./KV/ui.ts";
+import * as KeylessCertificateUI from "./KeylessCertificate/ui.ts";
+import * as LeakedCredentialCheckUI from "./LeakedCredentialCheck/ui.ts";
+import * as LoadBalancerUI from "./LoadBalancer/ui.ts";
+import * as LogpushUI from "./Logpush/ui.ts";
+import * as LogsControlUI from "./LogsControl/ui.ts";
+import * as MagicCloudNetworkingUI from "./MagicCloudNetworking/ui.ts";
+import * as MagicNetworkMonitoringUI from "./MagicNetworkMonitoring/ui.ts";
+import * as MagicTransitUI from "./MagicTransit/ui.ts";
+import * as ManagedTransformsUI from "./ManagedTransforms/ui.ts";
+import * as MtlsCertificateUI from "./MtlsCertificate/ui.ts";
+import * as NetworkInterconnectsUI from "./NetworkInterconnects/ui.ts";
+import * as OrganizationUI from "./Organization/ui.ts";
+import * as OriginCaCertificateUI from "./OriginCaCertificate/ui.ts";
+import * as OriginPostQuantumEncryptionUI from "./OriginPostQuantumEncryption/ui.ts";
+import * as OriginTlsClientAuthUI from "./OriginTlsClientAuth/ui.ts";
+import * as PageRuleUI from "./PageRule/ui.ts";
+import * as PageShieldUI from "./PageShield/ui.ts";
+import * as PagesUI from "./Pages/ui.ts";
+import * as PipelinesUI from "./Pipelines/ui.ts";
+import * as QueuesUI from "./Queues/ui.ts";
+import * as R2UI from "./R2/ui.ts";
+import * as RealtimeKitUI from "./RealtimeKit/ui.ts";
+import * as RegionalHostnameUI from "./RegionalHostname/ui.ts";
+import * as RegistrarUI from "./Registrar/ui.ts";
+import * as ResourceSharingUI from "./ResourceSharing/ui.ts";
+import * as RiskScoringUI from "./RiskScoring/ui.ts";
+import * as RulesUI from "./Rules/ui.ts";
+import * as RulesetUI from "./Ruleset/ui.ts";
+import * as RumUI from "./Rum/ui.ts";
+import * as SchemaValidationUI from "./SchemaValidation/ui.ts";
+import * as SecretsStoreUI from "./SecretsStore/ui.ts";
+import * as SecurityTxtUI from "./SecurityTxt/ui.ts";
+import * as SnippetsUI from "./Snippets/ui.ts";
+import * as SpectrumUI from "./Spectrum/ui.ts";
+import * as SpeedUI from "./Speed/ui.ts";
+import * as SslUI from "./Ssl/ui.ts";
+import * as StreamUI from "./Stream/ui.ts";
+import * as TagsUI from "./Tags/ui.ts";
+import * as TokenValidationUI from "./TokenValidation/ui.ts";
+import * as TunnelUI from "./Tunnel/ui.ts";
+import * as TurnstileUI from "./Turnstile/ui.ts";
+import * as UrlNormalizationUI from "./UrlNormalization/ui.ts";
+import * as VectorizeUI from "./Vectorize/ui.ts";
+import * as VpcServiceUI from "./VpcService/ui.ts";
+import * as VulnerabilityScannerUI from "./VulnerabilityScanner/ui.ts";
+import * as WaitingRoomUI from "./WaitingRoom/ui.ts";
+import * as Web3UI from "./Web3/ui.ts";
+import * as WorkersUI from "./Workers/ui.ts";
+import * as WorkersForPlatformsUI from "./WorkersForPlatforms/ui.ts";
+import * as WorkflowsUI from "./Workflows/ui.ts";
+import * as ZarazUI from "./Zaraz/ui.ts";
+import * as ZoneUI from "./Zone/ui.ts";
+
+/**
+ * Aggregated dashboard UI providers for every Cloudflare service.
+ *
+ * Generated by scripts (see processes/Dashboard.md). Per-service providers
+ * live in `Cloudflare/{Service}/ui.ts`; keep merge groups nested (≤ 40
+ * entries) to stay under tsc's variadic-inference ceiling.
+ */
+export const ui = () =>
+  Layer.mergeAll(
+    Layer.mergeAll(
+      AIUI.ui(),
+      AccessUI.ui(),
+      AccountUI.ui(),
+      AcmUI.ui(),
+      AddressingUI.ui(),
+      AlertingUI.ui(),
+      ApiShieldUI.ui(),
+      ApiTokenUI.ui(),
+      ArgoUI.ui(),
+      BotManagementUI.ui(),
+      CacheUI.ui(),
+      CallsUI.ui(),
+      CertificateAuthoritiesUI.ui(),
+      ClientCertificateUI.ui(),
+      CloudConnectorUI.ui(),
+      CloudforceOneUI.ui(),
+      ConnectivityUI.ui(),
+      ContentScanningUI.ui(),
+      CustomCertificateUI.ui(),
+      CustomHostnameUI.ui(),
+      CustomNameserverUI.ui(),
+      D1UI.ui(),
+      DNSUI.ui(),
+      DdosProtectionUI.ui(),
+      DevicesUI.ui(),
+      DiagnosticsUI.ui(),
+      DlpUI.ui(),
+      EmailUI.ui(),
+      FirewallUI.ui(),
+      FlagshipUI.ui(),
+      FraudUI.ui(),
+      GatewayUI.ui(),
+      GoogleTagGatewayUI.ui(),
+      HealthcheckUI.ui(),
+      HostnameTlsSettingUI.ui(),
+      HyperdriveUI.ui(),
+      IamUI.ui(),
+      ImagesUI.ui(),
+      IntelUI.ui(),
+      KVUI.ui(),
+    ),
+    Layer.mergeAll(
+      KeylessCertificateUI.ui(),
+      LeakedCredentialCheckUI.ui(),
+      LoadBalancerUI.ui(),
+      LogpushUI.ui(),
+      LogsControlUI.ui(),
+      MagicCloudNetworkingUI.ui(),
+      MagicNetworkMonitoringUI.ui(),
+      MagicTransitUI.ui(),
+      ManagedTransformsUI.ui(),
+      MtlsCertificateUI.ui(),
+      NetworkInterconnectsUI.ui(),
+      OrganizationUI.ui(),
+      OriginCaCertificateUI.ui(),
+      OriginPostQuantumEncryptionUI.ui(),
+      OriginTlsClientAuthUI.ui(),
+      PageRuleUI.ui(),
+      PageShieldUI.ui(),
+      PagesUI.ui(),
+      PipelinesUI.ui(),
+      QueuesUI.ui(),
+      R2UI.ui(),
+      RealtimeKitUI.ui(),
+      RegionalHostnameUI.ui(),
+      RegistrarUI.ui(),
+      ResourceSharingUI.ui(),
+      RiskScoringUI.ui(),
+      RulesUI.ui(),
+      RulesetUI.ui(),
+      RumUI.ui(),
+      SchemaValidationUI.ui(),
+      SecretsStoreUI.ui(),
+      SecurityTxtUI.ui(),
+      SnippetsUI.ui(),
+      SpectrumUI.ui(),
+      SpeedUI.ui(),
+      SslUI.ui(),
+      StreamUI.ui(),
+      TagsUI.ui(),
+      TokenValidationUI.ui(),
+      TunnelUI.ui(),
+    ),
+    Layer.mergeAll(
+      TurnstileUI.ui(),
+      UrlNormalizationUI.ui(),
+      VectorizeUI.ui(),
+      VpcServiceUI.ui(),
+      VulnerabilityScannerUI.ui(),
+      WaitingRoomUI.ui(),
+      Web3UI.ui(),
+      WorkersUI.ui(),
+      WorkersForPlatformsUI.ui(),
+      WorkflowsUI.ui(),
+      ZarazUI.ui(),
+      ZoneUI.ui(),
+    ),
+  );

--- a/packages/alchemy/src/Cloudflare/UrlNormalization/ui.ts
+++ b/packages/alchemy/src/Cloudflare/UrlNormalization/ui.ts
@@ -1,0 +1,30 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { UrlNormalization } from "./UrlNormalization.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare URL Normalization resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const UrlNormalizationUI = UIProvider.succeed<UrlNormalization>(
+  "Cloudflare.UrlNormalization.UrlNormalization",
+  {
+    displayName: "URL Normalization",
+    icon: "link-2",
+    color: "#F6821F",
+    category: "network",
+    summary: (ctx) =>
+      ctx.attrs?.type === undefined || ctx.attrs.scope === undefined
+        ? ctx.attrs?.zoneId
+        : `${ctx.attrs.type} (${ctx.attrs.scope})`,
+    facts: (ctx) => [
+      { label: "zone", value: ctx.attrs?.zoneId, mono: true, copy: true },
+      { label: "type", value: ctx.attrs?.type },
+      { label: "scope", value: ctx.attrs?.scope },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(UrlNormalizationUI);

--- a/packages/alchemy/src/Cloudflare/Vectorize/ui.ts
+++ b/packages/alchemy/src/Cloudflare/Vectorize/ui.ts
@@ -1,0 +1,48 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Index } from "./VectorizeIndex.ts";
+import type { MetadataIndex } from "./VectorizeMetadataIndex.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare Vectorize resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const IndexUI = UIProvider.succeed<Index>("Cloudflare.VectorizeIndex", {
+  displayName: "Vectorize Index",
+  icon: "box",
+  color: "#F6821F",
+  category: "ai",
+  summary: (ctx) => ctx.attrs?.indexName,
+  facts: (ctx) => [
+    { label: "index", value: ctx.attrs?.indexName, mono: true, copy: true },
+    { label: "dimensions", value: ctx.attrs?.dimensions },
+    { label: "metric", value: ctx.attrs?.metric },
+    { label: "account", value: ctx.attrs?.accountId, mono: true, copy: true },
+    { label: "description", value: ctx.attrs?.description },
+    { label: "created", value: ctx.attrs?.createdOn },
+  ],
+});
+
+export const MetadataIndexUI = UIProvider.succeed<MetadataIndex>(
+  "Cloudflare.VectorizeMetadataIndex",
+  {
+    displayName: "Vectorize Metadata Index",
+    icon: "tags",
+    color: "#F6821F",
+    category: "ai",
+    summary: (ctx) =>
+      ctx.attrs?.propertyName === undefined
+        ? undefined
+        : `${ctx.attrs.propertyName} (${ctx.attrs.indexType ?? "?"})`,
+    facts: (ctx) => [
+      { label: "property", value: ctx.attrs?.propertyName, copy: true },
+      { label: "type", value: ctx.attrs?.indexType },
+      { label: "index", value: ctx.attrs?.indexName, mono: true, copy: true },
+      { label: "account", value: ctx.attrs?.accountId, mono: true, copy: true },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(IndexUI, MetadataIndexUI);

--- a/packages/alchemy/src/Cloudflare/VpcService/ui.ts
+++ b/packages/alchemy/src/Cloudflare/VpcService/ui.ts
@@ -1,0 +1,45 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { VpcService } from "./VpcService.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare VPC Service resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+
+const hostLabel = (host: VpcService.Host | undefined): string | undefined => {
+  if (host === undefined) return undefined;
+  if ("hostname" in host) return host.hostname;
+  const ipv4 = "ipv4" in host ? host.ipv4 : undefined;
+  const ipv6 = "ipv6" in host ? host.ipv6 : undefined;
+  return [ipv4, ipv6].filter((ip) => ip !== undefined).join(" / ");
+};
+
+export const VpcServiceUI = UIProvider.succeed<VpcService>(
+  "Cloudflare.VpcService.VpcService",
+  {
+    displayName: "VPC Service",
+    icon: "server",
+    color: "#F6821F",
+    category: "network",
+    summary: (ctx) => ctx.attrs?.serviceName,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.serviceName, copy: true },
+      {
+        label: "service id",
+        value: ctx.attrs?.serviceId,
+        mono: true,
+        copy: true,
+      },
+      { label: "type", value: ctx.attrs?.serviceType },
+      { label: "host", value: hostLabel(ctx.attrs?.host), mono: true },
+      { label: "http port", value: ctx.attrs?.httpPort },
+      { label: "https port", value: ctx.attrs?.httpsPort },
+      { label: "account", value: ctx.attrs?.accountId, mono: true },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(VpcServiceUI);

--- a/packages/alchemy/src/Cloudflare/VulnerabilityScanner/ui.ts
+++ b/packages/alchemy/src/Cloudflare/VulnerabilityScanner/ui.ts
@@ -1,0 +1,107 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { VulnScannerCredential } from "./Credential.ts";
+import type { VulnScannerCredentialSet } from "./CredentialSet.ts";
+import type { VulnScannerTargetEnvironment } from "./TargetEnvironment.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare VulnerabilityScanner resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const CredentialUI = UIProvider.succeed<VulnScannerCredential>(
+  "Cloudflare.VulnerabilityScanner.Credential",
+  {
+    displayName: "Vulnerability Scanner Credential",
+    icon: "key",
+    color: "#F6821F",
+    category: "security",
+    summary: (ctx) => ctx.attrs?.name ?? ctx.props?.name,
+    facts: (ctx) => [
+      {
+        label: "credential id",
+        value: ctx.attrs?.credentialId,
+        mono: true,
+        copy: true,
+      },
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      { label: "location", value: ctx.attrs?.location ?? ctx.props?.location },
+      {
+        label: "location name",
+        value: ctx.attrs?.locationName ?? ctx.props?.locationName,
+        mono: true,
+      },
+      {
+        label: "credential set",
+        value: ctx.attrs?.credentialSetId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "account",
+        value: ctx.attrs?.accountId,
+        mono: true,
+        copy: true,
+      },
+    ],
+  },
+);
+
+export const CredentialSetUI = UIProvider.succeed<VulnScannerCredentialSet>(
+  "Cloudflare.VulnerabilityScanner.CredentialSet",
+  {
+    displayName: "Vulnerability Scanner Credential Set",
+    icon: "folder-key",
+    color: "#F6821F",
+    category: "security",
+    summary: (ctx) => ctx.attrs?.name ?? ctx.props?.name,
+    facts: (ctx) => [
+      {
+        label: "credential set id",
+        value: ctx.attrs?.credentialSetId,
+        mono: true,
+        copy: true,
+      },
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      {
+        label: "account",
+        value: ctx.attrs?.accountId,
+        mono: true,
+        copy: true,
+      },
+    ],
+  },
+);
+
+export const TargetEnvironmentUI =
+  UIProvider.succeed<VulnScannerTargetEnvironment>(
+    "Cloudflare.VulnerabilityScanner.TargetEnvironment",
+    {
+      displayName: "Vulnerability Scanner Target Environment",
+      icon: "crosshair",
+      color: "#F6821F",
+      category: "security",
+      summary: (ctx) => ctx.attrs?.name ?? ctx.props?.name,
+      facts: (ctx) => [
+        {
+          label: "target environment id",
+          value: ctx.attrs?.targetEnvironmentId,
+          mono: true,
+          copy: true,
+        },
+        { label: "name", value: ctx.attrs?.name, copy: true },
+        { label: "description", value: ctx.attrs?.description },
+        { label: "zone", value: ctx.attrs?.zoneId, mono: true, copy: true },
+        {
+          label: "account",
+          value: ctx.attrs?.accountId,
+          mono: true,
+          copy: true,
+        },
+      ],
+    },
+  );
+
+export const ui = () =>
+  Layer.mergeAll(CredentialUI, CredentialSetUI, TargetEnvironmentUI);

--- a/packages/alchemy/src/Cloudflare/WaitingRoom/ui.ts
+++ b/packages/alchemy/src/Cloudflare/WaitingRoom/ui.ts
@@ -1,0 +1,64 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Settings } from "./Settings.ts";
+import type { WaitingRoom } from "./WaitingRoom.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare Waiting Room resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no SDK code reaches the dashboard bundle.
+ */
+export const WaitingRoomUI = UIProvider.succeed<WaitingRoom>(
+  "Cloudflare.WaitingRoom.WaitingRoom",
+  {
+    displayName: "Waiting Room",
+    icon: "hourglass",
+    color: "#F6821F",
+    category: "network",
+    summary: (ctx) => ctx.attrs?.name ?? ctx.props?.host,
+    link: (ctx) =>
+      ctx.attrs?.host === undefined
+        ? undefined
+        : `https://${ctx.attrs.host}${ctx.attrs.path ?? ""}`,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      { label: "id", value: ctx.attrs?.waitingRoomId, mono: true, copy: true },
+      { label: "zone", value: ctx.attrs?.zoneId, mono: true, copy: true },
+      {
+        label: "host",
+        value: ctx.attrs?.host,
+        href:
+          ctx.attrs?.host === undefined
+            ? undefined
+            : `https://${ctx.attrs.host}`,
+      },
+      { label: "path", value: ctx.attrs?.path },
+      { label: "active users", value: ctx.attrs?.totalActiveUsers },
+      { label: "new users/min", value: ctx.attrs?.newUsersPerMinute },
+      { label: "queueing", value: ctx.attrs?.queueingMethod },
+      { label: "suspended", value: ctx.attrs?.suspended },
+    ],
+  },
+);
+
+export const SettingsUI = UIProvider.succeed<Settings>(
+  "Cloudflare.WaitingRoom.Settings",
+  {
+    displayName: "Waiting Room Settings",
+    icon: "settings-2",
+    color: "#F6821F",
+    category: "config",
+    summary: (ctx) => ctx.attrs?.zoneId ?? ctx.props?.zoneId,
+    facts: (ctx) => [
+      { label: "zone", value: ctx.attrs?.zoneId, mono: true, copy: true },
+      { label: "crawler bypass", value: ctx.attrs?.searchEngineCrawlerBypass },
+      {
+        label: "initial crawler bypass",
+        value: ctx.attrs?.initialSearchEngineCrawlerBypass,
+      },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(WaitingRoomUI, SettingsUI);

--- a/packages/alchemy/src/Cloudflare/Web3/ui.ts
+++ b/packages/alchemy/src/Cloudflare/Web3/ui.ts
@@ -1,0 +1,37 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Hostname } from "./Hostname.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare Web3 resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const HostnameUI = UIProvider.succeed<Hostname>(
+  "Cloudflare.Web3.Hostname",
+  {
+    displayName: "Web3 Hostname",
+    icon: "link",
+    color: "#F6821F",
+    category: "network",
+    summary: (ctx) => ctx.attrs?.name ?? ctx.props?.name,
+    link: (ctx) => (ctx.attrs?.name ? `https://${ctx.attrs.name}` : undefined),
+    facts: (ctx) => [
+      { label: "hostname", value: ctx.attrs?.name, copy: true },
+      {
+        label: "hostname id",
+        value: ctx.attrs?.hostnameId,
+        mono: true,
+        copy: true,
+      },
+      { label: "zone id", value: ctx.attrs?.zoneId, mono: true, copy: true },
+      { label: "target", value: ctx.attrs?.target },
+      { label: "status", value: ctx.attrs?.status },
+      { label: "dnslink", value: ctx.attrs?.dnslink, mono: true },
+      { label: "description", value: ctx.attrs?.description },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(HostnameUI);

--- a/packages/alchemy/src/Cloudflare/Workers/ui.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/ui.ts
@@ -1,0 +1,124 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { AccountSetting } from "./AccountSetting.ts";
+import type { ObservabilityDestination } from "./ObservabilityDestination.ts";
+import type { WorkerRoute } from "./Route.ts";
+import type { Subdomain } from "./Subdomain.ts";
+import type { Worker } from "./Worker.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare Workers resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ *
+ * Note: DurableObject, Browser, RateLimit, VersionMetadata, and
+ * WorkerLoader are `Binding.Service`s (Worker-only bindings with no
+ * backing Resource), so they have no Resource tag and no UIProvider —
+ * they surface on the dashboard as bindings of their host Worker.
+ */
+export const WorkerUI = UIProvider.succeed<Worker>("Cloudflare.Worker", {
+  displayName: "Worker",
+  icon: "zap",
+  color: "#F6821F",
+  category: "compute",
+  summary: (ctx) => ctx.attrs?.workerName,
+  link: (ctx) => ctx.attrs?.url,
+  consoleUrl: (ctx) =>
+    ctx.attrs?.accountId === undefined || ctx.attrs.workerName === undefined
+      ? undefined
+      : `https://dash.cloudflare.com/${ctx.attrs.accountId}/workers/services/view/${ctx.attrs.workerName}`,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.workerName, copy: true },
+    {
+      label: "url",
+      value: ctx.attrs?.url,
+      href: ctx.attrs?.url,
+      copy: true,
+    },
+    { label: "namespace", value: ctx.attrs?.namespace },
+    {
+      label: "crons",
+      value: ctx.attrs?.crons?.length ? ctx.attrs.crons.join(", ") : undefined,
+      mono: true,
+    },
+    {
+      label: "domain",
+      value: ctx.attrs?.domain
+        ? [ctx.attrs.domain.name, ...ctx.attrs.domain.aliases].join(", ")
+        : undefined,
+    },
+  ],
+});
+
+export const WorkerRouteUI = UIProvider.succeed<WorkerRoute>(
+  "Cloudflare.Workers.Route",
+  {
+    displayName: "Worker Route",
+    icon: "route",
+    color: "#F6821F",
+    category: "network",
+    summary: (ctx) => ctx.props?.pattern,
+  },
+);
+
+export const SubdomainUI = UIProvider.succeed<Subdomain>(
+  "Cloudflare.Workers.Subdomain",
+  {
+    displayName: "Workers Subdomain",
+    icon: "globe",
+    color: "#F6821F",
+    category: "dns",
+  },
+);
+
+export const AccountSettingUI = UIProvider.succeed<AccountSetting>(
+  "Cloudflare.Workers.AccountSetting",
+  {
+    displayName: "Workers Account Setting",
+    icon: "settings-2",
+    color: "#F6821F",
+    category: "config",
+  },
+);
+
+export const ObservabilityDestinationUI =
+  UIProvider.succeed<ObservabilityDestination>(
+    "Cloudflare.Workers.ObservabilityDestination",
+    {
+      displayName: "Observability Destination",
+      icon: "satellite-dish",
+      color: "#F6821F",
+      category: "observability",
+      summary: (ctx) => ctx.attrs?.name,
+      link: (ctx) => ctx.attrs?.url,
+      facts: (ctx) => [
+        { label: "name", value: ctx.attrs?.name, copy: true },
+        { label: "slug", value: ctx.attrs?.slug, mono: true, copy: true },
+        {
+          label: "endpoint",
+          value: ctx.attrs?.url,
+          href: ctx.attrs?.url,
+          copy: true,
+        },
+        { label: "dataset", value: ctx.attrs?.logpushDataset, mono: true },
+        { label: "enabled", value: ctx.attrs?.enabled },
+        {
+          label: "scripts",
+          value: ctx.attrs?.scripts?.length
+            ? ctx.attrs.scripts.join(", ")
+            : undefined,
+          mono: true,
+        },
+      ],
+    },
+  );
+
+export const ui = () =>
+  Layer.mergeAll(
+    WorkerUI,
+    WorkerRouteUI,
+    SubdomainUI,
+    AccountSettingUI,
+    ObservabilityDestinationUI,
+  );

--- a/packages/alchemy/src/Cloudflare/WorkersForPlatforms/ui.ts
+++ b/packages/alchemy/src/Cloudflare/WorkersForPlatforms/ui.ts
@@ -1,0 +1,33 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { DispatchNamespace } from "./DispatchNamespace.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare Workers for Platforms resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const DispatchNamespaceUI = UIProvider.succeed<DispatchNamespace>(
+  "Cloudflare.Workers.DispatchNamespace",
+  {
+    displayName: "Dispatch Namespace",
+    icon: "layers",
+    color: "#F6821F",
+    category: "compute",
+    summary: (ctx) => ctx.attrs?.name,
+    consoleUrl: (ctx) =>
+      ctx.attrs?.accountId === undefined
+        ? undefined
+        : `https://dash.cloudflare.com/${ctx.attrs.accountId}/workers-for-platforms`,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      { label: "id", value: ctx.attrs?.namespaceId, mono: true, copy: true },
+      { label: "scripts", value: ctx.attrs?.scriptCount },
+      { label: "trusted", value: ctx.attrs?.trustedWorkers },
+      { label: "created", value: ctx.attrs?.createdOn },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(DispatchNamespaceUI);

--- a/packages/alchemy/src/Cloudflare/Workflows/ui.ts
+++ b/packages/alchemy/src/Cloudflare/Workflows/ui.ts
@@ -1,0 +1,32 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { WorkflowResource } from "./Workflow.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare Workflows resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const WorkflowUI = UIProvider.succeed<WorkflowResource>(
+  "Cloudflare.Workflow",
+  {
+    displayName: "Workflow",
+    icon: "workflow",
+    color: "#F6821F",
+    category: "compute",
+    summary: (ctx) => ctx.attrs?.workflowName,
+    consoleUrl: (ctx) =>
+      ctx.attrs?.accountId === undefined || ctx.attrs.workflowName === undefined
+        ? undefined
+        : `https://dash.cloudflare.com/${ctx.attrs.accountId}/workers/workflows/${ctx.attrs.workflowName}`,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.workflowName, copy: true },
+      { label: "id", value: ctx.attrs?.workflowId, mono: true, copy: true },
+      { label: "class", value: ctx.attrs?.className, mono: true },
+      { label: "script", value: ctx.attrs?.scriptName, mono: true },
+    ],
+  },
+);
+
+export const ui = () => Layer.mergeAll(WorkflowUI);

--- a/packages/alchemy/src/Cloudflare/Zaraz/ui.ts
+++ b/packages/alchemy/src/Cloudflare/Zaraz/ui.ts
@@ -1,0 +1,46 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { Config } from "./Config.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare Zaraz resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const ConfigUI = UIProvider.succeed<Config>("Cloudflare.Zaraz.Config", {
+  displayName: "Zaraz Config",
+  icon: "tags",
+  color: "#F6821F",
+  category: "config",
+  summary: (ctx) => ctx.attrs?.zoneId,
+  facts: (ctx) => [
+    { label: "zone", value: ctx.attrs?.zoneId, mono: true, copy: true },
+    { label: "version", value: ctx.attrs?.zarazVersion },
+    { label: "data layer", value: ctx.attrs?.dataLayer },
+    { label: "debug key", value: ctx.attrs?.debugKey, mono: true, copy: true },
+    {
+      label: "tools",
+      value:
+        ctx.attrs?.tools === undefined
+          ? undefined
+          : Object.keys(ctx.attrs.tools).length,
+    },
+    {
+      label: "triggers",
+      value:
+        ctx.attrs?.triggers === undefined
+          ? undefined
+          : Object.keys(ctx.attrs.triggers).length,
+    },
+    {
+      label: "variables",
+      value:
+        ctx.attrs?.variables === undefined
+          ? undefined
+          : Object.keys(ctx.attrs.variables).length,
+    },
+  ],
+});
+
+export const ui = () => Layer.mergeAll(ConfigUI);

--- a/packages/alchemy/src/Cloudflare/Zone/ui.ts
+++ b/packages/alchemy/src/Cloudflare/Zone/ui.ts
@@ -1,0 +1,106 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../../UI/UIProvider.ts";
+import type { CustomNameservers } from "./CustomNameservers.ts";
+import type { Hold } from "./Hold.ts";
+import type { Setting } from "./Setting.ts";
+import type { Zone } from "./Zone.ts";
+
+/**
+ * Dashboard UI providers for Cloudflare Zone resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Cloudflare SDK code reaches the dashboard bundle.
+ */
+export const ZoneUI = UIProvider.succeed<Zone>("Cloudflare.Zone.Zone", {
+  displayName: "Zone",
+  icon: "globe",
+  color: "#F6821F",
+  category: "dns",
+  summary: (ctx) => ctx.attrs?.name,
+  link: (ctx) => (ctx.attrs?.name ? `https://${ctx.attrs.name}` : undefined),
+  consoleUrl: (ctx) =>
+    ctx.attrs?.accountId === undefined || ctx.attrs.name === undefined
+      ? undefined
+      : `https://dash.cloudflare.com/${ctx.attrs.accountId}/${ctx.attrs.name}`,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.name, copy: true },
+    { label: "zone id", value: ctx.attrs?.zoneId, mono: true, copy: true },
+    { label: "account", value: ctx.attrs?.accountId, mono: true, copy: true },
+    { label: "type", value: ctx.attrs?.type },
+    { label: "status", value: ctx.attrs?.status },
+    { label: "paused", value: ctx.attrs?.paused },
+    {
+      label: "name servers",
+      value: ctx.attrs?.nameServers?.length
+        ? ctx.attrs.nameServers.join(", ")
+        : undefined,
+      mono: true,
+    },
+  ],
+});
+
+export const SettingUI = UIProvider.succeed<Setting>(
+  "Cloudflare.Zone.Setting",
+  {
+    displayName: "Zone Setting",
+    icon: "settings-2",
+    color: "#F6821F",
+    category: "config",
+    summary: (ctx) => ctx.attrs?.settingId ?? ctx.props?.settingId,
+    facts: (ctx) => [
+      { label: "setting", value: ctx.attrs?.settingId, mono: true },
+      {
+        label: "value",
+        value:
+          ctx.attrs?.value === undefined
+            ? undefined
+            : typeof ctx.attrs.value === "object"
+              ? JSON.stringify(ctx.attrs.value)
+              : String(ctx.attrs.value as string | number | boolean),
+        mono: true,
+      },
+      { label: "zone id", value: ctx.attrs?.zoneId, mono: true, copy: true },
+      { label: "editable", value: ctx.attrs?.editable },
+      { label: "modified", value: ctx.attrs?.modifiedOn },
+    ],
+  },
+);
+
+export const HoldUI = UIProvider.succeed<Hold>("Cloudflare.Zone.Hold", {
+  displayName: "Zone Hold",
+  icon: "lock",
+  color: "#F6821F",
+  category: "security",
+  summary: (ctx) => ctx.attrs?.zoneId ?? ctx.props?.zoneId,
+  facts: (ctx) => [
+    { label: "zone id", value: ctx.attrs?.zoneId, mono: true, copy: true },
+    { label: "hold", value: ctx.attrs?.hold },
+    { label: "include subdomains", value: ctx.attrs?.includeSubdomains },
+    { label: "hold after", value: ctx.attrs?.holdAfter },
+  ],
+});
+
+export const CustomNameserversUI = UIProvider.succeed<CustomNameservers>(
+  "Cloudflare.Zone.CustomNameservers",
+  {
+    displayName: "Custom Nameservers",
+    icon: "server",
+    color: "#F6821F",
+    category: "dns",
+    summary: (ctx) =>
+      ctx.attrs?.enabled === undefined
+        ? ctx.props?.zoneId
+        : ctx.attrs.enabled
+          ? `enabled (set ${ctx.attrs.nsSet ?? 1})`
+          : "disabled",
+    facts: (ctx) => [
+      { label: "zone id", value: ctx.attrs?.zoneId, mono: true, copy: true },
+      { label: "enabled", value: ctx.attrs?.enabled },
+      { label: "ns set", value: ctx.attrs?.nsSet },
+      { label: "initial enabled", value: ctx.attrs?.initialEnabled },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(ZoneUI, SettingUI, HoldUI, CustomNameserversUI);

--- a/packages/alchemy/src/Docker/UI.ts
+++ b/packages/alchemy/src/Docker/UI.ts
@@ -1,0 +1,150 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../UI/UIProvider.ts";
+import type { Container } from "./Container.ts";
+import type { Context } from "./Context.ts";
+import type { Image } from "./Image.ts";
+import type { Network } from "./Network.ts";
+import type { RemoteImage } from "./RemoteImage.ts";
+import type { Swarm } from "./Swarm.ts";
+import type { Volume } from "./Volume.ts";
+
+/**
+ * Dashboard UI providers for Docker resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Docker CLI code reaches the dashboard bundle.
+ */
+
+const DOCKER_BLUE = "#2496ED";
+
+export const ContainerUI = UIProvider.succeed<Container>("Docker.Container", {
+  displayName: "Docker Container",
+  icon: "container",
+  color: DOCKER_BLUE,
+  category: "compute",
+  summary: (ctx) => ctx.attrs?.name,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.name, copy: true },
+    { label: "id", value: ctx.attrs?.id, mono: true, copy: true },
+    { label: "status", value: ctx.attrs?.status },
+    { label: "image", value: ctx.attrs?.imageRef, mono: true, copy: true },
+    {
+      label: "ports",
+      value: ctx.attrs?.ports
+        ? Object.entries(ctx.attrs.ports)
+            .map(([internal, external]) => `${external}->${internal}`)
+            .join(", ") || undefined
+        : undefined,
+      mono: true,
+    },
+    { label: "restart", value: ctx.props?.restart },
+  ],
+});
+
+export const ImageUI = UIProvider.succeed<Image>("Docker.Image", {
+  displayName: "Docker Image",
+  icon: "package",
+  color: DOCKER_BLUE,
+  category: "compute",
+  summary: (ctx) => ctx.attrs?.imageRef,
+  facts: (ctx) => [
+    { label: "ref", value: ctx.attrs?.imageRef, mono: true, copy: true },
+    { label: "name", value: ctx.attrs?.name },
+    { label: "tag", value: ctx.attrs?.tag, mono: true },
+    { label: "image id", value: ctx.attrs?.imageId, mono: true, copy: true },
+    { label: "digest", value: ctx.attrs?.repoDigest, mono: true, copy: true },
+    { label: "context", value: ctx.props?.build?.context, mono: true },
+    { label: "registry", value: ctx.props?.registry?.server },
+  ],
+});
+
+export const RemoteImageUI = UIProvider.succeed<RemoteImage>(
+  "Docker.RemoteImage",
+  {
+    displayName: "Docker Remote Image",
+    icon: "cloud-download",
+    color: DOCKER_BLUE,
+    category: "compute",
+    summary: (ctx) => ctx.attrs?.imageRef,
+    facts: (ctx) => [
+      { label: "ref", value: ctx.attrs?.imageRef, mono: true, copy: true },
+      { label: "name", value: ctx.attrs?.name },
+      { label: "tag", value: ctx.attrs?.tag, mono: true },
+      { label: "image id", value: ctx.attrs?.imageId, mono: true, copy: true },
+      { label: "digest", value: ctx.attrs?.repoDigest, mono: true, copy: true },
+      { label: "platform", value: ctx.props?.platform },
+      { label: "registry", value: ctx.props?.registry?.server },
+    ],
+  },
+);
+
+export const NetworkUI = UIProvider.succeed<Network>("Docker.Network", {
+  displayName: "Docker Network",
+  icon: "network",
+  color: DOCKER_BLUE,
+  category: "network",
+  summary: (ctx) => ctx.attrs?.name,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.name, copy: true },
+    { label: "id", value: ctx.attrs?.id, mono: true, copy: true },
+    { label: "driver", value: ctx.attrs?.driver },
+    { label: "ipv6", value: ctx.attrs?.enableIPv6 },
+  ],
+});
+
+export const VolumeUI = UIProvider.succeed<Volume>("Docker.Volume", {
+  displayName: "Docker Volume",
+  icon: "hard-drive",
+  color: DOCKER_BLUE,
+  category: "storage",
+  summary: (ctx) => ctx.attrs?.name,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.name, copy: true },
+    { label: "driver", value: ctx.attrs?.driver },
+    {
+      label: "mountpoint",
+      value: ctx.attrs?.mountpoint,
+      mono: true,
+      copy: true,
+    },
+  ],
+});
+
+export const ContextUI = UIProvider.succeed<Context>("Docker.Context", {
+  displayName: "Docker Context",
+  icon: "waypoints",
+  color: DOCKER_BLUE,
+  category: "config",
+  summary: (ctx) => ctx.attrs?.name,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.name, copy: true },
+    { label: "endpoint", value: ctx.attrs?.docker, mono: true, copy: true },
+    { label: "description", value: ctx.attrs?.description },
+  ],
+});
+
+export const SwarmUI = UIProvider.succeed<Swarm>("Docker.Swarm", {
+  displayName: "Docker Swarm",
+  icon: "boxes",
+  color: DOCKER_BLUE,
+  category: "compute",
+  summary: (ctx) => ctx.attrs?.id,
+  facts: (ctx) => [
+    { label: "cluster", value: ctx.attrs?.id, mono: true, copy: true },
+    { label: "node", value: ctx.attrs?.nodeId, mono: true },
+    { label: "context", value: ctx.attrs?.context },
+    { label: "managers", value: ctx.attrs?.managers },
+    { label: "nodes", value: ctx.attrs?.nodes },
+  ],
+});
+
+export const ui = () =>
+  Layer.mergeAll(
+    ContainerUI,
+    ContextUI,
+    ImageUI,
+    RemoteImageUI,
+    NetworkUI,
+    SwarmUI,
+    VolumeUI,
+  );

--- a/packages/alchemy/src/Fly/UI.ts
+++ b/packages/alchemy/src/Fly/UI.ts
@@ -1,0 +1,347 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../UI/UIProvider.ts";
+import type { App } from "./App.ts";
+import type { Bucket } from "./Bucket.ts";
+import type { Certificate } from "./Certificate.ts";
+import type { IpAssignment } from "./IpAssignment.ts";
+import type { Machine } from "./Machine.ts";
+import type { Postgres } from "./Postgres.ts";
+import type { Redis } from "./Redis.ts";
+import type { Secret } from "./Secret.ts";
+import type { SecretKey } from "./SecretKey.ts";
+import type { Service } from "./Service.ts";
+import type { Sprite } from "./Sprite.ts";
+import type { VolumeSnapshot } from "./VolumeSnapshot.ts";
+import type { AssetDeployment } from "./Website/AssetDeployment.ts";
+
+/**
+ * Dashboard UI providers for Fly.io resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Fly SDK code reaches the dashboard bundle.
+ */
+
+const FLY_PURPLE = "#7B3FE4";
+
+export const AppUI = UIProvider.succeed<App>("Fly.App", {
+  displayName: "Fly App",
+  icon: "app-window",
+  color: FLY_PURPLE,
+  category: "compute",
+  summary: (ctx) => ctx.attrs?.appName,
+  link: (ctx) => ctx.attrs?.url,
+  consoleUrl: (ctx) =>
+    ctx.attrs?.appName ? `https://fly.io/apps/${ctx.attrs.appName}` : undefined,
+  facts: (ctx) => [
+    { label: "app", value: ctx.attrs?.appName, copy: true },
+    { label: "app id", value: ctx.attrs?.appId, mono: true, copy: true },
+    { label: "org", value: ctx.attrs?.orgSlug },
+    { label: "status", value: ctx.attrs?.status },
+    { label: "network", value: ctx.attrs?.network },
+    { label: "machines", value: ctx.attrs?.machineCount },
+    { label: "url", value: ctx.attrs?.url, href: ctx.attrs?.url },
+  ],
+});
+
+export const BucketUI = UIProvider.succeed<Bucket>("Fly.Bucket", {
+  displayName: "Fly Bucket",
+  icon: "cylinder",
+  color: FLY_PURPLE,
+  category: "storage",
+  summary: (ctx) => ctx.attrs?.name,
+  consoleUrl: (ctx) => ctx.attrs?.ssoLink,
+  facts: (ctx) => [
+    { label: "bucket", value: ctx.attrs?.name, copy: true },
+    { label: "add-on id", value: ctx.attrs?.addOnId, mono: true, copy: true },
+    { label: "status", value: ctx.attrs?.status },
+    { label: "org", value: ctx.attrs?.orgSlug },
+    { label: "public", value: ctx.attrs?.public },
+    { label: "domain", value: ctx.attrs?.domainName },
+    { label: "created", value: ctx.attrs?.createdAt },
+  ],
+});
+
+export const CertificateUI = UIProvider.succeed<Certificate>(
+  "Fly.Certificate",
+  {
+    displayName: "Fly Certificate",
+    icon: "shield-check",
+    color: FLY_PURPLE,
+    category: "security",
+    summary: (ctx) => ctx.attrs?.hostname,
+    consoleUrl: (ctx) =>
+      ctx.attrs?.appName && ctx.attrs?.hostname
+        ? `https://fly.io/apps/${ctx.attrs.appName}/certificates/${ctx.attrs.hostname}`
+        : undefined,
+    facts: (ctx) => [
+      { label: "hostname", value: ctx.attrs?.hostname, copy: true },
+      { label: "app", value: ctx.attrs?.appName },
+      { label: "status", value: ctx.attrs?.status },
+      { label: "configured", value: ctx.attrs?.configured },
+      { label: "source", value: ctx.attrs?.source },
+      { label: "acme requested", value: ctx.attrs?.acmeRequested },
+    ],
+  },
+);
+
+export const IpAssignmentUI = UIProvider.succeed<IpAssignment>(
+  "Fly.IpAssignment",
+  {
+    displayName: "Fly IP Assignment",
+    icon: "network",
+    color: FLY_PURPLE,
+    category: "network",
+    summary: (ctx) => ctx.attrs?.ip,
+    consoleUrl: (ctx) =>
+      ctx.attrs?.appName
+        ? `https://fly.io/apps/${ctx.attrs.appName}`
+        : undefined,
+    facts: (ctx) => [
+      { label: "address", value: ctx.attrs?.ip, mono: true, copy: true },
+      { label: "type", value: ctx.attrs?.type },
+      { label: "app", value: ctx.attrs?.appName },
+      { label: "region", value: ctx.attrs?.region },
+      { label: "shared", value: ctx.attrs?.shared },
+      { label: "created", value: ctx.attrs?.createdAt },
+    ],
+  },
+);
+
+export const MachineUI = UIProvider.succeed<Machine>("Fly.Machine", {
+  displayName: "Fly Machine",
+  icon: "server",
+  color: FLY_PURPLE,
+  category: "compute",
+  summary: (ctx) => ctx.attrs?.name ?? ctx.attrs?.machineId,
+  link: (ctx) => ctx.attrs?.url,
+  consoleUrl: (ctx) =>
+    ctx.attrs?.appName && ctx.attrs?.machineId
+      ? `https://fly.io/apps/${ctx.attrs.appName}/machines/${ctx.attrs.machineId}`
+      : undefined,
+  facts: (ctx) => [
+    {
+      label: "machine id",
+      value: ctx.attrs?.machineId,
+      mono: true,
+      copy: true,
+    },
+    { label: "name", value: ctx.attrs?.name, copy: true },
+    { label: "app", value: ctx.attrs?.appName },
+    { label: "region", value: ctx.attrs?.region },
+    { label: "state", value: ctx.attrs?.state },
+    { label: "count", value: ctx.attrs?.count },
+    {
+      label: "image",
+      value:
+        ctx.attrs?.imageRef?.repository !== undefined
+          ? `${ctx.attrs.imageRef.repository}${
+              ctx.attrs.imageRef.tag !== undefined
+                ? `:${ctx.attrs.imageRef.tag}`
+                : ""
+            }`
+          : undefined,
+      mono: true,
+    },
+  ],
+});
+
+export const PostgresUI = UIProvider.succeed<Postgres>("Fly.Postgres", {
+  displayName: "Fly Postgres",
+  icon: "database",
+  color: FLY_PURPLE,
+  category: "database",
+  summary: (ctx) => ctx.attrs?.name,
+  facts: (ctx) => [
+    { label: "cluster", value: ctx.attrs?.name, copy: true },
+    {
+      label: "cluster id",
+      value: ctx.attrs?.clusterId,
+      mono: true,
+      copy: true,
+    },
+    { label: "status", value: ctx.attrs?.status },
+    { label: "region", value: ctx.attrs?.region },
+    { label: "plan", value: ctx.attrs?.plan },
+    { label: "org", value: ctx.attrs?.orgSlug },
+    { label: "disk (gb)", value: ctx.attrs?.disk },
+  ],
+});
+
+export const RedisUI = UIProvider.succeed<Redis>("Fly.Redis", {
+  displayName: "Fly Redis",
+  icon: "zap",
+  color: FLY_PURPLE,
+  category: "database",
+  summary: (ctx) => ctx.attrs?.name,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.name, copy: true },
+    { label: "add-on id", value: ctx.attrs?.redisId, mono: true, copy: true },
+    { label: "status", value: ctx.attrs?.status },
+    { label: "primary region", value: ctx.attrs?.primaryRegion },
+    { label: "plan", value: ctx.attrs?.planName },
+    {
+      label: "read regions",
+      value:
+        ctx.attrs?.readRegions !== undefined && ctx.attrs.readRegions.length > 0
+          ? ctx.attrs.readRegions.join(", ")
+          : undefined,
+    },
+    { label: "eviction", value: ctx.attrs?.eviction },
+  ],
+});
+
+export const SecretUI = UIProvider.succeed<Secret>("Fly.Secret", {
+  displayName: "Fly Secret",
+  icon: "lock",
+  color: FLY_PURPLE,
+  category: "security",
+  summary: (ctx) => ctx.attrs?.name,
+  consoleUrl: (ctx) =>
+    ctx.attrs?.appName
+      ? `https://fly.io/apps/${ctx.attrs.appName}/secrets`
+      : undefined,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.name, mono: true, copy: true },
+    { label: "app", value: ctx.attrs?.appName },
+    { label: "digest", value: ctx.attrs?.digest, mono: true },
+    { label: "created", value: ctx.attrs?.createdAt },
+    { label: "updated", value: ctx.attrs?.updatedAt },
+  ],
+});
+
+export const SecretKeyUI = UIProvider.succeed<SecretKey>("Fly.SecretKey", {
+  displayName: "Fly Secret Key",
+  icon: "key",
+  color: FLY_PURPLE,
+  category: "security",
+  summary: (ctx) => ctx.attrs?.name,
+  consoleUrl: (ctx) =>
+    ctx.attrs?.appName ? `https://fly.io/apps/${ctx.attrs.appName}` : undefined,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.name, mono: true, copy: true },
+    { label: "app", value: ctx.attrs?.appName },
+    { label: "type", value: ctx.attrs?.type },
+    {
+      label: "public key",
+      value: ctx.attrs?.publicKey,
+      mono: true,
+      copy: true,
+    },
+    { label: "created", value: ctx.attrs?.createdAt },
+    { label: "updated", value: ctx.attrs?.updatedAt },
+  ],
+});
+
+export const ServiceUI = UIProvider.succeed<Service>("Fly.Service", {
+  displayName: "Fly Service",
+  icon: "cpu",
+  color: FLY_PURPLE,
+  category: "compute",
+  summary: (ctx) => ctx.attrs?.name,
+  link: (ctx) => ctx.attrs?.url,
+  consoleUrl: (ctx) =>
+    ctx.attrs?.appName && ctx.attrs?.machineId
+      ? `https://fly.io/apps/${ctx.attrs.appName}/machines/${ctx.attrs.machineId}`
+      : undefined,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.name, copy: true },
+    { label: "app", value: ctx.attrs?.appName },
+    {
+      label: "machine id",
+      value: ctx.attrs?.machineId,
+      mono: true,
+      copy: true,
+    },
+    { label: "region", value: ctx.attrs?.region },
+    { label: "state", value: ctx.attrs?.state },
+    { label: "count", value: ctx.attrs?.count },
+    { label: "code hash", value: ctx.attrs?.code?.hash, mono: true },
+  ],
+});
+
+export const SpriteUI = UIProvider.succeed<Sprite>("Fly.Sprite", {
+  displayName: "Fly Sprite",
+  icon: "box",
+  color: FLY_PURPLE,
+  category: "compute",
+  summary: (ctx) => ctx.attrs?.name,
+  link: (ctx) => ctx.attrs?.url,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.name, copy: true },
+    { label: "sprite id", value: ctx.attrs?.spriteId, mono: true, copy: true },
+    { label: "status", value: ctx.attrs?.status },
+    { label: "url auth", value: ctx.attrs?.urlAuth },
+    { label: "org", value: ctx.attrs?.orgSlug },
+    { label: "url", value: ctx.attrs?.url, href: ctx.attrs?.url },
+    { label: "code hash", value: ctx.attrs?.code?.hash, mono: true },
+  ],
+});
+
+export const VolumeSnapshotUI = UIProvider.succeed<VolumeSnapshot>(
+  "Fly.VolumeSnapshot",
+  {
+    displayName: "Fly Volume Snapshot",
+    icon: "camera",
+    color: FLY_PURPLE,
+    category: "storage",
+    summary: (ctx) => ctx.attrs?.snapshotId,
+    consoleUrl: (ctx) =>
+      ctx.attrs?.appName
+        ? `https://fly.io/apps/${ctx.attrs.appName}/volumes`
+        : undefined,
+    facts: (ctx) => [
+      {
+        label: "snapshot id",
+        value: ctx.attrs?.snapshotId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "volume id",
+        value: ctx.attrs?.volumeId,
+        mono: true,
+        copy: true,
+      },
+      { label: "app", value: ctx.attrs?.appName },
+      { label: "status", value: ctx.attrs?.status },
+      { label: "size (bytes)", value: ctx.attrs?.size },
+      { label: "retention (days)", value: ctx.attrs?.retentionDays },
+      { label: "created", value: ctx.attrs?.createdAt },
+    ],
+  },
+);
+
+export const AssetDeploymentUI = UIProvider.succeed<AssetDeployment>(
+  "Fly.Website.AssetDeployment",
+  {
+    displayName: "Fly Website Assets",
+    icon: "globe",
+    color: FLY_PURPLE,
+    category: "cdn",
+    summary: (ctx) => ctx.attrs?.bucketName,
+    facts: (ctx) => [
+      { label: "bucket", value: ctx.attrs?.bucketName, copy: true },
+      { label: "prefix", value: ctx.attrs?.prefix, mono: true },
+      { label: "version", value: ctx.attrs?.version, mono: true, copy: true },
+      { label: "files", value: ctx.attrs?.fileCount },
+      { label: "source", value: ctx.props?.sourcePath, mono: true },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(
+    AppUI,
+    BucketUI,
+    CertificateUI,
+    IpAssignmentUI,
+    MachineUI,
+    PostgresUI,
+    RedisUI,
+    SecretUI,
+    SecretKeyUI,
+    ServiceUI,
+    SpriteUI,
+    VolumeSnapshotUI,
+    AssetDeploymentUI,
+  );

--- a/packages/alchemy/src/GitHub/UI.ts
+++ b/packages/alchemy/src/GitHub/UI.ts
@@ -1,0 +1,217 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../UI/UIProvider.ts";
+import type { Environment } from "./Environment.ts";
+import type { Comment } from "./Comment.ts";
+import type { Repository } from "./Repository.ts";
+import type { Secret } from "./Secret.ts";
+import type { Variable } from "./Variable.ts";
+import type { Webhook } from "./Webhook.ts";
+
+/**
+ * Dashboard UI providers for GitHub resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no GitHub SDK code reaches the dashboard bundle.
+ */
+
+const GITHUB = "#9198a1";
+
+export const RepositoryUI = UIProvider.succeed<Repository>(
+  "GitHub.Repository",
+  {
+    displayName: "GitHub Repository",
+    icon: "folder-git-2",
+    color: GITHUB,
+    category: "other",
+    summary: (ctx) =>
+      ctx.attrs?.fullName ??
+      (ctx.props?.owner && ctx.props?.name
+        ? `${ctx.props.owner}/${ctx.props.name}`
+        : undefined),
+    link: (ctx) => ctx.attrs?.htmlUrl,
+    consoleUrl: (ctx) => ctx.attrs?.htmlUrl,
+    facts: (ctx) => [
+      { label: "full name", value: ctx.attrs?.fullName, copy: true },
+      { label: "repo id", value: ctx.attrs?.repoId, mono: true, copy: true },
+      { label: "visibility", value: ctx.props?.visibility },
+      { label: "default branch", value: ctx.attrs?.defaultBranch },
+      {
+        label: "clone (https)",
+        value: ctx.attrs?.cloneUrl,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "clone (ssh)",
+        value: ctx.attrs?.sshUrl,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "url",
+        value: ctx.attrs?.htmlUrl,
+        href: ctx.attrs?.htmlUrl,
+      },
+    ],
+  },
+);
+
+export const SecretUI = UIProvider.succeed<Secret>("GitHub.Secret", {
+  displayName: "GitHub Actions Secret",
+  icon: "key-round",
+  color: GITHUB,
+  category: "security",
+  summary: (ctx) => ctx.props?.name,
+  consoleUrl: (ctx) =>
+    ctx.props?.owner && ctx.props?.repository
+      ? `https://github.com/${ctx.props.owner}/${ctx.props.repository}/settings/secrets/actions`
+      : undefined,
+  facts: (ctx) => [
+    { label: "name", value: ctx.props?.name, mono: true, copy: true },
+    {
+      label: "repository",
+      value:
+        ctx.props?.owner && ctx.props?.repository
+          ? `${ctx.props.owner}/${ctx.props.repository}`
+          : undefined,
+    },
+    { label: "environment", value: ctx.props?.environment },
+    { label: "updated", value: ctx.attrs?.updatedAt },
+  ],
+});
+
+export const VariableUI = UIProvider.succeed<Variable>("GitHub.Variable", {
+  displayName: "GitHub Actions Variable",
+  icon: "variable",
+  color: GITHUB,
+  category: "config",
+  summary: (ctx) => ctx.props?.name,
+  consoleUrl: (ctx) =>
+    ctx.props?.owner && ctx.props?.repository
+      ? `https://github.com/${ctx.props.owner}/${ctx.props.repository}/settings/variables/actions`
+      : undefined,
+  facts: (ctx) => [
+    { label: "name", value: ctx.props?.name, mono: true, copy: true },
+    { label: "value", value: ctx.props?.value, mono: true, copy: true },
+    {
+      label: "repository",
+      value:
+        ctx.props?.owner && ctx.props?.repository
+          ? `${ctx.props.owner}/${ctx.props.repository}`
+          : undefined,
+    },
+    { label: "updated", value: ctx.attrs?.updatedAt },
+  ],
+});
+
+export const WebhookUI = UIProvider.succeed<Webhook>("GitHub.Webhook", {
+  displayName: "GitHub Webhook",
+  icon: "webhook",
+  color: GITHUB,
+  category: "eventing",
+  summary: (ctx) => ctx.attrs?.url,
+  link: (ctx) => ctx.attrs?.url,
+  consoleUrl: (ctx) =>
+    ctx.props?.owner &&
+    ctx.props?.repository &&
+    ctx.attrs?.webhookId !== undefined
+      ? `https://github.com/${ctx.props.owner}/${ctx.props.repository}/settings/hooks/${ctx.attrs.webhookId}`
+      : undefined,
+  facts: (ctx) => [
+    {
+      label: "webhook id",
+      value: ctx.attrs?.webhookId,
+      mono: true,
+      copy: true,
+    },
+    {
+      label: "url",
+      value: ctx.attrs?.url,
+      href: ctx.attrs?.url,
+      copy: true,
+    },
+    {
+      label: "repository",
+      value:
+        ctx.props?.owner && ctx.props?.repository
+          ? `${ctx.props.owner}/${ctx.props.repository}`
+          : undefined,
+    },
+    {
+      label: "events",
+      value: Array.isArray(ctx.props?.events)
+        ? ctx.props.events.join(", ")
+        : undefined,
+    },
+    { label: "active", value: ctx.props?.active },
+    { label: "updated", value: ctx.attrs?.updatedAt },
+  ],
+});
+
+export const CommentUI = UIProvider.succeed<Comment>("GitHub.Comment", {
+  displayName: "GitHub Comment",
+  icon: "message-square",
+  color: GITHUB,
+  category: "other",
+  summary: (ctx) =>
+    ctx.props?.owner && ctx.props?.repository && ctx.props?.issueNumber
+      ? `${ctx.props.owner}/${ctx.props.repository}#${ctx.props.issueNumber}`
+      : undefined,
+  link: (ctx) => ctx.attrs?.htmlUrl,
+  consoleUrl: (ctx) => ctx.attrs?.htmlUrl,
+  facts: (ctx) => [
+    {
+      label: "comment id",
+      value: ctx.attrs?.commentId,
+      mono: true,
+      copy: true,
+    },
+    {
+      label: "issue",
+      value:
+        ctx.props?.owner && ctx.props?.repository && ctx.props?.issueNumber
+          ? `${ctx.props.owner}/${ctx.props.repository}#${ctx.props.issueNumber}`
+          : undefined,
+    },
+    {
+      label: "url",
+      value: ctx.attrs?.htmlUrl,
+      href: ctx.attrs?.htmlUrl,
+    },
+    { label: "updated", value: ctx.attrs?.updatedAt },
+  ],
+});
+
+export const EnvironmentUI = UIProvider.succeed<Environment>(
+  "GitHub.Environment",
+  {
+    displayName: "GitHub Environment",
+    icon: "shield-check",
+    color: GITHUB,
+    category: "config",
+    summary: (ctx) => ctx.attrs?.name,
+    link: (ctx) => ctx.attrs?.htmlUrl,
+    facts: (ctx) => [
+      { label: "environment", value: ctx.attrs?.name, copy: true },
+      { label: "repository", value: ctx.props?.repository, mono: true },
+      { label: "owner", value: ctx.props?.owner, mono: true },
+      { label: "id", value: ctx.attrs?.environmentId, mono: true },
+      {
+        label: "url",
+        value: ctx.attrs?.htmlUrl,
+        href: ctx.attrs?.htmlUrl,
+        copy: true,
+      },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(
+    RepositoryUI,
+    SecretUI,
+    VariableUI,
+    WebhookUI,
+    CommentUI,
+    EnvironmentUI,
+  );

--- a/packages/alchemy/src/Hetzner/UI.ts
+++ b/packages/alchemy/src/Hetzner/UI.ts
@@ -1,0 +1,434 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../UI/UIProvider.ts";
+import type { Certificate } from "./Certificate.ts";
+import type { Firewall } from "./Firewall.ts";
+import type { FloatingIp } from "./FloatingIp.ts";
+import type { FloatingIpAssignment } from "./FloatingIpAssignment.ts";
+import type { Image } from "./Image.ts";
+import type { LoadBalancer } from "./LoadBalancer.ts";
+import type { Network } from "./Network.ts";
+import type { PlacementGroup } from "./PlacementGroup.ts";
+import type { PrimaryIp } from "./PrimaryIp.ts";
+import type { RecordSet } from "./RecordSet.ts";
+import type { Server } from "./Server.ts";
+import type { Service } from "./Service.ts";
+import type { SshKey } from "./SshKey.ts";
+import type { Volume } from "./Volume.ts";
+import type { VolumeAttachment } from "./VolumeAttachment.ts";
+import type { Zone } from "./Zone.ts";
+
+/**
+ * Dashboard UI providers for Hetzner resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Hetzner SDK code reaches the dashboard bundle.
+ */
+
+const HETZNER_RED = "#D50C2D";
+
+export const CertificateUI = UIProvider.succeed<Certificate>(
+  "Hetzner.Certificate",
+  {
+    displayName: "Hetzner Certificate",
+    icon: "shield-check",
+    color: HETZNER_RED,
+    category: "security",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      { label: "id", value: ctx.attrs?.id, mono: true, copy: true },
+      { label: "type", value: ctx.attrs?.type },
+      {
+        label: "domains",
+        value: ctx.attrs?.domainNames?.length
+          ? ctx.attrs.domainNames.join(", ")
+          : undefined,
+      },
+      {
+        label: "fingerprint",
+        value: ctx.attrs?.fingerprint,
+        mono: true,
+        copy: true,
+      },
+      { label: "expires", value: ctx.attrs?.notValidAfter ?? undefined },
+    ],
+  },
+);
+
+export const FirewallUI = UIProvider.succeed<Firewall>("Hetzner.Firewall", {
+  displayName: "Hetzner Firewall",
+  icon: "shield",
+  color: HETZNER_RED,
+  category: "security",
+  summary: (ctx) => ctx.attrs?.name,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.name, copy: true },
+    { label: "id", value: ctx.attrs?.id, mono: true, copy: true },
+    { label: "rules", value: ctx.attrs?.rules?.length },
+    { label: "applied to", value: ctx.attrs?.appliedTo?.length },
+    { label: "created", value: ctx.attrs?.created },
+  ],
+});
+
+export const FloatingIpUI = UIProvider.succeed<FloatingIp>(
+  "Hetzner.FloatingIp",
+  {
+    displayName: "Hetzner Floating IP",
+    icon: "map-pin",
+    color: HETZNER_RED,
+    category: "network",
+    summary: (ctx) => ctx.attrs?.ip ?? ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "ip", value: ctx.attrs?.ip, mono: true, copy: true },
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      { label: "id", value: ctx.attrs?.id, mono: true, copy: true },
+      { label: "type", value: ctx.attrs?.type },
+      { label: "home location", value: ctx.attrs?.homeLocation },
+      {
+        label: "server",
+        value: ctx.attrs?.serverId ?? undefined,
+        mono: true,
+      },
+    ],
+  },
+);
+
+export const FloatingIpAssignmentUI = UIProvider.succeed<FloatingIpAssignment>(
+  "Hetzner.FloatingIpAssignment",
+  {
+    displayName: "Hetzner Floating IP Assignment",
+    icon: "link",
+    color: HETZNER_RED,
+    category: "network",
+    summary: (ctx) =>
+      ctx.attrs?.floatingIpId !== undefined && ctx.attrs?.serverId !== undefined
+        ? `ip ${ctx.attrs.floatingIpId} -> server ${ctx.attrs.serverId}`
+        : undefined,
+    facts: (ctx) => [
+      {
+        label: "floating ip id",
+        value: ctx.attrs?.floatingIpId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "server id",
+        value: ctx.attrs?.serverId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "assignment",
+        value:
+          ctx.attrs?.floatingIpId !== undefined &&
+          ctx.attrs?.serverId !== undefined
+            ? `${ctx.attrs.floatingIpId} -> ${ctx.attrs.serverId}`
+            : undefined,
+        mono: true,
+      },
+    ],
+  },
+);
+
+export const ImageUI = UIProvider.succeed<Image>("Hetzner.Image", {
+  displayName: "Hetzner Image",
+  icon: "disc",
+  color: HETZNER_RED,
+  category: "storage",
+  summary: (ctx) => ctx.attrs?.description ?? ctx.attrs?.name ?? undefined,
+  facts: (ctx) => [
+    { label: "id", value: ctx.attrs?.id, mono: true, copy: true },
+    { label: "type", value: ctx.attrs?.type },
+    { label: "status", value: ctx.attrs?.status },
+    { label: "os flavor", value: ctx.attrs?.osFlavor },
+    {
+      label: "disk size",
+      value:
+        ctx.attrs?.diskSize !== undefined
+          ? `${ctx.attrs.diskSize} GB`
+          : undefined,
+    },
+    {
+      label: "image size",
+      value:
+        ctx.attrs?.imageSize !== undefined && ctx.attrs.imageSize !== null
+          ? `${ctx.attrs.imageSize} GB`
+          : undefined,
+    },
+    {
+      label: "created from",
+      value:
+        ctx.attrs?.createdFromName ?? ctx.attrs?.createdFromId ?? undefined,
+    },
+  ],
+});
+
+export const LoadBalancerUI = UIProvider.succeed<LoadBalancer>(
+  "Hetzner.LoadBalancer",
+  {
+    displayName: "Hetzner Load Balancer",
+    icon: "split",
+    color: HETZNER_RED,
+    category: "network",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      { label: "id", value: ctx.attrs?.id, mono: true, copy: true },
+      { label: "type", value: ctx.attrs?.loadBalancerType },
+      { label: "location", value: ctx.attrs?.location },
+      {
+        label: "ipv4",
+        value: ctx.attrs?.ipv4 ?? undefined,
+        mono: true,
+        copy: true,
+      },
+      { label: "listeners", value: ctx.attrs?.services?.length },
+      { label: "targets", value: ctx.attrs?.targets?.length },
+    ],
+  },
+);
+
+export const NetworkUI = UIProvider.succeed<Network>("Hetzner.Network", {
+  displayName: "Hetzner Network",
+  icon: "network",
+  color: HETZNER_RED,
+  category: "network",
+  summary: (ctx) => ctx.attrs?.name,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.name, copy: true },
+    { label: "id", value: ctx.attrs?.networkId, mono: true, copy: true },
+    { label: "ip range", value: ctx.attrs?.ipRange, mono: true, copy: true },
+    { label: "subnets", value: ctx.attrs?.subnets?.length },
+    { label: "routes", value: ctx.attrs?.routes?.length },
+    { label: "servers", value: ctx.attrs?.servers?.length },
+    { label: "created", value: ctx.attrs?.created },
+  ],
+});
+
+export const PlacementGroupUI = UIProvider.succeed<PlacementGroup>(
+  "Hetzner.PlacementGroup",
+  {
+    displayName: "Hetzner Placement Group",
+    icon: "boxes",
+    color: HETZNER_RED,
+    category: "compute",
+    summary: (ctx) => ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      { label: "id", value: ctx.attrs?.id, mono: true, copy: true },
+      { label: "type", value: ctx.attrs?.type },
+      { label: "servers", value: ctx.attrs?.servers?.length },
+      { label: "created", value: ctx.attrs?.created },
+    ],
+  },
+);
+
+export const PrimaryIpUI = UIProvider.succeed<PrimaryIp>("Hetzner.PrimaryIp", {
+  displayName: "Hetzner Primary IP",
+  icon: "globe",
+  color: HETZNER_RED,
+  category: "network",
+  summary: (ctx) => ctx.attrs?.ip ?? ctx.attrs?.name,
+  facts: (ctx) => [
+    { label: "ip", value: ctx.attrs?.ip, mono: true, copy: true },
+    { label: "name", value: ctx.attrs?.name, copy: true },
+    { label: "id", value: ctx.attrs?.id, mono: true, copy: true },
+    { label: "type", value: ctx.attrs?.type },
+    { label: "location", value: ctx.attrs?.location },
+    {
+      label: "assignee",
+      value: ctx.attrs?.assigneeId ?? undefined,
+      mono: true,
+    },
+    { label: "auto delete", value: ctx.attrs?.autoDelete },
+  ],
+});
+
+export const RecordSetUI = UIProvider.succeed<RecordSet>("Hetzner.RecordSet", {
+  displayName: "Hetzner DNS Record Set",
+  icon: "list-ordered",
+  color: HETZNER_RED,
+  category: "dns",
+  summary: (ctx) => ctx.attrs?.id,
+  facts: (ctx) => [
+    { label: "id", value: ctx.attrs?.id, mono: true, copy: true },
+    { label: "name", value: ctx.attrs?.name, copy: true },
+    { label: "type", value: ctx.attrs?.type },
+    { label: "ttl", value: ctx.attrs?.ttl },
+    {
+      label: "values",
+      value: ctx.attrs?.records?.length
+        ? ctx.attrs.records.map((record) => record.value).join(", ")
+        : undefined,
+      mono: true,
+      copy: true,
+    },
+    { label: "zone id", value: ctx.attrs?.zoneId, mono: true },
+  ],
+});
+
+export const ServerUI = UIProvider.succeed<Server>("Hetzner.Server", {
+  displayName: "Hetzner Server",
+  icon: "server",
+  color: HETZNER_RED,
+  category: "compute",
+  summary: (ctx) => ctx.attrs?.name,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.name, copy: true },
+    { label: "id", value: ctx.attrs?.id, mono: true, copy: true },
+    { label: "status", value: ctx.attrs?.status },
+    { label: "server type", value: ctx.attrs?.serverType },
+    { label: "location", value: ctx.attrs?.location },
+    { label: "ipv4", value: ctx.attrs?.ipv4, mono: true, copy: true },
+    { label: "ipv6", value: ctx.attrs?.ipv6, mono: true, copy: true },
+  ],
+});
+
+export const ServiceUI = UIProvider.succeed<Service>("Hetzner.Service", {
+  displayName: "Hetzner Service",
+  icon: "app-window",
+  color: HETZNER_RED,
+  category: "compute",
+  summary: (ctx) => ctx.attrs?.url ?? ctx.attrs?.unitName,
+  link: (ctx) => ctx.attrs?.url,
+  facts: (ctx) => [
+    {
+      label: "url",
+      value: ctx.attrs?.url,
+      href: ctx.attrs?.url,
+      copy: true,
+    },
+    { label: "unit", value: ctx.attrs?.unitName, mono: true, copy: true },
+    { label: "server id", value: ctx.attrs?.serverId, mono: true },
+    { label: "ipv4", value: ctx.attrs?.ipv4, mono: true, copy: true },
+    { label: "port", value: ctx.attrs?.port },
+    { label: "code hash", value: ctx.attrs?.code?.hash, mono: true },
+  ],
+});
+
+export const SshKeyUI = UIProvider.succeed<SshKey>("Hetzner.SshKey", {
+  displayName: "Hetzner SSH Key",
+  icon: "key",
+  color: HETZNER_RED,
+  category: "security",
+  summary: (ctx) => ctx.attrs?.name,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.name, copy: true },
+    { label: "id", value: ctx.attrs?.id, mono: true, copy: true },
+    {
+      label: "fingerprint",
+      value: ctx.attrs?.fingerprint,
+      mono: true,
+      copy: true,
+    },
+    { label: "created", value: ctx.attrs?.created },
+  ],
+});
+
+export const VolumeUI = UIProvider.succeed<Volume>("Hetzner.Volume", {
+  displayName: "Hetzner Volume",
+  icon: "hard-drive",
+  color: HETZNER_RED,
+  category: "storage",
+  summary: (ctx) => ctx.attrs?.name,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.name, copy: true },
+    { label: "id", value: ctx.attrs?.id, mono: true, copy: true },
+    {
+      label: "size",
+      value: ctx.attrs?.size !== undefined ? `${ctx.attrs.size} GB` : undefined,
+    },
+    { label: "format", value: ctx.attrs?.format },
+    { label: "location", value: ctx.attrs?.location },
+    {
+      label: "server",
+      value: ctx.attrs?.serverId ?? undefined,
+      mono: true,
+    },
+    {
+      label: "device",
+      value: ctx.attrs?.linuxDevice,
+      mono: true,
+      copy: true,
+    },
+  ],
+});
+
+export const VolumeAttachmentUI = UIProvider.succeed<VolumeAttachment>(
+  "Hetzner.VolumeAttachment",
+  {
+    displayName: "Hetzner Volume Attachment",
+    icon: "anchor",
+    color: HETZNER_RED,
+    category: "storage",
+    summary: (ctx) =>
+      ctx.attrs?.volumeId !== undefined && ctx.attrs?.serverId !== undefined
+        ? `volume ${ctx.attrs.volumeId} -> server ${ctx.attrs.serverId}`
+        : undefined,
+    facts: (ctx) => [
+      {
+        label: "volume id",
+        value: ctx.attrs?.volumeId,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "server id",
+        value: ctx.attrs?.serverId,
+        mono: true,
+        copy: true,
+      },
+      { label: "automount", value: ctx.attrs?.automount },
+      {
+        label: "device",
+        value: ctx.attrs?.linuxDevice,
+        mono: true,
+        copy: true,
+      },
+    ],
+  },
+);
+
+export const ZoneUI = UIProvider.succeed<Zone>("Hetzner.Zone", {
+  displayName: "Hetzner DNS Zone",
+  icon: "globe",
+  color: HETZNER_RED,
+  category: "dns",
+  summary: (ctx) => ctx.attrs?.name,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.name, copy: true },
+    { label: "zone id", value: ctx.attrs?.zoneId, mono: true, copy: true },
+    { label: "mode", value: ctx.attrs?.mode },
+    { label: "status", value: ctx.attrs?.status },
+    { label: "ttl", value: ctx.attrs?.ttl },
+    { label: "records", value: ctx.attrs?.recordCount },
+    {
+      label: "nameservers",
+      value: ctx.attrs?.assignedNameservers?.length
+        ? ctx.attrs.assignedNameservers.join(", ")
+        : undefined,
+      mono: true,
+      copy: true,
+    },
+  ],
+});
+
+export const ui = () =>
+  Layer.mergeAll(
+    CertificateUI,
+    FirewallUI,
+    FloatingIpUI,
+    FloatingIpAssignmentUI,
+    ImageUI,
+    LoadBalancerUI,
+    NetworkUI,
+    PlacementGroupUI,
+    PrimaryIpUI,
+    RecordSetUI,
+    ServerUI,
+    ServiceUI,
+    SshKeyUI,
+    VolumeUI,
+    VolumeAttachmentUI,
+    ZoneUI,
+  );

--- a/packages/alchemy/src/Kubernetes/UI.ts
+++ b/packages/alchemy/src/Kubernetes/UI.ts
@@ -1,0 +1,74 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../UI/UIProvider.ts";
+import type { Connection } from "./Connection.ts";
+import type { HelmChart } from "./HelmChart.ts";
+import type { Manifest } from "./Manifest.ts";
+
+/**
+ * Dashboard UI providers for cluster-agnostic Kubernetes resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Kubernetes client code reaches the dashboard bundle.
+ */
+
+/** API server host a workload was applied to. */
+const endpointOf = (connection: Connection | undefined): string | undefined => {
+  const endpoint = connection?.endpoint;
+  if (endpoint === undefined) {
+    return undefined;
+  }
+  try {
+    return new URL(endpoint).host;
+  } catch {
+    return endpoint;
+  }
+};
+
+export const HelmChartUI = UIProvider.succeed<HelmChart>(
+  "Kubernetes.HelmChart",
+  {
+    displayName: "Helm Chart",
+    icon: "package",
+    // Kubernetes blue rather than the AWS orange these carried while they
+    // lived under EKS — they now target any cluster, not just EKS.
+    color: "#326CE5",
+    category: "config",
+    summary: (ctx) => ctx.attrs?.releaseName,
+    facts: (ctx) => [
+      { label: "release", value: ctx.attrs?.releaseName, copy: true },
+      { label: "namespace", value: ctx.attrs?.namespace },
+      { label: "chart", value: ctx.attrs?.chart, mono: true },
+      { label: "version", value: ctx.attrs?.version },
+      {
+        label: "cluster",
+        value: endpointOf(ctx.attrs?.connection),
+        mono: true,
+      },
+      { label: "auth", value: ctx.attrs?.connection?.auth?.kind },
+      { label: "objects", value: ctx.attrs?.objects?.length },
+      { label: "code hash", value: ctx.attrs?.code?.hash, mono: true },
+    ],
+  },
+);
+
+export const ManifestUI = UIProvider.succeed<Manifest>("Kubernetes.Manifest", {
+  displayName: "Kubernetes Manifest",
+  icon: "file-text",
+  color: "#326CE5",
+  category: "config",
+  summary: (ctx) =>
+    ctx.attrs?.kind === undefined
+      ? ctx.attrs?.name
+      : `${ctx.attrs.kind}/${ctx.attrs.name}`,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.name, copy: true },
+    { label: "kind", value: ctx.attrs?.kind },
+    { label: "api version", value: ctx.attrs?.apiVersion, mono: true },
+    { label: "namespace", value: ctx.attrs?.namespace },
+    { label: "cluster", value: endpointOf(ctx.attrs?.connection), mono: true },
+    { label: "auth", value: ctx.attrs?.connection?.auth?.kind },
+    { label: "uid", value: ctx.attrs?.uid, mono: true, copy: true },
+  ],
+});
+
+export const ui = () => Layer.mergeAll(HelmChartUI, ManifestUI);

--- a/packages/alchemy/src/Neon/UI.ts
+++ b/packages/alchemy/src/Neon/UI.ts
@@ -1,0 +1,62 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../UI/UIProvider.ts";
+import type { Branch } from "./Branch.ts";
+import type { Project } from "./Project.ts";
+
+/**
+ * Dashboard UI providers for Neon resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Neon SDK code reaches the dashboard bundle.
+ */
+export const ProjectUI = UIProvider.succeed<Project>("Neon.Project", {
+  displayName: "Neon Project",
+  icon: "database",
+  color: "#00E599",
+  category: "database",
+  summary: (ctx) => ctx.attrs?.projectName ?? ctx.attrs?.projectId,
+  consoleUrl: (ctx) =>
+    ctx.attrs?.projectId === undefined
+      ? undefined
+      : `https://console.neon.tech/app/projects/${ctx.attrs.projectId}`,
+  facts: (ctx) => [
+    { label: "project", value: ctx.attrs?.projectName, copy: true },
+    { label: "id", value: ctx.attrs?.projectId, mono: true, copy: true },
+    { label: "region", value: ctx.attrs?.region },
+    {
+      label: "postgres",
+      value:
+        ctx.attrs?.pgVersion === undefined
+          ? undefined
+          : `v${ctx.attrs.pgVersion}`,
+    },
+    { label: "default branch", value: ctx.attrs?.defaultBranchName },
+    { label: "database", value: ctx.attrs?.databaseName, mono: true },
+    { label: "role", value: ctx.attrs?.roleName, mono: true },
+    { label: "host", value: ctx.attrs?.origin?.host, mono: true, copy: true },
+  ],
+});
+
+export const BranchUI = UIProvider.succeed<Branch>("Neon.Branch", {
+  displayName: "Neon Branch",
+  icon: "git-branch",
+  color: "#00E599",
+  category: "database",
+  summary: (ctx) => ctx.attrs?.branchName ?? ctx.attrs?.branchId,
+  consoleUrl: (ctx) =>
+    ctx.attrs?.projectId === undefined || ctx.attrs?.branchId === undefined
+      ? undefined
+      : `https://console.neon.tech/app/projects/${ctx.attrs.projectId}/branches/${ctx.attrs.branchId}`,
+  facts: (ctx) => [
+    { label: "branch", value: ctx.attrs?.branchName, copy: true },
+    { label: "id", value: ctx.attrs?.branchId, mono: true, copy: true },
+    { label: "project", value: ctx.attrs?.projectId, mono: true, copy: true },
+    { label: "parent", value: ctx.attrs?.parentBranchId, mono: true },
+    { label: "database", value: ctx.attrs?.databaseName, mono: true },
+    { label: "role", value: ctx.attrs?.roleName, mono: true },
+    { label: "protected", value: ctx.attrs?.protected },
+    { label: "host", value: ctx.attrs?.origin?.host, mono: true, copy: true },
+  ],
+});
+
+export const ui = () => Layer.mergeAll(ProjectUI, BranchUI);

--- a/packages/alchemy/src/Planetscale/UI.ts
+++ b/packages/alchemy/src/Planetscale/UI.ts
@@ -1,0 +1,180 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../UI/UIProvider.ts";
+import type { MySQLBranch } from "./MySQL/MySQLBranch.ts";
+import type { MySQLDatabase } from "./MySQL/MySQLDatabase.ts";
+import type { MySQLPassword } from "./MySQL/MySQLPassword.ts";
+import type { PostgresBranch } from "./Postgres/PostgresBranch.ts";
+import type { PostgresDatabase } from "./Postgres/PostgresDatabase.ts";
+import type { PostgresDefaultRole } from "./Postgres/PostgresDefaultRole.ts";
+import type { PostgresRole } from "./Postgres/PostgresRole.ts";
+
+/**
+ * Dashboard UI providers for PlanetScale resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no SDK code reaches the dashboard bundle.
+ */
+
+const PLANETSCALE_ORANGE = "#f97316";
+
+export const MySQLDatabaseUI = UIProvider.succeed<MySQLDatabase>(
+  "Planetscale.MySQLDatabase",
+  {
+    displayName: "PlanetScale MySQL Database",
+    icon: "database",
+    color: PLANETSCALE_ORANGE,
+    category: "database",
+    summary: (ctx) => ctx.attrs?.name,
+    consoleUrl: (ctx) => ctx.attrs?.htmlUrl,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      { label: "id", value: ctx.attrs?.id, mono: true, copy: true },
+      { label: "organization", value: ctx.attrs?.organization },
+      { label: "region", value: ctx.attrs?.region?.slug },
+      { label: "plan", value: ctx.attrs?.plan },
+      { label: "cluster size", value: ctx.attrs?.clusterSize },
+      { label: "default branch", value: ctx.attrs?.defaultBranch },
+      { label: "state", value: ctx.attrs?.state },
+    ],
+  },
+);
+
+export const MySQLBranchUI = UIProvider.succeed<MySQLBranch>(
+  "Planetscale.MySQLBranch",
+  {
+    displayName: "PlanetScale MySQL Branch",
+    icon: "git-branch",
+    color: PLANETSCALE_ORANGE,
+    category: "database",
+    summary: (ctx) => ctx.attrs?.name,
+    consoleUrl: (ctx) => ctx.attrs?.htmlUrl,
+    facts: (ctx) => [
+      { label: "branch", value: ctx.attrs?.name, copy: true },
+      { label: "database", value: ctx.attrs?.database },
+      { label: "organization", value: ctx.attrs?.organization },
+      { label: "parent branch", value: ctx.attrs?.parentBranch },
+      { label: "production", value: ctx.attrs?.production },
+      { label: "region", value: ctx.attrs?.region?.slug },
+    ],
+  },
+);
+
+export const MySQLPasswordUI = UIProvider.succeed<MySQLPassword>(
+  "Planetscale.MySQLPassword",
+  {
+    displayName: "PlanetScale MySQL Password",
+    icon: "key-round",
+    color: PLANETSCALE_ORANGE,
+    category: "auth",
+    summary: (ctx) => ctx.attrs?.username ?? ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name },
+      { label: "id", value: ctx.attrs?.id, mono: true, copy: true },
+      { label: "username", value: ctx.attrs?.username, mono: true, copy: true },
+      { label: "host", value: ctx.attrs?.host, mono: true, copy: true },
+      { label: "database", value: ctx.attrs?.database },
+      { label: "branch", value: ctx.attrs?.branch },
+      { label: "role", value: ctx.attrs?.role },
+      { label: "expires", value: ctx.attrs?.expiresAt ?? undefined },
+    ],
+  },
+);
+
+export const PostgresDatabaseUI = UIProvider.succeed<PostgresDatabase>(
+  "Planetscale.PostgresDatabase",
+  {
+    displayName: "PlanetScale Postgres Database",
+    icon: "database",
+    color: PLANETSCALE_ORANGE,
+    category: "database",
+    summary: (ctx) => ctx.attrs?.name,
+    consoleUrl: (ctx) => ctx.attrs?.htmlUrl,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      { label: "id", value: ctx.attrs?.id, mono: true, copy: true },
+      { label: "organization", value: ctx.attrs?.organization },
+      { label: "region", value: ctx.attrs?.region?.slug },
+      { label: "plan", value: ctx.attrs?.plan },
+      { label: "cluster size", value: ctx.attrs?.clusterSize },
+      { label: "arch", value: ctx.attrs?.arch },
+      { label: "state", value: ctx.attrs?.state },
+    ],
+  },
+);
+
+export const PostgresBranchUI = UIProvider.succeed<PostgresBranch>(
+  "Planetscale.PostgresBranch",
+  {
+    displayName: "PlanetScale Postgres Branch",
+    icon: "git-branch",
+    color: PLANETSCALE_ORANGE,
+    category: "database",
+    summary: (ctx) => ctx.attrs?.name,
+    consoleUrl: (ctx) => ctx.attrs?.htmlUrl,
+    facts: (ctx) => [
+      { label: "branch", value: ctx.attrs?.name, copy: true },
+      { label: "database", value: ctx.attrs?.database },
+      { label: "organization", value: ctx.attrs?.organization },
+      { label: "parent branch", value: ctx.attrs?.parentBranch },
+      { label: "production", value: ctx.attrs?.production },
+      { label: "region", value: ctx.attrs?.region?.slug },
+    ],
+  },
+);
+
+export const PostgresRoleUI = UIProvider.succeed<PostgresRole>(
+  "Planetscale.PostgresRole",
+  {
+    displayName: "PlanetScale Postgres Role",
+    icon: "key-round",
+    color: PLANETSCALE_ORANGE,
+    category: "auth",
+    summary: (ctx) => ctx.attrs?.username ?? ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name },
+      { label: "id", value: ctx.attrs?.id, mono: true, copy: true },
+      { label: "username", value: ctx.attrs?.username, mono: true, copy: true },
+      { label: "host", value: ctx.attrs?.host, mono: true, copy: true },
+      {
+        label: "database",
+        value: ctx.attrs?.databaseName ?? ctx.attrs?.database,
+      },
+      { label: "branch", value: ctx.attrs?.branch },
+      { label: "expires", value: ctx.attrs?.expiresAt ?? undefined },
+    ],
+  },
+);
+
+export const PostgresDefaultRoleUI = UIProvider.succeed<PostgresDefaultRole>(
+  "Planetscale.PostgresDefaultRole",
+  {
+    displayName: "PlanetScale Postgres Default Role",
+    icon: "user-round",
+    color: PLANETSCALE_ORANGE,
+    category: "auth",
+    summary: (ctx) => ctx.attrs?.username ?? ctx.attrs?.name,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name },
+      { label: "id", value: ctx.attrs?.id, mono: true, copy: true },
+      { label: "username", value: ctx.attrs?.username, mono: true, copy: true },
+      { label: "host", value: ctx.attrs?.host, mono: true, copy: true },
+      {
+        label: "database",
+        value: ctx.attrs?.databaseName ?? ctx.attrs?.database,
+      },
+      { label: "branch", value: ctx.attrs?.branch },
+      { label: "expires", value: ctx.attrs?.expiresAt ?? undefined },
+    ],
+  },
+);
+
+export const ui = () =>
+  Layer.mergeAll(
+    MySQLDatabaseUI,
+    MySQLBranchUI,
+    MySQLPasswordUI,
+    PostgresDatabaseUI,
+    PostgresBranchUI,
+    PostgresRoleUI,
+    PostgresDefaultRoleUI,
+  );

--- a/packages/alchemy/src/Railway/UI.ts
+++ b/packages/alchemy/src/Railway/UI.ts
@@ -1,0 +1,716 @@
+import * as Layer from "effect/Layer";
+import * as UIProvider from "../UI/UIProvider.ts";
+import type { Bucket } from "./Bucket.ts";
+import type { CloudAgent } from "./CloudAgent.ts";
+import type { CustomDomain } from "./CustomDomain.ts";
+import type { Function as RailwayFunction } from "./Function.ts";
+import type { Group } from "./Group.ts";
+import type { Mongo } from "./Mongo.ts";
+import type { MySQL } from "./MySQL.ts";
+import type { Postgres } from "./Postgres.ts";
+import type {
+  PrivateNetwork,
+  PrivateNetworkEndpoint,
+} from "./PrivateNetwork.ts";
+import type { Project } from "./Project.ts";
+import type { Environment } from "./ProjectEnvironment.ts";
+import type { Redis } from "./Redis.ts";
+import type { Sandbox } from "./Sandbox.ts";
+import type { Service } from "./Service.ts";
+import type { TcpProxy } from "./TcpProxy.ts";
+import type { Template } from "./Template.ts";
+import type { UsageLimit } from "./Usage.ts";
+import type { Variable } from "./Variable.ts";
+import type { Volume } from "./Volume.ts";
+import type { VolumeBackup } from "./VolumeBackup.ts";
+import type { Cdn } from "./Website/Cdn.ts";
+
+/**
+ * Dashboard UI providers for Railway resources.
+ *
+ * Browser-safe: only `effect/*` runtime imports; resource types are
+ * type-only so no Railway SDK code reaches the dashboard bundle.
+ */
+
+const RAILWAY_PURPLE = "#853BCE";
+
+const projectUrl = (projectId: string | undefined): string | undefined =>
+  projectId === undefined
+    ? undefined
+    : `https://railway.com/project/${projectId}`;
+
+const serviceUrl = (
+  projectId: string | undefined,
+  serviceId: string | undefined,
+  environmentId: string | undefined,
+): string | undefined => {
+  if (projectId === undefined || serviceId === undefined) return undefined;
+  const base = `https://railway.com/project/${projectId}/service/${serviceId}`;
+  return environmentId === undefined
+    ? base
+    : `${base}?environmentId=${environmentId}`;
+};
+
+export const ProjectUI = UIProvider.succeed<Project>("Railway.Project", {
+  displayName: "Railway Project",
+  icon: "train-front",
+  color: RAILWAY_PURPLE,
+  category: "other",
+  summary: (ctx) => ctx.attrs?.name,
+  consoleUrl: (ctx) => ctx.attrs?.url,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.name, copy: true },
+    {
+      label: "project id",
+      value: ctx.attrs?.projectId,
+      mono: true,
+      copy: true,
+    },
+    { label: "workspace id", value: ctx.attrs?.workspaceId, mono: true },
+    { label: "base environment", value: ctx.attrs?.environmentId, mono: true },
+    { label: "url", value: ctx.attrs?.url, href: ctx.attrs?.url },
+  ],
+});
+
+export const EnvironmentUI = UIProvider.succeed<Environment>(
+  "Railway.Environment",
+  {
+    displayName: "Railway Environment",
+    icon: "layers",
+    color: RAILWAY_PURPLE,
+    category: "config",
+    summary: (ctx) => ctx.attrs?.name,
+    consoleUrl: (ctx) => ctx.attrs?.url,
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      {
+        label: "environment id",
+        value: ctx.attrs?.environmentId,
+        mono: true,
+        copy: true,
+      },
+      { label: "project id", value: ctx.attrs?.projectId, mono: true },
+      { label: "ephemeral", value: ctx.attrs?.isEphemeral },
+      { label: "url", value: ctx.attrs?.url, href: ctx.attrs?.url },
+    ],
+  },
+);
+
+export const ServiceUI = UIProvider.succeed<Service>("Railway.Service", {
+  displayName: "Railway Service",
+  icon: "server",
+  color: RAILWAY_PURPLE,
+  category: "compute",
+  summary: (ctx) => ctx.attrs?.name,
+  link: (ctx) => ctx.attrs?.url,
+  consoleUrl: (ctx) =>
+    serviceUrl(
+      ctx.attrs?.projectId,
+      ctx.attrs?.serviceId,
+      ctx.attrs?.environmentId,
+    ),
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.name, copy: true },
+    {
+      label: "service id",
+      value: ctx.attrs?.serviceId,
+      mono: true,
+      copy: true,
+    },
+    { label: "image", value: ctx.attrs?.image, mono: true },
+    { label: "repo", value: ctx.attrs?.repo, mono: true },
+    { label: "deployment", value: ctx.attrs?.deploymentStatus },
+    { label: "private dns", value: ctx.attrs?.dnsName, mono: true, copy: true },
+    {
+      label: "url",
+      value: ctx.attrs?.url,
+      href: ctx.attrs?.url,
+      copy: true,
+    },
+  ],
+});
+
+export const FunctionUI = UIProvider.succeed<RailwayFunction>(
+  "Railway.Function",
+  {
+    displayName: "Railway Function",
+    icon: "zap",
+    color: RAILWAY_PURPLE,
+    category: "compute",
+    summary: (ctx) => ctx.attrs?.name,
+    link: (ctx) => ctx.attrs?.url,
+    consoleUrl: (ctx) =>
+      serviceUrl(
+        ctx.attrs?.projectId,
+        ctx.attrs?.serviceId,
+        ctx.attrs?.environmentId,
+      ),
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      {
+        label: "service id",
+        value: ctx.attrs?.serviceId,
+        mono: true,
+        copy: true,
+      },
+      { label: "runtime", value: ctx.attrs?.runtime },
+      { label: "cron", value: ctx.attrs?.cronSchedule, mono: true },
+      { label: "deployment", value: ctx.attrs?.deploymentStatus },
+      {
+        label: "private dns",
+        value: ctx.attrs?.dnsName,
+        mono: true,
+        copy: true,
+      },
+      {
+        label: "url",
+        value: ctx.attrs?.url,
+        href: ctx.attrs?.url,
+        copy: true,
+      },
+    ],
+  },
+);
+
+export const PostgresUI = UIProvider.succeed<Postgres>("Railway.Postgres", {
+  displayName: "Railway Postgres",
+  icon: "database",
+  color: RAILWAY_PURPLE,
+  category: "database",
+  summary: (ctx) => ctx.attrs?.name,
+  consoleUrl: (ctx) =>
+    serviceUrl(
+      ctx.attrs?.projectId,
+      ctx.attrs?.serviceId,
+      ctx.attrs?.environmentId,
+    ),
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.name, copy: true },
+    {
+      label: "service id",
+      value: ctx.attrs?.serviceId,
+      mono: true,
+      copy: true,
+    },
+    { label: "image", value: ctx.attrs?.image, mono: true },
+    { label: "database", value: ctx.attrs?.database },
+    { label: "user", value: ctx.attrs?.user },
+    {
+      label: "public endpoint",
+      value:
+        ctx.attrs?.tcpProxyDomain !== undefined &&
+        ctx.attrs?.tcpProxyPort !== undefined
+          ? `${ctx.attrs.tcpProxyDomain}:${ctx.attrs.tcpProxyPort}`
+          : undefined,
+      mono: true,
+      copy: true,
+    },
+    { label: "deployment", value: ctx.attrs?.deploymentStatus },
+  ],
+});
+
+export const MySQLUI = UIProvider.succeed<MySQL>("Railway.MySQL", {
+  displayName: "Railway MySQL",
+  icon: "database",
+  color: RAILWAY_PURPLE,
+  category: "database",
+  summary: (ctx) => ctx.attrs?.name,
+  consoleUrl: (ctx) =>
+    serviceUrl(
+      ctx.attrs?.projectId,
+      ctx.attrs?.serviceId,
+      ctx.attrs?.environmentId,
+    ),
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.name, copy: true },
+    {
+      label: "service id",
+      value: ctx.attrs?.serviceId,
+      mono: true,
+      copy: true,
+    },
+    { label: "image", value: ctx.attrs?.image, mono: true },
+    { label: "database", value: ctx.attrs?.database },
+    { label: "user", value: ctx.attrs?.user },
+    {
+      label: "public endpoint",
+      value:
+        ctx.attrs?.tcpProxyDomain !== undefined &&
+        ctx.attrs?.tcpProxyPort !== undefined
+          ? `${ctx.attrs.tcpProxyDomain}:${ctx.attrs.tcpProxyPort}`
+          : undefined,
+      mono: true,
+      copy: true,
+    },
+    { label: "deployment", value: ctx.attrs?.deploymentStatus },
+  ],
+});
+
+export const MongoUI = UIProvider.succeed<Mongo>("Railway.Mongo", {
+  displayName: "Railway Mongo",
+  icon: "leaf",
+  color: RAILWAY_PURPLE,
+  category: "database",
+  summary: (ctx) => ctx.attrs?.name,
+  consoleUrl: (ctx) =>
+    serviceUrl(
+      ctx.attrs?.projectId,
+      ctx.attrs?.serviceId,
+      ctx.attrs?.environmentId,
+    ),
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.name, copy: true },
+    {
+      label: "service id",
+      value: ctx.attrs?.serviceId,
+      mono: true,
+      copy: true,
+    },
+    { label: "image", value: ctx.attrs?.image, mono: true },
+    { label: "database", value: ctx.attrs?.database },
+    { label: "user", value: ctx.attrs?.user },
+    {
+      label: "public endpoint",
+      value:
+        ctx.attrs?.tcpProxyDomain !== undefined &&
+        ctx.attrs?.tcpProxyPort !== undefined
+          ? `${ctx.attrs.tcpProxyDomain}:${ctx.attrs.tcpProxyPort}`
+          : undefined,
+      mono: true,
+      copy: true,
+    },
+    { label: "deployment", value: ctx.attrs?.deploymentStatus },
+  ],
+});
+
+export const RedisUI = UIProvider.succeed<Redis>("Railway.Redis", {
+  displayName: "Railway Redis",
+  icon: "database",
+  color: RAILWAY_PURPLE,
+  category: "database",
+  summary: (ctx) => ctx.attrs?.name,
+  consoleUrl: (ctx) =>
+    serviceUrl(
+      ctx.attrs?.projectId,
+      ctx.attrs?.serviceId,
+      ctx.attrs?.environmentId,
+    ),
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.name, copy: true },
+    {
+      label: "service id",
+      value: ctx.attrs?.serviceId,
+      mono: true,
+      copy: true,
+    },
+    { label: "image", value: ctx.attrs?.image, mono: true },
+    { label: "port", value: ctx.attrs?.port },
+    {
+      label: "private host",
+      value: ctx.attrs?.privateHost,
+      mono: true,
+      copy: true,
+    },
+    { label: "region", value: ctx.attrs?.region },
+    { label: "deployment", value: ctx.attrs?.deploymentStatus },
+  ],
+});
+
+export const BucketUI = UIProvider.succeed<Bucket>("Railway.Bucket", {
+  displayName: "Railway Bucket",
+  icon: "cylinder",
+  color: RAILWAY_PURPLE,
+  category: "storage",
+  summary: (ctx) => ctx.attrs?.name,
+  consoleUrl: (ctx) => projectUrl(ctx.attrs?.projectId),
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.name, copy: true },
+    { label: "bucket id", value: ctx.attrs?.bucketId, mono: true, copy: true },
+    {
+      label: "s3 bucket",
+      value: ctx.attrs?.s3BucketName,
+      mono: true,
+      copy: true,
+    },
+    {
+      label: "endpoint",
+      value: ctx.attrs?.endpoint,
+      href: ctx.attrs?.endpoint,
+      mono: true,
+      copy: true,
+    },
+    { label: "region", value: ctx.attrs?.region },
+    { label: "environment", value: ctx.attrs?.environmentId, mono: true },
+  ],
+});
+
+export const VolumeUI = UIProvider.succeed<Volume>("Railway.Volume", {
+  displayName: "Railway Volume",
+  icon: "hard-drive",
+  color: RAILWAY_PURPLE,
+  category: "storage",
+  summary: (ctx) => ctx.attrs?.name,
+  consoleUrl: (ctx) => projectUrl(ctx.attrs?.projectId),
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.name, copy: true },
+    { label: "volume id", value: ctx.attrs?.volumeId, mono: true, copy: true },
+    { label: "mount path", value: ctx.attrs?.mountPath, mono: true },
+    { label: "size (MB)", value: ctx.attrs?.sizeMB },
+    { label: "state", value: ctx.attrs?.state },
+    { label: "service", value: ctx.attrs?.serviceId, mono: true },
+    { label: "region", value: ctx.attrs?.region },
+  ],
+});
+
+export const VolumeBackupUI = UIProvider.succeed<VolumeBackup>(
+  "Railway.VolumeBackup",
+  {
+    displayName: "Railway Volume Backup",
+    icon: "archive",
+    color: RAILWAY_PURPLE,
+    category: "storage",
+    summary: (ctx) => ctx.attrs?.name,
+    consoleUrl: (ctx) => projectUrl(ctx.attrs?.projectId),
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      {
+        label: "backup id",
+        value: ctx.attrs?.volumeInstanceBackupId,
+        mono: true,
+        copy: true,
+      },
+      { label: "volume id", value: ctx.attrs?.volumeId, mono: true },
+      { label: "used (MB)", value: ctx.attrs?.usedMB },
+      { label: "locked", value: ctx.attrs?.locked },
+      { label: "expires", value: ctx.attrs?.expiresAt },
+      { label: "schedules", value: ctx.attrs?.schedules?.join(", ") },
+    ],
+  },
+);
+
+export const VariableUI = UIProvider.succeed<Variable>("Railway.Variable", {
+  displayName: "Railway Variable",
+  icon: "variable",
+  color: RAILWAY_PURPLE,
+  category: "config",
+  summary: (ctx) => ctx.attrs?.name,
+  consoleUrl: (ctx) =>
+    serviceUrl(
+      ctx.attrs?.projectId,
+      ctx.attrs?.serviceId,
+      ctx.attrs?.environmentId,
+    ) ?? projectUrl(ctx.attrs?.projectId),
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.name, mono: true, copy: true },
+    { label: "digest", value: ctx.attrs?.digest, mono: true },
+    { label: "service id", value: ctx.attrs?.serviceId, mono: true },
+    { label: "environment", value: ctx.attrs?.environmentId, mono: true },
+    { label: "project id", value: ctx.attrs?.projectId, mono: true },
+  ],
+});
+
+export const CustomDomainUI = UIProvider.succeed<CustomDomain>(
+  "Railway.CustomDomain",
+  {
+    displayName: "Railway Custom Domain",
+    icon: "globe",
+    color: RAILWAY_PURPLE,
+    category: "dns",
+    summary: (ctx) => ctx.attrs?.domain,
+    link: (ctx) => ctx.attrs?.url,
+    consoleUrl: (ctx) =>
+      serviceUrl(
+        ctx.attrs?.projectId,
+        ctx.attrs?.serviceId,
+        ctx.attrs?.environmentId,
+      ),
+    facts: (ctx) => [
+      { label: "domain", value: ctx.attrs?.domain, copy: true },
+      {
+        label: "domain id",
+        value: ctx.attrs?.customDomainId,
+        mono: true,
+        copy: true,
+      },
+      { label: "verified", value: ctx.attrs?.verified },
+      { label: "certificate", value: ctx.attrs?.certificateStatus },
+      { label: "target port", value: ctx.attrs?.targetPort },
+      { label: "sync status", value: ctx.attrs?.syncStatus },
+      {
+        label: "url",
+        value: ctx.attrs?.url,
+        href: ctx.attrs?.url,
+        copy: true,
+      },
+    ],
+  },
+);
+
+export const TcpProxyUI = UIProvider.succeed<TcpProxy>("Railway.TcpProxy", {
+  displayName: "Railway TCP Proxy",
+  icon: "network",
+  color: RAILWAY_PURPLE,
+  category: "network",
+  summary: (ctx) =>
+    ctx.attrs?.domain !== undefined && ctx.attrs?.proxyPort !== undefined
+      ? `${ctx.attrs.domain}:${ctx.attrs.proxyPort}`
+      : undefined,
+  facts: (ctx) => [
+    {
+      label: "endpoint",
+      value:
+        ctx.attrs?.domain !== undefined && ctx.attrs?.proxyPort !== undefined
+          ? `${ctx.attrs.domain}:${ctx.attrs.proxyPort}`
+          : undefined,
+      mono: true,
+      copy: true,
+    },
+    { label: "proxy id", value: ctx.attrs?.id, mono: true, copy: true },
+    { label: "application port", value: ctx.attrs?.applicationPort },
+    { label: "service id", value: ctx.attrs?.serviceId, mono: true },
+    { label: "sync status", value: ctx.attrs?.syncStatus },
+  ],
+});
+
+export const PrivateNetworkUI = UIProvider.succeed<PrivateNetwork>(
+  "Railway.PrivateNetwork",
+  {
+    displayName: "Railway Private Network",
+    icon: "network",
+    color: RAILWAY_PURPLE,
+    category: "network",
+    summary: (ctx) => ctx.attrs?.name,
+    consoleUrl: (ctx) => projectUrl(ctx.attrs?.projectId),
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      {
+        label: "public id",
+        value: ctx.attrs?.publicId,
+        mono: true,
+        copy: true,
+      },
+      { label: "network id", value: ctx.attrs?.networkId, mono: true },
+      { label: "dns", value: ctx.attrs?.dnsName, mono: true, copy: true },
+      { label: "environment", value: ctx.attrs?.environmentId, mono: true },
+      { label: "created", value: ctx.attrs?.createdAt },
+    ],
+  },
+);
+
+export const PrivateNetworkEndpointUI =
+  UIProvider.succeed<PrivateNetworkEndpoint>("Railway.PrivateNetworkEndpoint", {
+    displayName: "Railway Private Network Endpoint",
+    icon: "link",
+    color: RAILWAY_PURPLE,
+    category: "network",
+    summary: (ctx) => ctx.attrs?.dnsName,
+    consoleUrl: (ctx) =>
+      serviceUrl(
+        ctx.attrs?.projectId,
+        ctx.attrs?.serviceId,
+        ctx.attrs?.environmentId,
+      ),
+    facts: (ctx) => [
+      { label: "dns", value: ctx.attrs?.dnsName, mono: true, copy: true },
+      {
+        label: "endpoint id",
+        value: ctx.attrs?.publicId,
+        mono: true,
+        copy: true,
+      },
+      { label: "service id", value: ctx.attrs?.serviceId, mono: true },
+      { label: "network id", value: ctx.attrs?.privateNetworkId, mono: true },
+      {
+        label: "private ips",
+        value: ctx.attrs?.privateIps?.join(", "),
+        mono: true,
+      },
+      { label: "sync status", value: ctx.attrs?.syncStatus },
+    ],
+  });
+
+export const GroupUI = UIProvider.succeed<Group>("Railway.Group", {
+  displayName: "Railway Group",
+  icon: "boxes",
+  color: RAILWAY_PURPLE,
+  category: "other",
+  summary: (ctx) => ctx.attrs?.name,
+  consoleUrl: (ctx) => projectUrl(ctx.attrs?.projectId),
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.name, copy: true },
+    { label: "group id", value: ctx.attrs?.groupId, mono: true, copy: true },
+    { label: "services", value: ctx.attrs?.serviceIds?.length },
+    { label: "volumes", value: ctx.attrs?.volumeIds?.length },
+    { label: "buckets", value: ctx.attrs?.bucketIds?.length },
+    { label: "collapsed", value: ctx.attrs?.collapsed },
+  ],
+});
+
+export const TemplateUI = UIProvider.succeed<Template>("Railway.Template", {
+  displayName: "Railway Template",
+  icon: "layout-template",
+  color: RAILWAY_PURPLE,
+  category: "other",
+  summary: (ctx) => ctx.attrs?.name ?? ctx.props?.templateId,
+  consoleUrl: (ctx) => ctx.attrs?.url,
+  facts: (ctx) => [
+    { label: "name", value: ctx.attrs?.name, copy: true },
+    {
+      label: "template id",
+      value: ctx.attrs?.templateId,
+      mono: true,
+      copy: true,
+    },
+    { label: "code", value: ctx.attrs?.code, mono: true },
+    { label: "services", value: ctx.attrs?.serviceIds?.length },
+    { label: "owns project", value: ctx.attrs?.ownsProject },
+    { label: "url", value: ctx.attrs?.url, href: ctx.attrs?.url },
+  ],
+});
+
+export const CloudAgentUI = UIProvider.succeed<CloudAgent>(
+  "Railway.CloudAgent",
+  {
+    displayName: "Railway Cloud Agent",
+    icon: "cpu",
+    color: RAILWAY_PURPLE,
+    category: "compute",
+    summary: (ctx) => ctx.attrs?.name,
+    link: (ctx) =>
+      ctx.attrs?.domain === undefined
+        ? undefined
+        : `https://${ctx.attrs.domain}`,
+    consoleUrl: (ctx) => projectUrl(ctx.attrs?.projectId),
+    facts: (ctx) => [
+      { label: "name", value: ctx.attrs?.name, copy: true },
+      {
+        label: "agent id",
+        value: ctx.attrs?.cloudAgentId,
+        mono: true,
+        copy: true,
+      },
+      { label: "status", value: ctx.attrs?.status },
+      {
+        label: "domain",
+        value: ctx.attrs?.domain,
+        href:
+          ctx.attrs?.domain === undefined
+            ? undefined
+            : `https://${ctx.attrs.domain}`,
+        copy: true,
+      },
+      { label: "environment", value: ctx.attrs?.environmentId, mono: true },
+      { label: "created", value: ctx.attrs?.createdAt },
+    ],
+  },
+);
+
+export const SandboxUI = UIProvider.succeed<Sandbox>("Railway.Sandbox", {
+  displayName: "Railway Sandbox",
+  icon: "box",
+  color: RAILWAY_PURPLE,
+  category: "compute",
+  summary: (ctx) => ctx.attrs?.sandboxId,
+  consoleUrl: (ctx) => projectUrl(ctx.attrs?.projectId),
+  facts: (ctx) => [
+    {
+      label: "sandbox id",
+      value: ctx.attrs?.sandboxId,
+      mono: true,
+      copy: true,
+    },
+    { label: "status", value: ctx.attrs?.status },
+    { label: "region", value: ctx.attrs?.region },
+    { label: "isolation", value: ctx.attrs?.networkIsolation },
+    { label: "idle timeout (min)", value: ctx.attrs?.idleTimeoutMinutes },
+    { label: "environment", value: ctx.attrs?.environmentId, mono: true },
+    { label: "created", value: ctx.attrs?.createdAt },
+  ],
+});
+
+export const UsageLimitUI = UIProvider.succeed<UsageLimit>(
+  "Railway.UsageLimit",
+  {
+    displayName: "Railway Usage Limit",
+    icon: "wallet",
+    color: RAILWAY_PURPLE,
+    category: "billing",
+    summary: (ctx) =>
+      ctx.attrs?.softLimitDollars === undefined
+        ? undefined
+        : `$${ctx.attrs.softLimitDollars} soft cap`,
+    facts: (ctx) => [
+      {
+        label: "soft limit",
+        value:
+          ctx.attrs?.softLimitDollars === undefined
+            ? undefined
+            : `$${ctx.attrs.softLimitDollars}`,
+      },
+      {
+        label: "hard limit",
+        value:
+          ctx.attrs?.hardLimitDollars === undefined
+            ? undefined
+            : `$${ctx.attrs.hardLimitDollars}`,
+      },
+      { label: "over limit", value: ctx.attrs?.isOverLimit },
+      { label: "customer id", value: ctx.attrs?.customerId, mono: true },
+      { label: "workspace id", value: ctx.attrs?.workspaceId, mono: true },
+      {
+        label: "limit id",
+        value: ctx.attrs?.usageLimitId,
+        mono: true,
+        copy: true,
+      },
+    ],
+  },
+);
+
+export const CdnUI = UIProvider.succeed<Cdn>("Railway.Website.Cdn", {
+  displayName: "Railway Website CDN",
+  icon: "cloud",
+  color: RAILWAY_PURPLE,
+  category: "cdn",
+  summary: (ctx) => ctx.attrs?.edgeConfigId,
+  facts: (ctx) => [
+    {
+      label: "edge config id",
+      value: ctx.attrs?.edgeConfigId,
+      mono: true,
+      copy: true,
+    },
+    { label: "enabled", value: ctx.attrs?.enabled },
+    { label: "service id", value: ctx.attrs?.serviceId, mono: true },
+    { label: "environment", value: ctx.attrs?.environmentId, mono: true },
+    { label: "html caching", value: ctx.props?.htmlCaching },
+    { label: "purge on deploy", value: ctx.props?.purgeOnDeploy },
+    { label: "default ttl (s)", value: ctx.props?.defaultTtlSeconds },
+  ],
+});
+
+export const ui = () =>
+  Layer.mergeAll(
+    ProjectUI,
+    EnvironmentUI,
+    ServiceUI,
+    FunctionUI,
+    PostgresUI,
+    MySQLUI,
+    MongoUI,
+    RedisUI,
+    BucketUI,
+    VolumeUI,
+    VolumeBackupUI,
+    VariableUI,
+    CustomDomainUI,
+    TcpProxyUI,
+    PrivateNetworkUI,
+    PrivateNetworkEndpointUI,
+    GroupUI,
+    TemplateUI,
+    CloudAgentUI,
+    SandboxUI,
+    UsageLimitUI,
+    CdnUI,
+  );

--- a/packages/alchemy/src/UI/UIProvider.ts
+++ b/packages/alchemy/src/UI/UIProvider.ts
@@ -1,0 +1,216 @@
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import type { ComponentType } from "react";
+import type { ResourceLike } from "../Resource.ts";
+import type { ResourceStatus } from "../State/ResourceState.ts";
+
+/**
+ * UIProvider is the dashboard counterpart of {@link Provider}: where a
+ * `Provider` implements a resource's lifecycle operations, a `UIProvider`
+ * implements how the resource *renders* in the alchemy dashboard — its icon,
+ * accent color, category, one-line summary, key facts, console deep link, and
+ * (for flagship resources) custom canvas-card and detail-page components.
+ *
+ * UIProviders are aggregated exactly like lifecycle providers: each service
+ * exposes a `ui()` Layer, clouds merge their services' layers, and the
+ * dashboard SPA builds one merged Layer into a {@link UIRegistry}.
+ *
+ * IMPORTANT — browser safety: UIProvider modules are bundled into the
+ * dashboard web app. They must only import `effect/*` and types. Reference
+ * resource types with `import type` and key the tag by the type *string*:
+ *
+ * ```ts
+ * import type { Bucket } from "./Bucket.ts";
+ * export const BucketUI = UIProvider.succeed<Bucket>("AWS.S3.Bucket", {
+ *   displayName: "S3 Bucket",
+ *   icon: "cylinder",
+ *   category: "storage",
+ *   summary: (ctx) => ctx.attrs?.bucketName,
+ * });
+ * ```
+ */
+export interface UIProvider<
+  R extends ResourceLike = ResourceLike,
+> extends Effect.Effect<UIProviderService<R>, never, UIProvider<R>> {
+  asEffect: () => Effect.Effect<UIProviderService<R>, never, UIProvider<R>>;
+  [Symbol.iterator]: () => Effect.EffectIterator<UIProvider<R>>;
+  of: (service: UIProviderService<R>) => UIProviderService<R>;
+}
+
+/**
+ * Prefix used to namespace UIProvider tags so they never collide with the
+ * lifecycle {@link Provider} tags, which are keyed by the bare type string.
+ */
+const keyOf = (type: string) => `UI(${type})`;
+
+export const UIProvider = <R extends ResourceLike>(
+  type: R["Type"],
+): UIProvider<R> =>
+  Context.Service<UIProvider<R>, UIProviderService<R>>()(keyOf(type)) as any;
+
+/**
+ * Coarse grouping used for filtering and default styling in the dashboard.
+ */
+export type UICategory =
+  | "compute"
+  | "storage"
+  | "database"
+  | "network"
+  | "dns"
+  | "queue"
+  | "eventing"
+  | "ai"
+  | "auth"
+  | "security"
+  | "observability"
+  | "cdn"
+  | "email"
+  | "media"
+  | "config"
+  | "billing"
+  | "other";
+
+/**
+ * A key/value fact rendered in the inspector panel and the default detail
+ * page. Values are read from persisted state, so they may be `undefined`
+ * until the resource has been deployed.
+ */
+export interface UIFact {
+  label: string;
+  value: string | number | boolean | undefined;
+  /** Render the value in monospace (ids, ARNs, hashes). */
+  mono?: boolean;
+  /** Render the value as an external link. */
+  href?: string;
+  /** Show a copy-to-clipboard affordance. */
+  copy?: boolean;
+}
+
+/**
+ * Everything the dashboard knows about one resource instance, passed to every
+ * UIProvider callback. `props`/`attrs` come from the persisted state and may
+ * be absent for resources that have not been deployed yet — always use
+ * optional chaining.
+ */
+export interface ResourceUIContext<R extends ResourceLike = ResourceLike> {
+  fqn: string;
+  logicalId: string;
+  type: R["Type"];
+  status: ResourceStatus;
+  stack: string;
+  stage: string;
+  /** Persisted (resolved) input properties. */
+  props?: Record<string, any>;
+  /** Persisted output attributes. */
+  attrs?: Partial<R["Attributes"]>;
+  /** Bindings attached to this resource (it is the host). */
+  bindings: { sid: string; data: any }[];
+  /** FQNs of resources that depend on this one. */
+  downstream: string[];
+}
+
+export interface UIProviderService<R extends ResourceLike = ResourceLike> {
+  /**
+   * Short human name, e.g. "S3 Bucket". Defaults to the last segment of the
+   * resource type.
+   */
+  displayName?: string;
+  /**
+   * Icon: a lucide-react icon name in kebab-case (e.g. "database",
+   * "hard-drive") or a custom component for brand icons.
+   */
+  icon?: string | ComponentType<{ size?: number; color?: string }>;
+  /** Accent color (hex) used for the icon and node tint. */
+  color?: string;
+  /** Coarse grouping used for filtering + default colors. */
+  category?: UICategory;
+  /** One-line node subtitle, e.g. the physical name. */
+  summary?: (ctx: ResourceUIContext<R>) => string | undefined;
+  /**
+   * Primary external URL for the resource itself (workers.dev URL, Lambda
+   * function URL, hostname, ...).
+   */
+  link?: (ctx: ResourceUIContext<R>) => string | undefined;
+  /** Deep link into the cloud provider's web console. */
+  consoleUrl?: (ctx: ResourceUIContext<R>) => string | undefined;
+  /** Key/value facts for the inspector and default detail page. */
+  facts?: (ctx: ResourceUIContext<R>) => UIFact[];
+  /** Custom canvas-node card body (flagship resources only). */
+  Card?: ComponentType<{ ctx: ResourceUIContext<R> }>;
+  /** Custom full detail page (flagship resources only). */
+  Details?: ComponentType<{ ctx: ResourceUIContext<R> }>;
+}
+
+/**
+ * Provide a UIProvider eagerly, mirroring `Provider.succeed`.
+ *
+ * ```ts
+ * export const QueueUI = UIProvider.succeed<Queue>("AWS.SQS.Queue", {
+ *   displayName: "SQS Queue",
+ *   icon: "list-ordered",
+ *   category: "queue",
+ * });
+ * ```
+ */
+export const succeed = <R extends ResourceLike>(
+  type: R["Type"],
+  service: UIProviderService<R>,
+): Layer.Layer<UIProvider<R>> =>
+  Layer.succeed(UIProvider<R>(type) as any, service) as Layer.Layer<
+    UIProvider<R>
+  >;
+
+/**
+ * Provide a UIProvider from an Effect, mirroring `Provider.effect`. Useful
+ * when construction needs other services from the UI layer graph.
+ */
+export const effect = <R extends ResourceLike, Req = never>(
+  type: R["Type"],
+  eff: Effect.Effect<UIProviderService<R>, never, Req>,
+): Layer.Layer<UIProvider<R>, never, Req> =>
+  Layer.effect(UIProvider<R>(type) as any, eff) as Layer.Layer<
+    UIProvider<R>,
+    never,
+    Req
+  >;
+
+/**
+ * The registry the dashboard app resolves node renderers from. Built once at
+ * startup from the merged UI layer of every cloud.
+ */
+export interface UIRegistry {
+  readonly providers: ReadonlyMap<string, UIProviderService>;
+  get(type: string): UIProviderService | undefined;
+}
+
+/**
+ * Build a {@link UIRegistry} from a merged Layer of UIProviders. UIProvider
+ * services are plain objects with no finalizers, so the build scope is closed
+ * immediately after the context is materialized.
+ */
+export const buildRegistry = (
+  layer: Layer.Layer<any, never, never>,
+): Effect.Effect<UIRegistry> =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const context: Context.Context<never> = yield* Layer.build(layer);
+      const providers = new Map<string, UIProviderService>();
+      for (const [key, value] of (context as any).mapUnsafe as Map<
+        string,
+        unknown
+      >) {
+        if (
+          typeof key === "string" &&
+          key.startsWith("UI(") &&
+          key.endsWith(")")
+        ) {
+          providers.set(key.slice(3, -1), value as UIProviderService);
+        }
+      }
+      return {
+        providers,
+        get: (type: string) => providers.get(type),
+      } satisfies UIRegistry;
+    }),
+  );


### PR DESCRIPTION
Extracts the `UIProvider` layer out of [#1022](https://github.com/alchemy-run/alchemy/pull/1022) as a standalone, conflict-free PR: the contract plus per-resource UI provider modules for every implemented cloud, rebased onto current main. No dashboard app, server, or state-store changes — those come separately.

A `UIProvider` is the dashboard counterpart of `Provider`: where a `Provider` implements a resource's lifecycle, a `UIProvider` implements how it renders — icon, accent color, category, one-line summary, key facts, and console deep link.

```ts
export const BucketUI = UIProvider.succeed<Bucket>("AWS.S3.Bucket", {
  displayName: "S3 Bucket",
  icon: "cylinder",
  color: "#7AA116",
  category: "storage",
  summary: (ctx) => ctx.attrs?.bucketName,
  facts: (ctx) => [
    { label: "arn", value: ctx.attrs?.bucketArn, mono: true, copy: true },
  ],
});
```

UIProviders aggregate exactly like lifecycle providers: each service exposes a `ui()` Layer (`{Service}/ui.ts`), each cloud merges them in a `{Cloud}/UI.ts` barrel, and `UIProvider.buildRegistry` builds the merged Layer into a `UIRegistry`. Modules are browser-safe — runtime imports are only `effect/*`; resource types are `import type` so no SDK code reaches a dashboard bundle.

- `packages/alchemy/src/UI/UIProvider.ts` — contract, `succeed`/`effect` constructors, `buildRegistry`
- 298 UI modules covering 1,087 resource tags across ACME, AWS, Axiom, Cloudflare, Docker, Fly, GitHub, Hetzner, Kubernetes, Neon, Planetscale, Railway, Stripe
- includes coverage for everything that landed after #1022 diverged: Fly, Hetzner, Railway, Stripe, ACME, the new GitHub/EC2/ElastiCache resources, and additions to Cognito, Route53, Workers AI, and R2
- `package.json` export entries for `./UI/UIProvider` and the per-cloud `/UI` barrels that the `*/index.ts` wildcard exports would otherwise shadow

Every registered tag is verified against a real `Resource(...)`/`Platform(...)` tag, every string icon against lucide's icon names, and `tsc -b` on this branch reports exactly the same result as `main`.
