### PR TITLE
feat(cloudflare-runtime): update workerd and vendored Workers runtime sources

### DIFF
--- a/examples/cloudflare-agent/src/tools/Eval.ts
+++ b/examples/cloudflare-agent/src/tools/Eval.ts
@@ -24,7 +24,7 @@ export const EvalLive = Layer.effect(
       vm
         .load({
           mainModule: "index.js",
-          compatibilityDate: "2026-01-28",
+          compatibilityDate: "2026-08-31",
           modules: {
             "code.js": code,
             "index.js": dedent`

--- a/examples/cloudflare-dev/alchemy.run.ts
+++ b/examples/cloudflare-dev/alchemy.run.ts
@@ -122,7 +122,6 @@ const MediaWorker = Effect.gen(function* () {
   });
   const worker = yield* Cloudflare.Worker("MediaWorker", {
     main: "./src/MediaWorker.ts",
-    compatibility: { flags: ["nodejs_compat"] },
     env: {
       BROWSER: Cloudflare.Browser("BROWSER"),
       IMAGES: Cloudflare.Images.Images("IMAGES"),

--- a/examples/cloudflare-git-artifacts/src/Worker.ts
+++ b/examples/cloudflare-git-artifacts/src/Worker.ts
@@ -32,8 +32,7 @@ export default class Worker extends Cloudflare.Worker<Worker>()(
     main: import.meta.url,
     observability: { enabled: true },
     compatibility: {
-      flags: ["nodejs_compat"],
-      date: "2026-03-17",
+      date: "2026-08-31",
     },
   },
   Effect.gen(function* () {

--- a/examples/cloudflare-planetscale-mysql-drizzle/src/Api.ts
+++ b/examples/cloudflare-planetscale-mysql-drizzle/src/Api.ts
@@ -13,8 +13,7 @@ export default class Api extends Cloudflare.Worker<Api>()(
   {
     main: import.meta.url,
     compatibility: {
-      date: "2026-03-17",
-      flags: ["nodejs_compat"],
+      date: "2026-08-31",
     },
   },
   Effect.gen(function* () {

--- a/examples/cloudflare-solidjs-ssr/alchemy.run.ts
+++ b/examples/cloudflare-solidjs-ssr/alchemy.run.ts
@@ -10,9 +10,6 @@ export default Alchemy.Stack(
   },
   Effect.gen(function* () {
     const worker = yield* Cloudflare.Website.Vite("SolidJSSrr", {
-      compatibility: {
-        flags: ["nodejs_compat"],
-      },
       assets: {
         runWorkerFirst: true,
       },

--- a/examples/cloudflare-tanstack-rpc-drizzle/alchemy.run.ts
+++ b/examples/cloudflare-tanstack-rpc-drizzle/alchemy.run.ts
@@ -15,7 +15,8 @@ import { Hyperdrive, NeonDatabase } from "./src/backend/database.ts";
  */
 export class Website extends Cloudflare.Website.Vite<Website>()("Website", {
   compatibility: {
-    flags: ["nodejs_compat", "enable_request_signal"],
+    // Node.js compatibility is supplied by Alchemy's 2026-08-31 default.
+    flags: ["enable_request_signal"],
   },
   env: {
     BACKEND: Backend,

--- a/examples/cloudflare-tanstack-start-solid/alchemy.run.ts
+++ b/examples/cloudflare-tanstack-start-solid/alchemy.run.ts
@@ -2,11 +2,7 @@ import * as Alchemy from "alchemy";
 import * as Cloudflare from "alchemy/Cloudflare";
 import * as Effect from "effect/Effect";
 
-export const Website = Cloudflare.Website.Vite("Website", {
-  compatibility: {
-    flags: ["nodejs_compat"],
-  },
-});
+export const Website = Cloudflare.Website.Vite("Website", {});
 
 export default Alchemy.Stack(
   "CloudflareTanstackStartSolidExample",

--- a/examples/cloudflare-vue/alchemy.run.ts
+++ b/examples/cloudflare-vue/alchemy.run.ts
@@ -10,9 +10,6 @@ export default Alchemy.Stack(
   },
   Effect.gen(function* () {
     const worker = yield* Cloudflare.Website.Vite("Vue", {
-      compatibility: {
-        flags: ["nodejs_compat"],
-      },
       // vue-router runs in history mode, so deep links like /about must
       // fall back to index.html for the client router to resolve them.
       assets: {

--- a/examples/cloudflare-website-nuxt/nuxt.config.ts
+++ b/examples/cloudflare-website-nuxt/nuxt.config.ts
@@ -5,7 +5,7 @@ import { defineNuxtConfig } from "nuxt/config";
 // what the Cloudflare deploy needs (nitro's cloudflare_module preset).
 // Do NOT set `nitro.preset` here; the deploy target owns it.
 export default defineNuxtConfig({
-  compatibilityDate: "2026-07-01",
+  compatibilityDate: "2026-08-31",
   telemetry: { enabled: false },
   // Tailwind CSS v4 wired through this config — proof the project's own
   // nuxt.config.ts (vite plugins included) is loaded by the Alchemy build.

--- a/examples/cloudflare-website-react-router/README.md
+++ b/examples/cloudflare-website-react-router/README.md
@@ -9,7 +9,7 @@ they assemble into one Worker.
 
 - `app/routes/home.tsx` is a server component rendered in the Worker on
   every request; it reads the `GREETING` value declared in
-  `alchemy.run.ts` from `process.env` (populated by the `nodejs_compat`
+  `alchemy.run.ts` from `process.env` (populated by date-default Node.js
   compatibility flag).
 - `app/components/Card.tsx` is a React component styled with Tailwind
   utilities (wired through `@tailwindcss/vite` in `vite.config.ts`).

--- a/examples/cloudflare-website-react-router/alchemy.run.ts
+++ b/examples/cloudflare-website-react-router/alchemy.run.ts
@@ -16,8 +16,7 @@ export default Alchemy.Stack(
     // `loadModule` calls resolve in the deployed Worker.
     const site = yield* Cloudflare.Website.Vite("Website", {
       compatibility: {
-        date: "2026-03-10",
-        flags: ["nodejs_compat"],
+        date: "2026-08-31",
       },
       // Only hash the files that affect the build, so unchanged sources
       // skip the Vite build (and the deploy) entirely.

--- a/examples/cloudflare-website-react-router/app/routes/home.tsx
+++ b/examples/cloudflare-website-react-router/app/routes/home.tsx
@@ -2,7 +2,7 @@
 import { Card } from "../components/Card.tsx";
 
 // A server component: renders in the Worker on every request. With the
-// `nodejs_compat` compatibility flag, the `env` declared in
+// date-default Node.js compatibility, the `env` declared in
 // alchemy.run.ts is populated onto `process.env`.
 const Component = () => {
   const greeting = process.env.GREETING ?? "Hello!";

--- a/examples/cloudflare-website-solidstart/alchemy.run.ts
+++ b/examples/cloudflare-website-solidstart/alchemy.run.ts
@@ -10,9 +10,6 @@ export default Alchemy.Stack(
   },
   Effect.gen(function* () {
     const worker = yield* Cloudflare.Website.Vite("CloudflareSolidStart", {
-      compatibility: {
-        flags: ["nodejs_compat"],
-      },
       env: {
         GREETING: "Hello from SolidStart on Cloudflare!",
       },

--- a/examples/cloudflare-website-solidstart/src/routes/index.tsx
+++ b/examples/cloudflare-website-solidstart/src/routes/index.tsx
@@ -1,6 +1,6 @@
 import Card from "~/components/Card";
 
-// Server-rendered in the Cloudflare Worker. The `nodejs_compat` flag
+// Server-rendered in the Cloudflare Worker. Date-default Node.js compatibility
 // populates `process.env` from the Worker's environment, so the
 // `GREETING` value declared in alchemy.run.ts is read the same way as on
 // any Node server.

--- a/examples/cloudflare-website-tanstack-start/alchemy.run.ts
+++ b/examples/cloudflare-website-tanstack-start/alchemy.run.ts
@@ -4,9 +4,6 @@ import * as Effect from "effect/Effect";
 import Backend, { Bucket } from "./src/backend.ts";
 
 export class Website extends Cloudflare.Website.Vite<Website>()("Website", {
-  compatibility: {
-    flags: ["nodejs_compat"],
-  },
   env: {
     GREETING: "Hello from TanStack Start on Cloudflare!",
     BUCKET: Bucket,

--- a/examples/cloudflare-website-vocs/README.md
+++ b/examples/cloudflare-website-vocs/README.md
@@ -31,7 +31,7 @@ bun run destroy  # tear down the Worker and assets
 
 - `@alchemy.run/frontend-frameworks` must be installed in the project; the
   source provider is loaded from its `/vocs` exports at deploy time.
-- `nodejs_compat` is added automatically for the Vocs server runtime.
+- Node.js compatibility is enabled by the Worker's compatibility date.
 - Project inputs are content-hashed, respecting `.gitignore` by default, so
   unchanged projects skip the build and deployment.
 - When `vocs.config.ts` uses a custom `outDir`, pass the same value as the

--- a/examples/cloudflare-worker/src/Api.ts
+++ b/examples/cloudflare-worker/src/Api.ts
@@ -38,8 +38,7 @@ export default class Api extends Cloudflare.Worker<Api>()(
       bundleAnalyzer: true,
     },
     compatibility: {
-      date: "2026-03-17",
-      flags: ["nodejs_compat"],
+      date: "2026-08-31",
     },
   },
   Effect.gen(function* () {
@@ -196,7 +195,7 @@ export default class Api extends Cloudflare.Worker<Api>()(
           if (request.method === "POST") {
             const code = yield* request.text;
             const worker = yield* loader.load({
-              compatibilityDate: "2026-01-28",
+              compatibilityDate: "2026-08-31",
               mainModule: "worker.js",
               modules: {
                 "worker.js": `

--- a/examples/cloudflare-worker/src/WorkerTag.ts
+++ b/examples/cloudflare-worker/src/WorkerTag.ts
@@ -13,8 +13,7 @@ export default WorkerTag.make(
   {
     main: import.meta.url,
     compatibility: {
-      flags: ["nodejs_compat"],
-      date: "2026-04-26",
+      date: "2026-08-31",
     },
     observability: {
       enabled: true,

--- a/packages/alchemy/src/Cloudflare/Containers/Container.ts
+++ b/packages/alchemy/src/Cloudflare/Containers/Container.ts
@@ -82,7 +82,9 @@ export class ContainerCrashedError extends Data.TaggedError(
   readonly cause?: unknown;
 }> {}
 
-export interface ContainerStartupOptions extends cf.ContainerStartupOptions {}
+// Upstream changed ContainerStartupOptions to an intersection with an
+// image/containerSnapshot union, which an interface cannot extend.
+export type ContainerStartupOptions = cf.ContainerStartupOptions;
 
 import type {
   EffectfulContainerProps,

--- a/packages/alchemy/src/Cloudflare/EdgeSession.ts
+++ b/packages/alchemy/src/Cloudflare/EdgeSession.ts
@@ -1,3 +1,4 @@
+import { INTERNAL_WORKER_COMPATIBILITY_DATE as DEFAULT_COMPATIBILITY_DATE } from "@alchemy.run/cloudflare-runtime/core/internal/constants";
 import { Credentials } from "@distilled.cloud/cloudflare/Credentials";
 import * as workers from "@distilled.cloud/cloudflare/workers";
 import * as Data from "effect/Data";
@@ -46,10 +47,6 @@ export interface EdgeSessionHandle {
   readonly url: string;
   readonly headers: Record<string, string>;
 }
-
-// Keep previews aligned with the vendored workerd runtime. This date enables
-// Node.js compatibility by default without a compatibility flag.
-const DEFAULT_COMPATIBILITY_DATE = "2026-08-31";
 
 const wrap = <A, E, R>(effect: Effect.Effect<A, E, R>, message: string) =>
   effect.pipe(

--- a/packages/alchemy/src/Cloudflare/EdgeSession.ts
+++ b/packages/alchemy/src/Cloudflare/EdgeSession.ts
@@ -1,4 +1,4 @@
-import { INTERNAL_WORKER_COMPATIBILITY_DATE as DEFAULT_COMPATIBILITY_DATE } from "@alchemy.run/cloudflare-runtime/core/internal/constants";
+import { DEFAULT_COMPATIBILITY_DATE } from "@alchemy.run/cloudflare-runtime/core/internal/constants";
 import { Credentials } from "@distilled.cloud/cloudflare/Credentials";
 import * as workers from "@distilled.cloud/cloudflare/workers";
 import * as Data from "effect/Data";

--- a/packages/alchemy/src/Cloudflare/EdgeSession.ts
+++ b/packages/alchemy/src/Cloudflare/EdgeSession.ts
@@ -33,7 +33,7 @@ export interface EdgeSessionOptions {
   readonly files: ReadonlyArray<File>;
   /** Remote bindings attached to the preview worker. */
   readonly bindings: ReadonlyArray<EdgeBinding>;
-  /** @default "2025-04-28" */
+  /** @default "2026-08-31" */
   readonly compatibilityDate?: string;
 }
 
@@ -47,7 +47,9 @@ export interface EdgeSessionHandle {
   readonly headers: Record<string, string>;
 }
 
-const DEFAULT_COMPATIBILITY_DATE = "2025-04-28";
+// Keep previews aligned with the vendored workerd runtime. This date enables
+// Node.js compatibility by default without a compatibility flag.
+const DEFAULT_COMPATIBILITY_DATE = "2026-08-31";
 
 const wrap = <A, E, R>(effect: Effect.Effect<A, E, R>, message: string) =>
   effect.pipe(

--- a/packages/alchemy/src/Cloudflare/Pages/Project.ts
+++ b/packages/alchemy/src/Cloudflare/Pages/Project.ts
@@ -218,7 +218,7 @@ export type Project = Resource<
  * const project = yield* Cloudflare.Pages.Project("site", {
  *   deploymentConfigs: {
  *     production: {
- *       compatibilityDate: "2025-01-01",
+ *       compatibilityDate: "2026-08-31",
  *       envVars: {
  *         API_URL: { value: "https://api.example.com" },
  *         API_KEY: { type: "secret_text", value: apiKey },

--- a/packages/alchemy/src/Cloudflare/StateStore/Api.ts
+++ b/packages/alchemy/src/Cloudflare/StateStore/Api.ts
@@ -105,8 +105,8 @@ export default Worker(
     main: import.meta.url,
     workersDev: true,
     compatibility: {
-      flags: ["nodejs_compat"],
-      date: "2026-03-17",
+      // Node.js compatibility is default-on for this date.
+      date: "2026-08-31",
     },
   },
   Effect.gen(function* () {

--- a/packages/alchemy/src/Cloudflare/StateStore/Api.ts
+++ b/packages/alchemy/src/Cloudflare/StateStore/Api.ts
@@ -1,4 +1,4 @@
-import { INTERNAL_WORKER_COMPATIBILITY_DATE as DEFAULT_COMPATIBILITY_DATE } from "@alchemy.run/cloudflare-runtime/core/internal/constants";
+import { DEFAULT_COMPATIBILITY_DATE } from "@alchemy.run/cloudflare-runtime/core/internal/constants";
 import { Redacted } from "effect";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";

--- a/packages/alchemy/src/Cloudflare/StateStore/Api.ts
+++ b/packages/alchemy/src/Cloudflare/StateStore/Api.ts
@@ -1,3 +1,4 @@
+import { INTERNAL_WORKER_COMPATIBILITY_DATE as DEFAULT_COMPATIBILITY_DATE } from "@alchemy.run/cloudflare-runtime/core/internal/constants";
 import { Redacted } from "effect";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
@@ -105,8 +106,7 @@ export default Worker(
     main: import.meta.url,
     workersDev: true,
     compatibility: {
-      // Node.js compatibility is default-on for this date.
-      date: "2026-08-31",
+      date: DEFAULT_COMPATIBILITY_DATE,
     },
   },
   Effect.gen(function* () {

--- a/packages/alchemy/src/Cloudflare/Website/Nextjs.ts
+++ b/packages/alchemy/src/Cloudflare/Website/Nextjs.ts
@@ -1,3 +1,4 @@
+import { INTERNAL_WORKER_COMPATIBILITY_DATE as DEFAULT_COMPATIBILITY_DATE } from "@alchemy.run/cloudflare-runtime/core/internal/constants";
 import * as Effect from "effect/Effect";
 import type { MemoOptions } from "../../Command/Memo.ts";
 import type { InputProps } from "../../Input.ts";
@@ -20,13 +21,6 @@ import {
  * subpath.
  */
 const NEXTJS_SOURCE_PROVIDER = "@alchemy.run/frontend-frameworks/nextjs/source";
-
-/**
- * The default compatibility date when none is provided. Matches the
- * `@alchemy.run/frontend-frameworks/nextjs` integration's own default so deploy and local
- * dev agree.
- */
-const DEFAULT_COMPATIBILITY_DATE = "2026-08-31";
 
 export interface NextjsProps<
   Bindings extends WorkerBindingProps = {},

--- a/packages/alchemy/src/Cloudflare/Website/Nextjs.ts
+++ b/packages/alchemy/src/Cloudflare/Website/Nextjs.ts
@@ -26,7 +26,7 @@ const NEXTJS_SOURCE_PROVIDER = "@alchemy.run/frontend-frameworks/nextjs/source";
  * `@alchemy.run/frontend-frameworks/nextjs` integration's own default so deploy and local
  * dev agree.
  */
-const DEFAULT_COMPATIBILITY_DATE = "2026-05-12";
+const DEFAULT_COMPATIBILITY_DATE = "2026-08-31";
 
 export interface NextjsProps<
   Bindings extends WorkerBindingProps = {},
@@ -302,16 +302,11 @@ export const Nextjs: {
               WORKER_SELF_REFERENCE: Self,
               ...props?.env,
             },
-            // OpenNext requires nodejs_compat; the Worker here is external
-            // (no inline Effect entry), so the engine won't add it.
+            // OpenNext requires Node.js APIs. The 2026-08-31 default date
+            // enables both nodejs_compat modes, so no redundant flag is sent.
             compatibility: {
               date: props?.compatibility?.date ?? DEFAULT_COMPATIBILITY_DATE,
-              flags: Array.from(
-                new Set([
-                  "nodejs_compat",
-                  ...(props?.compatibility?.flags ?? []),
-                ]),
-              ),
+              flags: props?.compatibility?.flags,
             },
             // The OpenNext server owns routing: run the worker first and
             // leave asset-path rewriting off. Users can still override.

--- a/packages/alchemy/src/Cloudflare/Website/Nextjs.ts
+++ b/packages/alchemy/src/Cloudflare/Website/Nextjs.ts
@@ -1,4 +1,4 @@
-import { INTERNAL_WORKER_COMPATIBILITY_DATE as DEFAULT_COMPATIBILITY_DATE } from "@alchemy.run/cloudflare-runtime/core/internal/constants";
+import { DEFAULT_COMPATIBILITY_DATE } from "@alchemy.run/cloudflare-runtime/core/internal/constants";
 import * as Effect from "effect/Effect";
 import type { MemoOptions } from "../../Command/Memo.ts";
 import type { InputProps } from "../../Input.ts";

--- a/packages/alchemy/src/Cloudflare/Website/Vocs.ts
+++ b/packages/alchemy/src/Cloudflare/Website/Vocs.ts
@@ -58,7 +58,7 @@ export interface VocsProps<
  *
  * Input files are content-hashed (respecting `.gitignore` by default), so an
  * unchanged project skips its build and deployment. Vocs' server runtime uses
- * Node APIs, so `nodejs_compat` is included in the Worker's compatibility
+ * Node APIs, enabled by the Worker's compatibility date
  * flags automatically.
  *
  * ### Deploying a Vocs Site
@@ -170,12 +170,8 @@ export const Vocs: {
           Effect.isEffect(propsEff) ? propsEff : Effect.succeed(propsEff),
           (props) => ({
             ...props,
-            compatibility: {
-              ...props?.compatibility,
-              flags: props?.compatibility?.flags?.includes("nodejs_compat")
-                ? props.compatibility.flags
-                : [...(props?.compatibility?.flags ?? []), "nodejs_compat"],
-            },
+            // The Worker compatibility resolver enables Node.js APIs from
+            // the date (or adds the flag when a caller pins an older date).
             assets: {
               htmlHandling: "drop-trailing-slash" as const,
               ...props?.assets,

--- a/packages/alchemy/src/Cloudflare/Workers/BrowserHttpClient.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/BrowserHttpClient.ts
@@ -54,8 +54,8 @@ type BrowserByteStream = Stream.Stream<
  *   the distilled REST codec models as JSON status, not a byte stream.
  *
  * Because the REST data-plane only returns the action `result` (not the
- * runtime binding's `meta` envelope), `content`/`snapshot` populate `meta`
- * with a best-effort placeholder.
+ * runtime binding's `meta` envelope), JSON actions populate `meta` with a
+ * best-effort placeholder.
  */
 export const makeHttpBrowserClient = (auth: BrowserAuth): BrowserClient => {
   // Run a distilled Browser Rendering op with the injected auth and surface
@@ -94,6 +94,7 @@ export const makeHttpBrowserClient = (auth: BrowserAuth): BrowserClient => {
       Effect.map((result): BrowserMarkdownResult => ({
         success: true,
         result,
+        meta: { status: 200, title: "" },
       })),
     );
 
@@ -102,12 +103,17 @@ export const makeHttpBrowserClient = (auth: BrowserAuth): BrowserClient => {
       Effect.map((result): BrowserLinksResult => ({
         success: true,
         result: [...result],
+        meta: { status: 200, title: "" },
       })),
     );
 
   const json = (options: unknown) =>
     run(browser.createJson(req(options))).pipe(
-      Effect.map((result): BrowserJsonResult => ({ success: true, result })),
+      Effect.map((result): BrowserJsonResult => ({
+        success: true,
+        result,
+        meta: { status: 200, title: "" },
+      })),
     );
 
   const scrape = (options: unknown) =>
@@ -124,6 +130,7 @@ export const makeHttpBrowserClient = (auth: BrowserAuth): BrowserClient => {
                 item.results,
               ]) as BrowserScrapeResult["result"][number]["results"],
         })),
+        meta: { status: 200, title: "" },
       })),
     );
 

--- a/packages/alchemy/src/Cloudflare/Workers/Compatibility.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Compatibility.ts
@@ -34,6 +34,29 @@ const NODEJS_COMPAT_V2_DATE = "2024-09-23";
 // identical runtime behavior. Older user-pinned dates still need the flag.
 const NODEJS_COMPAT_DEFAULT_ON = "2026-08-04";
 
+/**
+ * Compatibility settings passed to build tools and framework adapters.
+ * Cloudflare rejects a redundant `nodejs_compat` flag after its default-on
+ * date, but downstream tools may still detect Node support from the explicit
+ * flag only, so internal build configuration materializes the effective flag.
+ */
+export const getToolingCompatibility = (
+  compatibility: { date: string; flags: string[] },
+  main: unknown,
+) => ({
+  date: compatibility.date,
+  // TODO: Stop materializing `nodejs_compat` once supported downstream tools
+  // consistently derive the default from the compatibility date.
+  flags:
+    isPythonMain(main) ||
+    compatibility.date < NODEJS_COMPAT_DEFAULT_ON ||
+    compatibility.flags.includes("nodejs_compat") ||
+    compatibility.flags.includes("nodejs_compat_v2") ||
+    compatibility.flags.includes("no_nodejs_compat")
+      ? compatibility.flags
+      : [...compatibility.flags, "nodejs_compat"],
+});
+
 export const getCompatibility = (props: WorkerProps) => {
   const userFlags = props.compatibility?.flags ?? [];
   const python = isPythonMain(props.main);

--- a/packages/alchemy/src/Cloudflare/Workers/Compatibility.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Compatibility.ts
@@ -1,7 +1,6 @@
+import { INTERNAL_WORKER_COMPATIBILITY_DATE as DEFAULT_COMPATIBILITY_DATE } from "@alchemy.run/cloudflare-runtime/core/internal/constants";
 import { isPythonMain } from "./Sources/Python.ts";
 import type { WorkerProps } from "./Worker.ts";
-
-const DEFAULT_COMPATIBILITY_DATE = "2026-08-31";
 
 /**
  * The Effect worker bridge builds its layer stack once per isolate and shares

--- a/packages/alchemy/src/Cloudflare/Workers/Compatibility.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Compatibility.ts
@@ -1,8 +1,7 @@
 import { isPythonMain } from "./Sources/Python.ts";
 import type { WorkerProps } from "./Worker.ts";
 
-// TODO: figure out why the later one from workerd breaks
-const DEFAULT_COMPATIBILITY_DATE = "2026-03-17";
+const DEFAULT_COMPATIBILITY_DATE = "2026-08-31";
 
 /**
  * The Effect worker bridge builds its layer stack once per isolate and shares
@@ -30,6 +29,11 @@ const CROSS_REQUEST_PROMISE_RESOLUTION_DEFAULT_ON = "2024-10-14";
 // `process.getBuiltinModule`) — deploying that combination fails at script
 // startup, so the default flag is only applied from this date onward.
 const NODEJS_COMPAT_V2_DATE = "2024-09-23";
+
+// Cloudflare enables both nodejs_compat modes from this date. Do not emit a
+// redundant positive flag for newer Workers; the compatibility date supplies
+// identical runtime behavior. Older user-pinned dates still need the flag.
+const NODEJS_COMPAT_DEFAULT_ON = "2026-08-04";
 
 export const getCompatibility = (props: WorkerProps) => {
   const userFlags = props.compatibility?.flags ?? [];
@@ -61,16 +65,20 @@ export const getCompatibility = (props: WorkerProps) => {
       // Required while Python Workers are in open beta — the upload API
       // rejects Python modules without it.
       ...(python ? ["python_workers"] : []),
-      // Every JS Worker gets `nodejs_compat` by default — Effect-native
+      // Every JS Worker gets Node.js compatibility by default — Effect-native
       // Workers need it for the bundled Effect runtime, and external Workers
       // (plain `export default { fetch }` entrypoints, vite builds) routinely
       // import `node:*` built-ins. Without it the bundle uploads fine but
       // Cloudflare rejects the script with `No such module "node:crypto"`
-      // (#796). Python Workers don't go through the JS bundler, so they get
-      // no default. An explicit `no_nodejs_compat` opts out — appending
+      // (#796). For dates before Cloudflare's default-on cutoff we still emit
+      // the flag; newer dates supply the behavior themselves. Python Workers
+      // don't go through the JS bundler, so they get no default. An explicit
+      // `no_nodejs_compat` opts out — appending
       // `nodejs_compat` alongside it would send Cloudflare a contradictory
       // flag pair.
-      ...(python || userFlags.includes("no_nodejs_compat")
+      ...(python ||
+      userFlags.includes("no_nodejs_compat") ||
+      date >= NODEJS_COMPAT_DEFAULT_ON
         ? []
         : props.isExternal
           ? // ISO dates compare lexically.

--- a/packages/alchemy/src/Cloudflare/Workers/Compatibility.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Compatibility.ts
@@ -1,4 +1,4 @@
-import { INTERNAL_WORKER_COMPATIBILITY_DATE as DEFAULT_COMPATIBILITY_DATE } from "@alchemy.run/cloudflare-runtime/core/internal/constants";
+import { DEFAULT_COMPATIBILITY_DATE } from "@alchemy.run/cloudflare-runtime/core/internal/constants";
 import { isPythonMain } from "./Sources/Python.ts";
 import type { WorkerProps } from "./Worker.ts";
 

--- a/packages/alchemy/src/Cloudflare/Workers/Source.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Source.ts
@@ -21,6 +21,7 @@ import type * as Bundle from "../../Bundle/Bundle.ts";
 import type { WorkflowExport } from "../Workflows/Workflow.ts";
 import type { AssetReadResult, ValidationError } from "./Assets.ts";
 import type { DurableObjectExport } from "./DurableObject.ts";
+import { getToolingCompatibility } from "./Compatibility.ts";
 import { makeInlineScriptSource } from "./Sources/InlineScript.ts";
 import { makePrebuiltSource } from "./Sources/Prebuilt.ts";
 import { isPythonMain, makePythonSource } from "./Sources/Python.ts";
@@ -396,7 +397,10 @@ export const makeSourceContext = (params: {
   id: params.id,
   fqn: params.fqn,
   workerName: params.workerName,
-  compatibility: params.compatibility,
+  compatibility: getToolingCompatibility(
+    params.compatibility,
+    params.props.main,
+  ),
   entry: params.props.isExternal
     ? { kind: "external" }
     : { kind: "effect", exports: params.props.exports ?? {} },

--- a/packages/alchemy/src/Cloudflare/Workers/Sources/Python.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Sources/Python.ts
@@ -140,15 +140,18 @@ const runUv = Effect.fn(function* (
  * - If the Worker's directory already contains `python_modules/` (the
  *   user vendored it themselves, e.g. with `pywrangler sync` or any other
  *   tool that produces Wrangler's vendored layout), it is used as-is.
- * - Otherwise, if `pyproject.toml` exists, its `[project.dependencies]`
- *   are vendored with uv into a staging directory under `.alchemy/`:
+ * - Otherwise, the managed Workers runtime SDK and any dependencies from an
+ *   optional `pyproject.toml` are vendored with uv into a staging directory
+ *   under `.alchemy/`:
  *   resolve against the Pyodide wheel index for the runtime's Python
  *   version (`uv pip compile` → `pylock.toml`), install the prebuilt
  *   wheels into an emscripten cross-venv (`uv venv` + `uv pip install
  *   --no-build`), and copy the venv's `site-packages` out. Re-vendoring
  *   is skipped while the `pyproject.toml` hash is unchanged.
- * - With neither, the Worker has no vendored dependencies (the `workers`
- *   SDK module built into the runtime is still importable).
+ *
+ * workerd no longer bundles the `workers` Python module at current
+ * compatibility dates, so even a dependency-free Worker needs the managed
+ * SDK under `python_modules/`.
  */
 const resolvePythonModulesDir = Effect.fn(function* (
   options: PythonWorkerBundleOptions & { root: string },
@@ -161,15 +164,15 @@ const resolvePythonModulesDir = Effect.fn(function* (
   }
 
   const pyproject = path.join(options.root, "pyproject.toml");
-  if (!(yield* orDefault(fs.exists(pyproject), false))) {
-    return undefined;
-  }
+  const hasPyproject = yield* orDefault(fs.exists(pyproject), false);
 
   const pythonVersion = pythonVersionForCompatibility(options.compatibility);
   const target = PYODIDE_TARGETS[pythonVersion];
-  const pyprojectContent = yield* fs
-    .readFileString(pyproject)
-    .pipe(Effect.mapError(uvError(`Failed to read "${pyproject}"`)));
+  const pyprojectContent = hasPyproject
+    ? yield* fs
+        .readFileString(pyproject)
+        .pipe(Effect.mapError(uvError(`Failed to read "${pyproject}"`)))
+    : "";
   const inputHash = yield* sha256(
     `${pythonVersion}\0${target.index}\0${pyprojectContent}`,
   );
@@ -206,7 +209,7 @@ const resolvePythonModulesDir = Effect.fn(function* (
     [
       "pip",
       "compile",
-      pyproject,
+      ...(hasPyproject ? [pyproject] : []),
       extraRequirements,
       "--python",
       target.interpreter,

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -1718,7 +1718,7 @@ export const isSelf = (value: unknown): value is Self =>
  *   main: import.meta.url,
  *   compatibility: {
  *     flags: ["nodejs_compat"],
- *     date: "2026-03-17",
+ *     date: "2026-08-31",
  *   },
  * }
  * ```
@@ -2273,7 +2273,7 @@ export const isSelf = (value: unknown): value is Self =>
  * return {
  *   fetch: Effect.gen(function* () {
  *     const worker = yield* loader.load({
- *       compatibilityDate: "2026-01-28",
+ *       compatibilityDate: "2026-08-31",
  *       mainModule: "worker.js",
  *       modules: {
  *         "worker.js": `export default {

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerLoader.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerLoader.ts
@@ -127,7 +127,7 @@ export interface WorkerLoaderClass extends Context.Service<
  *
  *         // Spin up an isolated, sandboxed Worker from inline source.
  *         const worker = yield* loader.load({
- *           compatibilityDate: "2026-01-28",
+ *           compatibilityDate: "2026-08-31",
  *           mainModule: "worker.js",
  *           modules: {
  *             "worker.js": `export default {
@@ -166,7 +166,7 @@ export interface WorkerLoaderClass extends Context.Service<
  * export default {
  *   async fetch(req: Request, env: WorkerEnv) {
  *     const worker = env.LOADER.load({
- *       compatibilityDate: "2026-01-28",
+ *       compatibilityDate: "2026-08-31",
  *       mainModule: "worker.js",
  *       modules: { "worker.js": "export default { fetch: () => new Response('ok') }" },
  *     });
@@ -184,7 +184,7 @@ export interface WorkerLoaderClass extends Context.Service<
  * **Example:** Loading and calling a dynamic Worker
  * ```typescript
  * const worker = loader.load({
- *   compatibilityDate: "2026-01-28",
+ *   compatibilityDate: "2026-08-31",
  *   mainModule: "worker.js",
  *   modules: {
  *     "worker.js": `export default {
@@ -208,7 +208,7 @@ export interface WorkerLoaderClass extends Context.Service<
  * **Example:** Blocking outbound access
  * ```typescript
  * const worker = loader.load({
- *   compatibilityDate: "2026-01-28",
+ *   compatibilityDate: "2026-08-31",
  *   mainModule: "worker.js",
  *   modules: {
  *     "worker.js": `export default {

--- a/packages/alchemy/test/Cloudflare/Browser/fixtures/effect-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Browser/fixtures/effect-worker.ts
@@ -68,7 +68,7 @@ export default class BrowserEffectWorker extends Cloudflare.Worker<BrowserEffect
               .pipe(Effect.orDie);
             return yield* HttpServerResponse.json({
               title: snapshot.meta.title,
-              screenshotLength: snapshot.result.screenshot.length,
+              screenshotLength: snapshot.result.screenshot?.length ?? 0,
             });
           }
           case "/json": {

--- a/packages/alchemy/test/Cloudflare/Workers/Compatibility.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/Compatibility.test.ts
@@ -4,18 +4,17 @@ import * as Output from "@/Output";
 import { describe, expect, test } from "alchemy-test";
 
 describe("getCompatibility", () => {
-  // The default nodejs_compat contract from #796: every JS Worker gets the
-  // flag — Effect-native Workers need it for the bundled Effect runtime,
-  // external Workers (plain `export default { fetch }`, vite builds)
-  // routinely import `node:*` built-ins.
-  test("defaults nodejs_compat for Effect-native workers", () => {
-    const { flags } = getCompatibility({} as WorkerProps);
-    expect(flags).toContain("nodejs_compat");
+  // Cloudflare enables both Node.js compatibility modes by date from
+  // 2026-08-04, so Alchemy's newer default no longer emits a redundant flag.
+  test("uses date-default Node.js compatibility for Effect-native workers", () => {
+    const { date, flags } = getCompatibility({} as WorkerProps);
+    expect(date).toBe("2026-08-31");
+    expect(flags).not.toContain("nodejs_compat");
   });
 
-  test("defaults nodejs_compat for external workers", () => {
+  test("uses date-default Node.js compatibility for external workers", () => {
     const { flags } = getCompatibility({ isExternal: true } as WorkerProps);
-    expect(flags).toContain("nodejs_compat");
+    expect(flags).not.toContain("nodejs_compat");
   });
 
   test("does not duplicate an explicit nodejs_compat", () => {
@@ -83,7 +82,7 @@ describe("getCompatibility", () => {
       main,
     } as WorkerProps);
     expect(flags).not.toContain("python_workers");
-    expect(flags).toContain("nodejs_compat");
+    expect(flags).not.toContain("nodejs_compat");
   });
 
   test("forces handle_cross_request_promise_resolution for Effect workers on old dates", () => {

--- a/packages/alchemy/test/Cloudflare/Workers/Compatibility.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/Compatibility.test.ts
@@ -1,4 +1,7 @@
-import { getCompatibility } from "@/Cloudflare/Workers/Compatibility";
+import {
+  getCompatibility,
+  getToolingCompatibility,
+} from "@/Cloudflare/Workers/Compatibility";
 import type { WorkerProps } from "@/Cloudflare/Workers/Worker";
 import * as Output from "@/Output";
 import { describe, expect, test } from "alchemy-test";
@@ -95,5 +98,32 @@ describe("getCompatibility", () => {
   test("omits handle_cross_request_promise_resolution once default-on", () => {
     const { flags } = getCompatibility({} as WorkerProps);
     expect(flags).not.toContain("handle_cross_request_promise_resolution");
+  });
+});
+
+describe("getToolingCompatibility", () => {
+  test("materializes date-default nodejs_compat for downstream tools", () => {
+    expect(
+      getToolingCompatibility({ date: "2026-08-31", flags: [] }, "worker.ts")
+        .flags,
+    ).toEqual(["nodejs_compat"]);
+  });
+
+  test("preserves an explicit opt-out", () => {
+    expect(
+      getToolingCompatibility(
+        { date: "2026-08-31", flags: ["no_nodejs_compat"] },
+        "worker.ts",
+      ).flags,
+    ).toEqual(["no_nodejs_compat"]);
+  });
+
+  test("does not add Node compatibility to Python tooling", () => {
+    expect(
+      getToolingCompatibility(
+        { date: "2026-08-31", flags: ["python_workers"] },
+        "worker.py",
+      ).flags,
+    ).toEqual(["python_workers"]);
   });
 });

--- a/packages/alchemy/test/Cloudflare/Workers/PythonWorker.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/PythonWorker.test.ts
@@ -48,10 +48,11 @@ describe.concurrent("Cloudflare.Worker with a Python entrypoint", () => {
           main,
           compatibility: { date: "2026-03-17", flags: ["python_workers"] },
         });
-        expect(expected.files.map((file) => file.path)).toEqual([
-          "worker.py",
-          "util.py",
-        ]);
+        const paths = expected.files.map((file) => file.path);
+        expect(paths.slice(0, 2)).toEqual(["worker.py", "util.py"]);
+        // Current workerd releases externalize the Python Workers SDK, so
+        // Alchemy vendors the managed runtime even without a pyproject.toml.
+        expect(paths).toContain("python_modules/workers/__init__.py");
 
         const worker = yield* stack.deploy(
           Effect.gen(function* () {
@@ -63,8 +64,8 @@ describe.concurrent("Cloudflare.Worker with a Python entrypoint", () => {
           }),
         );
 
-        // The stored bundle hash equals the hash of the source bytes only
-        // when no bundling/minification ran.
+        // The stored bundle hash covers the source and managed SDK bytes;
+        // Python modules are uploaded directly without JS bundling.
         expect(worker.hash?.bundle).toEqual(expected.hash);
 
         // End-to-end: the response interpolates a constant from the

--- a/packages/cloudflare-runtime/package.json
+++ b/packages/cloudflare-runtime/package.json
@@ -54,7 +54,7 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "catalog:cloudflare-runtime",
-    "@cloudflare/vitest-pool-workers": "catalog:cloudflare-runtime",
+    "@cloudflare/vitest-plugin": "catalog:cloudflare-runtime",
     "@effect/platform-bun": "catalog:effect",
     "@effect/platform-node": "catalog:effect",
     "@effect/vitest": "catalog:effect",

--- a/packages/cloudflare-runtime/src/core/bindings/assets/Assets.ts
+++ b/packages/cloudflare-runtime/src/core/bindings/assets/Assets.ts
@@ -36,7 +36,7 @@ import * as Plugin from "../../Plugin.ts";
 import { PluginContext, type BindingHook } from "../../PluginContext.ts";
 import { ConfigError, SystemError } from "../../RuntimeError.shared.ts";
 import type { RuntimeWorker } from "../../RuntimeWorker.ts";
-import { INTERNAL_WORKER_COMPATIBILITY_DATE } from "../../internal/constants.ts";
+import { DEFAULT_COMPATIBILITY_DATE } from "../../internal/constants.ts";
 import { formatInternalWorkerModules } from "../../internal/internal-modules.ts";
 
 const AssetsKvWorker = {
@@ -314,7 +314,7 @@ export const AssetsLive = Layer.effect(
             {
               name: "assets:worker",
               worker: {
-                compatibilityDate: INTERNAL_WORKER_COMPATIBILITY_DATE,
+                compatibilityDate: DEFAULT_COMPATIBILITY_DATE,
                 // Node.js compatibility is default-on for the internal date.
                 bindings: [
                   {
@@ -340,7 +340,7 @@ export const AssetsLive = Layer.effect(
             {
               name: "assets:router",
               worker: {
-                compatibilityDate: INTERNAL_WORKER_COMPATIBILITY_DATE,
+                compatibilityDate: DEFAULT_COMPATIBILITY_DATE,
                 // Keep the intentional v2 opt-out; the date supplies v1.
                 compatibilityFlags: ["no_nodejs_compat_v2"],
                 bindings: [

--- a/packages/cloudflare-runtime/src/core/bindings/assets/Assets.ts
+++ b/packages/cloudflare-runtime/src/core/bindings/assets/Assets.ts
@@ -315,7 +315,7 @@ export const AssetsLive = Layer.effect(
               name: "assets:worker",
               worker: {
                 compatibilityDate: INTERNAL_WORKER_COMPATIBILITY_DATE,
-                compatibilityFlags: ["nodejs_compat"],
+                // Node.js compatibility is default-on for the internal date.
                 bindings: [
                   {
                     name: "ASSETS_KV_NAMESPACE",
@@ -341,7 +341,8 @@ export const AssetsLive = Layer.effect(
               name: "assets:router",
               worker: {
                 compatibilityDate: INTERNAL_WORKER_COMPATIBILITY_DATE,
-                compatibilityFlags: ["nodejs_compat", "no_nodejs_compat_v2"],
+                // Keep the intentional v2 opt-out; the date supplies v1.
+                compatibilityFlags: ["no_nodejs_compat_v2"],
                 bindings: [
                   {
                     name: "ASSET_WORKER",

--- a/packages/cloudflare-runtime/src/core/bindings/browser/Browser.ts
+++ b/packages/cloudflare-runtime/src/core/bindings/browser/Browser.ts
@@ -32,7 +32,7 @@ import * as Plugin from "../../Plugin.ts";
 import type { BindingHook, PluginContext } from "../../PluginContext.ts";
 import { makeRemoteBinding } from "../../remote-bindings/RemoteBindings.ts";
 import type { ConfigError } from "../../RuntimeError.shared.ts";
-import { INTERNAL_WORKER_COMPATIBILITY_DATE } from "../../internal/constants.ts";
+import { DEFAULT_COMPATIBILITY_DATE } from "../../internal/constants.ts";
 import { kVoid } from "../../workerd/Config.ts";
 import type * as WorkerdConfig from "../../workerd/Config.ts";
 import type { BrowserProps } from "./BrowserOptions.shared.ts";
@@ -181,7 +181,7 @@ export const BrowserLive = Layer.effect(
                 // websocket_standard_binary_type: its Blob-default behavior,
                 // introduced on 2026-03-17, stops cross-service CDP WebSockets
                 // from delivering binary frames to the proxy.
-                compatibilityDate: INTERNAL_WORKER_COMPATIBILITY_DATE,
+                compatibilityDate: DEFAULT_COMPATIBILITY_DATE,
                 compatibilityFlags: ["no_websocket_standard_binary_type"],
                 modules: formatInternalWorkerModules(
                   yield* Effect.promise(BrowserWorker.worker),

--- a/packages/cloudflare-runtime/src/core/bindings/browser/Browser.ts
+++ b/packages/cloudflare-runtime/src/core/bindings/browser/Browser.ts
@@ -174,8 +174,14 @@ export const BrowserLive = Layer.effect(
             const browserService: WorkerdConfig.Service = {
               name: SERVICE_BROWSER,
               worker: {
-                // Stay pre-2026-04-07: CDP proxy hangs with auto-reply-to-close.
-                compatibilityDate: "2025-01-01",
+                // Miniflare avoids newer compatibility behavior wholesale by
+                // pinning its browser service to 2025-05-01 with nodejs_compat.
+                // Alchemy can adopt the current date and narrowly opt out of
+                // websocket_standard_binary_type: its Blob-default behavior,
+                // introduced on 2026-03-17, stops cross-service CDP WebSockets
+                // from delivering binary frames to the proxy.
+                compatibilityDate: "2026-08-31",
+                compatibilityFlags: ["no_websocket_standard_binary_type"],
                 modules: formatInternalWorkerModules(
                   yield* Effect.promise(BrowserWorker.worker),
                 ),

--- a/packages/cloudflare-runtime/src/core/bindings/browser/Browser.ts
+++ b/packages/cloudflare-runtime/src/core/bindings/browser/Browser.ts
@@ -32,6 +32,7 @@ import * as Plugin from "../../Plugin.ts";
 import type { BindingHook, PluginContext } from "../../PluginContext.ts";
 import { makeRemoteBinding } from "../../remote-bindings/RemoteBindings.ts";
 import type { ConfigError } from "../../RuntimeError.shared.ts";
+import { INTERNAL_WORKER_COMPATIBILITY_DATE } from "../../internal/constants.ts";
 import { kVoid } from "../../workerd/Config.ts";
 import type * as WorkerdConfig from "../../workerd/Config.ts";
 import type { BrowserProps } from "./BrowserOptions.shared.ts";
@@ -180,7 +181,7 @@ export const BrowserLive = Layer.effect(
                 // websocket_standard_binary_type: its Blob-default behavior,
                 // introduced on 2026-03-17, stops cross-service CDP WebSockets
                 // from delivering binary frames to the proxy.
-                compatibilityDate: "2026-08-31",
+                compatibilityDate: INTERNAL_WORKER_COMPATIBILITY_DATE,
                 compatibilityFlags: ["no_websocket_standard_binary_type"],
                 modules: formatInternalWorkerModules(
                   yield* Effect.promise(BrowserWorker.worker),

--- a/packages/cloudflare-runtime/src/core/bindings/cache/Cache.ts
+++ b/packages/cloudflare-runtime/src/core/bindings/cache/Cache.ts
@@ -10,7 +10,7 @@ const CacheWorker = {
     ),
 };
 import * as Storage from "../../globals/Storage.ts";
-import { INTERNAL_WORKER_COMPATIBILITY_DATE } from "../../internal/constants.ts";
+import { DEFAULT_COMPATIBILITY_DATE } from "../../internal/constants.ts";
 import { formatInternalWorkerModules } from "../../internal/internal-modules.ts";
 import * as Plugin from "../../Plugin.ts";
 import * as PluginContext from "../../PluginContext.ts";
@@ -90,7 +90,7 @@ export const CacheLive = Layer.effect(
             const cacheService: WorkerdConfig.Service = {
               name: SERVICE_CACHE,
               worker: {
-                compatibilityDate: INTERNAL_WORKER_COMPATIBILITY_DATE,
+                compatibilityDate: DEFAULT_COMPATIBILITY_DATE,
                 modules: formatInternalWorkerModules(
                   yield* Effect.promise(CacheWorker.worker),
                 ),

--- a/packages/cloudflare-runtime/src/core/bindings/d1/D1.ts
+++ b/packages/cloudflare-runtime/src/core/bindings/d1/D1.ts
@@ -8,7 +8,7 @@ const D1Worker = {
     loadInternalWorker("#cloudflare-runtime-core-worker/bindings/d1/D1.worker"),
 };
 import * as Storage from "../../globals/Storage.ts";
-import { INTERNAL_WORKER_COMPATIBILITY_DATE } from "../../internal/constants.ts";
+import { DEFAULT_COMPATIBILITY_DATE } from "../../internal/constants.ts";
 import { formatInternalWorkerModules } from "../../internal/internal-modules.ts";
 import * as Plugin from "../../Plugin.ts";
 import type { BindingHook } from "../../PluginContext.ts";
@@ -96,7 +96,7 @@ export const D1Live = Layer.effect(
             const d1Service: WorkerdConfig.Service = {
               name: SERVICE_D1,
               worker: {
-                compatibilityDate: INTERNAL_WORKER_COMPATIBILITY_DATE,
+                compatibilityDate: DEFAULT_COMPATIBILITY_DATE,
                 modules: formatInternalWorkerModules(
                   yield* Effect.promise(D1Worker.worker),
                 ),

--- a/packages/cloudflare-runtime/src/core/bindings/images/Images.ts
+++ b/packages/cloudflare-runtime/src/core/bindings/images/Images.ts
@@ -23,7 +23,7 @@ import * as Loopback from "../../globals/Loopback.ts";
 import type * as LoopbackServer from "../../globals/LoopbackServer.ts";
 import * as Storage from "../../globals/Storage.ts";
 import {
-  INTERNAL_WORKER_COMPATIBILITY_DATE,
+  DEFAULT_COMPATIBILITY_DATE,
   SOCKET_USER_ENTRY,
 } from "../../internal/constants.ts";
 import { formatInternalWorkerModules } from "../../internal/internal-modules.ts";
@@ -170,7 +170,7 @@ export const ImagesLive = Layer.effect(
             const storeService: WorkerdConfig.Service = {
               name: SERVICE_IMAGES_STORE,
               worker: {
-                compatibilityDate: INTERNAL_WORKER_COMPATIBILITY_DATE,
+                compatibilityDate: DEFAULT_COMPATIBILITY_DATE,
                 modules: formatInternalWorkerModules(
                   yield* Effect.promise(ImagesStoreWorker.worker),
                 ),
@@ -206,7 +206,7 @@ export const ImagesLive = Layer.effect(
             const imagesService: WorkerdConfig.Service = {
               name: SERVICE_IMAGES,
               worker: {
-                compatibilityDate: INTERNAL_WORKER_COMPATIBILITY_DATE,
+                compatibilityDate: DEFAULT_COMPATIBILITY_DATE,
                 modules: formatInternalWorkerModules(
                   yield* Effect.promise(ImagesWorker.worker),
                 ),
@@ -229,7 +229,7 @@ export const ImagesLive = Layer.effect(
             const deliveryMiddleware: Plugin.Middleware = {
               name: "images:delivery",
               worker: {
-                compatibilityDate: INTERNAL_WORKER_COMPATIBILITY_DATE,
+                compatibilityDate: DEFAULT_COMPATIBILITY_DATE,
                 modules: [
                   {
                     name: "images/delivery.worker.js",

--- a/packages/cloudflare-runtime/src/core/bindings/kv-namespace/KvNamespace.ts
+++ b/packages/cloudflare-runtime/src/core/bindings/kv-namespace/KvNamespace.ts
@@ -10,7 +10,7 @@ const KvNamespaceWorker = {
     ),
 };
 import * as Storage from "../../globals/Storage.ts";
-import { INTERNAL_WORKER_COMPATIBILITY_DATE } from "../../internal/constants.ts";
+import { DEFAULT_COMPATIBILITY_DATE } from "../../internal/constants.ts";
 import { formatInternalWorkerModules } from "../../internal/internal-modules.ts";
 import * as Plugin from "../../Plugin.ts";
 import type { BindingHook } from "../../PluginContext.ts";
@@ -104,7 +104,7 @@ export const KvNamespaceLive = Layer.effect(
             const kvService: WorkerdConfig.Service = {
               name: SERVICE_KV,
               worker: {
-                compatibilityDate: INTERNAL_WORKER_COMPATIBILITY_DATE,
+                compatibilityDate: DEFAULT_COMPATIBILITY_DATE,
                 modules: formatInternalWorkerModules(
                   yield* Effect.promise(KvNamespaceWorker.worker),
                 ),

--- a/packages/cloudflare-runtime/src/core/bindings/queue/Queue.ts
+++ b/packages/cloudflare-runtime/src/core/bindings/queue/Queue.ts
@@ -16,7 +16,7 @@ const QueueShimForwardWorker = {
     ),
 };
 import {
-  INTERNAL_WORKER_COMPATIBILITY_DATE,
+  DEFAULT_COMPATIBILITY_DATE,
   SERVICE_USER_WORKER,
 } from "../../internal/constants.ts";
 import { formatInternalWorkerModules } from "../../internal/internal-modules.ts";
@@ -162,7 +162,7 @@ export const QueueLive = Layer.effect(
           return {
             name: queueServiceName(consumer.queueName),
             worker: {
-              compatibilityDate: INTERNAL_WORKER_COMPATIBILITY_DATE,
+              compatibilityDate: DEFAULT_COMPATIBILITY_DATE,
               compatibilityFlags: [
                 "experimental",
                 "service_binding_extra_handlers",
@@ -225,7 +225,7 @@ export const QueueLive = Layer.effect(
           return {
             name: remoteShimServiceName(props.binding),
             worker: {
-              compatibilityDate: INTERNAL_WORKER_COMPATIBILITY_DATE,
+              compatibilityDate: DEFAULT_COMPATIBILITY_DATE,
               modules: formatInternalWorkerModules(
                 yield* Effect.promise(QueueShimForwardWorker.worker),
               ),

--- a/packages/cloudflare-runtime/src/core/bindings/r2-bucket/R2Bucket.ts
+++ b/packages/cloudflare-runtime/src/core/bindings/r2-bucket/R2Bucket.ts
@@ -10,7 +10,7 @@ const R2BucketWorker = {
     ),
 };
 import * as Storage from "../../globals/Storage.ts";
-import { INTERNAL_WORKER_COMPATIBILITY_DATE } from "../../internal/constants.ts";
+import { DEFAULT_COMPATIBILITY_DATE } from "../../internal/constants.ts";
 import { formatInternalWorkerModules } from "../../internal/internal-modules.ts";
 import * as Plugin from "../../Plugin.ts";
 import type { BindingHook } from "../../PluginContext.ts";
@@ -104,7 +104,7 @@ export const R2BucketLive = Layer.effect(
             const r2Service: WorkerdConfig.Service = {
               name: SERVICE_R2,
               worker: {
-                compatibilityDate: INTERNAL_WORKER_COMPATIBILITY_DATE,
+                compatibilityDate: DEFAULT_COMPATIBILITY_DATE,
                 // `node:crypto` is used to synchronously compute multipart etags
                 // Node.js compatibility is default-on for the 2026-08-31
                 // internal compatibility date.

--- a/packages/cloudflare-runtime/src/core/bindings/r2-bucket/R2Bucket.ts
+++ b/packages/cloudflare-runtime/src/core/bindings/r2-bucket/R2Bucket.ts
@@ -106,7 +106,8 @@ export const R2BucketLive = Layer.effect(
               worker: {
                 compatibilityDate: INTERNAL_WORKER_COMPATIBILITY_DATE,
                 // `node:crypto` is used to synchronously compute multipart etags
-                compatibilityFlags: ["nodejs_compat"],
+                // Node.js compatibility is default-on for the 2026-08-31
+                // internal compatibility date.
                 modules: formatInternalWorkerModules(
                   yield* Effect.promise(R2BucketWorker.worker),
                 ),

--- a/packages/cloudflare-runtime/src/core/bindings/r2-bucket/R2Bucket.worker.ts
+++ b/packages/cloudflare-runtime/src/core/bindings/r2-bucket/R2Bucket.worker.ts
@@ -14,7 +14,8 @@
  * metadata lives in Durable Object SQLite, values (and multipart parts) are
  * stored as blob files via the `r2:storage` disk service.
  *
- * This worker requires the `nodejs_compat` compatibility flag:
+ * This worker requires Node.js compatibility, supplied by the internal
+ * 2026-08-31 compatibility date without an explicit flag:
  * `node:crypto`'s `createHash("md5")` is needed to synchronously compute
  * multipart ETags inside SQLite transactions. Upstream's `Buffer` usages are
  * replaced with small hex/base64 helpers.

--- a/packages/cloudflare-runtime/src/core/bindings/secrets-store/SecretsStore.ts
+++ b/packages/cloudflare-runtime/src/core/bindings/secrets-store/SecretsStore.ts
@@ -16,7 +16,7 @@ const SecretsStoreSecretWorker = {
     ),
 };
 import * as Storage from "../../globals/Storage.ts";
-import { INTERNAL_WORKER_COMPATIBILITY_DATE } from "../../internal/constants.ts";
+import { DEFAULT_COMPATIBILITY_DATE } from "../../internal/constants.ts";
 import { formatInternalWorkerModules } from "../../internal/internal-modules.ts";
 import * as Plugin from "../../Plugin.ts";
 import type { BindingHook } from "../../PluginContext.ts";
@@ -135,7 +135,7 @@ export const SecretsStoreLive = Layer.effect(
             const storeService: WorkerdConfig.Service = {
               name: SERVICE_SECRETS_STORE,
               worker: {
-                compatibilityDate: INTERNAL_WORKER_COMPATIBILITY_DATE,
+                compatibilityDate: DEFAULT_COMPATIBILITY_DATE,
                 modules: formatInternalWorkerModules(
                   yield* Effect.promise(SecretsStoreStoreWorker.worker),
                 ),
@@ -175,7 +175,7 @@ export const SecretsStoreLive = Layer.effect(
             const secretService: WorkerdConfig.Service = {
               name: SERVICE_SECRETS_STORE_SECRET,
               worker: {
-                compatibilityDate: INTERNAL_WORKER_COMPATIBILITY_DATE,
+                compatibilityDate: DEFAULT_COMPATIBILITY_DATE,
                 modules: formatInternalWorkerModules(
                   yield* Effect.promise(SecretsStoreSecretWorker.worker),
                 ),

--- a/packages/cloudflare-runtime/src/core/bindings/send-email/SendEmail.ts
+++ b/packages/cloudflare-runtime/src/core/bindings/send-email/SendEmail.ts
@@ -16,7 +16,7 @@ const SendEmailBindingWorker = {
     ),
 };
 import * as Storage from "../../globals/Storage.ts";
-import { INTERNAL_WORKER_COMPATIBILITY_DATE } from "../../internal/constants.ts";
+import { DEFAULT_COMPATIBILITY_DATE } from "../../internal/constants.ts";
 import {
   formatExtensionModule,
   formatInternalWorkerModules,
@@ -135,7 +135,7 @@ export const SendEmailLive = Layer.effect(
             const sendEmailService: WorkerdConfig.Service = {
               name: SERVICE_SEND_EMAIL,
               worker: {
-                compatibilityDate: INTERNAL_WORKER_COMPATIBILITY_DATE,
+                compatibilityDate: DEFAULT_COMPATIBILITY_DATE,
                 modules: formatInternalWorkerModules(
                   yield* Effect.promise(SendEmailBindingWorker.worker),
                 ),

--- a/packages/cloudflare-runtime/src/core/bindings/stream/Stream.ts
+++ b/packages/cloudflare-runtime/src/core/bindings/stream/Stream.ts
@@ -13,7 +13,7 @@ import * as Loopback from "../../globals/Loopback.ts";
 import type * as LoopbackServer from "../../globals/LoopbackServer.ts";
 import * as Storage from "../../globals/Storage.ts";
 import {
-  INTERNAL_WORKER_COMPATIBILITY_DATE,
+  DEFAULT_COMPATIBILITY_DATE,
   SOCKET_USER_ENTRY,
 } from "../../internal/constants.ts";
 import { formatInternalWorkerModules } from "../../internal/internal-modules.ts";
@@ -177,7 +177,7 @@ export const StreamLive = Layer.effect(
             const streamService: WorkerdConfig.Service = {
               name: SERVICE_STREAM,
               worker: {
-                compatibilityDate: INTERNAL_WORKER_COMPATIBILITY_DATE,
+                compatibilityDate: DEFAULT_COMPATIBILITY_DATE,
                 modules: formatInternalWorkerModules(
                   yield* Effect.promise(StreamWorker.worker),
                 ),
@@ -222,7 +222,7 @@ export const StreamLive = Layer.effect(
                 {
                   name: "stream:router",
                   worker: {
-                    compatibilityDate: INTERNAL_WORKER_COMPATIBILITY_DATE,
+                    compatibilityDate: DEFAULT_COMPATIBILITY_DATE,
                     modules: [
                       {
                         name: "stream/router.worker.js",

--- a/packages/cloudflare-runtime/src/core/bindings/workflows/Workflows.ts
+++ b/packages/cloudflare-runtime/src/core/bindings/workflows/Workflows.ts
@@ -17,7 +17,7 @@ const WorkflowsWrappedBindingWorker = {
 };
 import * as Storage from "../../globals/Storage.ts";
 import {
-  INTERNAL_WORKER_COMPATIBILITY_DATE,
+  DEFAULT_COMPATIBILITY_DATE,
   SERVICE_USER_WORKER,
 } from "../../internal/constants.ts";
 import {
@@ -144,7 +144,7 @@ const makeEngineService = ({
 }): WorkerdConfig.Service => ({
   name: `workflows:${workflow.workflowName}`,
   worker: {
-    compatibilityDate: INTERNAL_WORKER_COMPATIBILITY_DATE,
+    compatibilityDate: DEFAULT_COMPATIBILITY_DATE,
     compatibilityFlags: ["experimental", ...(compatibilityFlags ?? [])],
     modules,
     durableObjectNamespaces: [

--- a/packages/cloudflare-runtime/src/core/bindings/workflows/wrapped-binding.worker.ts
+++ b/packages/cloudflare-runtime/src/core/bindings/workflows/wrapped-binding.worker.ts
@@ -34,7 +34,7 @@ class WorkflowImpl implements Workflow {
   }
 
   async deleteBatch(instanceIds: string[]): Promise<WorkflowBatchDeleteResult> {
-    return this.binding.deleteBatch(instanceIds);
+    return this.binding.deleteBatch({ instances: instanceIds });
   }
 
   async unsafeGetBindingName(): Promise<string> {

--- a/packages/cloudflare-runtime/src/core/bindings/workflows/wrapped-binding.worker.ts
+++ b/packages/cloudflare-runtime/src/core/bindings/workflows/wrapped-binding.worker.ts
@@ -138,11 +138,7 @@ class InstanceImpl implements WorkflowInstance {
 
   public async delete(): Promise<void> {
     using instance = await this.getInstance();
-    // Structural call: whether the ambient WorkflowInstance type in this
-    // program carries `delete` depends on which workers-types copy wins
-    // (vitest-pool-workers bundles an older one), but the runtime handle
-    // (WorkflowHandle) always implements it.
-    await (instance as unknown as { delete(): Promise<void> }).delete();
+    await instance.delete();
   }
 }
 

--- a/packages/cloudflare-runtime/src/core/globals/Globals.ts
+++ b/packages/cloudflare-runtime/src/core/globals/Globals.ts
@@ -12,7 +12,7 @@ const EntryWorker = {
     loadInternalWorker("#cloudflare-runtime-core-worker/globals/entry.worker"),
 };
 import {
-  INTERNAL_WORKER_COMPATIBILITY_DATE,
+  DEFAULT_COMPATIBILITY_DATE,
   SERVICE_USER_WORKER,
   SOCKET_USER_ENTRY,
 } from "../internal/constants.ts";
@@ -156,7 +156,7 @@ export const GlobalsLive = Layer.effect(
             {
               name: "plugin:entry",
               worker: {
-                compatibilityDate: INTERNAL_WORKER_COMPATIBILITY_DATE,
+                compatibilityDate: DEFAULT_COMPATIBILITY_DATE,
                 compatibilityFlags: [
                   "experimental",
                   "enable_request_signal",

--- a/packages/cloudflare-runtime/src/core/globals/Loopback.ts
+++ b/packages/cloudflare-runtime/src/core/globals/Loopback.ts
@@ -1,6 +1,6 @@
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
-import { INTERNAL_WORKER_COMPATIBILITY_DATE } from "../internal/constants.ts";
+import { DEFAULT_COMPATIBILITY_DATE } from "../internal/constants.ts";
 import * as Plugin from "../Plugin.ts";
 import type * as WorkerdConfig from "../workerd/Config.ts";
 import { HEADER_CF_BLOB } from "./CfOptions.shared.ts";
@@ -35,7 +35,7 @@ export const LoopbackLive = Layer.effect(
         {
           name: "loopback:fetcher",
           worker: {
-            compatibilityDate: INTERNAL_WORKER_COMPATIBILITY_DATE,
+            compatibilityDate: DEFAULT_COMPATIBILITY_DATE,
             modules: [
               {
                 name: "loopback/fetcher.worker.js",

--- a/packages/cloudflare-runtime/src/core/internal/constants.ts
+++ b/packages/cloudflare-runtime/src/core/internal/constants.ts
@@ -5,7 +5,7 @@ export const SERVICE_USER_WORKER = "user-worker";
  * Default date shared by deployed Workers, framework runners, previews, and
  * internal isolates. It is the newest date supported by catalog workerd.
  */
-export const INTERNAL_WORKER_COMPATIBILITY_DATE = "2026-08-31";
+export const DEFAULT_COMPATIBILITY_DATE = "2026-08-31";
 
 export const defaultDurableObjectUniqueKey = (
   scriptName: string,

--- a/packages/cloudflare-runtime/src/core/internal/constants.ts
+++ b/packages/cloudflare-runtime/src/core/internal/constants.ts
@@ -1,7 +1,10 @@
 export const SOCKET_USER_ENTRY = "user-entry";
 export const SERVICE_USER_WORKER = "user-worker";
 
-/** Newest date supported by catalog workerd 1.20260831.1. Used by internal isolates. */
+/**
+ * Default date shared by deployed Workers, framework runners, previews, and
+ * internal isolates. It is the newest date supported by catalog workerd.
+ */
 export const INTERNAL_WORKER_COMPATIBILITY_DATE = "2026-08-31";
 
 export const defaultDurableObjectUniqueKey = (

--- a/packages/cloudflare-runtime/src/core/internal/internal-modules.ts
+++ b/packages/cloudflare-runtime/src/core/internal/internal-modules.ts
@@ -14,12 +14,17 @@ export const formatExtensionModule = (self: {
   worker: () => Promise<{ main: string; modules: Record<string, string> }>;
 }): Effect.Effect<string> =>
   Effect.promise(self.worker).pipe(
-    Effect.map(({ modules }) => {
-      const entries = Object.entries(modules);
-      if (entries.length !== 1) {
-        throw new Error(`Expected exactly one module, got ${entries.length}`);
+    Effect.map(({ main, modules }) => {
+      // Date-default Node compatibility can emit generated support chunks in
+      // addition to an internal Worker's entry module. Extensions still need
+      // the entry source only, so select the export's declared main module.
+      const entry = modules[main];
+      if (entry === undefined) {
+        throw new Error(
+          `Worker entry module ${JSON.stringify(main)} is missing`,
+        );
       }
-      return entries[0][1];
+      return entry;
     }),
   );
 

--- a/packages/cloudflare-runtime/src/core/internal/internal-modules.ts
+++ b/packages/cloudflare-runtime/src/core/internal/internal-modules.ts
@@ -14,17 +14,12 @@ export const formatExtensionModule = (self: {
   worker: () => Promise<{ main: string; modules: Record<string, string> }>;
 }): Effect.Effect<string> =>
   Effect.promise(self.worker).pipe(
-    Effect.map(({ main, modules }) => {
-      // Date-default Node compatibility can emit generated support chunks in
-      // addition to an internal Worker's entry module. Extensions still need
-      // the entry source only, so select the export's declared main module.
-      const entry = modules[main];
-      if (entry === undefined) {
-        throw new Error(
-          `Worker entry module ${JSON.stringify(main)} is missing`,
-        );
+    Effect.map(({ modules }) => {
+      const entries = Object.entries(modules);
+      if (entries.length !== 1) {
+        throw new Error(`Expected exactly one module, got ${entries.length}`);
       }
-      return entry;
+      return entries[0][1];
     }),
   );
 

--- a/packages/cloudflare-runtime/src/core/platform-proxy/PlatformProxy.ts
+++ b/packages/cloudflare-runtime/src/core/platform-proxy/PlatformProxy.ts
@@ -1,4 +1,4 @@
-import { INTERNAL_WORKER_COMPATIBILITY_DATE } from "../internal/constants.ts";
+import { DEFAULT_COMPATIBILITY_DATE } from "../internal/constants.ts";
 import { loadInternalWorker } from "../internal/internal-worker.ts";
 /**
  * Node-side platform proxy: our reimplementation of wrangler's
@@ -196,8 +196,7 @@ export const open = Effect.fn("PlatformProxy.open")(function* <
   const modules = yield* makeModules(options as PlatformProxyOptions);
   const url = yield* runtime.start({
     name: options.name ?? "platform-proxy",
-    compatibilityDate:
-      options.compatibilityDate ?? INTERNAL_WORKER_COMPATIBILITY_DATE,
+    compatibilityDate: options.compatibilityDate ?? DEFAULT_COMPATIBILITY_DATE,
     compatibilityFlags: options.compatibilityFlags ?? [],
     bindings: [
       Text.local(BINDING_PLATFORM_PROXY_TOKEN, token),

--- a/packages/cloudflare-runtime/src/core/platform-proxy/PlatformProxy.ts
+++ b/packages/cloudflare-runtime/src/core/platform-proxy/PlatformProxy.ts
@@ -92,7 +92,7 @@ export interface PlatformProxyOptions<B extends BindingHooks = BindingHooks> {
    * @default "platform-proxy"
    */
   readonly name?: string;
-  /** @default "2026-03-10" */
+  /** @default "2026-08-31" */
   readonly compatibilityDate?: string;
   readonly compatibilityFlags?: Array<string>;
   /**

--- a/packages/cloudflare-runtime/src/core/platform-proxy/PlatformProxy.ts
+++ b/packages/cloudflare-runtime/src/core/platform-proxy/PlatformProxy.ts
@@ -79,8 +79,6 @@ export type {
   PlatformProxyCacheStorage,
 } from "./connect.ts";
 
-const DEFAULT_COMPATIBILITY_DATE = INTERNAL_WORKER_COMPATIBILITY_DATE;
-
 // ---------------------------------------------------------------------------
 // Public types
 // ---------------------------------------------------------------------------
@@ -198,7 +196,8 @@ export const open = Effect.fn("PlatformProxy.open")(function* <
   const modules = yield* makeModules(options as PlatformProxyOptions);
   const url = yield* runtime.start({
     name: options.name ?? "platform-proxy",
-    compatibilityDate: options.compatibilityDate ?? DEFAULT_COMPATIBILITY_DATE,
+    compatibilityDate:
+      options.compatibilityDate ?? INTERNAL_WORKER_COMPATIBILITY_DATE,
     compatibilityFlags: options.compatibilityFlags ?? [],
     bindings: [
       Text.local(BINDING_PLATFORM_PROXY_TOKEN, token),

--- a/packages/cloudflare-runtime/src/core/proxy/WorkerProxy.ts
+++ b/packages/cloudflare-runtime/src/core/proxy/WorkerProxy.ts
@@ -11,7 +11,7 @@ const ProxyWorker = {
     ),
 };
 import * as Internet from "../globals/Internet.ts";
-import { INTERNAL_WORKER_COMPATIBILITY_DATE } from "../internal/constants.ts";
+import { DEFAULT_COMPATIBILITY_DATE } from "../internal/constants.ts";
 import { formatInternalWorkerModules } from "../internal/internal-modules.ts";
 import * as Port from "../internal/Port.ts";
 import type { RuntimeError } from "../RuntimeError.shared.ts";
@@ -141,7 +141,7 @@ export const WorkerProxyLive = Layer.effect(
             {
               name: "proxy:worker",
               worker: {
-                compatibilityDate: INTERNAL_WORKER_COMPATIBILITY_DATE,
+                compatibilityDate: DEFAULT_COMPATIBILITY_DATE,
                 modules,
                 bindings: [
                   {

--- a/packages/cloudflare-runtime/src/core/registry/RegistryProxy.ts
+++ b/packages/cloudflare-runtime/src/core/registry/RegistryProxy.ts
@@ -13,7 +13,7 @@ const RegistryProxyWorker = {
 };
 import {
   defaultDurableObjectUniqueKey,
-  INTERNAL_WORKER_COMPATIBILITY_DATE,
+  DEFAULT_COMPATIBILITY_DATE,
   SERVICE_USER_WORKER,
 } from "../internal/constants.ts";
 import { formatInternalWorkerModules } from "../internal/internal-modules.ts";
@@ -88,7 +88,7 @@ export const RegistryProxyLive = Layer.effect(
             const service: WorkerdConfig.Service = {
               name: SERVICE_REGISTRY_PROXY,
               worker: {
-                compatibilityDate: INTERNAL_WORKER_COMPATIBILITY_DATE,
+                compatibilityDate: DEFAULT_COMPATIBILITY_DATE,
                 compatibilityFlags: ["service_binding_extra_handlers"],
                 modules: yield* registry
                   .read(subscribed)

--- a/packages/cloudflare-runtime/src/core/remote-bindings/RemoteBindings.ts
+++ b/packages/cloudflare-runtime/src/core/remote-bindings/RemoteBindings.ts
@@ -19,7 +19,7 @@ const OutboundWorker = {
     ),
 };
 import * as Loopback from "../globals/Loopback.ts";
-import { INTERNAL_WORKER_COMPATIBILITY_DATE } from "../internal/constants.ts";
+import { DEFAULT_COMPATIBILITY_DATE } from "../internal/constants.ts";
 import { formatInternalWorkerModules } from "../internal/internal-modules.ts";
 import * as Plugin from "../Plugin.ts";
 import * as PluginContext from "../PluginContext.ts";
@@ -101,7 +101,7 @@ export const RemoteBindingsLive = Layer.effect(
       const outbound = {
         name: "remote-bindings:outbound",
         worker: {
-          compatibilityDate: INTERNAL_WORKER_COMPATIBILITY_DATE,
+          compatibilityDate: DEFAULT_COMPATIBILITY_DATE,
           modules: outboundWorker,
           bindings: [
             {
@@ -130,7 +130,7 @@ export const RemoteBindingsLive = Layer.effect(
       const client = {
         name: "remote-bindings:client",
         worker: {
-          compatibilityDate: INTERNAL_WORKER_COMPATIBILITY_DATE,
+          compatibilityDate: DEFAULT_COMPATIBILITY_DATE,
           modules: clientWorker,
           globalOutbound: { name: outbound.name },
         },

--- a/packages/cloudflare-runtime/src/core/remote-bindings/RemoteWorker.ts
+++ b/packages/cloudflare-runtime/src/core/remote-bindings/RemoteWorker.ts
@@ -14,7 +14,7 @@ const RemoteWorkerScript = {
       "#cloudflare-runtime-core-worker/remote-bindings/workers/remote.worker",
     ),
 };
-import { INTERNAL_WORKER_COMPATIBILITY_DATE } from "../internal/constants.ts";
+import { DEFAULT_COMPATIBILITY_DATE } from "../internal/constants.ts";
 import type { ConfigError, SystemError } from "../RuntimeError.shared.ts";
 import { ApiError } from "../RuntimeError.shared.ts";
 import * as Access from "./Access.ts";
@@ -135,7 +135,7 @@ export const make: (
         cfPreviewUploadConfigToken,
         wranglerSessionConfig: { workersDev: true, minimalMode: true },
         metadata: {
-          compatibilityDate: INTERNAL_WORKER_COMPATIBILITY_DATE,
+          compatibilityDate: DEFAULT_COMPATIBILITY_DATE,
           bindings: options.bindings,
           mainModule: files[0].name,
         },

--- a/packages/cloudflare-runtime/src/core/test/bindings/KvNamespace.test.ts
+++ b/packages/cloudflare-runtime/src/core/test/bindings/KvNamespace.test.ts
@@ -17,8 +17,8 @@
  *   `setOptions`; restart persistence is covered by "persists on file-system".
  * - "migrates database to new location": migrates pre-Durable-Object Miniflare
  *   storage; this runtime has no legacy format.
- * - "sticky blobs never deleted": supports Miniflare's "stacked storage" for
- *   `vitest-pool-workers`, which this runtime doesn't implement.
+ * - "sticky blobs never deleted": supports Miniflare's "stacked storage",
+ *   which this runtime doesn't implement.
  */
 import assert from "node:assert";
 import { Blob } from "node:buffer";

--- a/packages/cloudflare-runtime/src/internal/workers-shared/README.md
+++ b/packages/cloudflare-runtime/src/internal/workers-shared/README.md
@@ -14,7 +14,7 @@ The source tree is split into three buckets that correspond to three tsconfig
 project references:
 
 - `src/internal/workers-shared/workers/` — code that runs in the Workers runtime. Typechecked against
-  `@cloudflare/workers-types` only (plus `@cloudflare/vitest-pool-workers/types`
+  `@cloudflare/workers-types` only (plus `@cloudflare/vitest-plugin/types`
   for the colocated `tests/` directories).
 - `src/internal/workers-shared/shared/` — isomorphic code (web-platform APIs only) used by both Workers
   and Node consumers. Typechecked against the intersection of Workers and Node

--- a/packages/cloudflare-runtime/src/internal/workers-shared/README.md
+++ b/packages/cloudflare-runtime/src/internal/workers-shared/README.md
@@ -28,7 +28,7 @@ project references:
 ## Provenance
 
 Sourced from [`cloudflare/workers-sdk`](https://github.com/cloudflare/workers-sdk)
-at commit `b973ed30015e4e4bface3c0733c33f624066523a` (path:
+at commit `b7b4ff84477982e7c770bb93928287893fcf2e03` (path:
 `packages/workers-shared`). Upstream license: MIT OR Apache-2.0.
 
 | Upstream path                                                                                         | Vendored path                                      |

--- a/packages/cloudflare-runtime/src/internal/workers-shared/shared/types.ts
+++ b/packages/cloudflare-runtime/src/internal/workers-shared/shared/types.ts
@@ -1,5 +1,6 @@
 // Alchemy modifications are licensed under Apache-2.0.
 // This file includes third-party code; see /THIRD_PARTY_LICENSES.md.
+// Alchemy modifications: uses Effect Schema instead of Zod and exposes mutable config types required by the worker implementations.
 import * as Schema from "effect/Schema";
 
 /**

--- a/packages/cloudflare-runtime/src/internal/workers-shared/workers/asset-worker/src/analytics.ts
+++ b/packages/cloudflare-runtime/src/internal/workers-shared/workers/asset-worker/src/analytics.ts
@@ -13,6 +13,38 @@ export enum EntrypointType {
   Inner = 1,
 }
 
+export type ServedBy =
+  | "asset"
+  | "spa"
+  | "404-page"
+  | "none"
+  | "redirect"
+  | "not-modified"
+  | "method-not-allowed"
+  | "error";
+
+export type RequestKind = "navigation" | "subresource";
+
+export function getRequestKind(request: Request): RequestKind {
+  const dest = request.headers.get("Sec-Fetch-Dest");
+  if (dest) {
+    return dest === "document" || dest === "iframe"
+      ? "navigation"
+      : "subresource";
+  }
+
+  const { pathname } = new URL(request.url);
+  const lastSegment = pathname.slice(pathname.lastIndexOf("/") + 1);
+  const dotIndex = lastSegment.lastIndexOf(".");
+  if (dotIndex <= 0) {
+    // No extension, or a dotfile with no other extension.
+    return "navigation";
+  }
+  return lastSegment.slice(dotIndex + 1).toLowerCase() === "html"
+    ? "navigation"
+    : "subresource";
+}
+
 // When adding new columns please update the schema
 type Data = {
   // -- Indexes --
@@ -54,6 +86,10 @@ type Data = {
   cacheStatus?: string;
   // blob9 - Account cohort ("ent", "paid", "free", "employee", or "unknown")
   cohort?: string;
+  // blob10 - What produced the served response (see ServedBy)
+  servedBy?: ServedBy;
+  // blob11 - Whether the request was a navigation or a subresource
+  requestKind?: RequestKind;
 };
 
 const COMPATIBILITY_FLAG_MASKS: Record<ENABLEMENT_COMPATIBILITY_FLAGS, number> =
@@ -76,7 +112,7 @@ export class Analytics {
     this.data = { ...this.data, ...newData };
   }
 
-  getData(key: keyof Data) {
+  getData<Key extends keyof Data>(key: Key): Data[Key] {
     return this.data[key];
   }
 
@@ -119,6 +155,8 @@ export class Analytics {
         this.data.coloRegion, // blob7
         this.data.cacheStatus, // blob8
         this.data.cohort, // blob9
+        this.data.servedBy, // blob10
+        this.data.requestKind, // blob11
       ],
     });
   }

--- a/packages/cloudflare-runtime/src/internal/workers-shared/workers/asset-worker/src/handler.ts
+++ b/packages/cloudflare-runtime/src/internal/workers-shared/workers/asset-worker/src/handler.ts
@@ -24,7 +24,7 @@ import {
   staticRedirectsMatcher,
 } from "./utils/rules-engine.ts";
 import type { AssetConfig } from "../../../shared/types.ts";
-import type { Analytics } from "./analytics.ts";
+import type { Analytics, ServedBy } from "./analytics.ts";
 import type EntrypointType from "./worker.ts";
 import type { Env } from "./worker.ts";
 
@@ -43,6 +43,7 @@ const getResponseOrAssetIntent = async (
   env: Env,
   configuration: Required<AssetConfig>,
   exists: typeof EntrypointType.prototype.unstable_exists,
+  analytics?: Analytics,
 ): Promise<Response | AssetIntentWithResolver> => {
   const url = new URL(request.url);
   const { search } = url;
@@ -56,6 +57,7 @@ const getResponseOrAssetIntent = async (
     search,
   );
   if (redirectResult instanceof Response) {
+    analytics?.setData({ servedBy: "redirect" });
     return redirectResult;
   }
   const { proxied, pathname } = redirectResult;
@@ -72,6 +74,7 @@ const getResponseOrAssetIntent = async (
   if (!intent) {
     const response = proxied ? new NotFoundResponse() : new NoIntentResponse();
 
+    analytics?.setData({ servedBy: "none" });
     return env.JAEGER.enterSpan("no_intent", (span) => {
       span.setTags({
         decodedPathname,
@@ -86,6 +89,7 @@ const getResponseOrAssetIntent = async (
 
   const method = request.method.toUpperCase();
   if (!["GET", "HEAD"].includes(method)) {
+    analytics?.setData({ servedBy: "method-not-allowed" });
     return env.JAEGER.enterSpan("method_not_allowed", (span) => {
       span.setTags({
         method,
@@ -105,6 +109,7 @@ const getResponseOrAssetIntent = async (
    * We combine this with other redirects (e.g. for html_handling) to avoid multiple redirects.
    */
   if ((encodedDestination !== pathname && intent.asset) || intent.redirect) {
+    analytics?.setData({ servedBy: "redirect" });
     return env.JAEGER.enterSpan("redirect", (span) => {
       span.setTags({
         originalPath: pathname,
@@ -120,6 +125,7 @@ const getResponseOrAssetIntent = async (
   }
 
   if (!intent.asset) {
+    analytics?.setData({ servedBy: "error" });
     return env.JAEGER.enterSpan("unknown_action", (span) => {
       span.setTags({
         pathname,
@@ -167,6 +173,7 @@ const resolveAssetIntentToResponse = async (
   const weakETag = `W/${strongETag}`;
   const ifNoneMatch = request.headers.get("If-None-Match") || "";
   if ([weakETag, strongETag].includes(ifNoneMatch)) {
+    analytics.setData({ servedBy: "not-modified" });
     return env.JAEGER.enterSpan("matched_etag", (span) => {
       span.setTags({
         matchedEtag: ifNoneMatch,
@@ -177,6 +184,9 @@ const resolveAssetIntentToResponse = async (
     });
   }
 
+  analytics.setData({
+    servedBy: servedByForResolver(assetIntent.resolver, configuration),
+  });
   return env.JAEGER.enterSpan("response", (span) => {
     span.setTags({
       etag: assetIntent.eTag,
@@ -241,6 +251,7 @@ export const handleRequest = async (
     env,
     configuration,
     exists,
+    analytics,
   );
 
   const response =
@@ -259,6 +270,28 @@ export const handleRequest = async (
 };
 
 type Resolver = "html-handling" | "not-found";
+
+function servedByForResolver(
+  resolver: Resolver,
+  configuration: Required<AssetConfig>,
+): ServedBy {
+  if (resolver === "html-handling") {
+    return "asset";
+  }
+
+  switch (configuration.not_found_handling) {
+    case "single-page-application":
+      return "spa";
+    case "404-page":
+      return "404-page";
+    case "none":
+      return "none";
+    default:
+      configuration.not_found_handling satisfies never;
+      return "error";
+  }
+}
+
 type Intent =
   | {
       asset: AssetIntent;
@@ -1034,7 +1067,9 @@ const handleRedirects = (
         const destination = new URL(to, request.url);
         const location =
           destination.origin === new URL(request.url).origin
-            ? `${destination.pathname}${destination.search || search}${destination.hash}`
+            ? `${destination.pathname}${destination.search || search}${
+                destination.hash
+              }`
             : `${destination.href.slice(0, destination.href.length - (destination.search.length + destination.hash.length))}${
                 destination.search ? destination.search : search
               }${destination.hash}`;

--- a/packages/cloudflare-runtime/src/internal/workers-shared/workers/asset-worker/src/utils/final-operations.ts
+++ b/packages/cloudflare-runtime/src/internal/workers-shared/workers/asset-worker/src/utils/final-operations.ts
@@ -18,6 +18,7 @@ export function handleError(
       sentry.captureException(err);
     }
 
+    analytics.setData({ servedBy: "error" });
     if (err instanceof Error) {
       analytics.setData({ error: err.message });
     }

--- a/packages/cloudflare-runtime/src/internal/workers-shared/workers/asset-worker/src/utils/kv.ts
+++ b/packages/cloudflare-runtime/src/internal/workers-shared/workers/asset-worker/src/utils/kv.ts
@@ -1,5 +1,6 @@
 // Alchemy modifications are licensed under Apache-2.0.
 // This file includes third-party code; see /THIRD_PARTY_LICENSES.md.
+// Alchemy modifications: preserves the original KV failure as Error.cause after retries are exhausted.
 import type { Toucan } from "toucan-js";
 
 export type AssetMetadata = {
@@ -10,7 +11,7 @@ export async function getAssetWithMetadataFromKV(
   assetsKVNamespace: KVNamespace,
   assetKey: string,
   sentry?: Toucan,
-  retries = 1,
+  retries = 3,
 ) {
   let attempts = 0;
 

--- a/packages/cloudflare-runtime/src/internal/workers-shared/workers/asset-worker/src/worker.ts
+++ b/packages/cloudflare-runtime/src/internal/workers-shared/workers/asset-worker/src/worker.ts
@@ -4,7 +4,7 @@ import { WorkerEntrypoint } from "cloudflare:workers";
 import { PerformanceTimer } from "../../../shared/performance.ts";
 import { setupSentry } from "../../../shared/sentry.ts";
 import { mockJaegerBinding } from "../../../shared/tracing.ts";
-import { Analytics, EntrypointType } from "./analytics.ts";
+import { Analytics, EntrypointType, getRequestKind } from "./analytics.ts";
 import { AssetsManifest } from "./assets-manifest.ts";
 import { normalizeConfiguration } from "./configuration.ts";
 import { ExperimentAnalytics } from "./experiment-analytics.ts";
@@ -312,6 +312,7 @@ async function runFetchRequest(
         userAgent: userAgent,
         entrypoint: EntrypointType.Inner,
         cohort: cohort ?? "unknown",
+        requestKind: getRequestKind(request),
       });
     }
 
@@ -360,8 +361,14 @@ async function runFetchRequest(
  *
  * AssetWorkerOuter serves as the dispatch layer. It forwards all method
  * calls to AssetWorkerInner via ctx.exports.
+ *
+ * This now-unused entrypoint can be used for loopback invocations if made the
+ * default export, which is how cohorted deployments will be implemented.
+ * For now, the latency added by loopback invocations is too high for normal
+ * traffic. When that has been addressed, re-enable loopback by making this
+ * the default export.
  */
-export default class AssetWorkerOuter<TEnv extends Env = Env>
+export class AssetWorkerOuter<TEnv extends Env = Env>
   extends WorkerEntrypoint<TEnv>
   implements AssetWorkerMethods
 {
@@ -429,6 +436,7 @@ export default class AssetWorkerOuter<TEnv extends Env = Env>
           hostname: url.hostname,
           version: this.env.VERSION_METADATA.tag,
           entrypoint: EntrypointType.Outer,
+          requestKind: getRequestKind(request),
         });
       }
       sentry = setupSentry(
@@ -449,7 +457,10 @@ export default class AssetWorkerOuter<TEnv extends Env = Env>
       const response = await this.getInnerEntrypoint(cohort).fetch(request);
       analytics.setData({ status: response.status });
       if (response.status >= 500) {
-        analytics.setData({ error: "inner entrypoint error" });
+        analytics.setData({
+          error: "inner entrypoint error",
+          servedBy: "error",
+        });
       }
       return response;
     } catch (err) {
@@ -503,10 +514,10 @@ export default class AssetWorkerOuter<TEnv extends Env = Env>
 
 /*
  * AssetWorkerInner contains the actual implementation logic for all asset
- * worker methods. In production, it is instantiated by AssetWorkerOuter via
- * ctx.exports. For local development, tools such as the Vite plugin can
- * subclass AssetWorkerInner directly to override methods like unstable_exists
- * and unstable_getByETag with dev-server-backed implementations.
+ * worker methods. AssetWorkerOuter can instantiate it via ctx.exports to
+ * enable cohort-based loopback. For local development, tools such as the Vite
+ * plugin can subclass AssetWorkerInner directly to override methods like
+ * unstable_exists and unstable_getByETag with dev-server-backed implementations.
  */
 export class AssetWorkerInner<TEnv extends Env = Env>
   extends WorkerEntrypoint<TEnv>
@@ -518,19 +529,19 @@ export class AssetWorkerInner<TEnv extends Env = Env>
     const loopbackCtx = this.ctx as AssetWorkerContext;
     const traceContext = loopbackCtx.props?.traceContext ?? null;
     const cohort = this.ctx.version?.cohort;
+    const runRequest = () =>
+      runFetchRequest(
+        request,
+        this.env,
+        this.ctx,
+        this.unstable_exists.bind(this),
+        this.unstable_getByETag.bind(this),
+        cohort,
+      );
 
-    const response = await this.env.JAEGER.runWithSpanContext(
-      traceContext,
-      () =>
-        runFetchRequest(
-          request,
-          this.env,
-          this.ctx,
-          this.unstable_exists.bind(this),
-          this.unstable_getByETag.bind(this),
-          cohort,
-        ),
-    );
+    const response = traceContext
+      ? await this.env.JAEGER.runWithSpanContext(traceContext, runRequest)
+      : await runRequest();
 
     if (response instanceof Response) {
       return response;
@@ -578,3 +589,5 @@ export class AssetWorkerInner<TEnv extends Env = Env>
     return unstableExistsImpl(this.env, pathname, request);
   }
 }
+
+export default AssetWorkerInner;

--- a/packages/cloudflare-runtime/src/internal/workers-shared/workers/asset-worker/tests/analytics.test.ts
+++ b/packages/cloudflare-runtime/src/internal/workers-shared/workers/asset-worker/tests/analytics.test.ts
@@ -1,7 +1,7 @@
 // Alchemy modifications are licensed under Apache-2.0.
 // This file includes third-party code; see /THIRD_PARTY_LICENSES.md.
 import { describe, it, vi } from "vitest";
-import { Analytics, EntrypointType } from "../src/analytics.ts";
+import { Analytics, EntrypointType, getRequestKind } from "../src/analytics.ts";
 import type { ReadyAnalyticsEvent } from "../src/types.ts";
 
 describe("[Asset Worker] Analytics", () => {
@@ -59,6 +59,8 @@ describe("[Asset Worker] Analytics", () => {
         coloRegion: "WEUR",
         cacheStatus: "HIT",
         cohort: "free",
+        servedBy: "asset",
+        requestKind: "navigation",
       });
       analytics.write();
 
@@ -83,10 +85,35 @@ describe("[Asset Worker] Analytics", () => {
       expect(event?.blobs?.[6]).toBe("WEUR"); // coloRegion
       expect(event?.blobs?.[7]).toBe("HIT"); // cacheStatus
       expect(event?.blobs?.[8]).toBe("free"); // cohort
+      expect(event?.blobs?.[9]).toBe("asset"); // servedBy
+      expect(event?.blobs?.[10]).toBe("navigation"); // requestKind
 
       // Indexes
       expect(event?.accountId).toBe(123);
       expect(event?.indexId).toBe("456");
     });
   });
+});
+
+describe("[Asset Worker] `getRequestKind`", () => {
+  const cases = [
+    ["document destination", "/style.css", "document", "navigation"],
+    ["iframe destination", "/style.css", "iframe", "navigation"],
+    ["script destination", "/index.html", "script", "subresource"],
+    ["extensionless path", "/about", undefined, "navigation"],
+    ["HTML path", "/page.html", undefined, "navigation"],
+    ["JavaScript path", "/app.js", undefined, "subresource"],
+  ] as const;
+
+  it.for(cases)(
+    "classifies $0 as $3",
+    ([, path, destination, expected], { expect }) => {
+      const headers = destination
+        ? { "Sec-Fetch-Dest": destination }
+        : undefined;
+      const request = new Request(`https://example.com${path}`, { headers });
+
+      expect(getRequestKind(request)).toBe(expected);
+    },
+  );
 });

--- a/packages/cloudflare-runtime/src/internal/workers-shared/workers/asset-worker/tests/handler.test.ts
+++ b/packages/cloudflare-runtime/src/internal/workers-shared/workers/asset-worker/tests/handler.test.ts
@@ -1558,3 +1558,79 @@ describe("[Asset Worker] `canFetch`", () => {
     );
   });
 });
+
+describe("[Asset Worker] `handleRequest` analytics", () => {
+  function streamingAsset() {
+    return {
+      readableStream: new ReadableStream(),
+      contentType: "text/html",
+      cacheStatus: "HIT" as const,
+    };
+  }
+
+  async function requestWithAnalytics({
+    request,
+    configuration,
+    assets,
+  }: {
+    request: Request;
+    configuration: AssetConfig;
+    assets: Readonly<Record<string, string>>;
+  }) {
+    const analytics = new Analytics();
+    await handleRequest(
+      request,
+      // @ts-expect-error Empty config default to using mocked jaeger
+      mockEnv,
+      normalizeConfiguration(configuration),
+      async (pathname) => assets[pathname] ?? null,
+      vi.fn().mockReturnValue(streamingAsset()),
+      analytics,
+    );
+
+    return analytics;
+  }
+
+  const cases = [
+    {
+      name: "an asset",
+      request: new Request("https://example.com/"),
+      configuration: {
+        html_handling: "none",
+        not_found_handling: "none",
+      },
+      assets: { "/": "some-etag" },
+      expectedServedBy: "asset",
+    },
+    {
+      name: "an SPA fallback",
+      request: new Request("https://example.com/missing"),
+      configuration: { not_found_handling: "single-page-application" },
+      assets: { "/index.html": "spa-etag" },
+      expectedServedBy: "spa",
+    },
+    {
+      name: "a 404 page fallback",
+      request: new Request("https://example.com/missing"),
+      configuration: { not_found_handling: "404-page" },
+      assets: { "/404.html": "404-etag" },
+      expectedServedBy: "404-page",
+    },
+  ] as const;
+
+  it.for(cases)(
+    "records servedBy=$expectedServedBy for $name",
+    async (
+      { request, configuration, assets, expectedServedBy },
+      { expect },
+    ) => {
+      const analytics = await requestWithAnalytics({
+        request,
+        configuration,
+        assets,
+      });
+
+      expect(analytics.getData("servedBy")).toBe(expectedServedBy);
+    },
+  );
+});

--- a/packages/cloudflare-runtime/src/internal/workers-shared/workers/asset-worker/tests/kv.test.ts
+++ b/packages/cloudflare-runtime/src/internal/workers-shared/workers/asset-worker/tests/kv.test.ts
@@ -55,7 +55,7 @@ describe("[Asset Worker] Fetching assets from KV", () => {
       ).rejects.toThrow("KV GET abcd failed.");
     });
 
-    it("should retry once by default if something went wrong while fetching the asset", async ({
+    it("should retry three times by default if something went wrong while fetching the asset", async ({
       expect,
     }) => {
       spy.mockReturnValue(Promise.reject("Oeps! Something went wrong"));
@@ -63,7 +63,7 @@ describe("[Asset Worker] Fetching assets from KV", () => {
       await expect(() =>
         getAssetWithMetadataFromKV(mockKVNamespace, "abcd"),
       ).rejects.toThrow("KV GET abcd failed.");
-      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenCalledTimes(4);
     });
 
     it("should support custom number of retries", async ({ expect }) => {
@@ -83,7 +83,7 @@ describe("[Asset Worker] Fetching assets from KV", () => {
       await expect(() =>
         getAssetWithMetadataFromKV(mockKVNamespace, "abcd"),
       ).rejects.toThrow("KV GET abcd failed: Oeps! Something went wrong");
-      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenCalledTimes(4);
     });
 
     it("should retry on 404 and cache with shorter ttl", async ({ expect }) => {

--- a/packages/cloudflare-runtime/src/internal/workers-shared/workers/asset-worker/wrangler.jsonc
+++ b/packages/cloudflare-runtime/src/internal/workers-shared/workers/asset-worker/wrangler.jsonc
@@ -15,9 +15,9 @@
   "workers_dev": false,
   "main": "src/worker.ts",
   "compatibility_date": "2026-08-31",
-  // nodejs_compat required when using @cloudflare/vitest-plugin
-  // ctx.exports is default-on as of 2025-11-17
-  "compatibility_flags": ["nodejs_compat"],
+  // nodejs_compat and nodejs_compat_v2 are default-on as of 2026-08-04;
+  // 2026-08-31 therefore needs no redundant positive compatibility flag.
+  // ctx.exports is default-on as of 2025-11-17.
   "unsafe": {
     "metadata": {
       "build_options": {
@@ -65,7 +65,7 @@
       "name": "asset-worker-staging",
       // enable_version_api is set per-environment (not top-level) because
       // the local workerd in vitest-pool-workers does not support it yet.
-      "compatibility_flags": ["nodejs_compat", "enable_version_api"],
+      "compatibility_flags": ["enable_version_api"],
       "unsafe": {
         "metadata": {
           "build_options": {
@@ -112,7 +112,7 @@
     "fed-prod": {
       "name": "asset-worker-fed-prod",
       "account_id": "fca6c231dc1d1780777997c5bce5a5e3", // workers assets
-      "compatibility_flags": ["nodejs_compat", "enable_version_api"],
+      "compatibility_flags": ["enable_version_api"],
       "vars": {
         "ENVIRONMENT": "fed-prod",
       },

--- a/packages/cloudflare-runtime/src/internal/workers-shared/workers/asset-worker/wrangler.jsonc
+++ b/packages/cloudflare-runtime/src/internal/workers-shared/workers/asset-worker/wrangler.jsonc
@@ -15,7 +15,7 @@
   "workers_dev": false,
   "main": "src/worker.ts",
   "compatibility_date": "2026-08-31",
-  // nodejs_compat required when using @cloudflare/vitest-pool-workers
+  // nodejs_compat required when using @cloudflare/vitest-plugin
   // ctx.exports is default-on as of 2025-11-17
   "compatibility_flags": ["nodejs_compat"],
   "unsafe": {

--- a/packages/cloudflare-runtime/src/internal/workers-shared/workers/asset-worker/wrangler.jsonc
+++ b/packages/cloudflare-runtime/src/internal/workers-shared/workers/asset-worker/wrangler.jsonc
@@ -63,8 +63,8 @@
   "env": {
     "staging": {
       "name": "asset-worker-staging",
-      // enable_version_api is set per-environment (not top-level) because
-      // the local workerd in vitest-pool-workers does not support it yet.
+      // Match upstream's environment-scoped behavior: only staging and
+      // fed-prod enable the experimental version API.
       "compatibility_flags": ["enable_version_api"],
       "unsafe": {
         "metadata": {

--- a/packages/cloudflare-runtime/src/internal/workers-shared/workers/router-worker/src/worker.ts
+++ b/packages/cloudflare-runtime/src/internal/workers-shared/workers/router-worker/src/worker.ts
@@ -51,44 +51,53 @@ type LoopbackExecutionContext = ExecutionContext & {
   };
 };
 
-export default {
-  async fetch(request: Request, env: Env, ctx: ExecutionContext) {
+// This now-unused Entrypoint can be used for loopback invocations if made the
+// default export, which is how cohorted deployments will be implemented.
+// For now, the latency added by loopback invocations is too much for such a
+// load-bearing Worker. When that has been addressed in the future, re-enable
+// loopback by making this the default export.
+export class RouterOuterEntrypoint extends WorkerEntrypoint<Env> {
+  override async fetch(request: Request): Promise<Response> {
     // Router worker is typechecked both in this package and as a transitive
     // dependency during miniflare builds. In the miniflare type context,
     // Cloudflare.Exports may not include this worker's mainModule mapping from
     // worker-configuration.d.ts, so `ctx.exports.RouterInnerEntrypoint` does not
     // resolve structurally. Keep this narrow cast so loopback typechecks in both
     // compilation contexts without changing runtime behavior.
-    const loopbackCtx = ctx as LoopbackExecutionContext;
+    const loopbackCtx = this.ctx as LoopbackExecutionContext;
 
-    const analytics = new Analytics(env.ANALYTICS);
+    const analytics = new Analytics(this.env.ANALYTICS);
     let inner;
     try {
-      if (env.COLO_METADATA && env.VERSION_METADATA && env.CONFIG) {
+      if (
+        this.env.COLO_METADATA &&
+        this.env.VERSION_METADATA &&
+        this.env.CONFIG
+      ) {
         const url = new URL(request.url);
         analytics.setData({
-          accountId: env.CONFIG.account_id,
-          scriptId: env.CONFIG.script_id,
-          coloId: env.COLO_METADATA.coloId,
-          metalId: env.COLO_METADATA.metalId,
-          coloTier: env.COLO_METADATA.coloTier,
-          coloRegion: env.COLO_METADATA.coloRegion,
+          accountId: this.env.CONFIG.account_id,
+          scriptId: this.env.CONFIG.script_id,
+          coloId: this.env.COLO_METADATA.coloId,
+          metalId: this.env.COLO_METADATA.metalId,
+          coloTier: this.env.COLO_METADATA.coloTier,
+          coloRegion: this.env.COLO_METADATA.coloRegion,
           hostname: url.hostname,
-          version: env.VERSION_METADATA.tag,
+          version: this.env.VERSION_METADATA.tag,
         });
       }
       inner = loopbackCtx.exports.RouterInnerEntrypoint({ props: {} });
     } catch (err) {
       const sentry = setupSentry(
         request,
-        ctx,
-        env.SENTRY_DSN,
-        env.SENTRY_ACCESS_CLIENT_ID,
-        env.SENTRY_ACCESS_CLIENT_SECRET,
-        env.COLO_METADATA,
-        env.VERSION_METADATA,
-        env.CONFIG?.account_id,
-        env.CONFIG?.script_id,
+        this.ctx,
+        this.env.SENTRY_DSN,
+        this.env.SENTRY_ACCESS_CLIENT_ID,
+        this.env.SENTRY_ACCESS_CLIENT_SECRET,
+        this.env.COLO_METADATA,
+        this.env.VERSION_METADATA,
+        this.env.CONFIG?.account_id,
+        this.env.CONFIG?.script_id,
       );
       sentry?.captureException(err);
 
@@ -101,8 +110,8 @@ export default {
     }
 
     return inner.fetch(request);
-  },
-};
+  }
+}
 
 export class RouterInnerEntrypoint extends WorkerEntrypoint<Env> {
   override async fetch(request: Request): Promise<Response> {
@@ -360,6 +369,8 @@ export class RouterInnerEntrypoint extends WorkerEntrypoint<Env> {
     }
   }
 }
+
+export default RouterInnerEntrypoint;
 
 /**
  * Check if the Content Type is allowed for the the `_next/image` endpoint.

--- a/packages/cloudflare-runtime/src/internal/workers-shared/workers/router-worker/tests/index.test.ts
+++ b/packages/cloudflare-runtime/src/internal/workers-shared/workers/router-worker/tests/index.test.ts
@@ -2,8 +2,11 @@
 // This file includes third-party code; see /THIRD_PARTY_LICENSES.md.
 import { createExecutionContext } from "cloudflare:test";
 import { exports, env as runtimeEnv } from "cloudflare:workers";
-import { describe, it } from "vitest";
-import { RouterInnerEntrypoint } from "../src/worker.ts";
+import { describe, it, vi } from "vitest";
+import DefaultRouterEntrypoint, {
+  RouterInnerEntrypoint,
+  RouterOuterEntrypoint,
+} from "../src/worker.ts";
 import type { Env } from "../src/worker.ts";
 
 async function fetchFromInnerEntrypoint(
@@ -14,16 +17,23 @@ async function fetchFromInnerEntrypoint(
   return new RouterInnerEntrypoint(ctx, env).fetch(request);
 }
 
-describe("runtime loopback", () => {
-  it("routes through outer->inner loopback at runtime boundary", async ({
+describe("entrypoints", () => {
+  it("uses the inner entrypoint as the default export", ({ expect }) => {
+    expect(DefaultRouterEntrypoint).toBe(RouterInnerEntrypoint);
+  });
+
+  it("routes directly through the inner entrypoint at the runtime boundary", async ({
     expect,
   }) => {
-    (runtimeEnv as unknown as Env).CONFIG = {
+    // Alchemy's generated Cloudflare.Env is empty, while the test runtime
+    // injects these router bindings dynamically.
+    const testRuntimeEnv = runtimeEnv as typeof runtimeEnv & Partial<Env>;
+    testRuntimeEnv.CONFIG = {
       has_user_worker: false,
     };
-    (runtimeEnv as unknown as Env).ASSET_WORKER = {
+    testRuntimeEnv.ASSET_WORKER = {
       async fetch(_request: Request): Promise<Response> {
-        return new Response("loopback asset worker");
+        return new Response("asset worker");
       },
       async unstable_canFetch(_request: Request): Promise<boolean> {
         return true;
@@ -35,7 +45,31 @@ describe("runtime loopback", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(await response.text()).toBe("loopback asset worker");
+    expect(await response.text()).toBe("asset worker");
+  });
+
+  it("keeps the outer-to-inner loopback available", async ({ expect }) => {
+    const request = new Request("https://example.com");
+    const ctx = createExecutionContext();
+    const innerFetch = vi.fn(async (_request: Request) => {
+      return new Response("inner response");
+    });
+    const createInnerEntrypoint = vi.fn(() => ({ fetch: innerFetch }));
+    Object.defineProperty(ctx, "exports", {
+      value: {
+        RouterInnerEntrypoint: createInnerEntrypoint,
+      },
+    });
+
+    const response = await new RouterOuterEntrypoint(ctx, {} as Env).fetch(
+      request,
+    );
+
+    expect(createInnerEntrypoint).toHaveBeenCalledOnce();
+    expect(createInnerEntrypoint).toHaveBeenCalledWith({ props: {} });
+    expect(innerFetch).toHaveBeenCalledOnce();
+    expect(innerFetch).toHaveBeenCalledWith(request);
+    expect(await response.text()).toBe("inner response");
   });
 });
 

--- a/packages/cloudflare-runtime/src/internal/workers-shared/workers/router-worker/wrangler.jsonc
+++ b/packages/cloudflare-runtime/src/internal/workers-shared/workers/router-worker/wrangler.jsonc
@@ -15,8 +15,9 @@
   "workers_dev": false,
   "main": "src/worker.ts",
   "compatibility_date": "2026-08-31",
-  // nodejs_compat required when using @cloudflare/vitest-plugin
-  "compatibility_flags": ["nodejs_compat", "no_nodejs_compat_v2"],
+  // nodejs_compat is default-on as of 2026-08-04. Keep the explicit v2 opt-out
+  // because this worker intentionally exercises the legacy Node.js mode.
+  "compatibility_flags": ["no_nodejs_compat_v2"],
   "version_metadata": {
     "binding": "VERSION_METADATA",
   },

--- a/packages/cloudflare-runtime/src/internal/workers-shared/workers/router-worker/wrangler.jsonc
+++ b/packages/cloudflare-runtime/src/internal/workers-shared/workers/router-worker/wrangler.jsonc
@@ -15,7 +15,7 @@
   "workers_dev": false,
   "main": "src/worker.ts",
   "compatibility_date": "2026-08-31",
-  // nodejs_compat required when using @cloudflare/vitest-pool-workers
+  // nodejs_compat required when using @cloudflare/vitest-plugin
   "compatibility_flags": ["nodejs_compat", "no_nodejs_compat_v2"],
   "version_metadata": {
     "binding": "VERSION_METADATA",

--- a/packages/cloudflare-runtime/src/internal/workflows-shared/README.md
+++ b/packages/cloudflare-runtime/src/internal/workflows-shared/README.md
@@ -5,15 +5,15 @@ Private workspace package vendoring raw TypeScript source from
 This package does not bundle or publish; consumer packages in this monorepo
 import the `.ts` files directly and apply their own bundling.
 
-The upstream source and tests are co-located under `src/internal/workflows-shared/`, with no
-modifications. Only the project metadata (`package.json`, `tsconfig.json`,
-`vitest.config.ts`) is rewritten to fit this monorepo's tooling. The upstream
-`wrangler.jsonc` is also copied unchanged.
+The upstream source and tests are co-located under
+`src/internal/workflows-shared/`. Deliberate behavioral differences from
+upstream are documented with `Alchemy modifications:` comments in the affected
+files. Project metadata and imports are adapted to this monorepo's tooling.
 
 ## Provenance
 
 Sourced from [`cloudflare/workers-sdk`](https://github.com/cloudflare/workers-sdk)
-at commit `b973ed30015e4e4bface3c0733c33f624066523a` (path:
+at commit `b7b4ff84477982e7c770bb93928287893fcf2e03` (path:
 `packages/workflows-shared`). Upstream license: MIT OR Apache-2.0.
 
 ## Consumer imports

--- a/packages/cloudflare-runtime/src/internal/workflows-shared/binding.ts
+++ b/packages/cloudflare-runtime/src/internal/workflows-shared/binding.ts
@@ -1,14 +1,20 @@
 // Alchemy modifications are licensed under Apache-2.0.
 // This file includes third-party code; see /THIRD_PARTY_LICENSES.md.
+// Alchemy modifications: uses Array<T> syntax for non-tuple array types to match the repository convention.
 import { RpcTarget, WorkerEntrypoint } from "cloudflare:workers";
 import { InstanceEvent, instanceStatusName } from "./instance.ts";
 import {
+  isUserTriggeredDelete,
   isUserTriggeredPause,
   isUserTriggeredRestart,
+  createWorkflowError,
   isUserTriggeredTerminate,
   WorkflowError,
 } from "./lib/errors.ts";
-import { isValidWorkflowInstanceId } from "./lib/validators.ts";
+import {
+  isValidAddressableWorkflowInstanceId,
+  isValidWorkflowInstanceId,
+} from "./lib/validators.ts";
 import type {
   DatabaseInstance,
   DatabaseVersion,
@@ -27,7 +33,51 @@ type Env = {
   ENGINE: DurableObjectNamespace<Engine>;
   BINDING_NAME: string;
   WORKFLOW_NAME: string;
+  MINIFLARE_LOOPBACK?: Fetcher;
 };
+
+/** Waits for Miniflare to finish deleting an instance's persistence files. */
+async function waitForPersistedInstanceDelete(
+  env: Env,
+  id: string | undefined,
+): Promise<void> {
+  if (id === undefined || env.MINIFLARE_LOOPBACK === undefined) {
+    return;
+  }
+
+  const hexId = env.ENGINE.idFromName(id).toString();
+  const response = await env.MINIFLARE_LOOPBACK.fetch(
+    `http://localhost/core/workflow-storage/${encodeURIComponent(env.WORKFLOW_NAME)}/${hexId}?waitForPendingDelete=1`,
+  );
+  if (!response.ok) {
+    throw new Error(
+      `Failed to wait for persisted workflow instance '${id}' deletion`,
+    );
+  }
+}
+
+/** Aborts an Engine object before removing its persistence files. */
+async function deletePersistedInstance(env: Env, id: string): Promise<void> {
+  if (env.MINIFLARE_LOOPBACK === undefined) {
+    return;
+  }
+
+  const stub = env.ENGINE.get(env.ENGINE.idFromName(id));
+  try {
+    await stub.unsafeAbort();
+  } catch {
+    // Aborting the Durable Object rejects its RPC.
+  }
+
+  const response = await env.MINIFLARE_LOOPBACK.fetch(
+    `http://localhost/core/workflow-storage/${encodeURIComponent(env.WORKFLOW_NAME)}/${stub.id.toString()}?defer=1`,
+    { method: "DELETE" },
+  );
+  if (!response.ok) {
+    throw new Error(`Failed to delete persisted workflow instance '${id}'`);
+  }
+  await waitForPersistedInstanceDelete(env, id);
+}
 
 type WorkflowIntrospectionSession = {
   id: string;
@@ -126,6 +176,13 @@ export interface RestartFromStep {
   type?: "do" | "sleep" | "waitForEvent";
 }
 
+export interface WorkflowInstanceTerminateOptions {
+  /**
+   * If true, run registered rollback handlers before terminating the instance.
+   */
+  rollback?: boolean;
+}
+
 export interface WorkflowInstanceRestartOptions {
   from?: RestartFromStep;
 }
@@ -146,6 +203,7 @@ export class WorkflowBinding extends WorkerEntrypoint<Env> {
       throw new WorkflowError("Workflow instance has invalid id");
     }
 
+    await waitForPersistedInstanceDelete(this.env, id);
     const stubId = this.env.ENGINE.idFromName(id);
     const stub = this.env.ENGINE.get(stubId);
     const introspectionSession = workflowIntrospectionSessions.get(
@@ -235,31 +293,117 @@ export class WorkflowBinding extends WorkerEntrypoint<Env> {
     );
   }
 
-  public async deleteBatch(
-    instanceIds: string[],
-  ): Promise<WorkflowBatchDeleteResult> {
-    if (instanceIds.length > 100) {
-      throw new WorkflowError(
-        "deleteBatch is limited to 100 instances at a time",
+  /**
+   * Deletes an instance. Named `deleteInstance` because `Fetcher.delete()` shadows
+   * a same-named JSRPC method.
+   */
+  public async deleteInstance(id: string): Promise<void> {
+    if (!isValidAddressableWorkflowInstanceId(id)) {
+      throw createWorkflowError(
+        "Instance ID is invalid",
+        "instance.invalid_id",
       );
     }
-    const deleted: { id: string }[] = [];
-    const errors: { id: string; code: number; message: string }[] = [];
-    for (const id of new Set(instanceIds)) {
-      try {
-        const handle = (await this.get(id)) as WorkflowHandle;
-        await handle.delete();
-        deleted.push({ id });
-      } catch (e) {
-        const message = e instanceof Error ? e.message : String(e);
-        errors.push({
-          id,
-          code: message.startsWith("instance.not_found") ? 404 : 400,
-          message,
-        });
+
+    const stub = this.env.ENGINE.get(this.env.ENGINE.idFromName(id));
+    try {
+      await stub.deleteInstance();
+    } catch (error) {
+      // delete aborts the instance
+      if (!isUserTriggeredDelete(error)) {
+        throw error;
       }
     }
-    return { deleted, errors };
+    await waitForPersistedInstanceDelete(this.env, id);
+  }
+
+  /** Deletes each unique instance once while preserving duplicate results. */
+  public async deleteBatch(options: {
+    instances: Array<string>;
+  }): Promise<WorkflowBatchDeleteResult> {
+    const instanceIds = options?.instances;
+    if (!Array.isArray(instanceIds)) {
+      throw createWorkflowError("Provided argument is invalid", "body");
+    }
+    if (instanceIds.length > 100) {
+      throw createWorkflowError(
+        "batchDeleteInstances only supports 100 instances at a time",
+        "body",
+      );
+    }
+    if (instanceIds.length === 0) {
+      throw createWorkflowError(
+        "batchDeleteInstances should have at least 1 instance",
+        "body",
+      );
+    }
+    if (!instanceIds.every(isValidAddressableWorkflowInstanceId)) {
+      throw createWorkflowError(
+        "Instance ID is invalid",
+        "instance.invalid_id",
+      );
+    }
+
+    const uniqueIds = [...new Set(instanceIds)];
+    const settled = await Promise.allSettled(
+      uniqueIds.map((id) => this.deleteInstance(id)),
+    );
+    const resultsById = new Map(
+      uniqueIds.map((id, index) => [id, settled[index]]),
+    );
+    const result: WorkflowBatchDeleteResult = { deleted: [], errors: [] };
+    for (const id of instanceIds) {
+      const deletion = resultsById.get(id);
+      if (deletion === undefined) {
+        throw new Error("Missing batch deletion result");
+      }
+      if (
+        deletion.status === "fulfilled" ||
+        isUserTriggeredDelete(deletion.reason)
+      ) {
+        result.deleted.push({ id });
+        continue;
+      }
+
+      const isNotFound =
+        deletion.reason instanceof Error &&
+        deletion.reason.message.includes("(instance.not_found)");
+      result.errors.push({
+        id,
+        code: isNotFound ? 10400 : 10001,
+        message: isNotFound
+          ? "workflows.api.error.instance.not_found"
+          : "workflows.api.error.internal_server",
+      });
+    }
+
+    const missingIds = new Set(
+      result.errors.filter(({ code }) => code === 10400).map(({ id }) => id),
+    );
+    const cleanupIds = [...missingIds];
+    const cleanups = await Promise.allSettled(
+      cleanupIds.map((id) => deletePersistedInstance(this.env, id)),
+    );
+    const failedCleanupIds = new Set(
+      cleanupIds.filter((_, index) => cleanups[index]?.status === "rejected"),
+    );
+    if (failedCleanupIds.size === 0) {
+      return result;
+    }
+
+    const errorsById = new Map(result.errors.map((error) => [error.id, error]));
+    return {
+      deleted: result.deleted.filter(({ id }) => !failedCleanupIds.has(id)),
+      errors: instanceIds.flatMap((id) => {
+        if (failedCleanupIds.has(id)) {
+          return [
+            { id, code: 10001, message: "workflows.api.error.internal_server" },
+          ];
+        }
+        const error = errorsById.get(id);
+        return error === undefined ? [] : [error];
+      }),
+    };
   }
 
   public async unsafeGetBindingName(): Promise<string> {
@@ -386,12 +530,25 @@ export class WorkflowHandle extends RpcTarget implements WorkflowInstance {
     await this.stub.changeInstanceStatus("resume");
   }
 
-  public async terminate(): Promise<void> {
+  public async terminate(
+    options?: WorkflowInstanceTerminateOptions,
+  ): Promise<void> {
     try {
-      await this.stub.changeInstanceStatus("terminate");
+      await this.stub.changeInstanceStatus("terminate", undefined, options);
     } catch (e) {
       // terminate causes instance abortion
       if (!isUserTriggeredTerminate(e)) {
+        throw e;
+      }
+    }
+  }
+
+  public async delete(): Promise<void> {
+    try {
+      await this.stub.deleteInstance();
+    } catch (e) {
+      // delete aborts the instance
+      if (!isUserTriggeredDelete(e)) {
         throw e;
       }
     }
@@ -480,26 +637,5 @@ export class WorkflowHandle extends RpcTarget implements WorkflowInstance {
       type: args.type,
       timestamp: new Date(),
     });
-  }
-
-  public async delete(): Promise<void> {
-    const { status } = await this.status();
-    if (
-      status !== "complete" &&
-      status !== "errored" &&
-      status !== "terminated"
-    ) {
-      throw new Error(
-        "instance.not_terminal: only instances in a terminal state (complete, errored, terminated) can be deleted",
-      );
-    }
-    try {
-      // Wiping the engine DO's storage makes a subsequent `get(id)` report
-      // instance.not_found — the local equivalent of deleting the record.
-      await this.stub.unsafeAbort("instance.deleted");
-    } catch {
-      // unsafeAbort aborts the DO out from under its own RPC channel, which
-      // may reject the call after the storage wipe already happened.
-    }
   }
 }

--- a/packages/cloudflare-runtime/src/internal/workflows-shared/context.ts
+++ b/packages/cloudflare-runtime/src/internal/workflows-shared/context.ts
@@ -1,5 +1,6 @@
 // Alchemy modifications are licensed under Apache-2.0.
 // This file includes third-party code; see /THIRD_PARTY_LICENSES.md.
+// Alchemy modifications: uses Array<T> syntax for non-tuple array types to match the repository convention.
 import { RpcTarget } from "cloudflare:workers";
 import { ms } from "itty-time";
 import {
@@ -9,8 +10,15 @@ import {
 } from "./instance.ts";
 import { computeHash } from "./lib/cache.ts";
 import {
+  DEFAULT_RETRY_DELAY_MS,
+  DELAY_FUNCTION_TIMEOUT_MS,
+  invokeDelayFunction,
+  raceAgainstAbort,
+} from "./lib/delay.ts";
+import {
   ABORT_REASONS,
   InvalidStepReadableStreamError,
+  NonRetryableDelayError,
   OversizedStreamChunkError,
   PreservedNonRetryableError,
   shouldPreserveNonRetryableError,
@@ -20,10 +28,9 @@ import {
   WorkflowInternalError,
   WorkflowTimeoutError,
 } from "./lib/errors.ts";
-import { calcRetryDuration } from "./lib/retries.ts";
+import { calcRetryDuration, DelayFunctionError } from "./lib/retries.ts";
 import {
   parseRollbackOptions,
-  registerRollbackFn,
   ROLLBACK_CACHE_KEY_PREFIX,
 } from "./lib/rollback.ts";
 import {
@@ -40,6 +47,7 @@ import {
   isValidStepConfig,
   isValidStepName,
   MAX_STEP_NAME_LENGTH,
+  SENSITIVE_STEP_OUTPUT,
 } from "./lib/validators.ts";
 import { MODIFIER_KEYS } from "./modifier.ts";
 import type { Engine } from "./engine.ts";
@@ -50,9 +58,14 @@ import type {
 } from "./lib/rollback.ts";
 import type { StreamOutputMeta } from "./lib/streams.ts";
 import type {
+  WorkflowBackoff,
+  WorkflowDelayDuration,
+  WorkflowDelayFunction,
   WorkflowSleepDuration,
   WorkflowStepConfig,
   WorkflowStepEvent,
+  WorkflowStepSensitivity,
+  WorkflowTimeoutDuration,
 } from "cloudflare:workers";
 
 export type Event = {
@@ -61,10 +74,74 @@ export type Event = {
   type: string;
 };
 
-export type ResolvedStepConfig = Required<
-  Pick<WorkflowStepConfig, "retries" | "timeout">
-> &
-  Pick<WorkflowStepConfig, "sensitive">;
+// Persisted in place of a dynamic delay function (functions can't be
+// serialized); the live function is re-read from the user's step config on each
+// execution.
+const SERIALIZABLE_DELAY_MARKER = "[dynamic]";
+type SerializableDelayMarker = typeof SERIALIZABLE_DELAY_MARKER;
+
+export const REDACTED_STEP_OUTPUT = "[REDACTED]";
+
+// The persisted, fully-merged config. A dynamic delay is stored as the marker.
+export type ResolvedStepConfig = {
+  retries: {
+    limit: number;
+    delay: WorkflowDelayDuration | SerializableDelayMarker;
+    backoff?: WorkflowBackoff;
+  };
+  timeout: WorkflowTimeoutDuration;
+  sensitive?: WorkflowStepSensitivity;
+};
+
+// The user-facing config (passed to step callbacks). The dynamic-delay marker is
+// never exposed: `delay` is omitted entirely when the delay is a function.
+export type EngineStepConfig = {
+  retries: {
+    limit: number;
+    delay?: WorkflowDelayDuration;
+    backoff?: WorkflowBackoff;
+  };
+  timeout: WorkflowTimeoutDuration;
+  sensitive?: WorkflowStepSensitivity;
+};
+
+export function toEngineStepConfig(
+  config: ResolvedStepConfig,
+): EngineStepConfig {
+  const { delay, ...retries } = config.retries;
+  if (
+    typeof delay === "number" ||
+    (typeof delay === "string" && delay !== SERIALIZABLE_DELAY_MARKER)
+  ) {
+    return { ...config, retries: { ...retries, delay } };
+  }
+  return { ...config, retries };
+}
+
+// Signal-aware wrapper around the global `scheduler.wait`. `scheduler.wait`
+// can't itself be cancelled, so an aborted signal resolves the returned promise
+// early and the dangling timer becomes a no-op.
+function schedulerWait(
+  durationMs: number,
+  opts?: { signal?: AbortSignal },
+): Promise<void> {
+  return new Promise<void>((resolve) => {
+    const signal = opts?.signal;
+    if (signal?.aborted) {
+      resolve();
+      return;
+    }
+    let done = false;
+    const finish = (): void => {
+      if (!done) {
+        done = true;
+        resolve();
+      }
+    };
+    void scheduler.wait(durationMs).then(finish);
+    signal?.addEventListener("abort", finish, { once: true });
+  });
+}
 
 const defaultConfig: ResolvedStepConfig = {
   retries: {
@@ -186,7 +263,7 @@ export type WorkflowStepContext = {
     count: number;
   };
   attempt: number;
-  config: ResolvedStepConfig;
+  config: EngineStepConfig;
 };
 
 const PAUSE_DATETIME = "PAUSE_DATETIME";
@@ -256,7 +333,7 @@ export class Context extends RpcTarget {
     const { cacheKey, rollbackFn, stepContext, output, rollbackConfig } =
       options;
     if (rollbackFn && this.#rollbackStep === undefined) {
-      registerRollbackFn(this.#engine.rollbackRegistry, {
+      this.#engine.registerRollbackFn({
         cacheKey,
         fn: rollbackFn,
         stepContext,
@@ -306,6 +383,12 @@ export class Context extends RpcTarget {
     const { rollback: rollbackFn, rollbackConfig } = rollbackOptions ?? {};
 
     const isRollback = this.#rollbackStep !== undefined;
+    if (this.#engine.rollbackPhase === "rollback" && !isRollback) {
+      throw new WorkflowFatalError(
+        "Cannot execute steps during rollback phase",
+      );
+    }
+
     const events = isRollback
       ? {
           start: InstanceEvent.ROLLBACK_STEP_START,
@@ -355,12 +438,19 @@ export class Context extends RpcTarget {
       throw error;
     }
 
+    let liveDelay: WorkflowDelayDuration | WorkflowDelayFunction =
+      stepConfig.retries?.delay ?? DEFAULT_RETRY_DELAY_MS;
+
     let config: ResolvedStepConfig = {
       ...defaultConfig,
       ...stepConfig,
       retries: {
         ...defaultConfig.retries,
         ...stepConfig.retries,
+        delay:
+          typeof liveDelay === "function"
+            ? SERIALIZABLE_DELAY_MARKER
+            : liveDelay,
       },
     };
 
@@ -426,7 +516,7 @@ export class Context extends RpcTarget {
         stepContext: {
           step: { name, count },
           attempt: cachedState?.attemptedCount ?? 1,
-          config: cachedConfig ?? config,
+          config: toEngineStepConfig(cachedConfig ?? config),
         },
         output: result,
         rollbackConfig,
@@ -450,7 +540,7 @@ export class Context extends RpcTarget {
         stepContext: {
           step: { name, count },
           attempt: cachedState?.attemptedCount ?? 1,
-          config: cachedConfig ?? config,
+          config: toEngineStepConfig(cachedConfig ?? config),
         },
         output: result,
         rollbackConfig,
@@ -463,6 +553,17 @@ export class Context extends RpcTarget {
     ) as Error | undefined;
 
     if (maybeError) {
+      const cachedState = maybeMap.get(stepStateKey) as StepState | undefined;
+      this.#registerRollback({
+        cacheKey,
+        rollbackFn,
+        stepContext: {
+          step: { name, count },
+          attempt: cachedState?.attemptedCount ?? 1,
+          config: toEngineStepConfig(cachedConfig ?? config),
+        },
+        rollbackConfig,
+      });
       maybeError.isUserError = true;
       throw maybeError;
     }
@@ -472,6 +573,29 @@ export class Context extends RpcTarget {
       await this.#state.storage.put(configKey, config);
     } else {
       config = cachedConfig;
+      // Recover the live delay from the (non-serializable) user config: a
+      // persisted marker means the user passed a function, so re-read it.
+      liveDelay =
+        config.retries.delay === SERIALIZABLE_DELAY_MARKER
+          ? typeof stepConfig.retries?.delay === "function"
+            ? stepConfig.retries.delay
+            : DEFAULT_RETRY_DELAY_MS
+          : config.retries.delay;
+    }
+
+    if (this.#engine.rollbackPhase === "replay" && !isRollback) {
+      const cachedState = maybeMap.get(stepStateKey) as StepState | undefined;
+      this.#registerRollback({
+        cacheKey,
+        rollbackFn,
+        stepContext: {
+          step: { name, count },
+          attempt: cachedState?.attemptedCount ?? 1,
+          config: toEngineStepConfig(config),
+        },
+        rollbackConfig,
+      });
+      return undefined;
     }
 
     const attemptLogs = this.#engine
@@ -534,7 +658,7 @@ export class Context extends RpcTarget {
       const forwardStepContext = (): WorkflowStepContext => ({
         step: { name, count },
         attempt: stepState.attemptedCount,
-        config,
+        config: toEngineStepConfig(config),
       });
 
       // NOTE(caio): this might be a stream returning step - if so cleanup stale data from previous lifetimes
@@ -546,7 +670,8 @@ export class Context extends RpcTarget {
 
       if (stepState.attemptedCount == 0) {
         this.#engine.writeLog(events.start, cacheKey, stepNameWithCounter, {
-          config,
+          config: toEngineStepConfig(config),
+          ...(!isRollback && rollbackFn ? { hasRollback: true } : {}),
         });
       } else {
         // in case the engine dies while retrying and wakes up before the retry period
@@ -632,6 +757,12 @@ export class Context extends RpcTarget {
           },
         );
         stepState.attemptedCount++;
+        this.#registerRollback({
+          cacheKey,
+          rollbackFn,
+          stepContext: forwardStepContext(),
+          rollbackConfig,
+        });
         await this.#state.storage.put(stepStateKey, stepState);
         const priorityQueueHash = `${cacheKey}-${stepState.attemptedCount}`;
 
@@ -742,7 +873,7 @@ export class Context extends RpcTarget {
             doWrapperClosure({
               step: { name, count },
               attempt: stepState.attemptedCount,
-              config: structuredClone(config),
+              config: toEngineStepConfig(config),
             }),
             timeoutTask,
           ]);
@@ -946,7 +1077,7 @@ export class Context extends RpcTarget {
             events.failure,
             cacheKey,
             stepNameWithCounter,
-            {},
+            !isRollback && rollbackFn ? { hasRollback: true } : {},
           );
           this.#registerRollback({
             cacheKey,
@@ -956,6 +1087,68 @@ export class Context extends RpcTarget {
           });
 
           throw error;
+        }
+
+        await this.#state.storage.put(stepStateKey, stepState);
+
+        const willRetry = stepState.attemptedCount <= config.retries.limit;
+        const priorityQueueHash = `${cacheKey}-${stepState.attemptedCount}`;
+
+        // Resolve the delay once per attempt. A broken delay function turns
+        // the retry into a non-retryable failure.
+        let retryDelayMs: number | undefined;
+        let delayFailure: (Error & UserErrorField) | undefined;
+        if (willRetry) {
+          try {
+            let resolvedDelay: unknown;
+            if (typeof liveDelay === "function") {
+              // Park a default-delayed retry before invoking the user's
+              // delay function so a crash while the function is in flight
+              // still reschedules the step. The PQ table is append-only
+              // with a UNIQUE(action, entryType, hash) constraint, so this
+              // exact entry is reused as the retry entry below — it is
+              // never removed and re-added (that would violate UNIQUE).
+              // @ts-expect-error priorityQueue is initiated in init
+              await this.#engine.priorityQueue.add({
+                hash: priorityQueueHash,
+                targetTimestamp: Date.now() + DEFAULT_RETRY_DELAY_MS,
+                type: "retry",
+              });
+
+              const stepCtx: WorkflowStepContext = {
+                step: { name, count },
+                attempt: stepState.attemptedCount,
+                config: toEngineStepConfig(config),
+              };
+
+              resolvedDelay = await invokeDelayFunction(
+                liveDelay,
+                { ctx: stepCtx, error },
+                {
+                  timeoutMs: DELAY_FUNCTION_TIMEOUT_MS,
+                  wait: schedulerWait,
+                  signal: this.#engine.engineAbortController.signal,
+                },
+              );
+            } else {
+              resolvedDelay = liveDelay;
+            }
+            retryDelayMs = calcRetryDuration(config, stepState, resolvedDelay);
+          } catch (delayErr) {
+            if (!(delayErr instanceof DelayFunctionError)) {
+              throw delayErr;
+            }
+            // @ts-expect-error priorityQueue is initiated in init
+            this.#engine.priorityQueue.remove({
+              hash: priorityQueueHash,
+              type: "retry",
+            });
+            const userError = new NonRetryableDelayError(
+              `The delay function for step "${stepNameWithCounter}" ${delayErr.message}`,
+            ) as Error & UserErrorField;
+            userError.isUserError = true;
+            delayFailure = userError;
+          }
         }
 
         this.#engine.writeLog(
@@ -970,14 +1163,13 @@ export class Context extends RpcTarget {
               // TODO (WOR-79): Stacks are all incorrect over RPC and need work
               // stack: error.stack,
             },
+            ...(retryDelayMs !== undefined ? { retryDelayMs } : {}),
           },
         );
 
-        await this.#state.storage.put(stepStateKey, stepState);
-
-        if (stepState.attemptedCount <= config.retries.limit) {
+        if (willRetry && delayFailure === undefined) {
           // TODO (WOR-71): Think through if every Error should transition
-          const durationMs = calcRetryDuration(config, stepState);
+          const durationMs = retryDelayMs ?? DEFAULT_RETRY_DELAY_MS;
           const disableAllRetryDelays = await this.#state.storage.get(
             MODIFIER_KEYS.DISABLE_ALL_RETRY_DELAYS,
           );
@@ -987,40 +1179,44 @@ export class Context extends RpcTarget {
             disableAllRetryDelays || disableThisRetryDelay;
           const effectiveDuration = disableRetryDelay ? 0 : durationMs;
 
-          const priorityQueueHash = `${cacheKey}-${stepState.attemptedCount}`;
-          // @ts-expect-error priorityQueue is initiated in init
-          await this.#engine.priorityQueue.add({
-            hash: priorityQueueHash,
-            targetTimestamp: Date.now() + effectiveDuration,
-            type: "retry",
-          });
+          // A dynamic delay already parked its retry entry under this hash
+          // above (the append-only PQ rejects re-adding the same hash), so
+          // only static delays add here. The live wait below uses
+          // effectiveDuration regardless; the parked entry's timestamp only
+          // drives crash recovery.
+          //
+          // Known trade-off: for a dynamic delay the parked entry keeps the
+          // DEFAULT_RETRY_DELAY_MS placeholder timestamp set before the delay
+          // function ran (see the add above) — the UNIQUE(action, entryType,
+          // hash) constraint means it can't be overwritten in place with the
+          // computed value without a remove+re-add that would violate the
+          // constraint. So if the engine crashes mid-wait, recovery resumes
+          // the step at the placeholder delay rather than the computed one.
+          // This is accepted for local dev: the step still retries with the
+          // correct semantics, only the post-crash wait can be shorter.
+          if (typeof liveDelay !== "function") {
+            // @ts-expect-error priorityQueue is initiated in init
+            await this.#engine.priorityQueue.add({
+              hash: priorityQueueHash,
+              targetTimestamp: Date.now() + effectiveDuration,
+              type: "retry",
+            });
+          }
           await this.#engine.timeoutHandler.release(this.#engine);
           // Race retry wait against the pause signal so pause
           // takes effect immediately during retries
           {
             const retryPauseSignal = this.#engine.pauseController.signal;
-            let pausedDuringRetry = false;
-            await Promise.race([
+            await raceAgainstAbort(
               scheduler.wait(effectiveDuration),
-              new Promise<void>((resolve) => {
-                if (retryPauseSignal.aborted) {
-                  resolve();
-                  return;
-                }
-                retryPauseSignal.addEventListener("abort", () => resolve(), {
-                  once: true,
-                });
-              }),
-            ]);
+              retryPauseSignal,
+            );
             const retryStatus = await this.#engine.getStatus();
-            if (
+            const pausedDuringRetry =
               retryStatus === InstanceStatus.Paused ||
-              retryStatus === InstanceStatus.WaitingForPause
-            ) {
-              pausedDuringRetry = true;
-            }
+              retryStatus === InstanceStatus.WaitingForPause;
             if (pausedDuringRetry) {
-              throw new Error(ABORT_REASONS.USER_PAUSE, { cause: e });
+              throw new Error(ABORT_REASONS.USER_PAUSE);
             }
           }
 
@@ -1048,7 +1244,7 @@ export class Context extends RpcTarget {
             events.failure,
             cacheKey,
             stepNameWithCounter,
-            {},
+            !isRollback && rollbackFn ? { hasRollback: true } : {},
           );
           this.#registerRollback({
             cacheKey,
@@ -1057,17 +1253,25 @@ export class Context extends RpcTarget {
             rollbackConfig,
           });
 
-          await this.#state.storage.put(errorKey, error);
-          throw error;
+          const finalError = delayFailure ?? error;
+          await this.#state.storage.put(errorKey, finalError);
+          throw finalError;
         }
       }
 
+      const redactOutput = config.sensitive === SENSITIVE_STEP_OUTPUT;
       this.#engine.writeLog(events.success, cacheKey, stepNameWithCounter, {
         // TODO (WOR-86): Add limits, figure out serialization
-        result: lastStreamMeta ? undefined : result,
-        ...(lastStreamMeta && {
-          streamOutput: { cacheKey, meta: lastStreamMeta },
-        }),
+        result: redactOutput
+          ? REDACTED_STEP_OUTPUT
+          : lastStreamMeta
+            ? undefined
+            : result,
+        ...(!redactOutput &&
+          lastStreamMeta && {
+            streamOutput: { cacheKey, meta: lastStreamMeta },
+          }),
+        ...(!isRollback && rollbackFn ? { hasRollback: true } : {}),
       });
       this.#registerRollback({
         cacheKey,
@@ -1082,13 +1286,21 @@ export class Context extends RpcTarget {
 
     const result = await doWrapper(closure);
 
-    // Check if a pause was requested while this step was running
-    await this.#checkForPendingPause();
+    // Check if a pause was requested while this step was running.
+    // Rollback steps may run while the instance is paused; don't let stale pause
+    // state abort rollback cleanup after the rollback step itself succeeds.
+    if (!isRollback) {
+      await this.#checkForPendingPause();
+    }
 
     return result;
   }
 
   async sleep(name: string, duration: WorkflowSleepDuration): Promise<void> {
+    if (this.#engine.rollbackPhase === "replay") {
+      return;
+    }
+
     if (typeof duration == "string") {
       duration = ms(duration);
     }
@@ -1169,28 +1381,13 @@ export class Context extends RpcTarget {
     const pauseSignal = this.#engine.pauseController.signal;
     const sleepDuration = disableSleep ? 0 : duration;
 
-    let pausedDuringSleep = false;
-    await Promise.race([
-      scheduler.wait(sleepDuration),
-      new Promise<void>((resolve) => {
-        if (pauseSignal.aborted) {
-          resolve();
-          return;
-        }
-        pauseSignal.addEventListener("abort", () => resolve(), {
-          once: true,
-        });
-      }),
-    ]);
+    await raceAgainstAbort(scheduler.wait(sleepDuration), pauseSignal);
 
     // Check if we were paused during the sleep
     const statusAfterSleep = await this.#engine.getStatus();
-    if (
+    const pausedDuringSleep =
       statusAfterSleep === InstanceStatus.Paused ||
-      statusAfterSleep === InstanceStatus.WaitingForPause
-    ) {
-      pausedDuringSleep = true;
-    }
+      statusAfterSleep === InstanceStatus.WaitingForPause;
 
     if (pausedDuringSleep) {
       // Throw pause error
@@ -1210,6 +1407,10 @@ export class Context extends RpcTarget {
   }
 
   async sleepUntil(name: string, timestamp: Date | number): Promise<void> {
+    if (this.#engine.rollbackPhase === "replay") {
+      return;
+    }
+
     if (timestamp instanceof Date) {
       timestamp = timestamp.valueOf();
     }
@@ -1232,6 +1433,12 @@ export class Context extends RpcTarget {
       timeout?: string | number;
     },
   ): Promise<WorkflowStepEvent<T>> {
+    if (this.#engine.rollbackPhase === "rollback") {
+      throw new WorkflowFatalError(
+        "Cannot execute steps during rollback phase",
+      );
+    }
+
     if (!options.timeout) {
       options.timeout = "24 hours";
     }
@@ -1250,6 +1457,10 @@ export class Context extends RpcTarget {
     ) as Error & UserErrorField;
 
     const maybeResult = await this.#state.storage.get<Event>(waitForEventKey);
+
+    if (this.#engine.rollbackPhase === "replay") {
+      return maybeResult as WorkflowStepEvent<T>;
+    }
 
     if (maybeResult) {
       const shouldWriteLog =
@@ -1366,26 +1577,17 @@ export class Context extends RpcTarget {
       this.#engine.waiters.set(options.type, callbacks);
     });
 
-    // Race event, timeout, and pause signal. The pause promise resolves
-    // when the race settles via event/timeout before the pause signal fires
+    // Race event and timeout against the pause signal.
     const pauseSignal = this.#engine.pauseController.signal;
-    const pausePromise = new Promise<void>((resolve) => {
-      if (pauseSignal.aborted) {
-        resolve();
-        return;
-      }
-      pauseSignal.addEventListener("abort", () => resolve(), {
-        once: true,
-      });
-    });
-
-    const raceResult = await Promise.race([
-      eventPromise,
-      timeoutEntryPQ !== undefined
-        ? timeoutPromise(timeoutEntryPQ.targetTimestamp - Date.now(), false)
-        : timeoutPromise(ms(options.timeout), true),
-      pausePromise,
-    ]).catch(async (error) => {
+    const raceResult = await raceAgainstAbort(
+      Promise.race([
+        eventPromise,
+        timeoutEntryPQ !== undefined
+          ? timeoutPromise(timeoutEntryPQ.targetTimestamp - Date.now(), false)
+          : timeoutPromise(ms(options.timeout), true),
+      ]),
+      pauseSignal,
+    ).catch(async (error) => {
       const callbacks = this.#engine.waiters.get(options.type);
       if (callbacks) {
         const idx = callbacks.findIndex(([key]) => key === cacheKey);
@@ -1405,18 +1607,19 @@ export class Context extends RpcTarget {
     });
 
     // Pause signal won the race — throw to stop the workflow
-    if (raceResult === undefined) {
+    if (raceResult.aborted) {
       throw new Error(ABORT_REASONS.USER_PAUSE);
     }
+    const event = raceResult.value;
 
     this.#engine.writeLog(
       InstanceEvent.WAIT_COMPLETE,
       cacheKey,
       waitForEventNameWithCounter,
-      raceResult as Event,
+      event,
     );
-    await this.#state.storage.put(waitForEventKey, raceResult);
+    await this.#state.storage.put(waitForEventKey, event);
 
-    return raceResult as WorkflowStepEvent<T>;
+    return event as WorkflowStepEvent<T>;
   }
 }

--- a/packages/cloudflare-runtime/src/internal/workflows-shared/engine.ts
+++ b/packages/cloudflare-runtime/src/internal/workflows-shared/engine.ts
@@ -1,5 +1,6 @@
 // Alchemy modifications are licensed under Apache-2.0.
 // This file includes third-party code; see /THIRD_PARTY_LICENSES.md.
+// Alchemy modifications: uses Array<T> syntax for non-tuple array types to match the repository convention.
 import { DurableObject } from "cloudflare:workers";
 import { Context } from "./context.ts";
 import {
@@ -31,7 +32,13 @@ import {
   storeRestartFromStep,
   wipeRestartState,
 } from "./lib/restart.ts";
-import { clearRollbackRegistry, executeRollbacks } from "./lib/rollback.ts";
+import {
+  clearRollbackRegistry,
+  disposeRollbackStub,
+  executeRollbacks,
+  registerRollbackFn,
+  ROLLBACK_CACHE_KEY_PREFIX,
+} from "./lib/rollback.ts";
 import {
   createReplayReadableStream,
   getInvalidStoredStreamOutputError,
@@ -40,10 +47,16 @@ import {
 } from "./lib/streams.ts";
 import { TimePriorityQueue } from "./lib/timePriorityQueue.ts";
 import { MODIFIER_KEYS, WorkflowInstanceModifier } from "./modifier.ts";
-import type { RestartFromStep } from "./binding.ts";
+import type {
+  RestartFromStep,
+  WorkflowInstanceTerminateOptions,
+} from "./binding.ts";
 import type { Event } from "./context.ts";
 import type { InstanceMetadata, RawInstanceLog } from "./instance.ts";
-import type { RollbackRegistryEntry } from "./lib/rollback.ts";
+import type {
+  RollbackRegistration,
+  RollbackRegistryEntry,
+} from "./lib/rollback.ts";
 import type { StreamOutputMeta } from "./lib/streams.ts";
 import type {
   WorkflowEntrypoint,
@@ -54,6 +67,8 @@ import type {
 interface Env {
   ENGINE: DurableObjectNamespace<Engine>;
   USER_WORKFLOW: WorkflowEntrypoint;
+  MINIFLARE_LOOPBACK?: Fetcher;
+  WORKFLOW_NAME?: string;
   STEP_LIMIT?: string; // JSON-encoded number from miniflare binding
 }
 
@@ -110,6 +125,8 @@ export const DEFAULT_STEP_LIMIT = 10_000;
 
 const PAUSE_DATETIME = "PAUSE_DATETIME";
 
+export type RollbackPhase = "replay" | "rollback";
+
 /**
  * JSON.stringify replacer that converts TypedArrays and ArrayBuffers to a
  * human-readable description. Without this, JSON.stringify(Uint8Array) encodes
@@ -147,6 +164,8 @@ export class Engine extends DurableObject<Env> {
   stepLimit: number;
   engineAbortController: AbortController = new AbortController();
   pauseController: AbortController = new AbortController();
+  rollbackPhase: RollbackPhase | undefined = undefined;
+  rollbackEligibleCacheKeys: Set<string> | undefined = undefined;
 
   waiters: Map<
     string,
@@ -229,14 +248,98 @@ export class Engine extends DurableObject<Env> {
     }
   }
 
-  readStepStartGroupKeysDesc(): Array<string> {
+  readEligibleRollbackStepsDesc(
+    limit?: number,
+  ): Array<{ cacheKey: string; target: string }> {
+    const rollbackTerminalGroups = new Set<string>();
+    const rollbackEligibleGroups = new Set<string>();
+    const stepStartsDesc: Array<{ groupKey: string; target: string | null }> =
+      [];
     const rows = [
-      ...this.ctx.storage.sql.exec<{ groupKey: string }>(
-        "SELECT groupKey FROM states WHERE event = ? AND groupKey IS NOT NULL ORDER BY id DESC",
-        InstanceEvent.STEP_START,
+      ...this.ctx.storage.sql.exec<{
+        event: InstanceEvent;
+        groupKey: string;
+        target: string | null;
+        metadata: string;
+      }>(
+        "SELECT event, groupKey, target, metadata FROM states WHERE groupKey IS NOT NULL ORDER BY id DESC",
       ),
     ];
-    return rows.map(({ groupKey }) => groupKey);
+
+    for (const row of rows) {
+      if (row.event === InstanceEvent.STEP_START) {
+        stepStartsDesc.push({ groupKey: row.groupKey, target: row.target });
+      }
+
+      if (
+        row.event === InstanceEvent.ROLLBACK_STEP_SUCCESS ||
+        row.event === InstanceEvent.ROLLBACK_STEP_FAILURE
+      ) {
+        rollbackTerminalGroups.add(
+          row.groupKey.startsWith(ROLLBACK_CACHE_KEY_PREFIX)
+            ? row.groupKey.slice(ROLLBACK_CACHE_KEY_PREFIX.length)
+            : row.groupKey,
+        );
+        continue;
+      }
+
+      if (
+        row.event !== InstanceEvent.STEP_START &&
+        row.event !== InstanceEvent.STEP_SUCCESS &&
+        row.event !== InstanceEvent.STEP_FAILURE
+      ) {
+        continue;
+      }
+
+      try {
+        if (
+          (JSON.parse(row.metadata) as { hasRollback?: boolean })
+            .hasRollback === true
+        ) {
+          rollbackEligibleGroups.add(row.groupKey);
+        }
+      } catch {
+        // Ignore malformed metadata in local persisted logs.
+      }
+    }
+
+    const eligible: Array<{ cacheKey: string; target: string }> = [];
+    for (const { groupKey, target } of stepStartsDesc) {
+      if (
+        rollbackEligibleGroups.has(groupKey) &&
+        !rollbackTerminalGroups.has(groupKey)
+      ) {
+        eligible.push({ cacheKey: groupKey, target: target ?? groupKey });
+        if (limit !== undefined && eligible.length >= limit) {
+          break;
+        }
+      }
+    }
+
+    return eligible;
+  }
+
+  private getEligibleRollbackSteps(limit?: number): Array<string> {
+    return this.readEligibleRollbackStepsDesc(limit).map(
+      ({ cacheKey }) => cacheKey,
+    );
+  }
+
+  registerRollbackFn(registration: RollbackRegistration): void {
+    if (
+      this.rollbackPhase === "replay" &&
+      this.rollbackEligibleCacheKeys !== undefined &&
+      !this.rollbackEligibleCacheKeys.has(registration.cacheKey)
+    ) {
+      disposeRollbackStub(registration.fn);
+      return;
+    }
+
+    registerRollbackFn(this.rollbackRegistry, registration);
+  }
+
+  setRollbackPhase(phase: RollbackPhase | undefined): void {
+    this.rollbackPhase = phase;
   }
 
   // Lives here for access to the protected DurableObject `ctx`.
@@ -699,7 +802,7 @@ export class Engine extends DurableObject<Env> {
   }
 
   // Called by the dispose function when introspecting the instance in tests
-  // TODO: Ideally this abort should be done by `abortAllDurableObjects` from worked called by vitest-pool-workers
+  // TODO: Ideally this abort should be done by `abortAllDurableObjects` from worked called by vitest-plugin
   async unsafeAbort(reason?: string) {
     await this.ctx.storage.sync();
     await this.ctx.storage.deleteAll();
@@ -807,7 +910,8 @@ export class Engine extends DurableObject<Env> {
   async changeInstanceStatus(
     newStatus: "resume" | "pause" | "terminate" | "restart",
     from?: RestartFromStep,
-  ) {
+    terminateOptions?: WorkflowInstanceTerminateOptions,
+  ): Promise<void> {
     const metadata =
       await this.ctx.storage.get<InstanceMetadata>(INSTANCE_METADATA);
 
@@ -851,7 +955,7 @@ export class Engine extends DurableObject<Env> {
             "instance.cannot_terminate",
           );
         }
-        await this.userTriggeredTerminate();
+        await this.userTriggeredTerminate(terminateOptions);
         break;
       }
       case "restart":
@@ -866,7 +970,37 @@ export class Engine extends DurableObject<Env> {
     }
   }
 
-  async userTriggeredTerminate() {
+  private async replayRollbackRegistry(
+    metadata: InstanceMetadata,
+  ): Promise<void> {
+    if (this.rollbackRegistry.size > 0) {
+      return;
+    }
+
+    const eligible = this.getEligibleRollbackSteps();
+    if (eligible.length === 0) {
+      return;
+    }
+
+    this.rollbackEligibleCacheKeys = new Set(eligible);
+    const stubStep = this.createRollbackContext();
+    this.setRollbackPhase("replay");
+    try {
+      await this.env.USER_WORKFLOW.run(
+        metadata.event,
+        stubStep as unknown as WorkflowStep,
+      );
+    } catch (replayErr) {
+      // Match the production engine: replay may stop on normal workflow control
+      // flow; rollback execution uses whatever handlers replay registered.
+      console.debug("Rollback replay stopped:", replayErr);
+    } finally {
+      this.setRollbackPhase(undefined);
+      this.rollbackEligibleCacheKeys = undefined;
+    }
+  }
+
+  async userTriggeredTerminate(options?: WorkflowInstanceTerminateOptions) {
     const metadata =
       await this.ctx.storage.get<InstanceMetadata>(INSTANCE_METADATA);
 
@@ -875,6 +1009,22 @@ export class Engine extends DurableObject<Env> {
         "Instance does not exist",
         "instance.not_found",
       );
+    }
+
+    if (options?.rollback === true) {
+      this.priorityQueue ??= new TimePriorityQueue(this.ctx, metadata);
+      await this.replayRollbackRegistry(metadata);
+
+      const error = new Error("Instance terminated during rollback");
+      error.name = "Terminated";
+      this.setRollbackPhase("rollback");
+      try {
+        await executeRollbacks(this, error);
+      } catch (rollbackErr) {
+        console.error("Rollback execution failed:", rollbackErr);
+      } finally {
+        this.setRollbackPhase(undefined);
+      }
     }
 
     this.writeLog(InstanceEvent.WORKFLOW_TERMINATED, null, null, {
@@ -890,6 +1040,37 @@ export class Engine extends DurableObject<Env> {
     );
 
     await this.abort(ABORT_REASONS.USER_TERMINATE);
+  }
+
+  /** Deletes all instance state and aborts its current execution. */
+  async deleteInstance(): Promise<void> {
+    if ((await this.ctx.storage.get(INSTANCE_METADATA)) === undefined) {
+      throw createWorkflowError(
+        "Instance does not exist",
+        "instance.not_found",
+      );
+    }
+
+    await this.ctx.storage.deleteAll();
+
+    if (
+      this.env.MINIFLARE_LOOPBACK !== undefined &&
+      this.env.WORKFLOW_NAME !== undefined
+    ) {
+      try {
+        const response = await this.env.MINIFLARE_LOOPBACK.fetch(
+          `http://localhost/core/workflow-storage/${encodeURIComponent(this.env.WORKFLOW_NAME)}/${this.ctx.id.toString()}?defer=1`,
+          { method: "DELETE" },
+        );
+        if (!response.ok && response.status !== 404) {
+          console.error("Failed to delete persisted workflow instance");
+        }
+      } catch (error) {
+        console.error("Failed to delete persisted workflow instance", error);
+      }
+    }
+
+    await this.abort(ABORT_REASONS.USER_DELETE);
   }
 
   async userTriggeredPause() {

--- a/packages/cloudflare-runtime/src/internal/workflows-shared/lib/delay.ts
+++ b/packages/cloudflare-runtime/src/internal/workflows-shared/lib/delay.ts
@@ -1,0 +1,114 @@
+// Alchemy modifications are licensed under Apache-2.0.
+// This file includes third-party code; see /THIRD_PARTY_LICENSES.md.
+import { ms } from "itty-time";
+import { DelayFunctionError } from "./retries.ts";
+import type {
+	WorkflowDelayDuration,
+	WorkflowDelayFunction,
+	WorkflowDynamicDelayContext,
+} from "cloudflare:workers";
+
+export const DEFAULT_RETRY_DELAY_MS = 1000;
+
+export const DELAY_FUNCTION_TIMEOUT_MS = ms("5 seconds");
+
+type DelayLogger = {
+	warn(...msgs: unknown[]): void;
+	debug(...msgs: unknown[]): void;
+};
+
+type Waiter = (ms: number, opts?: { signal?: AbortSignal }) => Promise<void>;
+
+type AbortRaceResult<T> = { aborted: true } | { aborted: false; value: T };
+
+export async function raceAgainstAbort<T>(
+	promise: Promise<T>,
+	signal: AbortSignal
+): Promise<AbortRaceResult<T>> {
+	const resultPromise = promise.then(
+		(value): AbortRaceResult<T> => ({
+			aborted: false,
+			value,
+		})
+	);
+	if (signal.aborted) {
+		// Observe a later rejection from the losing promise so it doesn't become
+		// an unhandled rejection after returning the already-aborted result.
+		void resultPromise.catch(() => undefined);
+		return { aborted: true };
+	}
+
+	let resolveAbort: ((result: AbortRaceResult<T>) => void) | undefined;
+	const abortPromise = new Promise<AbortRaceResult<T>>((resolve) => {
+		resolveAbort = resolve;
+	});
+	const onAbort = (): void => resolveAbort?.({ aborted: true });
+	signal.addEventListener("abort", onAbort, { once: true });
+
+	try {
+		return await Promise.race([resultPromise, abortPromise]);
+	} finally {
+		signal.removeEventListener("abort", onAbort);
+	}
+}
+
+export async function invokeDelayFunction(
+	delay: WorkflowDelayFunction,
+	input: WorkflowDynamicDelayContext,
+	options: {
+		timeoutMs: number;
+		wait: Waiter;
+		signal?: AbortSignal;
+		logger?: DelayLogger;
+	}
+): Promise<WorkflowDelayDuration> {
+	const { wait, signal, logger } = options;
+	const logFields = { step: input.ctx.step.name, attempt: input.ctx.attempt };
+
+	const settled = new AbortController();
+	const timeoutSignal = signal
+		? AbortSignal.any([signal, settled.signal])
+		: settled.signal;
+
+	type Raced =
+		| { timedOut: true }
+		| { timedOut: false; value: WorkflowDelayDuration };
+
+	try {
+		const result = await Promise.race<Raced>([
+			Promise.resolve(delay(input)).then((value) => ({
+				timedOut: false,
+				value,
+			})),
+			wait(options.timeoutMs, { signal: timeoutSignal })
+				.then((): Raced => ({ timedOut: true }))
+				.catch((): Raced => ({ timedOut: true })),
+		]);
+		if (result.timedOut) {
+			if (signal?.aborted) {
+				logger?.debug(
+					"delay function aborted by engine shutdown; using default delay",
+					logFields
+				);
+				return DEFAULT_RETRY_DELAY_MS;
+			}
+			logger?.warn(
+				`delay function did not resolve within ${options.timeoutMs}ms`,
+				logFields
+			);
+			throw new DelayFunctionError(
+				`did not return within ${options.timeoutMs / 1000} seconds`
+			);
+		}
+		return result.value;
+	} catch (e) {
+		if (e instanceof DelayFunctionError) {
+			throw e;
+		}
+		const message = e instanceof Error ? e.message : String(e);
+		logger?.warn("delay function threw", { ...logFields, error: message });
+		throw new DelayFunctionError(`threw an error: ${message}`);
+	} finally {
+		settled.abort();
+	}
+}

--- a/packages/cloudflare-runtime/src/internal/workflows-shared/lib/errors.ts
+++ b/packages/cloudflare-runtime/src/internal/workflows-shared/lib/errors.ts
@@ -1,120 +1,135 @@
 // Alchemy modifications are licensed under Apache-2.0.
 // This file includes third-party code; see /THIRD_PARTY_LICENSES.md.
 export class WorkflowTimeoutError extends Error {
-  name = "WorkflowTimeoutError";
+	name = "WorkflowTimeoutError";
 }
 
 export class WorkflowInternalError extends Error {
-  name = "WorkflowInternalError";
+	name = "WorkflowInternalError";
 }
 
 export class WorkflowFatalError extends Error {
-  name = "WorkflowFatalError";
+	name = "WorkflowFatalError";
 
-  toJSON() {
-    return {
-      name: this.name,
-      message: this.message,
-    };
-  }
+	toJSON() {
+		return {
+			name: this.name,
+			message: this.message,
+		};
+	}
+}
+
+export class NonRetryableDelayError extends WorkflowFatalError {
+	name = "NonRetryableDelayError";
 }
 
 export class PreservedNonRetryableError extends WorkflowFatalError {
-  name = "NonRetryableError";
+	name = "NonRetryableError";
 
-  constructor(err: Error) {
-    // When the error crosses an RPC boundary, the name gets
-    // prepended to the message (e.g. "NonRetryableError: msg",
-    // or just "NonRetryableError" if the original message was empty).
-    // Parse it back out so we surface the original message.
-    const message =
-      err.name === "NonRetryableError"
-        ? err.message
-        : err.message.replace(/^NonRetryableError:?\s*/, "");
-    super(message);
-  }
+	constructor(err: Error) {
+		// When the error crosses an RPC boundary, the name gets
+		// prepended to the message (e.g. "NonRetryableError: msg",
+		// or just "NonRetryableError" if the original message was empty).
+		// Parse it back out so we surface the original message.
+		const message =
+			err.name === "NonRetryableError"
+				? err.message
+				: err.message.replace(/^NonRetryableError:?\s*/, "");
+		super(message);
+	}
 }
 
 export class WorkflowError extends Error {
-  name = "WorkflowError";
+	name = "WorkflowError";
 }
 
 export class InvalidStepReadableStreamError extends Error {
-  name = "InvalidStepReadableStreamError";
+	name = "InvalidStepReadableStreamError";
 }
 
 export class OversizedStreamChunkError extends Error {
-  name = "OversizedStreamChunkError";
+	name = "OversizedStreamChunkError";
 }
 
 export class UnsupportedStreamChunkError extends Error {
-  name = "UnsupportedStreamChunkError";
+	name = "UnsupportedStreamChunkError";
 }
 
 export class StreamOutputStorageLimitError extends Error {
-  name = "StreamOutputStorageLimitError";
+	name = "StreamOutputStorageLimitError";
 }
 
-export function createWorkflowError(message: string, errorCode: string): WorkflowError {
-  return new WorkflowError(`(${errorCode}) ${message}`);
+export function createWorkflowError(
+	message: string,
+	errorCode: string
+): WorkflowError {
+	return new WorkflowError(`(${errorCode}) ${message}`);
 }
 
 const ABORT_PREFIX = "Aborting engine:" as const;
 
 export const ABORT_REASONS = {
-  USER_PAUSE: `${ABORT_PREFIX} User called pause`,
-  USER_RESTART: `${ABORT_PREFIX} User called restart`,
-  USER_TERMINATE: `${ABORT_PREFIX} User called terminate`,
-  NON_RETRYABLE_ERROR: `${ABORT_PREFIX} A step threw a NonRetryableError`,
-  NOT_SERIALISABLE: `${ABORT_PREFIX} Value is not serialisable`,
-  STORAGE_LIMIT_EXCEEDED: `${ABORT_PREFIX} Storage limit exceeded`,
-  GRACE_PERIOD_COMPLETE: `${ABORT_PREFIX} Grace period complete`,
+	USER_PAUSE: `${ABORT_PREFIX} User called pause`,
+	USER_RESTART: `${ABORT_PREFIX} User called restart`,
+	USER_TERMINATE: `${ABORT_PREFIX} User called terminate`,
+	USER_DELETE: `${ABORT_PREFIX} User called delete`,
+	NON_RETRYABLE_ERROR: `${ABORT_PREFIX} A step threw a NonRetryableError`,
+	NOT_SERIALISABLE: `${ABORT_PREFIX} Value is not serialisable`,
+	STORAGE_LIMIT_EXCEEDED: `${ABORT_PREFIX} Storage limit exceeded`,
+	GRACE_PERIOD_COMPLETE: `${ABORT_PREFIX} Grace period complete`,
 } as const;
 
-const ABORT_REASON_SET: ReadonlySet<string> = new Set(Object.values(ABORT_REASONS));
+const ABORT_REASON_SET: ReadonlySet<string> = new Set(
+	Object.values(ABORT_REASONS)
+);
 
 function getErrorMessage(e: unknown): string | undefined {
-  if (e instanceof Error) {
-    return e.message;
-  }
-  if (typeof e === "object" && e !== null) {
-    const msg = (e as { message?: string }).message;
-    if (typeof msg === "string") {
-      return msg;
-    }
-  }
-  return undefined;
+	if (e instanceof Error) {
+		return e.message;
+	}
+	if (typeof e === "object" && e !== null) {
+		const msg = (e as { message?: string }).message;
+		if (typeof msg === "string") {
+			return msg;
+		}
+	}
+	return undefined;
 }
 
 export function isAbortError(e: unknown): boolean {
-  const msg = getErrorMessage(e);
-  return msg !== undefined && ABORT_REASON_SET.has(msg);
+	const msg = getErrorMessage(e);
+	return msg !== undefined && ABORT_REASON_SET.has(msg);
 }
 
 export function isUserTriggeredPause(e: unknown): boolean {
-  return getErrorMessage(e) === ABORT_REASONS.USER_PAUSE;
+	return getErrorMessage(e) === ABORT_REASONS.USER_PAUSE;
 }
 
 export function isUserTriggeredRestart(e: unknown): boolean {
-  return getErrorMessage(e) === ABORT_REASONS.USER_RESTART;
+	return getErrorMessage(e) === ABORT_REASONS.USER_RESTART;
 }
 
 export function isUserTriggeredTerminate(e: unknown): boolean {
-  return getErrorMessage(e) === ABORT_REASONS.USER_TERMINATE;
+	return getErrorMessage(e) === ABORT_REASONS.USER_TERMINATE;
+}
+
+/** Checks whether an Engine RPC ended because deletion intentionally aborted it. */
+export function isUserTriggeredDelete(e: unknown): boolean {
+	return getErrorMessage(e) === ABORT_REASONS.USER_DELETE;
 }
 
 function getCompatFlag(name: string): boolean {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- safe globalThis access for environments where cloudflare global may not exist
-  return (globalThis as any).Cloudflare?.compatibilityFlags?.[name] ?? false;
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any -- safe globalThis access for environments where cloudflare global may not exist
+	return (globalThis as any).Cloudflare?.compatibilityFlags?.[name] ?? false;
 }
 
 export function shouldPreserveNonRetryableError(): boolean {
-  return getCompatFlag("workflows_preserve_non_retryable_error_message");
+	return getCompatFlag("workflows_preserve_non_retryable_error_message");
 }
 
 export function stepNotFoundError(name: string): WorkflowError {
-  return createWorkflowError(
-    `Step "${name}" not found in execution history`,
-    "instance.cannot_restart",
-  );
+	return createWorkflowError(
+		`Step "${name}" not found in execution history`,
+		"instance.cannot_restart"
+	);
 }

--- a/packages/cloudflare-runtime/src/internal/workflows-shared/lib/retries.ts
+++ b/packages/cloudflare-runtime/src/internal/workflows-shared/lib/retries.ts
@@ -1,25 +1,48 @@
 // Alchemy modifications are licensed under Apache-2.0.
 // This file includes third-party code; see /THIRD_PARTY_LICENSES.md.
 import { ms } from "itty-time";
-// @ts-expect-error workflows "shared" package will be pulled in later
-import type { ResolvedStepConfig, StepState } from "shared";
+import type { ResolvedStepConfig, StepState } from "../context.ts";
+import type { WorkflowSleepDuration } from "cloudflare:workers";
 
-export function calcRetryDuration(config: ResolvedStepConfig, stepState: StepState): number {
-  const { attemptedCount: attemptCount } = stepState;
-  const { retries } = config;
+export class DelayFunctionError extends Error {
+	constructor(reason: string) {
+		super(reason);
+		this.name = "DelayFunctionError";
+	}
+}
 
-  const delay = ms(retries.delay);
+export function calcRetryDuration(
+	config: ResolvedStepConfig,
+	stepState: StepState,
+	delayValue: unknown
+): number {
+	const { attemptedCount: attemptCount } = stepState;
+	const { retries } = config;
 
-  switch (retries.backoff) {
-    case "exponential": {
-      return delay * Math.pow(2, attemptCount - 1);
-    }
-    case "linear": {
-      return delay * attemptCount;
-    }
-    case "constant":
-    default: {
-      return delay;
-    }
-  }
+	let base: number;
+	try {
+		base = ms(delayValue as WorkflowSleepDuration);
+	} catch {
+		throw new DelayFunctionError(
+			'returned an invalid delay value (expected a number of ms or a duration string like "30 seconds")'
+		);
+	}
+	if (!Number.isFinite(base) || base < 0) {
+		throw new DelayFunctionError(
+			'returned an invalid delay value (expected a number of ms or a duration string like "30 seconds")'
+		);
+	}
+
+	switch (retries.backoff) {
+		case "exponential": {
+			return base * Math.pow(2, attemptCount - 1);
+		}
+		case "linear": {
+			return base * attemptCount;
+		}
+		case "constant":
+		default: {
+			return base;
+		}
+	}
 }

--- a/packages/cloudflare-runtime/src/internal/workflows-shared/lib/rollback.ts
+++ b/packages/cloudflare-runtime/src/internal/workflows-shared/lib/rollback.ts
@@ -8,200 +8,206 @@ import type { Engine } from "../engine.ts";
 import type { WorkflowStepConfig } from "cloudflare:workers";
 
 type UserErrorField = {
-  isUserError?: boolean;
+	isUserError?: boolean;
 };
 
 // `:` can't appear in user-step cacheKeys (sha1-hex + `-` only).
 export const ROLLBACK_CACHE_KEY_PREFIX = "rollback:";
 
 export type RollbackContext = {
-  ctx: WorkflowStepContext;
-  error: Error;
-  output: unknown;
-  /** @deprecated Use `${ctx.step.name}-${ctx.step.count}` instead. */
-  stepName: string;
+	ctx: WorkflowStepContext;
+	error: Error;
+	output: unknown;
+	/** @deprecated Use `${ctx.step.name}-${ctx.step.count}` instead. */
+	stepName: string;
 };
 
 // dup() to outlive the originating step.do call; Symbol.dispose locally
 // (calling `.dispose()` would RPC to a non-existent remote method).
 export type RollbackFn = ((ctx: RollbackContext) => Promise<void>) & {
-  dup?: () => RollbackFn;
-  [Symbol.dispose]?: () => void;
+	dup?: () => RollbackFn;
+	[Symbol.dispose]?: () => void;
 };
 
-export type WorkflowStepRollbackConfig = Pick<WorkflowStepConfig, "retries" | "timeout">;
+export type WorkflowStepRollbackConfig = Pick<
+	WorkflowStepConfig,
+	"retries" | "timeout"
+>;
 
 export type WorkflowStepRollbackOptions = {
-  rollback: RollbackFn;
-  rollbackConfig?: WorkflowStepRollbackConfig;
+	rollback: RollbackFn;
+	rollbackConfig?: WorkflowStepRollbackConfig;
 };
 
 export type RollbackRegistryEntry = {
-  fn: RollbackFn;
-  stepContext: WorkflowStepContext;
-  output?: unknown;
-  config?: WorkflowStepConfig;
+	fn: RollbackFn;
+	stepContext: WorkflowStepContext;
+	output?: unknown;
+	config?: WorkflowStepConfig;
 };
 
 export type RollbackRegistration = RollbackRegistryEntry & {
-  cacheKey: string;
+	cacheKey: string;
 };
 
 export function parseRollbackOptions(
-  stepName: string,
-  options: unknown,
+	stepName: string,
+	options: unknown
 ): WorkflowStepRollbackOptions | undefined {
-  if (options === undefined) {
-    return undefined;
-  }
+	if (options === undefined) {
+		return undefined;
+	}
 
-  if (typeof options !== "object" || options === null || Array.isArray(options)) {
-    const error = new WorkflowFatalError(
-      `Rollback options for "${stepName}" must be an object`,
-    ) as Error & UserErrorField;
-    error.isUserError = true;
-    throw error;
-  }
+	if (
+		typeof options !== "object" ||
+		options === null ||
+		Array.isArray(options)
+	) {
+		const error = new WorkflowFatalError(
+			`Rollback options for "${stepName}" must be an object`
+		) as Error & UserErrorField;
+		error.isUserError = true;
+		throw error;
+	}
 
-  const rollbackOptions = options as Partial<WorkflowStepRollbackOptions>;
-  if (typeof rollbackOptions.rollback !== "function") {
-    const error = new WorkflowFatalError(`Rollback for "${stepName}" must be a function`) as Error &
-      UserErrorField;
-    error.isUserError = true;
-    throw error;
-  }
+	const rollbackOptions = options as Partial<WorkflowStepRollbackOptions>;
+	if (typeof rollbackOptions.rollback !== "function") {
+		const error = new WorkflowFatalError(
+			`Rollback for "${stepName}" must be a function`
+		) as Error & UserErrorField;
+		error.isUserError = true;
+		throw error;
+	}
 
-  if (
-    rollbackOptions.rollbackConfig !== undefined &&
-    !isValidStepConfig(rollbackOptions.rollbackConfig)
-  ) {
-    const error = new WorkflowFatalError(
-      `Rollback config for "${stepName}" is in a invalid format. See https://developers.cloudflare.com/workflows/build/sleeping-and-retrying/`,
-    ) as Error & UserErrorField;
-    error.isUserError = true;
-    throw error;
-  }
+	if (
+		rollbackOptions.rollbackConfig !== undefined &&
+		!isValidStepConfig(rollbackOptions.rollbackConfig)
+	) {
+		const error = new WorkflowFatalError(
+			`Rollback config for "${stepName}" is in a invalid format. See https://developers.cloudflare.com/workflows/build/sleeping-and-retrying/`
+		) as Error & UserErrorField;
+		error.isUserError = true;
+		throw error;
+	}
 
-  return rollbackOptions as WorkflowStepRollbackOptions;
+	return rollbackOptions as WorkflowStepRollbackOptions;
 }
 
 export function dupRollbackStub(fn: RollbackFn): RollbackFn {
-  return fn.dup ? fn.dup() : fn;
+	return fn.dup ? fn.dup() : fn;
 }
 
 export function disposeRollbackStub(fn: RollbackFn): void {
-  try {
-    fn[Symbol.dispose]?.();
-  } catch (err) {
-    console.warn("Failed to dispose rollback stub", err);
-  }
+	try {
+		fn[Symbol.dispose]?.();
+	} catch (err) {
+		console.warn("Failed to dispose rollback stub", err);
+	}
 }
 
 export function registerRollbackFn(
-  registry: Map<string, RollbackRegistryEntry>,
-  registration: RollbackRegistration,
+	registry: Map<string, RollbackRegistryEntry>,
+	registration: RollbackRegistration
 ): void {
-  const { cacheKey, fn, stepContext, output, config } = registration;
-  const existing = registry.get(cacheKey);
-  if (existing) {
-    disposeRollbackStub(existing.fn);
-  }
-  registry.set(cacheKey, {
-    fn: dupRollbackStub(fn),
-    stepContext,
-    ...("output" in registration && { output }),
-    ...(config !== undefined && { config }),
-  });
+	const { cacheKey, fn, stepContext, output, config } = registration;
+	const existing = registry.get(cacheKey);
+	if (existing) {
+		// Existing entry already owns the duped rollback stub. Duplicate registrations
+		// refresh context/output only; this helper has not duped the incoming fn.
+		registry.set(cacheKey, {
+			...existing,
+			stepContext,
+			...("output" in registration && { output }),
+		});
+		return;
+	}
+	registry.set(cacheKey, {
+		fn: dupRollbackStub(fn),
+		stepContext,
+		...("output" in registration && { output }),
+		...(config !== undefined && { config }),
+	});
 }
 
-export function clearRollbackRegistry(registry: Map<string, RollbackRegistryEntry>): void {
-  for (const entry of registry.values()) {
-    disposeRollbackStub(entry.fn);
-  }
-  registry.clear();
-}
-
-function getRollbackRegistryEntriesInExecutionOrder(
-  engine: Engine,
-): Array<[string, RollbackRegistryEntry]> {
-  const entries: Array<[string, RollbackRegistryEntry]> = [];
-  const seen = new Set<string>();
-  const stepStartGroupKeysDesc = engine.readStepStartGroupKeysDesc();
-  const rollbackRegistryEntriesDesc = [...engine.rollbackRegistry.entries()].reverse();
-
-  for (const cacheKey of stepStartGroupKeysDesc) {
-    const entry = engine.rollbackRegistry.get(cacheKey);
-    if (entry === undefined || seen.has(cacheKey)) {
-      continue;
-    }
-    entries.push([cacheKey, entry]);
-    seen.add(cacheKey);
-  }
-
-  for (const [cacheKey, entry] of rollbackRegistryEntriesDesc) {
-    if (!seen.has(cacheKey)) {
-      entries.push([cacheKey, entry]);
-    }
-  }
-
-  return entries;
+export function clearRollbackRegistry(
+	registry: Map<string, RollbackRegistryEntry>
+): void {
+	for (const entry of registry.values()) {
+		disposeRollbackStub(entry.fn);
+	}
+	registry.clear();
 }
 
 // LIFO; halts on first failure. Goes through Context.do so each rollback
 // inherits retries/timeouts/attempt-logging.
 export async function executeRollbacks(
-  engine: Engine,
-  triggerError: Error,
+	engine: Engine,
+	triggerError: Error
 ): Promise<{ ranAny: boolean; allSucceeded: boolean }> {
-  if (engine.rollbackRegistry.size === 0) {
-    return { ranAny: false, allSucceeded: true };
-  }
+	const eligibleSteps = engine.readEligibleRollbackStepsDesc();
+	if (eligibleSteps.length === 0) {
+		clearRollbackRegistry(engine.rollbackRegistry);
+		return { ranAny: false, allSucceeded: true };
+	}
 
-  const entries = getRollbackRegistryEntriesInExecutionOrder(engine);
-  engine.rollbackRegistry.clear();
+	engine.writeLog(InstanceEvent.ROLLBACK_START, null, null, {
+		triggerError: { name: triggerError.name, message: triggerError.message },
+		totalSteps: eligibleSteps.length,
+	});
 
-  engine.writeLog(InstanceEvent.ROLLBACK_START, null, null, {
-    triggerError: { name: triggerError.name, message: triggerError.message },
-    totalSteps: entries.length,
-  });
+	let allSucceeded = true;
+	let completed = 0;
 
-  let allSucceeded = true;
-  let completed = 0;
-  let stoppedAt = entries.length;
+	try {
+		for (const step of eligibleSteps) {
+			const entry = engine.rollbackRegistry.get(step.cacheKey);
+			if (entry === undefined) {
+				engine.writeLog(
+					InstanceEvent.ROLLBACK_STEP_FAILURE,
+					step.cacheKey,
+					step.target,
+					{
+						error: {
+							name: "RollbackMissing",
+							message: "Rollback function not available in registry",
+						},
+					}
+				);
+				allSucceeded = false;
+				break;
+			}
 
-  for (const [i, [cacheKey, entry]] of entries.entries()) {
-    const ctx = engine.createRollbackContext({ cacheKey });
-    const rollbackName = `${entry.stepContext.step.name}-${entry.stepContext.step.count}`;
-    try {
-      await ctx.do(rollbackName, entry.config ?? {}, async () => {
-        await entry.fn({
-          ctx: structuredClone(entry.stepContext),
-          error: triggerError,
-          output: entry.output,
-          stepName: rollbackName,
-        });
-      });
-      completed++;
-    } catch {
-      // Context.do already wrote ROLLBACK_STEP_FAILURE; halt the chain.
-      allSucceeded = false;
-      stoppedAt = i + 1;
-      break;
-    } finally {
-      disposeRollbackStub(entry.fn);
-    }
-  }
+			const ctx = engine.createRollbackContext({ cacheKey: step.cacheKey });
+			try {
+				await ctx.do(step.target, entry.config ?? {}, async () => {
+					await entry.fn({
+						ctx: structuredClone(entry.stepContext),
+						error: triggerError,
+						output: entry.output,
+						stepName: step.target,
+					});
+				});
+				completed++;
+			} catch {
+				// Context.do already wrote ROLLBACK_STEP_FAILURE; halt the chain.
+				allSucceeded = false;
+				break;
+			} finally {
+				disposeRollbackStub(entry.fn);
+				engine.rollbackRegistry.delete(step.cacheKey);
+			}
+		}
+	} finally {
+		clearRollbackRegistry(engine.rollbackRegistry);
+	}
 
-  const remainingEntries = entries.slice(stoppedAt);
-  for (const [, entry] of remainingEntries) {
-    disposeRollbackStub(entry.fn);
-  }
-
-  engine.writeLog(
-    allSucceeded ? InstanceEvent.ROLLBACK_COMPLETE : InstanceEvent.ROLLBACK_FAILED,
-    null,
-    null,
-    { totalSteps: entries.length, completedSteps: completed },
-  );
-  return { ranAny: completed > 0, allSucceeded };
+	engine.writeLog(
+		allSucceeded
+			? InstanceEvent.ROLLBACK_COMPLETE
+			: InstanceEvent.ROLLBACK_FAILED,
+		null,
+		null,
+		{ totalSteps: eligibleSteps.length, completedSteps: completed }
+	);
+	return { ranAny: completed > 0, allSucceeded };
 }

--- a/packages/cloudflare-runtime/src/internal/workflows-shared/lib/validators.ts
+++ b/packages/cloudflare-runtime/src/internal/workflows-shared/lib/validators.ts
@@ -1,17 +1,27 @@
 // Alchemy modifications are licensed under Apache-2.0.
 // This file includes third-party code; see /THIRD_PARTY_LICENSES.md.
+// Alchemy modifications: uses Effect Schema instead of Zod, preserves strict excess-property validation, and supports function retry delays.
 import * as Result from "effect/Result";
 import * as Schema from "effect/Schema";
 import { ms } from "itty-time";
+
+export const SENSITIVE_STEP_OUTPUT = "output";
 
 export const MAX_WORKFLOW_NAME_LENGTH = 64;
 
 export const MAX_WORKFLOW_INSTANCE_ID_LENGTH = 100;
 
+export const MAX_ADDRESSABLE_WORKFLOW_INSTANCE_ID_LENGTH = 271;
+
 export const MAX_STEP_NAME_LENGTH = 256;
 
 export const ALLOWED_STRING_ID_PATTERN = "^[a-zA-Z0-9_][a-zA-Z0-9-_]*$";
+export const ALLOWED_ADDRESSABLE_WORKFLOW_INSTANCE_ID_PATTERN =
+  "^[a-zA-Z0-9, */#_-]+$";
 const ALLOWED_WORKFLOW_INSTANCE_ID_REGEX = new RegExp(ALLOWED_STRING_ID_PATTERN);
+const ALLOWED_ADDRESSABLE_WORKFLOW_INSTANCE_ID_REGEX = new RegExp(
+  ALLOWED_ADDRESSABLE_WORKFLOW_INSTANCE_ID_PATTERN,
+);
 const ALLOWED_WORKFLOW_NAME_REGEX = ALLOWED_WORKFLOW_INSTANCE_ID_REGEX;
 
 // eslint-disable-next-line no-control-regex -- intentional use of control character range to detect invalid characters in workflow names
@@ -40,6 +50,16 @@ export function isValidWorkflowInstanceId(id: string): boolean {
   return ALLOWED_WORKFLOW_INSTANCE_ID_REGEX.test(id);
 }
 
+/** Validates IDs that address existing instances, including generated cron IDs. */
+export function isValidAddressableWorkflowInstanceId(id: string): boolean {
+  return (
+    typeof id === "string" &&
+    id.length > 0 &&
+    id.length <= MAX_ADDRESSABLE_WORKFLOW_INSTANCE_ID_LENGTH &&
+    ALLOWED_ADDRESSABLE_WORKFLOW_INSTANCE_ID_REGEX.test(id)
+  );
+}
+
 export function isValidStepName(name: string): boolean {
   if (name.length > MAX_STEP_NAME_LENGTH) {
     return false;
@@ -56,12 +76,13 @@ const NonNegativeNumberOrString = Schema.Union([
 const STEP_CONFIG_SCHEMA = Schema.Struct({
   retries: Schema.optional(
     Schema.Struct({
-      delay: NonNegativeNumberOrString,
+      delay: Schema.Unknown,
       limit: Schema.Number.check(Schema.isGreaterThanOrEqualTo(0)),
       backoff: Schema.optional(Schema.Literals(["constant", "linear", "exponential"])),
     }),
   ),
   timeout: Schema.optional(NonNegativeNumberOrString),
+  sensitive: Schema.optional(Schema.Literal(SENSITIVE_STEP_OUTPUT)),
 });
 
 const decodeStepConfig = Schema.decodeUnknownResult(STEP_CONFIG_SCHEMA);
@@ -75,8 +96,18 @@ export function isValidStepConfig(stepConfig: unknown): boolean {
 
   const data = config.success;
 
-  if (data.retries !== undefined && Number.isNaN(ms(data.retries.delay))) {
-    return false;
+  if (data.retries !== undefined) {
+    const delay = data.retries.delay;
+    if (
+      !(
+        typeof delay === "function" ||
+        typeof delay === "string" ||
+        (typeof delay === "number" && delay >= 0)
+      ) ||
+      (typeof delay !== "function" && Number.isNaN(ms(delay)))
+    ) {
+      return false;
+    }
   }
 
   if (data.timeout !== undefined) {

--- a/packages/cloudflare-runtime/src/internal/workflows-shared/test/binding.test.ts
+++ b/packages/cloudflare-runtime/src/internal/workflows-shared/test/binding.test.ts
@@ -1,14 +1,14 @@
 // Alchemy modifications are licensed under Apache-2.0.
 // This file includes third-party code; see /THIRD_PARTY_LICENSES.md.
+// Alchemy modifications: tests RPC disposal with a typed stub because the current Vitest pool does not expose methods replaced on a live Durable Object.
 import { createExecutionContext, runInDurableObject } from "cloudflare:test";
-import type { WorkflowEvent } from "cloudflare:workers";
 import { env } from "cloudflare:workers";
 import { describe, it, vi } from "vitest";
 import { InstanceEvent, InstanceStatus } from "../index.ts";
-import type { WorkflowHandle } from "../binding.ts";
-import { WorkflowBinding } from "../binding.ts";
-import type { Engine, EngineLogs } from "../engine.ts";
+import { WorkflowBinding, WorkflowHandle } from "../binding.ts";
 import { setTestWorkflowCallback } from "./test-entry.ts";
+import type { Engine, EngineLogs } from "../engine.ts";
+import type { WorkflowEvent } from "cloudflare:workers";
 
 let instanceCounter = 0;
 function uniqueId(prefix = "instance"): string {
@@ -110,6 +110,23 @@ describe("WorkflowBinding", () => {
         "Workflow instance has invalid id",
       );
     });
+
+    it("should block creation when pending persistence deletion fails", async ({
+      expect,
+    }) => {
+      const binding = new WorkflowBinding(createExecutionContext(), {
+        ENGINE: env.ENGINE,
+        BINDING_NAME: "TEST_WORKFLOW",
+        WORKFLOW_NAME: "test-workflow",
+        MINIFLARE_LOOPBACK: {
+          fetch: () => Promise.resolve(new Response(null, { status: 500 })),
+        } as unknown as Fetcher,
+      });
+
+      await expect(binding.create({ id: "cleanup-failed" })).rejects.toThrow(
+        "Failed to wait for persisted workflow instance 'cleanup-failed' deletion",
+      );
+    });
   });
 
   describe("get()", () => {
@@ -132,6 +149,7 @@ describe("WorkflowBinding", () => {
         resume: expect.any(Function),
         terminate: expect.any(Function),
         restart: expect.any(Function),
+        delete: expect.any(Function),
       });
 
       // Wait for the workflow to complete before the test ends so
@@ -142,6 +160,245 @@ describe("WorkflowBinding", () => {
           return s.status === "complete";
         },
         { timeout: 5000 },
+      );
+    });
+  });
+
+  describe("instance deletion", () => {
+    it("deleteInstance should delete an instance and wipe its stored state", async ({
+      expect,
+    }) => {
+      const id = uniqueId();
+      const binding = createBinding();
+
+      setTestWorkflowCallback(async () => "done");
+      await binding.create({ id });
+
+      const instance = await binding.get(id);
+      await vi.waitUntil(
+        async () => {
+          const status = await instance.status();
+          return status.status === "complete";
+        },
+        { timeout: 5000 },
+      );
+
+      await expect(binding.deleteInstance(id)).resolves.toBeUndefined();
+      await expect(binding.get(id)).rejects.toThrow("instance.not_found");
+    });
+
+    it("should reject an invalid instance ID", async ({ expect }) => {
+      await expect(createBinding().deleteInstance("")).rejects.toThrow(
+        "(instance.invalid_id) Instance ID is invalid",
+      );
+    });
+
+    it("should accept a cron-generated instance ID", async ({ expect }) => {
+      await expect(
+        createBinding().deleteInstance("*/30 * * * *-1786001400000"),
+      ).rejects.toThrow("instance.not_found");
+    });
+
+    it("should let a running instance delete itself and stop execution", async ({
+      expect,
+    }) => {
+      const id = uniqueId();
+      const binding = createBinding();
+      let deleteStarted = false;
+      let continuedAfterDelete = false;
+
+      setTestWorkflowCallback(async () => {
+        deleteStarted = true;
+        const instance = await binding.get(id);
+        await (instance as unknown as { delete(): Promise<void> }).delete();
+        continuedAfterDelete = true;
+      });
+      await binding.create({ id });
+      await vi.waitUntil(() => deleteStarted, { timeout: 5000 });
+
+      await vi.waitUntil(
+        async () => {
+          try {
+            await binding.get(id);
+            return false;
+          } catch {
+            return true;
+          }
+        },
+        { timeout: 5000 },
+      );
+
+      await scheduler.wait(50);
+      expect(continuedAfterDelete).toBe(false);
+      await expect(binding.get(id)).rejects.toThrow("instance.not_found");
+    });
+  });
+
+  describe("deleteBatch()", () => {
+    it("should delete instances and wipe their stored state", async ({
+      expect,
+    }) => {
+      const ids = [uniqueId(), uniqueId()];
+      const binding = createBinding();
+
+      setTestWorkflowCallback(async () => "done");
+      await binding.createBatch(ids.map((id) => ({ id })));
+
+      for (const id of ids) {
+        const instance = await binding.get(id);
+        await vi.waitUntil(
+          async () => {
+            const status = await instance.status();
+            return status.status === "complete";
+          },
+          { timeout: 5000 },
+        );
+      }
+
+      await expect(binding.deleteBatch({ instances: ids })).resolves.toEqual({
+        deleted: ids.map((id) => ({ id })),
+        errors: [],
+      });
+      for (const id of ids) {
+        await expect(binding.get(id)).rejects.toThrow("instance.not_found");
+      }
+    });
+
+    it("should report each duplicate missing cron-generated ID", async ({
+      expect,
+    }) => {
+      const binding = createBinding();
+      const cronId = "*/30 * * * *-1786001400000";
+      await expect(
+        binding.deleteBatch({
+          instances: [cronId, cronId],
+        }),
+      ).resolves.toEqual({
+        deleted: [],
+        errors: [
+          {
+            id: cronId,
+            code: 10400,
+            message: "workflows.api.error.instance.not_found",
+          },
+          {
+            id: cronId,
+            code: 10400,
+            message: "workflows.api.error.instance.not_found",
+          },
+        ],
+      });
+    });
+
+    it("should normalize unexpected deletion errors", async ({ expect }) => {
+      const deleteInstance = vi
+        .fn()
+        .mockRejectedValue(new Error("sensitive failure"));
+      const binding = new WorkflowBinding(createExecutionContext(), {
+        ENGINE: {
+          idFromName: (id: string) => id,
+          get: () => ({ deleteInstance }),
+        } as unknown as DurableObjectNamespace<Engine>,
+        BINDING_NAME: "TEST_WORKFLOW",
+        WORKFLOW_NAME: "test-workflow",
+      });
+
+      await expect(
+        binding.deleteBatch({ instances: ["broken-instance"] }),
+      ).resolves.toEqual({
+        deleted: [],
+        errors: [
+          {
+            id: "broken-instance",
+            code: 10001,
+            message: "workflows.api.error.internal_server",
+          },
+        ],
+      });
+      expect(deleteInstance).toHaveBeenCalledOnce();
+    });
+
+    it("should report persistence cleanup failures per instance", async ({
+      expect,
+    }) => {
+      const abort = vi.fn(() =>
+        Promise.reject(new Error("Durable Object aborted")),
+      );
+      const loopbackFetch = vi.fn((url: string) =>
+        Promise.resolve(
+          new Response(null, {
+            status: url.includes("/cleanup-failed") ? 500 : 204,
+          }),
+        ),
+      );
+      const binding = new WorkflowBinding(createExecutionContext(), {
+        ENGINE: {
+          idFromName: (id: string) => ({ toString: () => id }),
+          get: (id: { toString(): string }) => ({
+            id,
+            deleteInstance: () => {
+              if (id.toString() === "missing") {
+                return Promise.reject(
+                  new Error("(instance.not_found) Instance does not exist"),
+                );
+              }
+              return Promise.resolve();
+            },
+            unsafeAbort: abort,
+          }),
+        } as unknown as DurableObjectNamespace<Engine>,
+        BINDING_NAME: "TEST_WORKFLOW",
+        WORKFLOW_NAME: "test-workflow",
+        MINIFLARE_LOOPBACK: { fetch: loopbackFetch } as unknown as Fetcher,
+      });
+
+      await expect(
+        binding.deleteBatch({
+          instances: ["cleanup-failed", "missing", "deleted", "cleanup-failed"],
+        }),
+      ).resolves.toEqual({
+        deleted: [{ id: "deleted" }],
+        errors: [
+          {
+            id: "cleanup-failed",
+            code: 10001,
+            message: "workflows.api.error.internal_server",
+          },
+          {
+            id: "missing",
+            code: 10400,
+            message: "workflows.api.error.instance.not_found",
+          },
+          {
+            id: "cleanup-failed",
+            code: 10001,
+            message: "workflows.api.error.internal_server",
+          },
+        ],
+      });
+      expect(abort).toHaveBeenCalledOnce();
+      expect(loopbackFetch.mock.calls.map(([url]) => url)).toEqual(
+        expect.arrayContaining([
+          expect.stringContaining("/missing?defer=1"),
+          expect.stringContaining("/missing?waitForPendingDelete=1"),
+        ]),
+      );
+    });
+
+    it("should reject invalid batches", async ({ expect }) => {
+      const binding = createBinding();
+      await expect(binding.deleteBatch({ instances: [] })).rejects.toThrow(
+        "(body) batchDeleteInstances should have at least 1 instance",
+      );
+      await expect(
+        binding.deleteBatch({
+          instances: Array.from({ length: 101 }, (_, i) => `instance-${i}`),
+        }),
+      ).rejects.toThrow(
+        "(body) batchDeleteInstances only supports 100 instances at a time",
+      );
+      await expect(binding.deleteBatch({ instances: [""] })).rejects.toThrow(
+        "(instance.invalid_id) Instance ID is invalid",
       );
     });
   });
@@ -191,48 +448,20 @@ describe("WorkflowBinding", () => {
     expect,
   }) => {
     const id = uniqueId();
-    const binding = createBinding();
-    const engineStub = env.ENGINE.get(env.ENGINE.idFromName(id));
-
-    setTestWorkflowCallback(async (_event, step) => {
-      const receivedEvent = await step.waitForEvent("wait-for-test-event", {
-        type: "test-event",
-        timeout: "10 seconds",
-      });
-      return receivedEvent;
-    });
-
-    const createdInstance = await binding.create({ id });
-    expect(createdInstance.id).toBe(id);
-
-    const instance = await binding.get(id);
-    expect(instance.id).toBe(id);
-
     const disposeSpy = vi.fn();
-
-    await runInDurableObject<Engine, void>(engineStub, (engine) => {
-      const originalReceiveEvent = engine.receiveEvent.bind(engine);
-      engine.receiveEvent = (event) => {
-        const result = originalReceiveEvent(event);
-        return Object.assign(result, {
-          [Symbol.dispose]: disposeSpy,
-        });
-      };
-    });
+    const receiveEvent = vi.fn(() =>
+      Object.assign(Promise.resolve(), { [Symbol.dispose]: disposeSpy }),
+    );
+    const engineStub = env.ENGINE.get(env.ENGINE.idFromName(id));
+    Object.defineProperty(engineStub, "receiveEvent", { value: receiveEvent });
+    const instance = new WorkflowHandle(id, engineStub, () => engineStub);
 
     using _ = (await instance.sendEvent({
       type: "test-event",
       payload: { test: "data" },
     })) as unknown as Disposable;
 
-    await vi.waitUntil(
-      async () => {
-        const status = await instance.status();
-        return status.status === "complete";
-      },
-      { timeout: 5000 },
-    );
-
+    expect(receiveEvent).toHaveBeenCalledOnce();
     expect(disposeSpy).not.toHaveBeenCalled();
   });
 });
@@ -477,53 +706,48 @@ describe("WorkflowHandle", () => {
   });
 
   describe("terminate()", () => {
-    // This test was flaky in macOS CI, so we retry it.
-    it(
-      "should terminate a running workflow instance",
-      { retry: 3 },
-      async ({ expect }) => {
-        const id = uniqueId();
-        const binding = createBinding();
-        const engineStub = env.ENGINE.get(env.ENGINE.idFromName(id));
+    it("should terminate a running workflow instance", async ({ expect }) => {
+      const id = uniqueId();
+      const binding = createBinding();
+      const engineStub = env.ENGINE.get(env.ENGINE.idFromName(id));
 
-        setTestWorkflowCallback(async (_event, step) => {
-          await step.waitForEvent("wait-for-event", {
-            type: "some-event",
-            timeout: "1 second",
-          });
-          await step.do("should not be called", async () => {
-            return "should not be called";
-          });
-          return "should never complete";
+      setTestWorkflowCallback(async (_event, step) => {
+        await step.waitForEvent("wait-for-event", {
+          type: "some-event",
+          timeout: "1 second",
         });
-
-        await binding.create({ id });
-        await waitUntilLogEvent(engineStub, InstanceEvent.WAIT_START);
-
-        const instance = await binding.get(id);
-        await instance.terminate();
-
-        // Get a new stub since the engine was aborted
-        const newEngineStub = env.ENGINE.get(env.ENGINE.idFromName(id));
-
-        const status = await runInDurableObject(newEngineStub, (engine) => {
-          return engine.getStatus();
+        await step.do("should not be called", async () => {
+          return "should not be called";
         });
-        expect(status).toBe(InstanceStatus.Terminated);
+        return "should never complete";
+      });
 
-        const logs = (await newEngineStub.readLogs()) as EngineLogs;
-        const hasTerminatedEvent = logs.logs.some(
-          (log) => log.event === InstanceEvent.WORKFLOW_TERMINATED,
-        );
-        expect(hasTerminatedEvent).toBe(true);
+      await binding.create({ id });
+      await waitUntilLogEvent(engineStub, InstanceEvent.WAIT_START);
 
-        // assert that step.do never started
-        const hasStepStart = logs.logs.some(
-          (log) => log.event === InstanceEvent.STEP_START,
-        );
-        expect(hasStepStart).toBe(false);
-      },
-    );
+      const instance = await binding.get(id);
+      await instance.terminate();
+
+      // Get a new stub since the engine was aborted
+      const newEngineStub = env.ENGINE.get(env.ENGINE.idFromName(id));
+
+      const status = await runInDurableObject(newEngineStub, (engine) => {
+        return engine.getStatus();
+      });
+      expect(status).toBe(InstanceStatus.Terminated);
+
+      const logs = (await newEngineStub.readLogs()) as EngineLogs;
+      const hasTerminatedEvent = logs.logs.some(
+        (log) => log.event === InstanceEvent.WORKFLOW_TERMINATED,
+      );
+      expect(hasTerminatedEvent).toBe(true);
+
+      // assert that step.do never started
+      const hasStepStart = logs.logs.some(
+        (log) => log.event === InstanceEvent.STEP_START,
+      );
+      expect(hasStepStart).toBe(false);
+    });
   });
 
   describe("restart()", () => {

--- a/packages/cloudflare-runtime/src/internal/workflows-shared/test/context.test.ts
+++ b/packages/cloudflare-runtime/src/internal/workflows-shared/test/context.test.ts
@@ -1,9 +1,13 @@
 // Alchemy modifications are licensed under Apache-2.0.
 // This file includes third-party code; see /THIRD_PARTY_LICENSES.md.
-import { env, runInDurableObject } from "cloudflare:test";
+// Alchemy modifications: uses Array<T> syntax for non-tuple array types to match the repository convention.
+import { runInDurableObject } from "cloudflare:test";
+import { env } from "cloudflare:workers";
+import { NonRetryableError } from "cloudflare:workflows";
 import { afterEach, describe, it, vi } from "vitest";
 import workerdUnsafe from "workerd:unsafe";
 import { InstanceEvent } from "../index.ts";
+import { REDACTED_STEP_OUTPUT } from "../context.ts";
 import { computeHash } from "../lib/cache.ts";
 import {
   InvalidStepReadableStreamError,
@@ -1451,5 +1455,162 @@ describe("Context - typed-array step outputs (issue #14101)", () => {
     expect(
       logs.logs.some((val) => val.event === InstanceEvent.WORKFLOW_FAILURE),
     ).toBe(false);
+  });
+});
+
+describe("Sensitive step output", () => {
+  it("should redact a sensitive step's output in logs while passing the real value downstream", async ({
+    expect,
+  }) => {
+    let downstreamValue: unknown;
+
+    const engineStub = await runWorkflowAndAwait(
+      "SENSITIVE-STEP-OUTPUT",
+      async (_event, step) => {
+        const secret = await step.do(
+          "sensitive step",
+          { sensitive: "output" },
+          async () => {
+            return { token: "super-secret" };
+          },
+        );
+        await step.do("downstream step", async () => {
+          downstreamValue = secret;
+          return "ok";
+        });
+      },
+    );
+
+    await vi.waitUntil(
+      async () => {
+        const logs = (await engineStub.readLogs()) as EngineLogs;
+        return logs.logs.some(
+          (val) => val.event === InstanceEvent.WORKFLOW_SUCCESS,
+        );
+      },
+      { timeout: 5000 },
+    );
+
+    const logs = (await engineStub.readLogs()) as EngineLogs;
+    const stepLog = logs.logs.find(
+      (val) =>
+        val.event === InstanceEvent.STEP_SUCCESS &&
+        val.target === "sensitive step-1",
+    );
+    expect(stepLog?.metadata.result).toBe(REDACTED_STEP_OUTPUT);
+
+    // The real value is still cached and handed to the running workflow.
+    expect(downstreamValue).toEqual({ token: "super-secret" });
+  });
+
+  it("should redact a sensitive step's output from waitForStepResult", async ({
+    expect,
+  }) => {
+    const engineStub = await runWorkflowAndAwait(
+      "SENSITIVE-STEP-WAIT-RESULT",
+      async (_event, step) => {
+        await step.do(
+          "sensitive step",
+          { sensitive: "output" },
+          async () => "super-secret",
+        );
+      },
+    );
+
+    await vi.waitUntil(
+      async () => {
+        const logs = (await engineStub.readLogs()) as EngineLogs;
+        return logs.logs.some(
+          (val) => val.event === InstanceEvent.WORKFLOW_SUCCESS,
+        );
+      },
+      { timeout: 5000 },
+    );
+
+    const result = await engineStub.waitForStepResult("sensitive step");
+    expect(result).toBe(REDACTED_STEP_OUTPUT);
+  });
+
+  it("should not redact a sensitive step's error", async ({ expect }) => {
+    const engineStub = await runWorkflowAndAwait(
+      "SENSITIVE-STEP-ERROR",
+      async (_event, step) => {
+        try {
+          await step.do(
+            "sensitive failing step",
+            { sensitive: "output", retries: { limit: 0, delay: 0 } },
+            async () => {
+              throw new NonRetryableError("boom with secret context");
+            },
+          );
+        } catch {}
+      },
+    );
+
+    await vi.waitUntil(
+      async () => {
+        const logs = (await engineStub.readLogs()) as EngineLogs;
+        return logs.logs.some(
+          (val) => val.event === InstanceEvent.WORKFLOW_SUCCESS,
+        );
+      },
+      { timeout: 5000 },
+    );
+
+    const logs = (await engineStub.readLogs()) as EngineLogs;
+    const attemptFailure = logs.logs.find(
+      (val) => val.event === InstanceEvent.ATTEMPT_FAILURE,
+    );
+    const error = attemptFailure?.metadata.error as
+      | { message: string }
+      | undefined;
+    expect(error?.message).toContain("boom with secret context");
+  });
+
+  it("should redact a sensitive streaming step output in readLogs", async ({
+    expect,
+  }) => {
+    const payload = "streamed secret";
+    const payloadBytes = encodeUtf8(payload);
+
+    const engineStub = await runWorkflowAndAwait(
+      "SENSITIVE-STREAM-OUTPUT",
+      async (_event, step) => {
+        const stream = await step.do(
+          "sensitive stream step",
+          { sensitive: "output" },
+          async () => {
+            return new ReadableStream<Uint8Array>({
+              start(controller) {
+                controller.enqueue(payloadBytes);
+                controller.close();
+              },
+            });
+          },
+        );
+        const bytes = await readStreamBytes(
+          stream as ReadableStream<Uint8Array>,
+        );
+        return decodeUtf8(bytes);
+      },
+    );
+
+    await vi.waitUntil(
+      async () => {
+        const logs = (await engineStub.readLogs()) as EngineLogs;
+        return logs.logs.some(
+          (val) => val.event === InstanceEvent.WORKFLOW_SUCCESS,
+        );
+      },
+      { timeout: 5000 },
+    );
+
+    const logs = (await engineStub.readLogs()) as EngineLogs;
+    const stepLog = logs.logs.find(
+      (val) =>
+        val.event === InstanceEvent.STEP_SUCCESS &&
+        val.target === "sensitive stream step-1",
+    );
+    expect(stepLog?.metadata.result).toBe(REDACTED_STEP_OUTPUT);
   });
 });

--- a/packages/cloudflare-runtime/src/internal/workflows-shared/test/engine.test.ts
+++ b/packages/cloudflare-runtime/src/internal/workflows-shared/test/engine.test.ts
@@ -1,5 +1,6 @@
 // Alchemy modifications are licensed under Apache-2.0.
 // This file includes third-party code; see /THIRD_PARTY_LICENSES.md.
+// Alchemy modifications: uses Array<T> syntax and expects current workerd error serialization, which preserves the message without prefixing the custom class name.
 import { runInDurableObject } from "cloudflare:test";
 import { env } from "cloudflare:workers";
 import { NonRetryableError } from "cloudflare:workflows";
@@ -20,7 +21,12 @@ import type {
   RollbackFn,
   WorkflowStepRollbackOptions,
 } from "../lib/rollback.ts";
-import type { WorkflowStep, WorkflowStepConfig } from "cloudflare:workers";
+import type {
+  WorkflowDelayFunction,
+  WorkflowStep,
+  WorkflowStepConfig,
+  WorkflowStepContext,
+} from "cloudflare:workers";
 
 afterEach(async () => {
   await workerdUnsafe.abortAllDurableObjects();
@@ -180,6 +186,166 @@ describe("Engine", () => {
     expect(
       logs.logs.filter((val) => val.event == InstanceEvent.ATTEMPT_FAILURE),
     ).toHaveLength(1);
+  });
+
+  it("applies a dynamic delay function and succeeds after retries", async ({
+    expect,
+  }) => {
+    const instanceId = "DYNAMIC-DELAY-APPLIED";
+    const dynamicDelay: WorkflowDelayFunction = () => 50;
+    let attempts = 0;
+
+    const engineStub = await runWorkflow(instanceId, async (_event, step) => {
+      await step.do(
+        "dynamic-delay-step",
+        {
+          retries: { limit: 3, delay: dynamicDelay, backoff: "constant" },
+        },
+        async () => {
+          attempts++;
+          if (attempts < 2) {
+            throw new Error("transient");
+          }
+          return "ok";
+        },
+      );
+      return "done";
+    });
+
+    await vi.waitUntil(
+      async () => {
+        const logs = (await engineStub.readLogs()) as EngineLogs;
+        return logs.logs.some(
+          (val) => val.event === InstanceEvent.WORKFLOW_SUCCESS,
+        );
+      },
+      { timeout: 5000 },
+    );
+
+    const logs = (await engineStub.readLogs()) as EngineLogs;
+    const attemptFailures = logs.logs.filter(
+      (val) => val.event === InstanceEvent.ATTEMPT_FAILURE,
+    );
+
+    expect(attemptFailures.length).toBeGreaterThanOrEqual(1);
+    expect(attemptFailures[0]?.metadata).toMatchObject({ retryDelayMs: 50 });
+  });
+
+  it("fails non-retryably when the delay function throws", async ({
+    expect,
+  }) => {
+    const instanceId = "DYNAMIC-DELAY-BROKEN";
+    const throwingDelay: WorkflowDelayFunction = () => {
+      throw new Error("delay boom");
+    };
+
+    const engineStub = await runWorkflow(instanceId, async (_event, step) => {
+      await step.do(
+        "broken-delay-step",
+        {
+          retries: { limit: 5, delay: throwingDelay, backoff: "constant" },
+        },
+        async () => {
+          throw new Error("step failed");
+        },
+      );
+      return "done";
+    });
+
+    await vi.waitUntil(
+      async () => {
+        const logs = (await engineStub.readLogs()) as EngineLogs;
+        return logs.logs.some(
+          (val) => val.event === InstanceEvent.WORKFLOW_FAILURE,
+        );
+      },
+      { timeout: 5000 },
+    );
+
+    const logs = (await engineStub.readLogs()) as EngineLogs;
+
+    // The broken delay function turns the retry into a non-retryable failure,
+    // so the step is only attempted once.
+    expect(
+      logs.logs.filter((val) => val.event === InstanceEvent.ATTEMPT_START),
+    ).toHaveLength(1);
+
+    // Current workerd preserves the error message across the RPC boundary
+    // without folding the custom class name into it.
+    const workflowFailure = logs.logs.find(
+      (val) => val.event === InstanceEvent.WORKFLOW_FAILURE,
+    );
+    expect(workflowFailure?.metadata.error.message).toContain("delay function");
+    expect(workflowFailure?.metadata.error.message).toContain("delay boom");
+  });
+
+  it("omits delay from ctx.config for a dynamic delay but includes it for a static delay", async ({
+    expect,
+  }) => {
+    const dynamicDelay: WorkflowDelayFunction = () => 10;
+    let dynamicConfig:
+      | WorkflowStepContext<WorkflowDelayFunction>["config"]
+      | undefined;
+    let staticConfig: WorkflowStepContext<number>["config"] | undefined;
+
+    const dynamicStub = await runWorkflow(
+      "DYNAMIC-DELAY-CTX-HIDDEN",
+      async (_event, step) => {
+        await step.do(
+          "dynamic-config-step",
+          {
+            retries: { limit: 1, delay: dynamicDelay, backoff: "constant" },
+          },
+          async (ctx) => {
+            dynamicConfig = ctx.config;
+            return "ok";
+          },
+        );
+        return "done";
+      },
+    );
+
+    await vi.waitUntil(
+      async () => {
+        const logs = (await dynamicStub.readLogs()) as EngineLogs;
+        return logs.logs.some(
+          (val) => val.event === InstanceEvent.WORKFLOW_SUCCESS,
+        );
+      },
+      { timeout: 5000 },
+    );
+
+    const staticStub = await runWorkflow(
+      "STATIC-DELAY-CTX-VISIBLE",
+      async (_event, step) => {
+        await step.do(
+          "static-config-step",
+          {
+            retries: { limit: 1, delay: 1234, backoff: "constant" },
+          },
+          async (ctx) => {
+            staticConfig = ctx.config;
+            return "ok";
+          },
+        );
+        return "done";
+      },
+    );
+
+    await vi.waitUntil(
+      async () => {
+        const logs = (await staticStub.readLogs()) as EngineLogs;
+        return logs.logs.some(
+          (val) => val.event === InstanceEvent.WORKFLOW_SUCCESS,
+        );
+      },
+      { timeout: 5000 },
+    );
+
+    const dynamicRetries = dynamicConfig?.retries;
+    expect(dynamicRetries).toBeDefined();
+    expect(dynamicRetries && "delay" in dynamicRetries).toBe(false);
+    expect(staticConfig?.retries?.delay).toBe(1234);
   });
 
   it("waitForEvent should receive events while active", async ({ expect }) => {
@@ -1562,7 +1728,7 @@ describe("Rollback", () => {
             ctx.output !== "out" ||
             ctx.ctx.step.name !== "ctx-step" ||
             ctx.ctx.step.count !== 1 ||
-            ctx.stepName !== "ctx-step-1"
+            `${ctx.ctx.step.name}-${ctx.ctx.step.count}` !== "ctx-step-1"
           ) {
             throw new Error("unexpected rollback context");
           }
@@ -1595,7 +1761,7 @@ describe("Rollback", () => {
               ctx.output !== undefined ||
               ctx.ctx.step.name !== "failed-step" ||
               ctx.ctx.step.count !== 1 ||
-              ctx.stepName !== "failed-step-1"
+              `${ctx.ctx.step.name}-${ctx.ctx.step.count}` !== "failed-step-1"
             ) {
               throw new Error("unexpected failed-step rollback context");
             }
@@ -1673,6 +1839,459 @@ describe("Rollback", () => {
       "step-2-1",
     ]);
     expect(countOf(logs, InstanceEvent.ROLLBACK_COMPLETE)).toBe(0);
+  });
+
+  it("runs rollback when terminate requests it", async ({ expect }) => {
+    const instanceId = "RB-TERMINATE";
+    const engineStub = await runWorkflow(instanceId, async (_e, step) => {
+      await doWithRollback(
+        step,
+        "setup-resource",
+        async () => "resource-id",
+        rollbackOptions(),
+      );
+      await step.sleep("wait-forever", "1 hour");
+    });
+
+    await readLogsAfter(engineStub, (currentLogs) =>
+      currentLogs.logs.some(
+        (log) =>
+          log.event === InstanceEvent.STEP_SUCCESS &&
+          log.target === "setup-resource-1",
+      ),
+    );
+
+    try {
+      await runInDurableObject(engineStub, async (engine) => {
+        await engine.changeInstanceStatus("terminate", undefined, {
+          rollback: true,
+        });
+      });
+    } catch (error) {
+      if (
+        !(error instanceof Error) ||
+        !error.message.startsWith("Aborting engine:")
+      ) {
+        throw error;
+      }
+    }
+
+    const logs = await readLogsAfter(
+      env.ENGINE.get(env.ENGINE.idFromName(instanceId)),
+      (currentLogs) =>
+        currentLogs.logs.some(
+          (log) => log.event === InstanceEvent.WORKFLOW_TERMINATED,
+        ),
+    );
+    expect(targetsOf(logs, InstanceEvent.ROLLBACK_STEP_SUCCESS)).toEqual([
+      "setup-resource-1",
+    ]);
+    expect(countOf(logs, InstanceEvent.ROLLBACK_COMPLETE)).toBe(1);
+  });
+
+  it("replays cached steps before terminate rollback when registry is empty", async ({
+    expect,
+  }) => {
+    const instanceId = "RB-TERMINATE-REPLAY";
+    const engineStub = await runWorkflow(instanceId, async (_e, step) => {
+      await doWithRollback(
+        step,
+        "setup-resource",
+        async () => "resource-id",
+        rollbackOptions(),
+      );
+      await step.sleep("wait-forever", "1 hour");
+    });
+
+    await readLogsAfter(engineStub, (currentLogs) =>
+      currentLogs.logs.some(
+        (log) =>
+          log.event === InstanceEvent.STEP_SUCCESS &&
+          log.target === "setup-resource-1",
+      ),
+    );
+
+    await runInDurableObject(engineStub, async (engine) => {
+      engine.rollbackRegistry.clear();
+    });
+
+    try {
+      await runInDurableObject(engineStub, async (engine) => {
+        await engine.changeInstanceStatus("terminate", undefined, {
+          rollback: true,
+        });
+      });
+    } catch (error) {
+      if (
+        !(error instanceof Error) ||
+        !error.message.startsWith("Aborting engine:")
+      ) {
+        throw error;
+      }
+    }
+
+    const logs = await readLogsAfter(
+      env.ENGINE.get(env.ENGINE.idFromName(instanceId)),
+      (currentLogs) =>
+        currentLogs.logs.some(
+          (log) => log.event === InstanceEvent.WORKFLOW_TERMINATED,
+        ),
+    );
+    expect(targetsOf(logs, InstanceEvent.ROLLBACK_STEP_SUCCESS)).toEqual([
+      "setup-resource-1",
+    ]);
+    expect(countOf(logs, InstanceEvent.ROLLBACK_COMPLETE)).toBe(1);
+  });
+
+  it("replays started unfinished steps before terminate rollback when registry is empty", async ({
+    expect,
+  }) => {
+    const instanceId = `RB-TERMINATE-STARTED-REPLAY-${crypto.randomUUID()}`;
+    const engineId = env.ENGINE.idFromName(instanceId);
+    const engineStub = await runWorkflow(instanceId, async (_e, step) => {
+      await doWithRollback(
+        step,
+        "started-setup",
+        async () => {
+          await scheduler.wait(30_000);
+          return "late-resource-id";
+        },
+        rollbackOptions(),
+      );
+    });
+
+    await readLogsAfter(engineStub, (currentLogs) =>
+      currentLogs.logs.some(
+        (log) =>
+          log.event === InstanceEvent.ATTEMPT_START &&
+          log.target === "started-setup-1",
+      ),
+    );
+
+    try {
+      await runInDurableObject(engineStub, async (engine) => {
+        await engine.abort("test restart before step completion");
+      });
+    } catch (error) {
+      if (
+        !(error instanceof Error) ||
+        error.message !== "test restart before step completion"
+      ) {
+        throw error;
+      }
+    }
+
+    const restartedStub = env.ENGINE.get(engineId);
+    await runInDurableObject(restartedStub, async (engine) => {
+      engine.rollbackRegistry.clear();
+    });
+
+    try {
+      await runInDurableObject(restartedStub, async (engine) => {
+        await engine.changeInstanceStatus("terminate", undefined, {
+          rollback: true,
+        });
+      });
+    } catch (error) {
+      if (!isAbortError(error)) {
+        throw error;
+      }
+    }
+
+    let logs: EngineLogs | undefined;
+    await vi.waitUntil(
+      async () => {
+        try {
+          logs = (await env.ENGINE.get(engineId).readLogs()) as EngineLogs;
+          return logs.logs.some(
+            (log) => log.event === InstanceEvent.WORKFLOW_TERMINATED,
+          );
+        } catch (error) {
+          if (isAbortError(error)) {
+            return false;
+          }
+          throw error;
+        }
+      },
+      { timeout: 5000 },
+    );
+    if (logs === undefined) {
+      throw new Error("Expected workflow logs after terminate");
+    }
+    expect(targetsOf(logs, InstanceEvent.ROLLBACK_STEP_SUCCESS)).toEqual([
+      "started-setup-1",
+    ]);
+    expect(countOf(logs, InstanceEvent.ROLLBACK_COMPLETE)).toBe(1);
+  });
+
+  it("fails terminate rollback when replay cannot rebuild an eligible handler", async ({
+    expect,
+  }) => {
+    const instanceId = `RB-TERMINATE-MISSING-REPLAY-${crypto.randomUUID()}`;
+    const engineId = env.ENGINE.idFromName(instanceId);
+    const engineStub = await runWorkflow(instanceId, async (_e, step) => {
+      await doWithRollback(
+        step,
+        "branchy-setup",
+        async () => "resource-id",
+        rollbackOptions(),
+      );
+      await step.sleep("wait-forever", "1 hour");
+    });
+
+    await readLogsAfter(engineStub, (currentLogs) =>
+      currentLogs.logs.some(
+        (log) =>
+          log.event === InstanceEvent.STEP_SUCCESS &&
+          log.target === "branchy-setup-1",
+      ),
+    );
+
+    try {
+      await runInDurableObject(engineStub, async (engine) => {
+        await engine.abort("test restart before replay branch changes");
+      });
+    } catch (error) {
+      if (
+        !(error instanceof Error) ||
+        error.message !== "test restart before replay branch changes"
+      ) {
+        throw error;
+      }
+    }
+
+    setTestWorkflowCallback(async () => {
+      // Simulate nondeterministic replay control flow that no longer reaches
+      // the persisted eligible step. Production treats this as rollback failure.
+    });
+
+    try {
+      await runInDurableObject(env.ENGINE.get(engineId), async (engine) => {
+        await engine.changeInstanceStatus("terminate", undefined, {
+          rollback: true,
+        });
+      });
+    } catch (error) {
+      if (!isAbortError(error)) {
+        throw error;
+      }
+    }
+
+    const logs = await readLogsAfter(env.ENGINE.get(engineId), (currentLogs) =>
+      currentLogs.logs.some(
+        (log) => log.event === InstanceEvent.WORKFLOW_TERMINATED,
+      ),
+    );
+    expect(targetsOf(logs, InstanceEvent.ROLLBACK_STEP_FAILURE)).toEqual([
+      "branchy-setup-1",
+    ]);
+    expect(countOf(logs, InstanceEvent.ROLLBACK_FAILED)).toBe(1);
+    expect(countOf(logs, InstanceEvent.ROLLBACK_COMPLETE)).toBe(0);
+  });
+
+  it("replays cached failed steps before terminate rollback when registry is empty", async ({
+    expect,
+  }) => {
+    const instanceId = "RB-TERMINATE-FAILED-REPLAY";
+    const engineStub = await runWorkflow(instanceId, async (_e, step) => {
+      try {
+        await doWithRollback(
+          step,
+          "failed-setup",
+          { retries: { limit: 0, delay: 0, backoff: "constant" } },
+          async () => {
+            throw new Error("step-boom");
+          },
+          rollbackOptions(),
+        );
+      } catch {
+        // Keep the workflow running so terminate rollback can replay the cached
+        // failed step and re-register its rollback handler.
+      }
+      await step.sleep("wait-forever", "1 hour");
+    });
+
+    await readLogsAfter(engineStub, (currentLogs) =>
+      currentLogs.logs.some(
+        (log) =>
+          log.event === InstanceEvent.STEP_FAILURE &&
+          log.target === "failed-setup-1",
+      ),
+    );
+
+    await runInDurableObject(engineStub, async (engine) => {
+      engine.rollbackRegistry.clear();
+    });
+
+    try {
+      await runInDurableObject(engineStub, async (engine) => {
+        await engine.changeInstanceStatus("terminate", undefined, {
+          rollback: true,
+        });
+      });
+    } catch (error) {
+      if (
+        !(error instanceof Error) ||
+        !error.message.startsWith("Aborting engine:")
+      ) {
+        throw error;
+      }
+    }
+
+    const logs = await readLogsAfter(
+      env.ENGINE.get(env.ENGINE.idFromName(instanceId)),
+      (currentLogs) =>
+        currentLogs.logs.some(
+          (log) => log.event === InstanceEvent.WORKFLOW_TERMINATED,
+        ),
+    );
+    expect(targetsOf(logs, InstanceEvent.ROLLBACK_STEP_SUCCESS)).toEqual([
+      "failed-setup-1",
+    ]);
+    expect(countOf(logs, InstanceEvent.ROLLBACK_COMPLETE)).toBe(1);
+  });
+
+  it("omits dynamic delay from rollback ctx.config on cached-error replay", async ({
+    expect,
+  }) => {
+    const dynamicDelay: WorkflowDelayFunction = () => 1000;
+    const instanceId = "RB-TERMINATE-FAILED-REPLAY-DYNAMIC-DELAY";
+    const engineStub = await runWorkflow(instanceId, async (_e, step) => {
+      try {
+        await doWithRollback(
+          step,
+          "failed-setup",
+          { retries: { limit: 0, delay: dynamicDelay, backoff: "constant" } },
+          async () => {
+            throw new Error("step-boom");
+          },
+          rollbackOptions(async (ctx) => {
+            // A dynamic delay must be omitted from the user-facing config,
+            // never surfaced as the internal "[dynamic]" marker string.
+            if ("delay" in ctx.ctx.config.retries) {
+              throw new Error(
+                "dynamic delay marker leaked into rollback ctx.config",
+              );
+            }
+          }),
+        );
+      } catch {
+        // Keep the workflow running so terminate rollback can replay the cached
+        // failed step and re-register its rollback handler.
+      }
+      await step.sleep("wait-forever", "1 hour");
+    });
+
+    await readLogsAfter(engineStub, (currentLogs) =>
+      currentLogs.logs.some(
+        (log) =>
+          log.event === InstanceEvent.STEP_FAILURE &&
+          log.target === "failed-setup-1",
+      ),
+    );
+
+    await runInDurableObject(engineStub, async (engine) => {
+      engine.rollbackRegistry.clear();
+    });
+
+    try {
+      await runInDurableObject(engineStub, async (engine) => {
+        await engine.changeInstanceStatus("terminate", undefined, {
+          rollback: true,
+        });
+      });
+    } catch (error) {
+      if (
+        !(error instanceof Error) ||
+        !error.message.startsWith("Aborting engine:")
+      ) {
+        throw error;
+      }
+    }
+
+    const logs = await readLogsAfter(
+      env.ENGINE.get(env.ENGINE.idFromName(instanceId)),
+      (currentLogs) =>
+        currentLogs.logs.some(
+          (log) => log.event === InstanceEvent.WORKFLOW_TERMINATED,
+        ),
+    );
+    // ROLLBACK_STEP_SUCCESS only fires if the rollback fn did not throw, i.e.
+    // the leaked marker was stripped by toEngineStepConfig on the replay path.
+    expect(targetsOf(logs, InstanceEvent.ROLLBACK_STEP_SUCCESS)).toEqual([
+      "failed-setup-1",
+    ]);
+    expect(countOf(logs, InstanceEvent.ROLLBACK_COMPLETE)).toBe(1);
+  });
+
+  it("runs terminate rollback while paused with an empty registry", async ({
+    expect,
+  }) => {
+    const instanceId = "RB-TERMINATE-PAUSED";
+    const engineId = env.ENGINE.idFromName(instanceId);
+    const engineStub = await runWorkflow(instanceId, async (_e, step) => {
+      await doWithRollback(
+        step,
+        "setup-resource",
+        async () => "resource-id",
+        rollbackOptions(),
+      );
+      await step.sleep("wait-forever", "1 hour");
+    });
+
+    await readLogsAfter(engineStub, (currentLogs) =>
+      currentLogs.logs.some(
+        (log) =>
+          log.event === InstanceEvent.STEP_SUCCESS &&
+          log.target === "setup-resource-1",
+      ),
+    );
+
+    try {
+      await runInDurableObject(engineStub, async (engine) => {
+        await engine.changeInstanceStatus("pause");
+      });
+    } catch (error) {
+      if (!isAbortError(error)) {
+        throw error;
+      }
+    }
+
+    await vi.waitUntil(
+      async () =>
+        runInDurableObject(
+          env.ENGINE.get(engineId),
+          async (engine) =>
+            (await engine.getStatus()) === InstanceStatus.Paused,
+        ),
+      { timeout: 5000 },
+    );
+
+    await runInDurableObject(env.ENGINE.get(engineId), async (engine) => {
+      engine.rollbackRegistry.clear();
+    });
+
+    try {
+      await runInDurableObject(env.ENGINE.get(engineId), async (engine) => {
+        await engine.changeInstanceStatus("terminate", undefined, {
+          rollback: true,
+        });
+      });
+    } catch (error) {
+      if (!isAbortError(error)) {
+        throw error;
+      }
+    }
+
+    const logs = await readLogsAfter(env.ENGINE.get(engineId), (currentLogs) =>
+      currentLogs.logs.some(
+        (log) => log.event === InstanceEvent.WORKFLOW_TERMINATED,
+      ),
+    );
+    expect(targetsOf(logs, InstanceEvent.ROLLBACK_STEP_SUCCESS)).toEqual([
+      "setup-resource-1",
+    ]);
+    expect(countOf(logs, InstanceEvent.ROLLBACK_COMPLETE)).toBe(1);
   });
 
   it("does not run rollback when workflow succeeds", async ({ expect }) => {

--- a/packages/cloudflare-runtime/src/internal/workflows-shared/test/lib/delay.test.ts
+++ b/packages/cloudflare-runtime/src/internal/workflows-shared/test/lib/delay.test.ts
@@ -1,0 +1,252 @@
+// Alchemy modifications are licensed under Apache-2.0.
+// This file includes third-party code; see /THIRD_PARTY_LICENSES.md.
+import { describe, it, vi } from "vitest";
+import {
+	DEFAULT_RETRY_DELAY_MS,
+	invokeDelayFunction,
+	raceAgainstAbort,
+} from "../../lib/delay.ts";
+import { DelayFunctionError } from "../../lib/retries.ts";
+import type { WorkflowDynamicDelayContext } from "cloudflare:workers";
+
+const input: WorkflowDynamicDelayContext = {
+	ctx: {
+		step: { name: "step", count: 1 },
+		attempt: 1,
+		config: { retries: { limit: 5, backoff: "constant" }, timeout: 0 },
+	},
+	error: new Error("boom"),
+};
+
+const makeLogger = () => ({ warn: vi.fn(), debug: vi.fn() });
+
+const noTimeout =
+	(): ((ms: number, opts?: { signal?: AbortSignal }) => Promise<void>) => () =>
+		new Promise<void>(() => {});
+
+describe("raceAgainstAbort", () => {
+	it("removes the abort listener when the raced promise resolves", async ({
+		expect,
+	}) => {
+		const controller = new AbortController();
+		const addEventListener = vi.spyOn(controller.signal, "addEventListener");
+		const removeEventListener = vi.spyOn(
+			controller.signal,
+			"removeEventListener"
+		);
+
+		await expect(
+			raceAgainstAbort(Promise.resolve("done"), controller.signal)
+		).resolves.toEqual({ aborted: false, value: "done" });
+
+		expect(addEventListener).toHaveBeenCalledOnce();
+		expect(removeEventListener).toHaveBeenCalledWith(
+			"abort",
+			addEventListener.mock.calls[0]?.[1]
+		);
+	});
+
+	it("removes the abort listener when the signal wins", async ({ expect }) => {
+		const controller = new AbortController();
+		const addEventListener = vi.spyOn(controller.signal, "addEventListener");
+		const removeEventListener = vi.spyOn(
+			controller.signal,
+			"removeEventListener"
+		);
+		const result = raceAgainstAbort(
+			new Promise<void>(() => {}),
+			controller.signal
+		);
+
+		controller.abort();
+
+		await expect(result).resolves.toEqual({ aborted: true });
+		expect(removeEventListener).toHaveBeenCalledWith(
+			"abort",
+			addEventListener.mock.calls[0]?.[1]
+		);
+	});
+
+	it("removes the abort listener when the raced promise rejects", async ({
+		expect,
+	}) => {
+		const controller = new AbortController();
+		const addEventListener = vi.spyOn(controller.signal, "addEventListener");
+		const removeEventListener = vi.spyOn(
+			controller.signal,
+			"removeEventListener"
+		);
+		const error = new Error("boom");
+
+		await expect(
+			raceAgainstAbort(Promise.reject(error), controller.signal)
+		).rejects.toBe(error);
+		expect(removeEventListener).toHaveBeenCalledWith(
+			"abort",
+			addEventListener.mock.calls[0]?.[1]
+		);
+	});
+
+	it("does not register a listener for an already-aborted signal", async ({
+		expect,
+	}) => {
+		const controller = new AbortController();
+		controller.abort();
+		const addEventListener = vi.spyOn(controller.signal, "addEventListener");
+		const removeEventListener = vi.spyOn(
+			controller.signal,
+			"removeEventListener"
+		);
+
+		await expect(
+			raceAgainstAbort(
+				Promise.reject(new Error("late rejection")),
+				controller.signal
+			)
+		).resolves.toEqual({ aborted: true });
+		expect(addEventListener).not.toHaveBeenCalled();
+		expect(removeEventListener).not.toHaveBeenCalled();
+	});
+});
+
+describe("invokeDelayFunction", () => {
+	it("returns the value a synchronous delay function produces", async ({
+		expect,
+	}) => {
+		const logger = makeLogger();
+		const result = await invokeDelayFunction(() => 1234, input, {
+			timeoutMs: 5000,
+			wait: noTimeout(),
+			logger,
+		});
+		expect(result).toBe(1234);
+		expect(logger.warn).not.toHaveBeenCalled();
+		expect(logger.debug).not.toHaveBeenCalled();
+	});
+
+	it("awaits an asynchronous delay function", async ({ expect }) => {
+		const logger = makeLogger();
+		const result = await invokeDelayFunction(async () => 1234, input, {
+			timeoutMs: 5000,
+			wait: noTimeout(),
+			logger,
+		});
+		expect(result).toBe(1234);
+		expect(logger.warn).not.toHaveBeenCalled();
+		expect(logger.debug).not.toHaveBeenCalled();
+	});
+
+	it("throws when the delay function never resolves (timeout)", async ({
+		expect,
+	}) => {
+		const logger = makeLogger();
+		const promise = invokeDelayFunction(
+			() => new Promise<number>(() => {}),
+			input,
+			{
+				timeoutMs: 5000,
+				wait: () => Promise.resolve(),
+				logger,
+			}
+		);
+		await expect(promise).rejects.toThrow(
+			new DelayFunctionError("did not return within 5 seconds")
+		);
+		expect(logger.warn).toHaveBeenCalledTimes(1);
+		expect(logger.warn).toHaveBeenCalledWith(
+			expect.stringContaining("did not resolve"),
+			{ step: "step", attempt: 1 }
+		);
+		expect(logger.debug).not.toHaveBeenCalled();
+	});
+
+	it("throws when the delay function throws synchronously", async ({
+		expect,
+	}) => {
+		const logger = makeLogger();
+		const promise = invokeDelayFunction(
+			() => {
+				throw new Error("sync boom");
+			},
+			input,
+			{
+				timeoutMs: 5000,
+				wait: noTimeout(),
+				logger,
+			}
+		);
+		await expect(promise).rejects.toThrow(
+			new DelayFunctionError("threw an error: sync boom")
+		);
+		expect(logger.warn).toHaveBeenCalledWith(
+			expect.stringContaining("threw"),
+			expect.objectContaining({ error: "sync boom" })
+		);
+	});
+
+	it("throws when the delay function rejects", async ({ expect }) => {
+		const logger = makeLogger();
+		const promise = invokeDelayFunction(
+			async () => {
+				throw new Error("async boom");
+			},
+			input,
+			{
+				timeoutMs: 5000,
+				wait: noTimeout(),
+				logger,
+			}
+		);
+		await expect(promise).rejects.toThrow(
+			new DelayFunctionError("threw an error: async boom")
+		);
+		expect(logger.warn).toHaveBeenCalledWith(
+			expect.stringContaining("threw"),
+			expect.objectContaining({ error: "async boom" })
+		);
+	});
+
+	it("logs a debug (not a warn) when the provided signal aborts before the function resolves", async ({
+		expect,
+	}) => {
+		const logger = makeLogger();
+		const abort = new AbortController();
+		const promise = invokeDelayFunction(
+			() => new Promise<number>(() => {}),
+			input,
+			{
+				timeoutMs: 5000,
+				wait: (_ms, opts) =>
+					new Promise<void>((resolve) => {
+						opts?.signal?.addEventListener("abort", () => resolve(), {
+							once: true,
+						});
+					}),
+				signal: abort.signal,
+				logger,
+			}
+		);
+		abort.abort();
+		await expect(promise).resolves.toBe(DEFAULT_RETRY_DELAY_MS);
+		expect(logger.debug).toHaveBeenCalledTimes(1);
+		expect(logger.debug).toHaveBeenCalledWith(
+			expect.stringContaining("engine shutdown"),
+			{ step: "step", attempt: 1 }
+		);
+		expect(logger.warn).not.toHaveBeenCalled();
+	});
+
+	it("throws without a logger", async ({ expect }) => {
+		const promise = invokeDelayFunction(
+			() => {
+				throw new Error("sync boom");
+			},
+			input,
+			{
+				timeoutMs: 5000,
+				wait: noTimeout(),
+			}
+		);
+		await expect(promise).rejects.toThrow(DelayFunctionError);
+	});
+});

--- a/packages/cloudflare-runtime/src/internal/workflows-shared/test/utils.ts
+++ b/packages/cloudflare-runtime/src/internal/workflows-shared/test/utils.ts
@@ -1,6 +1,7 @@
 // Alchemy modifications are licensed under Apache-2.0.
 // This file includes third-party code; see /THIRD_PARTY_LICENSES.md.
-import { env } from "cloudflare:test";
+// Alchemy modifications: uses Array<T> syntax for non-tuple array types to match the repository convention.
+import { env } from "cloudflare:workers";
 import { setTestWorkflowCallback } from "./test-entry.ts";
 import type {
   DatabaseInstance,

--- a/packages/cloudflare-runtime/src/internal/workflows-shared/test/validators.test.ts
+++ b/packages/cloudflare-runtime/src/internal/workflows-shared/test/validators.test.ts
@@ -2,10 +2,12 @@
 // This file includes third-party code; see /THIRD_PARTY_LICENSES.md.
 import { describe, it } from "vitest";
 import {
+  isValidAddressableWorkflowInstanceId,
   isValidStepConfig,
   isValidStepName,
   isValidWorkflowInstanceId,
   isValidWorkflowName,
+  MAX_ADDRESSABLE_WORKFLOW_INSTANCE_ID_LENGTH,
   MAX_STEP_NAME_LENGTH,
   MAX_WORKFLOW_INSTANCE_ID_LENGTH,
   MAX_WORKFLOW_NAME_LENGTH,
@@ -58,6 +60,30 @@ describe("Workflow instance ID validation", () => {
   });
 });
 
+describe("Addressable Workflow instance ID validation", () => {
+  it.for([
+    "",
+    NaN,
+    undefined,
+    "w".repeat(MAX_ADDRESSABLE_WORKFLOW_INSTANCE_ID_LENGTH + 1),
+    "invalid!",
+    "0 0 * * MON?2-1786001400000",
+  ])("should reject invalid IDs", (value, { expect }) => {
+    expect(isValidAddressableWorkflowInstanceId(value as string)).toBe(false);
+  });
+
+  it.for([
+    "abc",
+    "*/30 * * * *-1786001400000",
+    "0 0 * * MON#2-1786001400000",
+    "0 0 1,15 * *-1786001400000",
+    "NAME_123-/cron",
+    "w".repeat(MAX_ADDRESSABLE_WORKFLOW_INSTANCE_ID_LENGTH),
+  ])("should accept valid IDs", (value, { expect }) => {
+    expect(isValidAddressableWorkflowInstanceId(value)).toBe(true);
+  });
+});
+
 describe("Workflow instance step name validation", () => {
   it.for(["\x00", "w".repeat(MAX_STEP_NAME_LENGTH + 1)])(
     "should reject invalid names",
@@ -90,8 +116,26 @@ describe("Workflow step config validation", () => {
         "i-like-trains": "yes".repeat(100),
       },
     },
+    {
+      retries: { limit: 3, delay: "i like trains", backoff: "constant" },
+      timeout: "10 minutes",
+    },
+    {
+      retries: { limit: 3, delay: 10, backoff: "constant" },
+      timeout: 0,
+    },
+    { timeout: "5 minutes", sensitive: "all" },
+    { timeout: "5 minutes", sensitive: true },
   ])("should reject invalid step configs", (value, { expect }) => {
     expect(isValidStepConfig(value)).toBe(false);
+  });
+
+  it("should accept a dynamic delay function", ({ expect }) => {
+    const config = {
+      retries: { limit: 3, delay: () => "10 seconds", backoff: "constant" },
+      timeout: "10 minutes",
+    };
+    expect(isValidStepConfig(config)).toBe(true);
   });
 
   it.for([
@@ -102,6 +146,11 @@ describe("Workflow step config validation", () => {
     {
       retries: { limit: 5, delay: 0, backoff: "constant" },
       timeout: "2 minutes",
+    },
+    {
+      retries: { limit: 3, delay: 10, backoff: "constant" },
+      timeout: "2 minutes",
+      sensitive: "output",
     },
   ])("should accept valid step configs", (value, { expect }) => {
     expect(isValidStepConfig(value)).toBe(true);

--- a/packages/cloudflare-runtime/src/rolldown/README.md
+++ b/packages/cloudflare-runtime/src/rolldown/README.md
@@ -18,8 +18,8 @@ const bundle = await rolldown({
   input: "./src/index.ts",
   plugins: [
     cloudflare({
-      compatibilityDate: "2026-04-01",
-      compatibilityFlags: ["nodejs_compat"],
+      // Node.js compatibility is default-on for this date.
+      compatibilityDate: "2026-08-31",
     }),
   ],
 });
@@ -35,7 +35,8 @@ await bundle.write({
 
 - Applies Cloudflare-friendly Rolldown defaults for resolution and output targeting.
 - Treats supported `cloudflare:*` imports as external.
-- Enables Node.js compatibility shims when `nodejs_compat` is set.
+- Enables Node.js compatibility shims when `nodejs_compat` is set or the
+  compatibility date is `2026-08-04` or later.
 - Supports Cloudflare-style additional modules for `.wasm`, `.bin`, `.txt`, `.html`, and `.sql`.
 - Supports `.wasm?init` imports.
 

--- a/packages/cloudflare-runtime/src/rolldown/options.ts
+++ b/packages/cloudflare-runtime/src/rolldown/options.ts
@@ -20,6 +20,13 @@ export interface BasePluginOptions {
    */
   compatibilityFlags?: Array<string>;
   /**
+   * Whether external CommonJS `require()` calls should be rewritten as ESM.
+   * Internal single-module Workers disable this because they cannot carry the
+   * generated helper chunk; user bundles should leave it enabled.
+   * @default true
+   */
+  externalRequire?: boolean;
+  /**
    * The exports to include in the bundle.
    * By default, all exports are included. However, if you only want to include certain exports, you can use this option.
    * @example

--- a/packages/cloudflare-runtime/src/rolldown/options.ts
+++ b/packages/cloudflare-runtime/src/rolldown/options.ts
@@ -15,7 +15,7 @@ export interface BasePluginOptions {
    * @default []
    * @example
    * ```ts
-   * cloudflare({ compatibilityDate: "2026-04-01", compatibilityFlags: ["nodejs_compat"] });
+   * cloudflare({ compatibilityDate: "2026-08-31" });
    * ```
    */
   compatibilityFlags?: Array<string>;

--- a/packages/cloudflare-runtime/src/rolldown/plugin.ts
+++ b/packages/cloudflare-runtime/src/rolldown/plugin.ts
@@ -22,7 +22,7 @@ export type RolldownPlugin = (
 
 const cloudflare: RolldownPlugin = (options = {}) => {
   return [
-    hasNodejsCompat(options.compatibilityFlags)
+    hasNodejsCompat(options.compatibilityFlags, options.compatibilityDate)
       ? esmExternalRequirePlugin({
           external: [...getUnenv(options).external],
           skipDuplicateCheck: true,

--- a/packages/cloudflare-runtime/src/rolldown/plugin.ts
+++ b/packages/cloudflare-runtime/src/rolldown/plugin.ts
@@ -22,6 +22,7 @@ export type RolldownPlugin = (
 
 const cloudflare: RolldownPlugin = (options = {}) => {
   return [
+    options.externalRequire !== false &&
     hasNodejsCompat(options.compatibilityFlags, options.compatibilityDate)
       ? esmExternalRequirePlugin({
           external: [...getUnenv(options).external],

--- a/packages/cloudflare-runtime/src/rolldown/plugins/nodejs-compat.ts
+++ b/packages/cloudflare-runtime/src/rolldown/plugins/nodejs-compat.ts
@@ -62,7 +62,8 @@ export const getUnenv = (options: BasePluginOptions) =>
 export const nodejsUnenvPlugin = createPlugin<"nodejs-unenv", UnenvApi>(
   "nodejs-unenv",
   (options) => {
-    if (!hasNodejsCompat(options.compatibilityFlags)) return;
+    if (!hasNodejsCompat(options.compatibilityFlags, options.compatibilityDate))
+      return;
     const { alias, inject, polyfill, external } = getUnenv(options);
     const entries = new Set(Object.values(alias));
     for (const globalInject of Object.values(inject)) {
@@ -237,7 +238,8 @@ const supportsMissingImportRegistration = (environment: {
 export const nodejsImportWarningPlugin = createPlugin(
   "nodejs-import-warning",
   (options) => {
-    if (hasNodejsCompat(options.compatibilityFlags)) return;
+    if (hasNodejsCompat(options.compatibilityFlags, options.compatibilityDate))
+      return;
     const imports = new Map<string, Set<string>>();
     let root = process.cwd();
     return {

--- a/packages/cloudflare-runtime/src/rolldown/test/nodejs-compat.test.ts
+++ b/packages/cloudflare-runtime/src/rolldown/test/nodejs-compat.test.ts
@@ -4,6 +4,12 @@ import cloudflare from "../plugin.ts";
 import { buildFixture } from "./utils/build-fixture.ts";
 
 describe("nodejs_compat", () => {
+  it("rewrites external CommonJS requires when compatibility enables Node by date", () => {
+    const plugins = cloudflare({ compatibilityDate: "2026-08-31" });
+
+    expect(plugins[0]?.name).toBe("builtin:esm-external-require");
+  });
+
   it("runs node builtin imports with nodejs_compat enabled", async () => {
     const built = await buildFixture({
       fixture: "node-compat/index.ts",

--- a/packages/cloudflare-runtime/src/rolldown/test/nodejs-compat.test.ts
+++ b/packages/cloudflare-runtime/src/rolldown/test/nodejs-compat.test.ts
@@ -10,6 +10,15 @@ describe("nodejs_compat", () => {
     expect(plugins[0]?.name).toBe("builtin:esm-external-require");
   });
 
+  it("can omit the external require rewrite for single-module internal workers", () => {
+    const plugins = cloudflare({
+      compatibilityDate: "2026-08-31",
+      externalRequire: false,
+    });
+
+    expect(plugins[0]?.name).not.toBe("builtin:esm-external-require");
+  });
+
   it("runs node builtin imports with nodejs_compat enabled", async () => {
     const built = await buildFixture({
       fixture: "node-compat/index.ts",

--- a/packages/cloudflare-runtime/src/rolldown/test/utils.test.ts
+++ b/packages/cloudflare-runtime/src/rolldown/test/utils.test.ts
@@ -29,6 +29,14 @@ describe("utils", () => {
       expect(hasNodejsCompat(["nodejs_compat_v2"])).toBe(true);
     });
 
+    it("detects Node.js compatibility enabled by date", () => {
+      expect(hasNodejsCompat(undefined, "2026-08-31")).toBe(true);
+    });
+
+    it("honors an explicit opt-out on a default-on date", () => {
+      expect(hasNodejsCompat(["no_nodejs_compat"], "2026-08-31")).toBe(false);
+    });
+
     it("returns false without compatibility flags", () => {
       expect(hasNodejsCompat()).toBe(false);
       expect(hasNodejsCompat(["durable_object_alarms"])).toBe(false);

--- a/packages/cloudflare-runtime/src/rolldown/utils.ts
+++ b/packages/cloudflare-runtime/src/rolldown/utils.ts
@@ -13,7 +13,19 @@ export function toPosixPath(path: string): string {
   return path.replace(/\\/g, "/");
 }
 
-export function hasNodejsCompat(flags?: ReadonlyArray<string>): boolean {
+export function hasNodejsCompat(
+  flags?: ReadonlyArray<string>,
+  compatibilityDate?: string,
+): boolean {
+  // Both nodejs_compat modes are runtime defaults from 2026-08-04, so builds
+  // for newer dates must enable the same transforms without a redundant flag.
+  if (
+    compatibilityDate !== undefined &&
+    compatibilityDate >= "2026-08-04" &&
+    !flags?.includes("no_nodejs_compat")
+  ) {
+    return true;
+  }
   return (
     flags?.some(
       (flag) => flag === "nodejs_compat" || flag === "nodejs_compat_v2",

--- a/packages/cloudflare-runtime/src/vite/assets/ViteAssets.ts
+++ b/packages/cloudflare-runtime/src/vite/assets/ViteAssets.ts
@@ -78,7 +78,8 @@ export const ViteAssetsLive = (viteDevServer: vite.ViteDevServer) =>
                 name: "assets:worker",
                 worker: {
                   compatibilityDate: INTERNAL_WORKER_COMPATIBILITY_DATE,
-                  compatibilityFlags: ["nodejs_compat"],
+                  // Node.js compatibility is supplied by the 2026-08-31
+                  // internal compatibility date.
                   bindings: [
                     {
                       name: "CONFIG",
@@ -108,7 +109,9 @@ export const ViteAssetsLive = (viteDevServer: vite.ViteDevServer) =>
                 name: "assets:router",
                 worker: {
                   compatibilityDate: INTERNAL_WORKER_COMPATIBILITY_DATE,
-                  compatibilityFlags: ["nodejs_compat", "no_nodejs_compat_v2"],
+                  // The date supplies nodejs_compat; this worker deliberately
+                  // retains only its v2 opt-out.
+                  compatibilityFlags: ["no_nodejs_compat_v2"],
                   bindings: [
                     {
                       name: "ASSET_WORKER",

--- a/packages/cloudflare-runtime/src/vite/assets/ViteAssets.ts
+++ b/packages/cloudflare-runtime/src/vite/assets/ViteAssets.ts
@@ -2,7 +2,7 @@
 // This file includes third-party code; see /THIRD_PARTY_LICENSES.md.
 import { loadInternalWorker } from "../../core/internal/internal-worker.ts";
 import * as Assets from "../../core/bindings/assets/Assets.ts";
-import { INTERNAL_WORKER_COMPATIBILITY_DATE } from "../../core/internal/constants.ts";
+import { DEFAULT_COMPATIBILITY_DATE } from "../../core/internal/constants.ts";
 import * as Loopback from "../../core/globals/Loopback.ts";
 import { PluginContext } from "../../core/PluginContext.ts";
 import * as Effect from "effect/Effect";
@@ -77,7 +77,7 @@ export const ViteAssetsLive = (viteDevServer: vite.ViteDevServer) =>
               {
                 name: "assets:worker",
                 worker: {
-                  compatibilityDate: INTERNAL_WORKER_COMPATIBILITY_DATE,
+                  compatibilityDate: DEFAULT_COMPATIBILITY_DATE,
                   // Node.js compatibility is supplied by the 2026-08-31
                   // internal compatibility date.
                   bindings: [
@@ -108,7 +108,7 @@ export const ViteAssetsLive = (viteDevServer: vite.ViteDevServer) =>
               {
                 name: "assets:router",
                 worker: {
-                  compatibilityDate: INTERNAL_WORKER_COMPATIBILITY_DATE,
+                  compatibilityDate: DEFAULT_COMPATIBILITY_DATE,
                   // The date supplies nodejs_compat; this worker deliberately
                   // retains only its v2 opt-out.
                   compatibilityFlags: ["no_nodejs_compat_v2"],

--- a/packages/cloudflare-runtime/src/vite/dev-server.ts
+++ b/packages/cloudflare-runtime/src/vite/dev-server.ts
@@ -1,4 +1,4 @@
-import { INTERNAL_WORKER_COMPATIBILITY_DATE } from "../core/internal/constants.ts";
+import { DEFAULT_COMPATIBILITY_DATE } from "../core/internal/constants.ts";
 import { loadInternalWorker } from "../core/internal/internal-worker.ts";
 import type { ExportTypes } from "../rolldown/export-types.ts";
 import { EXPORT_TYPES_MODULE_ID } from "../rolldown/export-types.ts";
@@ -203,8 +203,7 @@ const serve = Effect.fn(function* <B extends BindingHooks = BindingHooks>(
   return yield* runtime.start({
     name,
     modules: yield* Effect.promise(() => makeWorkerModules(exportTypes)),
-    compatibilityDate:
-      options.compatibilityDate ?? INTERNAL_WORKER_COMPATIBILITY_DATE,
+    compatibilityDate: options.compatibilityDate ?? DEFAULT_COMPATIBILITY_DATE,
     compatibilityFlags: options.compatibilityFlags ?? [],
     bindings: [
       UnsafeEval.local("__DISTILLED_UNSAFE_EVAL__"),

--- a/packages/cloudflare-runtime/src/vite/preview-server.ts
+++ b/packages/cloudflare-runtime/src/vite/preview-server.ts
@@ -1,4 +1,4 @@
-import { INTERNAL_WORKER_COMPATIBILITY_DATE } from "../core/internal/constants.ts";
+import { DEFAULT_COMPATIBILITY_DATE } from "../core/internal/constants.ts";
 import type { BindingHooks, Module } from "../core/index.ts";
 import * as Runtime from "../core/Runtime.ts";
 import * as RuntimeServices from "../core/RuntimeServices.ts";
@@ -159,8 +159,7 @@ const serve = Effect.fn(function* (
   return yield* runtime.start({
     name: options.worker?.name ?? `vite-preview-${crypto.randomUUID()}`,
     modules,
-    compatibilityDate:
-      options.compatibilityDate ?? INTERNAL_WORKER_COMPATIBILITY_DATE,
+    compatibilityDate: options.compatibilityDate ?? DEFAULT_COMPATIBILITY_DATE,
     compatibilityFlags: options.compatibilityFlags ?? [],
     bindings: options.worker?.bindings ?? [],
     durableObjectNamespaces: options.worker?.durableObjectNamespaces,

--- a/packages/cloudflare-runtime/tsconfig.json
+++ b/packages/cloudflare-runtime/tsconfig.json
@@ -15,7 +15,7 @@
     "types": [
       "bun",
       "@cloudflare/workers-types/experimental",
-      "@cloudflare/vitest-pool-workers/types"
+      "@cloudflare/vitest-plugin/types"
     ]
   }
 }

--- a/packages/cloudflare-runtime/tsdown.config.ts
+++ b/packages/cloudflare-runtime/tsdown.config.ts
@@ -70,7 +70,8 @@ export default defineConfig([
     "!src/core/internal/shared.worker.ts",
     "!src/core/**/R2Bucket.worker.ts",
   ]),
-  // The R2 worker uses `node:crypto` and runs with `nodejs_compat`. Don't
+  // The R2 worker uses `node:crypto`; the 2026-08-31 date enables Node.js
+  // compatibility without a redundant flag. Don't
   // clean the shared `dist/workers` directory, which the previous config
   // already populated. The entry is named explicitly to keep the output at
   // the path `worker:` imports resolve to.
@@ -79,7 +80,7 @@ export default defineConfig([
       "bindings/r2-bucket/R2Bucket.worker":
         "src/core/bindings/r2-bucket/R2Bucket.worker.ts",
     },
-    { compatibilityFlags: ["nodejs_compat"], clean: false },
+    { clean: false },
   ),
   {
     cwd: ".",

--- a/packages/cloudflare-runtime/tsdown.config.ts
+++ b/packages/cloudflare-runtime/tsdown.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig, type UserConfig } from "tsdown";
-import { INTERNAL_WORKER_COMPATIBILITY_DATE } from "./src/core/internal/constants.ts";
+import { DEFAULT_COMPATIBILITY_DATE } from "./src/core/internal/constants.ts";
 import {
   InternalWorkerExportPlugin,
   RuntimeSubpathExportPlugin,
@@ -32,7 +32,7 @@ const workerConfig = (
   // depth limit, so bridge through `unknown`.
   plugins: [
     cloudflare({
-      compatibilityDate: INTERNAL_WORKER_COMPATIBILITY_DATE,
+      compatibilityDate: DEFAULT_COMPATIBILITY_DATE,
       compatibilityFlags: options.compatibilityFlags,
     }),
     InternalWorkerExportPlugin(),
@@ -125,7 +125,7 @@ export default defineConfig([
       mangle: false,
     },
     plugins: [
-      cloudflare({ compatibilityDate: INTERNAL_WORKER_COMPATIBILITY_DATE }),
+      cloudflare({ compatibilityDate: DEFAULT_COMPATIBILITY_DATE }),
       InternalWorkerExportPlugin(),
     ],
     deps: {

--- a/packages/cloudflare-runtime/tsdown.config.ts
+++ b/packages/cloudflare-runtime/tsdown.config.ts
@@ -34,6 +34,7 @@ const workerConfig = (
     cloudflare({
       compatibilityDate: DEFAULT_COMPATIBILITY_DATE,
       compatibilityFlags: options.compatibilityFlags,
+      externalRequire: false,
     }),
     InternalWorkerExportPlugin(),
   ] as unknown as UserConfig["plugins"],
@@ -125,7 +126,12 @@ export default defineConfig([
       mangle: false,
     },
     plugins: [
-      cloudflare({ compatibilityDate: DEFAULT_COMPATIBILITY_DATE }),
+      cloudflare({
+        compatibilityDate: DEFAULT_COMPATIBILITY_DATE,
+        // These workers are exported as single modules, so they cannot carry
+        // the helper chunk emitted by the external-require rewrite.
+        externalRequire: false,
+      }),
       InternalWorkerExportPlugin(),
     ],
     deps: {

--- a/packages/cloudflare-runtime/vitest.config.ts
+++ b/packages/cloudflare-runtime/vitest.config.ts
@@ -1,4 +1,4 @@
-import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
+import { cloudflareTest } from "@cloudflare/vitest-plugin";
 import path from "node:path";
 import { loadEnv } from "vite";
 import { defineConfig } from "vitest/config";

--- a/packages/frontend-frameworks/src/astro/prerenderer.ts
+++ b/packages/frontend-frameworks/src/astro/prerenderer.ts
@@ -29,7 +29,7 @@ import type {
   BindingHooks,
   Module,
 } from "@alchemy.run/cloudflare-runtime/core";
-import { INTERNAL_WORKER_COMPATIBILITY_DATE as DEFAULT_COMPATIBILITY_DATE } from "@alchemy.run/cloudflare-runtime/core/internal/constants";
+import { DEFAULT_COMPATIBILITY_DATE } from "@alchemy.run/cloudflare-runtime/core/internal/constants";
 import * as Runtime from "@alchemy.run/cloudflare-runtime/core/Runtime";
 import * as RuntimeServices from "@alchemy.run/cloudflare-runtime/core/RuntimeServices";
 import * as Credentials from "@distilled.cloud/cloudflare/Credentials";

--- a/packages/frontend-frameworks/src/astro/prerenderer.ts
+++ b/packages/frontend-frameworks/src/astro/prerenderer.ts
@@ -54,7 +54,7 @@ import {
 } from "./runtime/utils/prerender-constants.ts";
 
 /** Matches `dev-server.ts` in `@alchemy.run/cloudflare-runtime/vite`. */
-const DEFAULT_COMPATIBILITY_DATE = "2026-05-12";
+const DEFAULT_COMPATIBILITY_DATE = "2026-08-31";
 
 /** The subdirectory of the server output dir that hosts the prerender build. */
 const PRERENDER_OUTPUT_SUBDIR = "./.prerender/";

--- a/packages/frontend-frameworks/src/astro/prerenderer.ts
+++ b/packages/frontend-frameworks/src/astro/prerenderer.ts
@@ -29,6 +29,7 @@ import type {
   BindingHooks,
   Module,
 } from "@alchemy.run/cloudflare-runtime/core";
+import { INTERNAL_WORKER_COMPATIBILITY_DATE as DEFAULT_COMPATIBILITY_DATE } from "@alchemy.run/cloudflare-runtime/core/internal/constants";
 import * as Runtime from "@alchemy.run/cloudflare-runtime/core/Runtime";
 import * as RuntimeServices from "@alchemy.run/cloudflare-runtime/core/RuntimeServices";
 import * as Credentials from "@distilled.cloud/cloudflare/Credentials";
@@ -52,9 +53,6 @@ import {
   PRERENDER_ENDPOINT,
   STATIC_PATHS_ENDPOINT,
 } from "./runtime/utils/prerender-constants.ts";
-
-/** Matches `dev-server.ts` in `@alchemy.run/cloudflare-runtime/vite`. */
-const DEFAULT_COMPATIBILITY_DATE = "2026-08-31";
 
 /** The subdirectory of the server output dir that hosts the prerender build. */
 const PRERENDER_OUTPUT_SUBDIR = "./.prerender/";

--- a/packages/frontend-frameworks/src/nextjs/Nextjs.ts
+++ b/packages/frontend-frameworks/src/nextjs/Nextjs.ts
@@ -121,7 +121,7 @@ export const listEdgeFunctions = (manifest: unknown): Array<string> => {
 };
 
 /** The default compatibility date when the options provide none. */
-export const DEFAULT_COMPATIBILITY_DATE = "2026-05-12";
+export const DEFAULT_COMPATIBILITY_DATE = "2026-08-31";
 
 /** The server-module name of the worker entry (`serverModules[0]`). */
 export const WORKER_ENTRY_MODULE = `worker/${Bundle.WORKER_ENTRY_NAME}`;

--- a/packages/frontend-frameworks/src/nextjs/Nextjs.ts
+++ b/packages/frontend-frameworks/src/nextjs/Nextjs.ts
@@ -3,7 +3,7 @@ import type {
   Module,
   RuntimeWorker,
 } from "@alchemy.run/cloudflare-runtime/core";
-import { INTERNAL_WORKER_COMPATIBILITY_DATE as DEFAULT_COMPATIBILITY_DATE } from "@alchemy.run/cloudflare-runtime/core/internal/constants";
+import { DEFAULT_COMPATIBILITY_DATE } from "@alchemy.run/cloudflare-runtime/core/internal/constants";
 import * as Runtime from "@alchemy.run/cloudflare-runtime/core/Runtime";
 import * as RuntimeServices from "@alchemy.run/cloudflare-runtime/core/RuntimeServices";
 import * as DurableObjectNamespace from "@alchemy.run/cloudflare-runtime/core/bindings/DurableObjectNamespace";

--- a/packages/frontend-frameworks/src/nextjs/Nextjs.ts
+++ b/packages/frontend-frameworks/src/nextjs/Nextjs.ts
@@ -3,6 +3,7 @@ import type {
   Module,
   RuntimeWorker,
 } from "@alchemy.run/cloudflare-runtime/core";
+import { INTERNAL_WORKER_COMPATIBILITY_DATE as DEFAULT_COMPATIBILITY_DATE } from "@alchemy.run/cloudflare-runtime/core/internal/constants";
 import * as Runtime from "@alchemy.run/cloudflare-runtime/core/Runtime";
 import * as RuntimeServices from "@alchemy.run/cloudflare-runtime/core/RuntimeServices";
 import * as DurableObjectNamespace from "@alchemy.run/cloudflare-runtime/core/bindings/DurableObjectNamespace";
@@ -120,8 +121,7 @@ export const listEdgeFunctions = (manifest: unknown): Array<string> => {
   return functions === undefined ? [] : Object.keys(functions);
 };
 
-/** The default compatibility date when the options provide none. */
-export const DEFAULT_COMPATIBILITY_DATE = "2026-08-31";
+export { DEFAULT_COMPATIBILITY_DATE };
 
 /** The server-module name of the worker entry (`serverModules[0]`). */
 export const WORKER_ENTRY_MODULE = `worker/${Bundle.WORKER_ENTRY_NAME}`;

--- a/packages/frontend-frameworks/src/nextjs/README.md
+++ b/packages/frontend-frameworks/src/nextjs/README.md
@@ -36,7 +36,7 @@ import * as Nextjs from "@alchemy.run/frontend-frameworks/nextjs";
 const layer = Nextjs.make({
   dev: { mode: "hmr" },
   vite: {
-    compatibilityDate: "2026-05-12",
+    compatibilityDate: "2026-08-31",
     worker: { name: "my-app", bindings: [Text.local("TEST_TEXT", "value")] },
   },
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,9 +70,9 @@ catalogs:
     '@cloudflare/unenv-preset':
       specifier: ^2.16.1
       version: 2.16.1
-    '@cloudflare/vitest-pool-workers':
-      specifier: ^0.22.0
-      version: 0.22.0
+    '@cloudflare/vitest-plugin':
+      specifier: ^1.0.0
+      version: 1.1.2
     '@puppeteer/browsers':
       specifier: ^3.2.0
       version: 3.2.1
@@ -1442,7 +1442,7 @@ importers:
         version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
       '@react-router/dev':
         specifier: catalog:frontend
-        version: 7.16.0(@types/node@26.2.0)(@vitejs/plugin-rsc@0.5.34(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(react@19.2.8)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))(jiti@2.7.0)(lightningcss@1.33.0)(react-router@7.16.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(supports-color@10.2.2)(terser@5.50.0)(tsx@4.23.12)(typescript@7.0.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(wrangler@4.124.0(@cloudflare/workers-types@5.20260901.1))(yaml@2.9.0)
+        version: 7.16.0(@types/node@26.2.0)(@vitejs/plugin-rsc@0.5.34(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(react@19.2.8)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))(jiti@2.7.0)(lightningcss@1.33.0)(react-router@7.16.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(supports-color@10.2.2)(terser@5.50.0)(tsx@4.23.12)(typescript@7.0.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(wrangler@4.127.1(@cloudflare/workers-types@5.20260901.1))(yaml@2.9.0)
       '@tailwindcss/vite':
         specifier: catalog:frontend
         version: 4.3.3(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
@@ -2343,7 +2343,7 @@ importers:
         version: link:../../packages/frontend-frameworks
       '@opennextjs/cloudflare':
         specifier: catalog:frontend
-        version: 1.20.1(next@16.2.10(@babel/core@7.29.7(supports-color@10.2.2))(@playwright/test@1.62.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@10.2.2)(wrangler@4.124.0(@cloudflare/workers-types@5.20260901.1))
+        version: 1.20.1(next@16.2.10(@babel/core@7.29.7(supports-color@10.2.2))(@playwright/test@1.62.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@10.2.2)(wrangler@4.127.1(@cloudflare/workers-types@5.20260901.1))
       '@tailwindcss/postcss':
         specifier: catalog:frontend
         version: 4.3.3
@@ -3053,7 +3053,7 @@ importers:
         version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
       '@react-router/dev':
         specifier: catalog:frontend
-        version: 7.16.0(@types/node@26.2.0)(@vitejs/plugin-rsc@0.5.34(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(react@19.2.8)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))(jiti@2.7.0)(lightningcss@1.33.0)(react-router@7.16.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(supports-color@10.2.2)(terser@5.50.0)(tsx@4.23.12)(typescript@7.0.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(wrangler@4.124.0(@cloudflare/workers-types@5.20260901.1))(yaml@2.9.0)
+        version: 7.16.0(@types/node@26.2.0)(@vitejs/plugin-rsc@0.5.34(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(react@19.2.8)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))(jiti@2.7.0)(lightningcss@1.33.0)(react-router@7.16.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(supports-color@10.2.2)(terser@5.50.0)(tsx@4.23.12)(typescript@7.0.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(wrangler@4.127.1(@cloudflare/workers-types@5.20260901.1))(yaml@2.9.0)
       '@tailwindcss/vite':
         specifier: catalog:frontend
         version: 4.3.3(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
@@ -3583,7 +3583,7 @@ importers:
         version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
       '@react-router/dev':
         specifier: catalog:frontend
-        version: 7.16.0(@types/node@26.2.0)(@vitejs/plugin-rsc@0.5.34(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(react@19.2.8)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))(jiti@2.7.0)(lightningcss@1.33.0)(react-router@7.16.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(supports-color@10.2.2)(terser@5.50.0)(tsx@4.23.12)(typescript@7.0.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(wrangler@4.124.0(@cloudflare/workers-types@5.20260901.1))(yaml@2.9.0)
+        version: 7.16.0(@types/node@26.2.0)(@vitejs/plugin-rsc@0.5.34(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(react@19.2.8)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))(jiti@2.7.0)(lightningcss@1.33.0)(react-router@7.16.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(supports-color@10.2.2)(terser@5.50.0)(tsx@4.23.12)(typescript@7.0.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(wrangler@4.127.1(@cloudflare/workers-types@5.20260901.1))(yaml@2.9.0)
       '@tailwindcss/vite':
         specifier: catalog:frontend
         version: 4.3.3(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
@@ -4040,7 +4040,7 @@ importers:
         version: 4.0.0-rc.112
       nitro:
         specifier: ^3.0.260415-beta
-        version: 3.0.260415-beta(c9f87dee608690d191681cb8190233ef)
+        version: 3.0.260415-beta(294bcc53448324bf1f93f9ae9444d27d)
       pg:
         specifier: catalog:database
         version: 8.23.0
@@ -4314,7 +4314,7 @@ importers:
         version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
       '@react-router/dev':
         specifier: catalog:frontend
-        version: 7.16.0(@types/node@26.2.0)(@vitejs/plugin-rsc@0.5.34(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(react@19.2.8)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))(jiti@2.7.0)(lightningcss@1.33.0)(react-router@7.16.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(supports-color@10.2.2)(terser@5.50.0)(tsx@4.23.12)(typescript@7.0.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(wrangler@4.124.0(@cloudflare/workers-types@5.20260901.1))(yaml@2.9.0)
+        version: 7.16.0(@types/node@26.2.0)(@vitejs/plugin-rsc@0.5.34(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(react@19.2.8)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))(jiti@2.7.0)(lightningcss@1.33.0)(react-router@7.16.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(supports-color@10.2.2)(terser@5.50.0)(tsx@4.23.12)(typescript@7.0.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(wrangler@4.127.1(@cloudflare/workers-types@5.20260901.1))(yaml@2.9.0)
       '@tailwindcss/vite':
         specifier: catalog:frontend
         version: 4.3.3(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
@@ -5758,9 +5758,9 @@ importers:
         specifier: catalog:cloudflare-runtime
         version: 3.4.0
     devDependencies:
-      '@cloudflare/vitest-pool-workers':
+      '@cloudflare/vitest-plugin':
         specifier: catalog:cloudflare-runtime
-        version: 0.22.0(@cloudflare/workers-types@5.20260901.1)(@vitest/runner@4.1.10)(@vitest/snapshot@4.1.10)(vitest@4.1.10(@types/node@26.2.0)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))
+        version: 1.1.2(@cloudflare/workers-types@5.20260901.1)(@vitest/runner@4.1.10)(@vitest/snapshot@4.1.10)(vitest@4.1.10(@types/node@26.2.0)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))
       '@cloudflare/workers-types':
         specifier: 5.20260901.1
         version: 5.20260901.1
@@ -5900,7 +5900,7 @@ importers:
         version: 0.1.22(octane@0.1.22(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
       '@opennextjs/cloudflare':
         specifier: catalog:frontend
-        version: 1.20.1(next@16.2.10(@babel/core@7.29.7(supports-color@10.2.2))(@playwright/test@1.62.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@10.2.2)(wrangler@4.124.0(@cloudflare/workers-types@5.20260901.1))
+        version: 1.20.1(next@16.2.10(@babel/core@7.29.7(supports-color@10.2.2))(@playwright/test@1.62.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@10.2.2)(wrangler@4.127.1(@cloudflare/workers-types@5.20260901.1))
       '@sveltejs/kit':
         specifier: catalog:frontend
         version: 3.0.0-next.9(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.8)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))(svelte@5.56.8)(typescript@7.0.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
@@ -6921,8 +6921,8 @@ packages:
       workerd:
         optional: true
 
-  '@cloudflare/vitest-pool-workers@0.22.0':
-    resolution: {integrity: sha512-OJv/qikkOgxnKxJ5xrLS7zuOLZhc/6iziU+llqZm4tiQf2CJUYwlMuXN68VaWIQebORd1AUx4w6A0oy8XRbuaQ==}
+  '@cloudflare/vitest-plugin@1.1.2':
+    resolution: {integrity: sha512-TLkPo1JTKk0LyFwQlNWY0MnZ0RW7FsjianjSdrKiPi/NbL7DUnIEe8O8leJAeBboiRyn23g/NG5jLeyZvWlmVA==}
     peerDependencies:
       '@vitest/runner': ^4.1.0
       '@vitest/snapshot': ^4.1.0
@@ -15398,8 +15398,8 @@ packages:
     engines: {node: '>=22.0.0'}
     hasBin: true
 
-  miniflare@5.20260815.0-alpha:
-    resolution: {integrity: sha512-YAaGj4Sh5f4fqHKiMQ8zRHDOOM5IGUVtMhnLIeyjuQfU+9P6hcOTrHUVtbfj/ZPay9Kzik4pWELB39pGgefjiQ==}
+  miniflare@5.20260828.0-alpha:
+    resolution: {integrity: sha512-6nbxhZEcz/UET3Y1OnYPsrAUjUmuFoib3ynUqteRdn1YnDxsLg8cwgZJZCk9QmtOmGzXwzXzgE/d/C0dJAPtVw==}
     engines: {node: '>=22.0.0'}
 
   minimatch@10.2.6:
@@ -18582,8 +18582,8 @@ packages:
       '@cloudflare/workers-types':
         optional: true
 
-  wrangler@4.124.0:
-    resolution: {integrity: sha512-75euoZKjVTJYFy+Xhctt/5JlZL4M6A4xmovZsUlep+6GHcCm14n9VtdGzNIybOW2t8wuNxRj5iMUwjT5E7Ctog==}
+  wrangler@4.127.1:
+    resolution: {integrity: sha512-OzsiNgaI8i681L/+KnAKc+uEZ5D57xK5JuNvCOpRKICF4/5Q3Cu1oTGuUiT/f3GDUqQb3gzXNT0tfOHGMEtknw==}
     engines: {node: '>=22.0.0'}
     hasBin: true
     peerDependencies:
@@ -20160,15 +20160,15 @@ snapshots:
     optionalDependencies:
       workerd: 1.20260901.1
 
-  '@cloudflare/vitest-pool-workers@0.22.0(@cloudflare/workers-types@5.20260901.1)(@vitest/runner@4.1.10)(@vitest/snapshot@4.1.10)(vitest@4.1.10(@types/node@26.2.0)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))':
+  '@cloudflare/vitest-plugin@1.1.2(@cloudflare/workers-types@5.20260901.1)(@vitest/runner@4.1.10)(@vitest/snapshot@4.1.10)(vitest@4.1.10(@types/node@26.2.0)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))':
     dependencies:
       '@vitest/runner': 4.1.10
       '@vitest/snapshot': 4.1.10
       cjs-module-lexer: 1.2.3
       esbuild: 0.28.1
-      miniflare: 5.20260815.0-alpha
+      miniflare: 5.20260828.0-alpha
       vitest: 4.1.10(@types/node@26.2.0)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
-      wrangler: 4.124.0(@cloudflare/workers-types@5.20260901.1)
+      wrangler: 4.127.1(@cloudflare/workers-types@5.20260901.1)
       zod: 4.4.3
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
@@ -22754,7 +22754,7 @@ snapshots:
       - encoding
       - supports-color
 
-  '@opennextjs/cloudflare@1.20.1(next@16.2.10(@babel/core@7.29.7(supports-color@10.2.2))(@playwright/test@1.62.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@10.2.2)(wrangler@4.124.0(@cloudflare/workers-types@5.20260901.1))':
+  '@opennextjs/cloudflare@1.20.1(next@16.2.10(@babel/core@7.29.7(supports-color@10.2.2))(@playwright/test@1.62.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@10.2.2)(wrangler@4.127.1(@cloudflare/workers-types@5.20260901.1))':
     dependencies:
       '@ast-grep/napi': 0.40.5
       '@dotenvx/dotenvx': 1.31.0
@@ -22766,7 +22766,7 @@ snapshots:
       glob: 12.0.0
       next: 16.2.10(@babel/core@7.29.7(supports-color@10.2.2))(@playwright/test@1.62.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       ts-tqdm: 0.8.6
-      wrangler: 4.124.0(@cloudflare/workers-types@5.20260901.1)
+      wrangler: 4.127.1(@cloudflare/workers-types@5.20260901.1)
       yargs: 18.1.0
     transitivePeerDependencies:
       - encoding
@@ -23624,7 +23624,7 @@ snapshots:
       - tsx
       - yaml
 
-  '@react-router/dev@7.16.0(@types/node@26.2.0)(@vitejs/plugin-rsc@0.5.34(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(react@19.2.8)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))(jiti@2.7.0)(lightningcss@1.33.0)(react-router@7.16.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(supports-color@10.2.2)(terser@5.50.0)(tsx@4.23.12)(typescript@7.0.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(wrangler@4.124.0(@cloudflare/workers-types@5.20260901.1))(yaml@2.9.0)':
+  '@react-router/dev@7.16.0(@types/node@26.2.0)(@vitejs/plugin-rsc@0.5.34(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(react@19.2.8)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))(jiti@2.7.0)(lightningcss@1.33.0)(react-router@7.16.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(supports-color@10.2.2)(terser@5.50.0)(tsx@4.23.12)(typescript@7.0.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(wrangler@4.127.1(@cloudflare/workers-types@5.20260901.1))(yaml@2.9.0)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/generator': 7.29.8
@@ -23660,7 +23660,7 @@ snapshots:
       '@vitejs/plugin-rsc': 0.5.34(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(react@19.2.8)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
       react-server-dom-webpack: 19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
       typescript: 7.0.2
-      wrangler: 4.124.0(@cloudflare/workers-types@5.20260901.1)
+      wrangler: 4.127.1(@cloudflare/workers-types@5.20260901.1)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -28485,7 +28485,7 @@ snapshots:
 
   entities@8.0.0: {}
 
-  env-runner@0.1.16(miniflare@4.20260722.0)(wrangler@4.124.0(@cloudflare/workers-types@5.20260901.1)):
+  env-runner@0.1.16(miniflare@4.20260722.0)(wrangler@4.127.1(@cloudflare/workers-types@5.20260901.1)):
     dependencies:
       crossws: 0.4.10(srvx@0.11.22)
       exsolve: 1.1.1
@@ -28493,7 +28493,7 @@ snapshots:
       srvx: 0.11.22
     optionalDependencies:
       miniflare: 4.20260722.0
-      wrangler: 4.124.0(@cloudflare/workers-types@5.20260901.1)
+      wrangler: 4.127.1(@cloudflare/workers-types@5.20260901.1)
 
   error-ex@1.3.4:
     dependencies:
@@ -30630,7 +30630,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  miniflare@5.20260815.0-alpha:
+  miniflare@5.20260828.0-alpha:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.35.2
@@ -30828,12 +30828,12 @@ snapshots:
 
   nf3@0.3.23: {}
 
-  nitro@3.0.260415-beta(c9f87dee608690d191681cb8190233ef):
+  nitro@3.0.260415-beta(294bcc53448324bf1f93f9ae9444d27d):
     dependencies:
       consola: 3.4.2
       crossws: 0.4.10(srvx@0.11.22)
       db0: 0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0))
-      env-runner: 0.1.16(miniflare@4.20260722.0)(wrangler@4.124.0(@cloudflare/workers-types@5.20260901.1))
+      env-runner: 0.1.16(miniflare@4.20260722.0)(wrangler@4.127.1(@cloudflare/workers-types@5.20260901.1))
       h3: 2.0.1-rc.26(crossws@0.4.10(srvx@0.11.22))
       hookable: 6.1.1
       nf3: 0.3.23
@@ -35779,13 +35779,13 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  wrangler@4.124.0(@cloudflare/workers-types@5.20260901.1):
+  wrangler@4.127.1(@cloudflare/workers-types@5.20260901.1):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.5.0
       '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260901.1)
       blake3-wasm: 2.1.5
       esbuild: 0.28.1
-      miniflare: 5.20260815.0-alpha
+      miniflare: 5.20260828.0-alpha
       path-to-regexp: 6.3.0
       unenv: 2.0.0-rc.24
       workerd: 1.20260901.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,11 +68,11 @@ catalogs:
       version: 4.114.0
   cloudflare-runtime:
     '@cloudflare/unenv-preset':
-      specifier: ^2.16.0
+      specifier: ^2.16.1
       version: 2.16.1
     '@cloudflare/vitest-pool-workers':
-      specifier: ^0.13.0
-      version: 0.13.5
+      specifier: ^0.22.0
+      version: 0.22.0
     '@puppeteer/browsers':
       specifier: ^3.2.0
       version: 3.2.1
@@ -83,11 +83,11 @@ catalogs:
       specifier: ^8.18.1
       version: 8.18.1
     capnp-es:
-      specifier: ^0.0.14
-      version: 0.0.14
+      specifier: ^0.0.16
+      version: 0.0.16
     capnweb:
-      specifier: ^0.8.0
-      version: 0.8.0
+      specifier: ^0.12.0
+      version: 0.12.0
     esbuild:
       specifier: ^0.28.1
       version: 0.28.2
@@ -130,9 +130,6 @@ catalogs:
     vite:
       specifier: ^7.0.0 || ^8.0.0
       version: 8.2.1
-    workerd:
-      specifier: 1.20260831.1
-      version: 1.20260831.1
     ws:
       specifier: ^8.21.0
       version: 8.21.3
@@ -369,7 +366,8 @@ catalogs:
       version: 4.23.12
 
 overrides:
-  '@cloudflare/workers-types': 5.20260812.1
+  '@cloudflare/workers-types': 5.20260901.1
+  workerd: 1.20260901.1
   effect: 4.0.0-rc.112
   '@effect/platform-browser': 4.0.0-rc.112
   drizzle-kit: 1.0.0-rc.5-ab785fc
@@ -488,8 +486,8 @@ importers:
         specifier: catalog:cloudflare
         version: 0.3.7
       '@cloudflare/workers-types':
-        specifier: 5.20260812.1
-        version: 5.20260812.1
+        specifier: 5.20260901.1
+        version: 5.20260901.1
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -1259,7 +1257,7 @@ importers:
     dependencies:
       astro:
         specifier: catalog:frontend
-        version: 7.2.0(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
+        version: 7.2.0(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
     devDependencies:
       '@alchemy.run/frontend-frameworks':
         specifier: workspace:*
@@ -1404,10 +1402,10 @@ importers:
         version: link:../../packages/alchemy-test
       nitropack:
         specifier: catalog:frontend
-        version: 2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@24.13.3)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@24.13.3))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@24.13.3))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
+        version: 2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@24.13.3)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@24.13.3))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@24.13.3))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
       nuxt:
         specifier: catalog:frontend
-        version: 4.5.1(38a0ae7adc2044c05f636f188c0deddc)
+        version: 4.5.1(8afcc381206f858c9998bb23d771b3c2)
       tailwindcss:
         specifier: catalog:frontend
         version: 4.3.3
@@ -1444,7 +1442,7 @@ importers:
         version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
       '@react-router/dev':
         specifier: catalog:frontend
-        version: 7.16.0(@types/node@26.2.0)(@vitejs/plugin-rsc@0.5.34(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(react@19.2.8)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))(jiti@2.7.0)(lightningcss@1.33.0)(react-router@7.16.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(supports-color@10.2.2)(terser@5.50.0)(tsx@4.23.12)(typescript@7.0.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(wrangler@4.114.0(@cloudflare/workers-types@5.20260812.1))(yaml@2.9.0)
+        version: 7.16.0(@types/node@26.2.0)(@vitejs/plugin-rsc@0.5.34(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(react@19.2.8)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))(jiti@2.7.0)(lightningcss@1.33.0)(react-router@7.16.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(supports-color@10.2.2)(terser@5.50.0)(tsx@4.23.12)(typescript@7.0.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(wrangler@4.124.0(@cloudflare/workers-types@5.20260901.1))(yaml@2.9.0)
       '@tailwindcss/vite':
         specifier: catalog:frontend
         version: 4.3.3(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
@@ -1730,8 +1728,8 @@ importers:
   examples/cloudflare-d1-drizzle:
     dependencies:
       '@cloudflare/workers-types':
-        specifier: 5.20260812.1
-        version: 5.20260812.1
+        specifier: 5.20260901.1
+        version: 5.20260901.1
       '@effect/platform-bun':
         specifier: catalog:effect
         version: 4.0.0-rc.112(effect@4.0.0-rc.112)
@@ -1743,7 +1741,7 @@ importers:
         version: link:../../packages/alchemy
       drizzle-orm:
         specifier: 1.0.0-rc.5-ab785fc
-        version: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3)
+        version: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3)
       effect:
         specifier: 4.0.0-rc.112
         version: 4.0.0-rc.112
@@ -1758,8 +1756,8 @@ importers:
         specifier: catalog:cloudflare
         version: 1.3.0(supports-color@10.2.2)
       '@cloudflare/workers-types':
-        specifier: 5.20260812.1
-        version: 5.20260812.1
+        specifier: 5.20260901.1
+        version: 5.20260901.1
       '@effect/platform-bun':
         specifier: catalog:effect
         version: 4.0.0-rc.112(effect@4.0.0-rc.112)
@@ -1780,8 +1778,8 @@ importers:
   examples/cloudflare-effect-sql-d1:
     dependencies:
       '@cloudflare/workers-types':
-        specifier: 5.20260812.1
-        version: 5.20260812.1
+        specifier: 5.20260901.1
+        version: 5.20260901.1
       '@effect/platform-bun':
         specifier: catalog:effect
         version: 4.0.0-rc.112(effect@4.0.0-rc.112)
@@ -1798,8 +1796,8 @@ importers:
   examples/cloudflare-email:
     dependencies:
       '@cloudflare/workers-types':
-        specifier: 5.20260812.1
-        version: 5.20260812.1
+        specifier: 5.20260901.1
+        version: 5.20260901.1
       '@effect/platform-bun':
         specifier: catalog:effect
         version: 4.0.0-rc.112(effect@4.0.0-rc.112)
@@ -1906,8 +1904,8 @@ importers:
   examples/cloudflare-neon-drizzle:
     dependencies:
       '@cloudflare/workers-types':
-        specifier: 5.20260812.1
-        version: 5.20260812.1
+        specifier: 5.20260901.1
+        version: 5.20260901.1
       '@effect/platform-bun':
         specifier: catalog:effect
         version: 4.0.0-rc.112(effect@4.0.0-rc.112)
@@ -1922,7 +1920,7 @@ importers:
         version: link:../../packages/alchemy
       drizzle-orm:
         specifier: 1.0.0-rc.5-ab785fc
-        version: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3)
+        version: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3)
       effect:
         specifier: 4.0.0-rc.112
         version: 4.0.0-rc.112
@@ -1971,8 +1969,8 @@ importers:
   examples/cloudflare-planetscale-mysql-drizzle:
     dependencies:
       '@cloudflare/workers-types':
-        specifier: 5.20260812.1
-        version: 5.20260812.1
+        specifier: 5.20260901.1
+        version: 5.20260901.1
       '@effect/platform-bun':
         specifier: catalog:effect
         version: 4.0.0-rc.112(effect@4.0.0-rc.112)
@@ -1987,7 +1985,7 @@ importers:
         version: link:../../packages/alchemy
       drizzle-orm:
         specifier: 1.0.0-rc.5-ab785fc
-        version: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3)
+        version: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3)
       effect:
         specifier: 4.0.0-rc.112
         version: 4.0.0-rc.112
@@ -2002,8 +2000,8 @@ importers:
   examples/cloudflare-planetscale-postgres-drizzle:
     dependencies:
       '@cloudflare/workers-types':
-        specifier: 5.20260812.1
-        version: 5.20260812.1
+        specifier: 5.20260901.1
+        version: 5.20260901.1
       '@effect/platform-bun':
         specifier: catalog:effect
         version: 4.0.0-rc.112(effect@4.0.0-rc.112)
@@ -2018,7 +2016,7 @@ importers:
         version: link:../../packages/alchemy
       drizzle-orm:
         specifier: 1.0.0-rc.5-ab785fc
-        version: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3)
+        version: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3)
       effect:
         specifier: 4.0.0-rc.112
         version: 4.0.0-rc.112
@@ -2039,8 +2037,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/pr-package
       '@cloudflare/workers-types':
-        specifier: 5.20260812.1
-        version: 5.20260812.1
+        specifier: 5.20260901.1
+        version: 5.20260901.1
       '@effect/platform-bun':
         specifier: catalog:effect
         version: 4.0.0-rc.112(effect@4.0.0-rc.112)
@@ -2057,8 +2055,8 @@ importers:
   examples/cloudflare-secrets-store:
     dependencies:
       '@cloudflare/workers-types':
-        specifier: 5.20260812.1
-        version: 5.20260812.1
+        specifier: 5.20260901.1
+        version: 5.20260901.1
       '@effect/platform-bun':
         specifier: catalog:effect
         version: 4.0.0-rc.112(effect@4.0.0-rc.112)
@@ -2150,7 +2148,7 @@ importers:
         version: link:../../packages/alchemy
       drizzle-orm:
         specifier: 1.0.0-rc.5-ab785fc
-        version: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3)
+        version: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3)
       effect:
         specifier: 4.0.0-rc.112
         version: 4.0.0-rc.112
@@ -2165,8 +2163,8 @@ importers:
         version: 19.2.8(react@19.2.8)
     devDependencies:
       '@cloudflare/workers-types':
-        specifier: 5.20260812.1
-        version: 5.20260812.1
+        specifier: 5.20260901.1
+        version: 5.20260901.1
       '@types/pg':
         specifier: catalog:database
         version: 8.20.0
@@ -2208,8 +2206,8 @@ importers:
         version: 1.9.15
     devDependencies:
       '@cloudflare/workers-types':
-        specifier: 5.20260812.1
-        version: 5.20260812.1
+        specifier: 5.20260901.1
+        version: 5.20260901.1
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -2279,7 +2277,7 @@ importers:
     dependencies:
       astro:
         specifier: catalog:frontend
-        version: 7.2.0(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
+        version: 7.2.0(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
     devDependencies:
       '@alchemy.run/frontend-frameworks':
         specifier: workspace:*
@@ -2345,7 +2343,7 @@ importers:
         version: link:../../packages/frontend-frameworks
       '@opennextjs/cloudflare':
         specifier: catalog:frontend
-        version: 1.20.1(next@16.2.10(@babel/core@7.29.7(supports-color@10.2.2))(@playwright/test@1.62.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@10.2.2)(wrangler@4.114.0(@cloudflare/workers-types@5.20260812.1))
+        version: 1.20.1(next@16.2.10(@babel/core@7.29.7(supports-color@10.2.2))(@playwright/test@1.62.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@10.2.2)(wrangler@4.124.0(@cloudflare/workers-types@5.20260901.1))
       '@tailwindcss/postcss':
         specifier: catalog:frontend
         version: 4.3.3
@@ -2388,10 +2386,10 @@ importers:
         version: 24.13.3
       nitropack:
         specifier: catalog:frontend
-        version: 2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@24.13.3)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@24.13.3))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@24.13.3))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
+        version: 2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@24.13.3)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@24.13.3))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@24.13.3))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
       nuxt:
         specifier: catalog:frontend
-        version: 4.5.1(38a0ae7adc2044c05f636f188c0deddc)
+        version: 4.5.1(8afcc381206f858c9998bb23d771b3c2)
       tailwindcss:
         specifier: catalog:frontend
         version: 4.3.3
@@ -2532,8 +2530,8 @@ importers:
         version: 19.2.8(react@19.2.8)
     devDependencies:
       '@cloudflare/workers-types':
-        specifier: 5.20260812.1
-        version: 5.20260812.1
+        specifier: 5.20260901.1
+        version: 5.20260901.1
       '@tailwindcss/vite':
         specifier: catalog:frontend
         version: 4.3.3(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
@@ -2622,7 +2620,7 @@ importers:
         version: link:../../packages/frontend-frameworks
       '@cloudflare/unenv-preset':
         specifier: catalog:cloudflare-runtime
-        version: 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260831.1)
+        version: 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260901.1)
       '@types/node':
         specifier: ^24.12.0
         version: 24.13.3
@@ -2713,7 +2711,7 @@ importers:
         version: link:../../packages/alchemy
       better-auth:
         specifier: catalog:auth
-        version: 1.6.25(aca4c2f227e13471598301066580e538)
+        version: 1.6.25(e20f5e9f480a52fe3a4e9438c63ccf5e)
       effect:
         specifier: 4.0.0-rc.112
         version: 4.0.0-rc.112
@@ -2724,8 +2722,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/better-auth
       '@cloudflare/workers-types':
-        specifier: 5.20260812.1
-        version: 5.20260812.1
+        specifier: 5.20260901.1
+        version: 5.20260901.1
       '@effect/platform-bun':
         specifier: catalog:effect
         version: 4.0.0-rc.112(effect@4.0.0-rc.112)
@@ -2737,7 +2735,7 @@ importers:
         version: link:../../packages/alchemy
       better-auth:
         specifier: catalog:auth
-        version: 1.6.25(aca4c2f227e13471598301066580e538)
+        version: 1.6.25(e20f5e9f480a52fe3a4e9438c63ccf5e)
       effect:
         specifier: 4.0.0-rc.112
         version: 4.0.0-rc.112
@@ -2745,8 +2743,8 @@ importers:
   examples/dev-stress:
     dependencies:
       '@cloudflare/workers-types':
-        specifier: 5.20260812.1
-        version: 5.20260812.1
+        specifier: 5.20260901.1
+        version: 5.20260901.1
       '@effect/platform-node':
         specifier: catalog:effect
         version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
@@ -2812,7 +2810,7 @@ importers:
         version: link:../../packages/alchemy
       drizzle-orm:
         specifier: 1.0.0-rc.5-ab785fc
-        version: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3)
+        version: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3)
       effect:
         specifier: 4.0.0-rc.112
         version: 4.0.0-rc.112
@@ -2876,7 +2874,7 @@ importers:
     dependencies:
       astro:
         specifier: catalog:frontend
-        version: 7.2.0(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
+        version: 7.2.0(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
     devDependencies:
       '@alchemy.run/frontend-frameworks':
         specifier: workspace:*
@@ -3009,10 +3007,10 @@ importers:
         version: 24.13.3
       nitropack:
         specifier: catalog:frontend
-        version: 2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@24.13.3)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@24.13.3))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@24.13.3))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
+        version: 2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@24.13.3)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@24.13.3))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@24.13.3))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
       nuxt:
         specifier: catalog:frontend
-        version: 4.5.1(38a0ae7adc2044c05f636f188c0deddc)
+        version: 4.5.1(8afcc381206f858c9998bb23d771b3c2)
       tailwindcss:
         specifier: catalog:frontend
         version: 4.3.3
@@ -3055,7 +3053,7 @@ importers:
         version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
       '@react-router/dev':
         specifier: catalog:frontend
-        version: 7.16.0(@types/node@26.2.0)(@vitejs/plugin-rsc@0.5.34(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(react@19.2.8)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))(jiti@2.7.0)(lightningcss@1.33.0)(react-router@7.16.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(supports-color@10.2.2)(terser@5.50.0)(tsx@4.23.12)(typescript@7.0.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(wrangler@4.114.0(@cloudflare/workers-types@5.20260812.1))(yaml@2.9.0)
+        version: 7.16.0(@types/node@26.2.0)(@vitejs/plugin-rsc@0.5.34(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(react@19.2.8)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))(jiti@2.7.0)(lightningcss@1.33.0)(react-router@7.16.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(supports-color@10.2.2)(terser@5.50.0)(tsx@4.23.12)(typescript@7.0.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(wrangler@4.124.0(@cloudflare/workers-types@5.20260901.1))(yaml@2.9.0)
       '@tailwindcss/vite':
         specifier: catalog:frontend
         version: 4.3.3(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
@@ -3229,7 +3227,7 @@ importers:
         version: link:../../packages/alchemy
       drizzle-orm:
         specifier: 1.0.0-rc.5-ab785fc
-        version: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3)
+        version: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3)
       effect:
         specifier: 4.0.0-rc.112
         version: 4.0.0-rc.112
@@ -3412,7 +3410,7 @@ importers:
     dependencies:
       astro:
         specifier: catalog:frontend
-        version: 7.2.0(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
+        version: 7.2.0(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
     devDependencies:
       '@alchemy.run/frontend-frameworks':
         specifier: workspace:*
@@ -3545,10 +3543,10 @@ importers:
         version: 24.13.3
       nitropack:
         specifier: catalog:frontend
-        version: 2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@24.13.3)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@24.13.3))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@24.13.3))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
+        version: 2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@24.13.3)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@24.13.3))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@24.13.3))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
       nuxt:
         specifier: catalog:frontend
-        version: 4.5.1(38a0ae7adc2044c05f636f188c0deddc)
+        version: 4.5.1(8afcc381206f858c9998bb23d771b3c2)
       tailwindcss:
         specifier: catalog:frontend
         version: 4.3.3
@@ -3585,7 +3583,7 @@ importers:
         version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
       '@react-router/dev':
         specifier: catalog:frontend
-        version: 7.16.0(@types/node@26.2.0)(@vitejs/plugin-rsc@0.5.34(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(react@19.2.8)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))(jiti@2.7.0)(lightningcss@1.33.0)(react-router@7.16.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(supports-color@10.2.2)(terser@5.50.0)(tsx@4.23.12)(typescript@7.0.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(wrangler@4.114.0(@cloudflare/workers-types@5.20260812.1))(yaml@2.9.0)
+        version: 7.16.0(@types/node@26.2.0)(@vitejs/plugin-rsc@0.5.34(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(react@19.2.8)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))(jiti@2.7.0)(lightningcss@1.33.0)(react-router@7.16.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(supports-color@10.2.2)(terser@5.50.0)(tsx@4.23.12)(typescript@7.0.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(wrangler@4.124.0(@cloudflare/workers-types@5.20260901.1))(yaml@2.9.0)
       '@tailwindcss/vite':
         specifier: catalog:frontend
         version: 4.3.3(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
@@ -3765,7 +3763,7 @@ importers:
         version: link:../../packages/alchemy
       drizzle-orm:
         specifier: 1.0.0-rc.5-ab785fc
-        version: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3)
+        version: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3)
       effect:
         specifier: 4.0.0-rc.112
         version: 4.0.0-rc.112
@@ -4042,7 +4040,7 @@ importers:
         version: 4.0.0-rc.112
       nitro:
         specifier: ^3.0.260415-beta
-        version: 3.0.260415-beta(3a8120cc95eaa7c634e8c0d4e0c76d72)
+        version: 3.0.260415-beta(c9f87dee608690d191681cb8190233ef)
       pg:
         specifier: catalog:database
         version: 8.23.0
@@ -4121,7 +4119,7 @@ importers:
         version: link:../../packages/alchemy
       drizzle-orm:
         specifier: 1.0.0-rc.5-ab785fc
-        version: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3)
+        version: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3)
       effect:
         specifier: 4.0.0-rc.112
         version: 4.0.0-rc.112
@@ -4137,7 +4135,7 @@ importers:
     dependencies:
       astro:
         specifier: catalog:frontend
-        version: 7.2.0(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
+        version: 7.2.0(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
     devDependencies:
       '@alchemy.run/frontend-frameworks':
         specifier: workspace:*
@@ -4270,10 +4268,10 @@ importers:
         version: 24.13.3
       nitropack:
         specifier: catalog:frontend
-        version: 2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@24.13.3)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@24.13.3))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@24.13.3))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
+        version: 2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@24.13.3)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@24.13.3))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@24.13.3))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
       nuxt:
         specifier: catalog:frontend
-        version: 4.5.1(38a0ae7adc2044c05f636f188c0deddc)
+        version: 4.5.1(8afcc381206f858c9998bb23d771b3c2)
       tailwindcss:
         specifier: catalog:frontend
         version: 4.3.3
@@ -4316,7 +4314,7 @@ importers:
         version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
       '@react-router/dev':
         specifier: catalog:frontend
-        version: 7.16.0(@types/node@26.2.0)(@vitejs/plugin-rsc@0.5.34(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(react@19.2.8)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))(jiti@2.7.0)(lightningcss@1.33.0)(react-router@7.16.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(supports-color@10.2.2)(terser@5.50.0)(tsx@4.23.12)(typescript@7.0.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(wrangler@4.114.0(@cloudflare/workers-types@5.20260812.1))(yaml@2.9.0)
+        version: 7.16.0(@types/node@26.2.0)(@vitejs/plugin-rsc@0.5.34(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(react@19.2.8)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))(jiti@2.7.0)(lightningcss@1.33.0)(react-router@7.16.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(supports-color@10.2.2)(terser@5.50.0)(tsx@4.23.12)(typescript@7.0.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(wrangler@4.124.0(@cloudflare/workers-types@5.20260901.1))(yaml@2.9.0)
       '@tailwindcss/vite':
         specifier: catalog:frontend
         version: 4.3.3(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
@@ -4490,7 +4488,7 @@ importers:
         version: link:../../packages/alchemy
       drizzle-orm:
         specifier: 1.0.0-rc.5-ab785fc
-        version: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3)
+        version: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3)
       effect:
         specifier: 4.0.0-rc.112
         version: 4.0.0-rc.112
@@ -4643,7 +4641,7 @@ importers:
     dependencies:
       astro:
         specifier: catalog:frontend
-        version: 7.2.0(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
+        version: 7.2.0(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
     devDependencies:
       '@alchemy.run/cloudflare-runtime':
         specifier: workspace:*
@@ -4655,8 +4653,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/frontend-frameworks
       '@cloudflare/workers-types':
-        specifier: 5.20260812.1
-        version: 5.20260812.1
+        specifier: 5.20260901.1
+        version: 5.20260901.1
       '@effect/platform-node':
         specifier: catalog:effect
         version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
@@ -4674,7 +4672,7 @@ importers:
     dependencies:
       astro:
         specifier: catalog:frontend
-        version: 7.2.0(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
+        version: 7.2.0(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
     devDependencies:
       '@alchemy.run/cloudflare-runtime':
         specifier: workspace:*
@@ -4686,8 +4684,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/frontend-frameworks
       '@cloudflare/workers-types':
-        specifier: 5.20260812.1
-        version: 5.20260812.1
+        specifier: 5.20260901.1
+        version: 5.20260901.1
       '@effect/platform-node':
         specifier: catalog:effect
         version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
@@ -4705,7 +4703,7 @@ importers:
     dependencies:
       astro:
         specifier: catalog:frontend
-        version: 7.2.0(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
+        version: 7.2.0(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
     devDependencies:
       '@alchemy.run/cloudflare-runtime':
         specifier: workspace:*
@@ -4717,8 +4715,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/frontend-frameworks
       '@cloudflare/workers-types':
-        specifier: 5.20260812.1
-        version: 5.20260812.1
+        specifier: 5.20260901.1
+        version: 5.20260901.1
       '@effect/platform-node':
         specifier: catalog:effect
         version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
@@ -4741,8 +4739,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/frontend-frameworks
       '@cloudflare/workers-types':
-        specifier: 5.20260812.1
-        version: 5.20260812.1
+        specifier: 5.20260901.1
+        version: 5.20260901.1
       '@playwright/test':
         specifier: catalog:testing
         version: 1.62.0
@@ -4837,10 +4835,10 @@ importers:
     dependencies:
       nitropack:
         specifier: catalog:frontend
-        version: 2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@24.13.3)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@24.13.3))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@24.13.3))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
+        version: 2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@24.13.3)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@24.13.3))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@24.13.3))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
       nuxt:
         specifier: catalog:frontend
-        version: 4.5.1(38a0ae7adc2044c05f636f188c0deddc)
+        version: 4.5.1(8afcc381206f858c9998bb23d771b3c2)
     devDependencies:
       '@alchemy.run/cloudflare-runtime':
         specifier: workspace:*
@@ -4852,8 +4850,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/frontend-frameworks
       '@cloudflare/workers-types':
-        specifier: 5.20260812.1
-        version: 5.20260812.1
+        specifier: 5.20260901.1
+        version: 5.20260901.1
       '@playwright/test':
         specifier: catalog:testing
         version: 1.62.0
@@ -4886,8 +4884,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/frontend-frameworks
       '@cloudflare/workers-types':
-        specifier: 5.20260812.1
-        version: 5.20260812.1
+        specifier: 5.20260901.1
+        version: 5.20260901.1
       '@playwright/test':
         specifier: catalog:testing
         version: 1.62.0
@@ -4911,8 +4909,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/cloudflare-test-tools
       '@cloudflare/workers-types':
-        specifier: 5.20260812.1
-        version: 5.20260812.1
+        specifier: 5.20260901.1
+        version: 5.20260901.1
       '@playwright/test':
         specifier: catalog:testing
         version: 1.62.0
@@ -5131,8 +5129,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/cloudflare-test-tools
       '@cloudflare/workers-types':
-        specifier: 5.20260812.1
-        version: 5.20260812.1
+        specifier: 5.20260901.1
+        version: 5.20260901.1
       '@effect/platform-node':
         specifier: catalog:effect
         version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
@@ -5208,10 +5206,10 @@ importers:
         version: link:../../packages/frontend-frameworks
       '@cloudflare/unenv-preset':
         specifier: catalog:cloudflare-runtime
-        version: 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260831.1)
+        version: 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260901.1)
       '@cloudflare/workers-types':
-        specifier: 5.20260812.1
-        version: 5.20260812.1
+        specifier: 5.20260901.1
+        version: 5.20260901.1
       '@playwright/test':
         specifier: catalog:testing
         version: 1.62.0
@@ -5268,8 +5266,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/frontend-frameworks
       '@cloudflare/workers-types':
-        specifier: 5.20260812.1
-        version: 5.20260812.1
+        specifier: 5.20260901.1
+        version: 5.20260901.1
       '@playwright/test':
         specifier: catalog:testing
         version: 1.62.0
@@ -5314,8 +5312,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/frontend-frameworks
       '@cloudflare/workers-types':
-        specifier: 5.20260812.1
-        version: 5.20260812.1
+        specifier: 5.20260901.1
+        version: 5.20260901.1
       '@playwright/test':
         specifier: catalog:testing
         version: 1.62.0
@@ -5426,7 +5424,7 @@ importers:
         version: 1.0.0-rc.5-ab785fc
       drizzle-orm:
         specifier: 1.0.0-rc.5-ab785fc
-        version: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3)
+        version: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3)
       fast-glob:
         specifier: catalog:cloudflare-runtime
         version: 3.3.3
@@ -5478,10 +5476,10 @@ importers:
         version: 1.3.0(supports-color@10.2.2)
       '@cloudflare/unenv-preset':
         specifier: catalog:cloudflare-runtime
-        version: 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260722.1)
+        version: 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260901.1)
       '@cloudflare/workers-types':
-        specifier: 5.20260812.1
-        version: 5.20260812.1
+        specifier: 5.20260901.1
+        version: 5.20260901.1
       '@effect/platform-bun':
         specifier: catalog:effect
         version: 4.0.0-rc.112(effect@4.0.0-rc.112)
@@ -5505,13 +5503,13 @@ importers:
         version: 4.1.0(next@16.2.10(@babel/core@7.29.7(supports-color@10.2.2))(@playwright/test@1.62.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@10.2.2)
       '@opennextjs/cloudflare':
         specifier: catalog:frontend
-        version: 1.20.1(next@16.2.10(@babel/core@7.29.7(supports-color@10.2.2))(@playwright/test@1.62.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@10.2.2)(wrangler@4.114.0(@cloudflare/workers-types@5.20260812.1))
+        version: 1.20.1(next@16.2.10(@babel/core@7.29.7(supports-color@10.2.2))(@playwright/test@1.62.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@10.2.2)(wrangler@4.114.0(@cloudflare/workers-types@5.20260901.1))
       '@oxc-project/types':
         specifier: ^0.146.0
         version: 0.146.0
       '@react-router/dev':
         specifier: catalog:frontend
-        version: 7.16.0(@types/node@26.2.0)(@vitejs/plugin-rsc@0.5.34(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(react@19.2.8)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))(jiti@2.7.0)(lightningcss@1.33.0)(react-router@7.16.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(supports-color@10.2.2)(terser@5.50.0)(tsx@4.23.12)(typescript@7.0.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(wrangler@4.114.0(@cloudflare/workers-types@5.20260812.1))(yaml@2.9.0)
+        version: 7.16.0(@types/node@26.2.0)(@vitejs/plugin-rsc@0.5.34(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(react@19.2.8)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))(jiti@2.7.0)(lightningcss@1.33.0)(react-router@7.16.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(supports-color@10.2.2)(terser@5.50.0)(tsx@4.23.12)(typescript@7.0.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(wrangler@4.114.0(@cloudflare/workers-types@5.20260901.1))(yaml@2.9.0)
       '@react-router/node':
         specifier: catalog:frontend
         version: 7.16.0(react-router@7.16.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(typescript@7.0.2)
@@ -5523,7 +5521,7 @@ importers:
         version: 2.0.4(@solidjs/router@0.16.3(solid-js@1.9.15))(crossws@0.4.10(srvx@0.12.5))(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
       '@solidjs/vite-plugin-nitro-2':
         specifier: catalog:frontend
-        version: 0.3.2(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
+        version: 0.3.2(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
       '@sveltejs/kit':
         specifier: catalog:frontend
         version: 3.0.0-next.9(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.8)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))(svelte@5.56.8)(typescript@7.0.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
@@ -5571,7 +5569,7 @@ importers:
         version: link:../alchemy-test
       astro:
         specifier: catalog:frontend
-        version: 7.2.0(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
+        version: 7.2.0(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
       effect:
         specifier: 4.0.0-rc.112
         version: 4.0.0-rc.112
@@ -5598,10 +5596,10 @@ importers:
         version: 16.2.10(@babel/core@7.29.7(supports-color@10.2.2))(@playwright/test@1.62.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       nitropack:
         specifier: catalog:frontend
-        version: 2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
+        version: 2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
       nuxt:
         specifier: catalog:frontend
-        version: 4.5.1(6cab6962d170d75e6cc46dcb3ab1fb0a)
+        version: 4.5.1(3206fa55841a5479ca4c78edc8ffa76d)
       octane:
         specifier: catalog:frontend
         version: 0.1.22(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
@@ -5655,7 +5653,7 @@ importers:
         version: 1.0.0-beta.7(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(react@19.2.8)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
       wrangler:
         specifier: catalog:cloudflare
-        version: 4.114.0(@cloudflare/workers-types@5.20260812.1)
+        version: 4.114.0(@cloudflare/workers-types@5.20260901.1)
       ws:
         specifier: catalog:shared
         version: 8.21.3
@@ -5682,8 +5680,8 @@ importers:
   packages/better-auth:
     devDependencies:
       '@cloudflare/workers-types':
-        specifier: 5.20260812.1
-        version: 5.20260812.1
+        specifier: 5.20260901.1
+        version: 5.20260901.1
       '@distilled.cloud/aws':
         specifier: workspace:*
         version: link:../../distilled/packages/aws
@@ -5707,10 +5705,10 @@ importers:
         version: link:../alchemy-test
       better-auth:
         specifier: catalog:auth
-        version: 1.6.25(aca4c2f227e13471598301066580e538)
+        version: 1.6.25(e20f5e9f480a52fe3a4e9438c63ccf5e)
       drizzle-orm:
         specifier: 1.0.0-rc.5-ab785fc
-        version: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3)
+        version: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3)
       effect:
         specifier: 4.0.0-rc.112
         version: 4.0.0-rc.112
@@ -5731,7 +5729,7 @@ importers:
         version: link:../node-utils
       '@cloudflare/unenv-preset':
         specifier: catalog:cloudflare-runtime
-        version: 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260831.1)
+        version: 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260901.1)
       '@distilled.cloud/cloudflare':
         specifier: workspace:*
         version: link:../../distilled/packages/cloudflare
@@ -5740,7 +5738,7 @@ importers:
         version: 3.2.1(yauzl@3.4.0)
       capnp-es:
         specifier: catalog:cloudflare-runtime
-        version: 0.0.14(typescript@7.0.2)
+        version: 0.0.16(typescript@7.0.2)
       effect:
         specifier: 4.0.0-rc.112
         version: 4.0.0-rc.112
@@ -5754,18 +5752,18 @@ importers:
         specifier: catalog:cloudflare-runtime
         version: 2.0.0-rc.24
       workerd:
-        specifier: catalog:cloudflare-runtime
-        version: 1.20260831.1
+        specifier: 1.20260901.1
+        version: 1.20260901.1
       yauzl:
         specifier: catalog:cloudflare-runtime
         version: 3.4.0
     devDependencies:
       '@cloudflare/vitest-pool-workers':
         specifier: catalog:cloudflare-runtime
-        version: 0.13.5(@cloudflare/workers-types@5.20260812.1)(@vitest/runner@4.1.10)(@vitest/snapshot@4.1.10)(vitest@4.1.10(@types/node@26.2.0)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))
+        version: 0.22.0(@cloudflare/workers-types@5.20260901.1)(@vitest/runner@4.1.10)(@vitest/snapshot@4.1.10)(vitest@4.1.10(@types/node@26.2.0)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))
       '@cloudflare/workers-types':
-        specifier: 5.20260812.1
-        version: 5.20260812.1
+        specifier: 5.20260901.1
+        version: 5.20260901.1
       '@effect/platform-bun':
         specifier: catalog:effect
         version: 4.0.0-rc.112(effect@4.0.0-rc.112)
@@ -5786,7 +5784,7 @@ importers:
         version: 8.18.1
       capnweb:
         specifier: catalog:cloudflare-runtime
-        version: 0.8.0
+        version: 0.12.0
       heap-js:
         specifier: catalog:cloudflare-runtime
         version: 2.7.1
@@ -5892,8 +5890,8 @@ importers:
         specifier: catalog:frontend
         version: 1.0.3
       '@cloudflare/workers-types':
-        specifier: 5.20260812.1
-        version: 5.20260812.1
+        specifier: 5.20260901.1
+        version: 5.20260901.1
       '@effect/platform-bun':
         specifier: catalog:effect
         version: 4.0.0-rc.112(effect@4.0.0-rc.112)
@@ -5902,7 +5900,7 @@ importers:
         version: 0.1.22(octane@0.1.22(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
       '@opennextjs/cloudflare':
         specifier: catalog:frontend
-        version: 1.20.1(next@16.2.10(@babel/core@7.29.7(supports-color@10.2.2))(@playwright/test@1.62.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@10.2.2)(wrangler@4.114.0(@cloudflare/workers-types@5.20260812.1))
+        version: 1.20.1(next@16.2.10(@babel/core@7.29.7(supports-color@10.2.2))(@playwright/test@1.62.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@10.2.2)(wrangler@4.124.0(@cloudflare/workers-types@5.20260901.1))
       '@sveltejs/kit':
         specifier: catalog:frontend
         version: 3.0.0-next.9(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.8)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))(svelte@5.56.8)(typescript@7.0.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
@@ -5911,7 +5909,7 @@ importers:
         version: 6.0.5(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
       astro:
         specifier: catalog:frontend
-        version: 7.2.0(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
+        version: 7.2.0(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
       effect:
         specifier: 4.0.0-rc.112
         version: 4.0.0-rc.112
@@ -5920,10 +5918,10 @@ importers:
         version: 4.12.33
       nitropack:
         specifier: catalog:frontend
-        version: 2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
+        version: 2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
       nuxt:
         specifier: catalog:frontend
-        version: 4.5.1(0baa57aa261304dcdb12983501874da1)
+        version: 4.5.1(10f78aabed4c566ba3a2c1702c35888c)
       tsdown:
         specifier: catalog:build
         version: 0.22.14(@volar/typescript@2.4.28(typescript@7.0.2))(tsx@4.23.12)(typescript@7.0.2)(vue-tsc@3.3.9(typescript@7.0.2))
@@ -5965,7 +5963,7 @@ importers:
         version: 0.9.10(prettier@3.9.6)(typescript@7.0.2)
       '@astrojs/mdx':
         specifier: 7.0.5
-        version: 7.0.5(@astrojs/markdown-satteri@0.3.5)(astro@7.2.0(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@3.25.76))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(supports-color@10.2.2)
+        version: 7.0.5(@astrojs/markdown-satteri@0.3.5)(astro@7.2.0(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@3.25.76))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(supports-color@10.2.2)
       '@astrojs/react':
         specifier: 6.0.2
         version: 6.0.2(@types/node@26.2.0)(@types/react-dom@19.2.4(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.2)(jiti@2.7.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@10.2.2)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
@@ -5974,10 +5972,10 @@ importers:
         version: 3.7.3
       '@astrojs/starlight':
         specifier: 0.41.7
-        version: 0.41.7(patch_hash=7ab76e506900e9b0f934039b4b3f797fdf6ea76e9668891402a75ef46dd79b8c)(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(astro@7.2.0(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@3.25.76))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(supports-color@10.2.2)(typescript@7.0.2)
+        version: 0.41.7(patch_hash=7ab76e506900e9b0f934039b4b3f797fdf6ea76e9668891402a75ef46dd79b8c)(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(astro@7.2.0(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@3.25.76))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(supports-color@10.2.2)(typescript@7.0.2)
       '@astrojs/starlight-tailwind':
         specifier: ^5.0.0
-        version: 5.0.0(71dfb54e531903e2eaad60f2f53b349f)
+        version: 5.0.0(5ab0907d3c3b25b7906fe7568eb155ee)
       '@effect/platform-node':
         specifier: catalog:effect
         version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
@@ -6007,7 +6005,7 @@ importers:
         version: link:../packages/alchemy
       astro:
         specifier: catalog:frontend
-        version: 7.2.0(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@3.25.76))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
+        version: 7.2.0(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@3.25.76))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
       effect:
         specifier: 4.0.0-rc.112
         version: 4.0.0-rc.112
@@ -6028,7 +6026,7 @@ importers:
         version: 0.9.5
       starlight-blog:
         specifier: ^0.28.0
-        version: 0.28.0(patch_hash=7b6e57367fab3517e0cfd5e4d0da3459ac1430bf4b6036cf03002c978602c23b)(835c89c84373614fdbf634191ed13edd)
+        version: 0.28.0(patch_hash=7b6e57367fab3517e0cfd5e4d0da3459ac1430bf4b6036cf03002c978602c23b)(9e6397aee9364e8f624d35dfa7bd21f2)
       tailwindcss:
         specifier: ^4.1.14
         version: 4.3.3
@@ -6737,7 +6735,7 @@ packages:
     peerDependencies:
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
-      '@cloudflare/workers-types': 5.20260812.1
+      '@cloudflare/workers-types': 5.20260901.1
       '@opentelemetry/api': ^1.9.0
       better-call: 1.3.7
       jose: ^6.1.0
@@ -6914,123 +6912,54 @@ packages:
     resolution: {integrity: sha512-NBrJEUnqe082nopLh0eqnTXK4DjwsTsZGzoAcs71NFnBgzWU6Yb/ibUJHveCHV4AyAkM+mE/DChFev5gwaKZEg==}
     engines: {node: '>=18'}
 
-  '@cloudflare/unenv-preset@2.16.0':
-    resolution: {integrity: sha512-8ovsRpwzPoEqPUzoErAYVv8l3FMZNeBVQfJTvtzP4AgLSRGZISRfuChFxHWUQd3n6cnrwkuTGxT+2cGo8EsyYg==}
-    peerDependencies:
-      unenv: 2.0.0-rc.24
-      workerd: 1.20260301.1 || ~1.20260302.1 || ~1.20260303.1 || ~1.20260304.1 || >1.20260305.0 <2.0.0-0
-    peerDependenciesMeta:
-      workerd:
-        optional: true
-
   '@cloudflare/unenv-preset@2.16.1':
     resolution: {integrity: sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==}
     peerDependencies:
       unenv: 2.0.0-rc.24
-      workerd: '>1.20260305.0 <2.0.0-0'
+      workerd: 1.20260901.1
     peerDependenciesMeta:
       workerd:
         optional: true
 
-  '@cloudflare/vitest-pool-workers@0.13.5':
-    resolution: {integrity: sha512-T9yRcJXbJOguWvwCv4NjjPt0iOwUorbuR1pkEPWhmRKWBmZJ9ag/WFrIxCjQ6ZIFkKprJR3y+nels4jRQVZNiA==}
+  '@cloudflare/vitest-pool-workers@0.22.0':
+    resolution: {integrity: sha512-OJv/qikkOgxnKxJ5xrLS7zuOLZhc/6iziU+llqZm4tiQf2CJUYwlMuXN68VaWIQebORd1AUx4w6A0oy8XRbuaQ==}
     peerDependencies:
       '@vitest/runner': ^4.1.0
       '@vitest/snapshot': ^4.1.0
       vitest: ^4.1.0
 
-  '@cloudflare/workerd-darwin-64@1.20260317.1':
-    resolution: {integrity: sha512-8hjh3sPMwY8M/zedq3/sXoA2Q4BedlGufn3KOOleIG+5a4ReQKLlUah140D7J6zlKmYZAFMJ4tWC7hCuI/s79g==}
+  '@cloudflare/workerd-darwin-64@1.20260901.1':
+    resolution: {integrity: sha512-5nJCpnclV6cc5v3aZOewu+djFvNvm9A/owQ+WJ2G1450roeFHfZGsyW7vVjSRWx3v2iykfkviyJfGm9ApeFDGg==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [darwin]
 
-  '@cloudflare/workerd-darwin-64@1.20260722.1':
-    resolution: {integrity: sha512-vZOP8vIS3NwnuaO+gz0FZ7kIGeiO3bZmxV35Ph9zOXKSREhDFlH7wQ7mkCdhW3O4jnXsew+XT7b+DNEI2CcJGQ==}
-    engines: {node: '>=16'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@cloudflare/workerd-darwin-64@1.20260831.1':
-    resolution: {integrity: sha512-oyZ8xhu+gYTvoxV/sn6NRmTHK95RhEO1Dk54/6oPb0Uu70w7ZeRoCjkJ5aNmfS8Vrkdu6+oL0HNg6EcC61uQ2Q==}
-    engines: {node: '>=16'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@cloudflare/workerd-darwin-arm64@1.20260317.1':
-    resolution: {integrity: sha512-M/MnNyvO5HMgoIdr3QHjdCj2T1ki9gt0vIUnxYxBu9ISXS/jgtMl6chUVPJ7zHYBn9MyYr8ByeN6frjYxj0MGg==}
+  '@cloudflare/workerd-darwin-arm64@1.20260901.1':
+    resolution: {integrity: sha512-nLwfUVoYmFNW1Ntp0BfZ2K1UWIll4zTTYP8Ni7NQnyrNkTnFeU/prrllWtnw7OG8Z/jyaEAAFaDFEBobrNTU3A==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [darwin]
 
-  '@cloudflare/workerd-darwin-arm64@1.20260722.1':
-    resolution: {integrity: sha512-EmIQymihDq6WNdER4+LF8Qn80yqayBUpJ+tkOO7wmY8pmgfyXjIUFNXotl21AHovTeu2seR7HdVUgeN/BilCWw==}
-    engines: {node: '>=16'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@cloudflare/workerd-darwin-arm64@1.20260831.1':
-    resolution: {integrity: sha512-s6Go53KPnoXZ1sTGBZ3en3otfHDuMPJhiwXMYWU21JkJQkpoeRt6HFUwM0GPhK3YhXWm+8baGMvCGZYS/KA9eA==}
-    engines: {node: '>=16'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@cloudflare/workerd-linux-64@1.20260317.1':
-    resolution: {integrity: sha512-1ltuEjkRcS3fsVF7CxsKlWiRmzq2ZqMfqDN0qUOgbUwkpXsLVJsXmoblaLf5OP00ELlcgF0QsN0p2xPEua4Uug==}
+  '@cloudflare/workerd-linux-64@1.20260901.1':
+    resolution: {integrity: sha512-wzCO0cMrFLRRs6bG5KXDpLSe70GpzpsxPjxwBzQngQOfyI2cxs5i4Rb5rDB0GG8E19feZEhjGXcHgY9+5Lq8YA==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [linux]
 
-  '@cloudflare/workerd-linux-64@1.20260722.1':
-    resolution: {integrity: sha512-jvZ3k9fxcnEn04s80CgIYxQfpOyAiz/8qC42DP8EBa9tR27qWyg9wmm31zIobVlrgBZn/+8NfdP73avRGcQOjQ==}
-    engines: {node: '>=16'}
-    cpu: [x64]
-    os: [linux]
-
-  '@cloudflare/workerd-linux-64@1.20260831.1':
-    resolution: {integrity: sha512-WxNKBgjKgeYTolW3yl1Lt3Lu67UlxdeyzWYi9MIqrKBdyQcz+UNG36RevSBf8rv1sTWapRW234VX2keZ+wXapA==}
-    engines: {node: '>=16'}
-    cpu: [x64]
-    os: [linux]
-
-  '@cloudflare/workerd-linux-arm64@1.20260317.1':
-    resolution: {integrity: sha512-3QrNnPF1xlaNwkHpasvRvAMidOvQs2NhXQmALJrEfpIJ/IDL2la8g499yXp3eqhG3hVMCB07XVY149GTs42Xtw==}
+  '@cloudflare/workerd-linux-arm64@1.20260901.1':
+    resolution: {integrity: sha512-aBk82+sSphMa6uR6h/CFN/GXmELJ2YOgQKYSsOsCTvbVLvHjclmyoEdLTY5FEImvo1ch1uXpGQgTjI8/suHGEg==}
     engines: {node: '>=16'}
     cpu: [arm64]
     os: [linux]
 
-  '@cloudflare/workerd-linux-arm64@1.20260722.1':
-    resolution: {integrity: sha512-BOSB55SMNdy+DA5uj2WirgiNanpHGis5PVvXH1wSfvjRKr4JGgWK+EZzxz0RFUo6QjjQQC/NimEzNZ7va7jmKg==}
-    engines: {node: '>=16'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@cloudflare/workerd-linux-arm64@1.20260831.1':
-    resolution: {integrity: sha512-JTF9+9clUT3gaCq7Xnmd+Q/wEMaitpngSTOec/Ffb/r3xexA9XwNJVFSOKfk6q61flHGjAYJ4H9B7Mu5Qur49w==}
-    engines: {node: '>=16'}
-    cpu: [arm64]
-    os: [linux]
-
-  '@cloudflare/workerd-windows-64@1.20260317.1':
-    resolution: {integrity: sha512-MfZTz+7LfuIpMGTa3RLXHX8Z/pnycZLItn94WRdHr8LPVet+C5/1Nzei399w/jr3+kzT4pDKk26JF/tlI5elpQ==}
+  '@cloudflare/workerd-windows-64@1.20260901.1':
+    resolution: {integrity: sha512-3oJnCV7mWwzqmqz+3E+KYLbw1FylH+8n+p84srWv9MEsY9II1QuKiRKVf3CQTIdTDb6rkr5fCuRtkmLgRpAsNg==}
     engines: {node: '>=16'}
     cpu: [x64]
     os: [win32]
 
-  '@cloudflare/workerd-windows-64@1.20260722.1':
-    resolution: {integrity: sha512-sYM8YgUpKnRz2xjvdJLX1Ojzoi4MlA4gk8WTTExhGydjYB2UTs5NIbv0ZmpKgMoK9io3ixgmiW56ZnTbcWOdiA==}
-    engines: {node: '>=16'}
-    cpu: [x64]
-    os: [win32]
-
-  '@cloudflare/workerd-windows-64@1.20260831.1':
-    resolution: {integrity: sha512-do+KDYw0PABwsrKUQIccWBZB70kqKcADoSnvzJ8pvMaWUVB4qaCspEZYfm97WNdtY1wt8mlKYqIJyYUNOkTvQg==}
-    engines: {node: '>=16'}
-    cpu: [x64]
-    os: [win32]
-
-  '@cloudflare/workers-types@5.20260812.1':
-    resolution: {integrity: sha512-eG2aQdUWH8RYEubpBjUE98L2G57JYzGEcI8PgROTjt9YjunbEnPBHP4371Usj8v8pTWcXtbOmI+LRCXF4KhJgQ==}
+  '@cloudflare/workers-types@5.20260901.1':
+    resolution: {integrity: sha512-m1rNbR3UYC1pgaEyXkSlwLFLDB11QziYUlY0z/nqjwuYtg5dw9zBrgDudoSfYM6ebbPDKU81ogBQAzLp6h1y4w==}
 
   '@codemirror/autocomplete@6.20.3':
     resolution: {integrity: sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g==}
@@ -7275,12 +7204,6 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/aix-ppc64@0.27.3':
-    resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [aix]
-
   '@esbuild/aix-ppc64@0.28.1':
     resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
     engines: {node: '>=18'}
@@ -7301,12 +7224,6 @@ packages:
 
   '@esbuild/android-arm64@0.25.4':
     resolution: {integrity: sha512-bBy69pgfhMGtCnwpC/x5QhfxAz/cBgQ9enbtwjf6V9lnPI/hMyT9iWpR1arm0l3kttTr4L0KSLpKmLp/ilKS9A==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [android]
-
-  '@esbuild/android-arm64@0.27.3':
-    resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -7335,12 +7252,6 @@ packages:
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-arm@0.27.3':
-    resolution: {integrity: sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [android]
-
   '@esbuild/android-arm@0.28.1':
     resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
     engines: {node: '>=18'}
@@ -7361,12 +7272,6 @@ packages:
 
   '@esbuild/android-x64@0.25.4':
     resolution: {integrity: sha512-TVhdVtQIFuVpIIR282btcGC2oGQoSfZfmBdTip2anCaVYcqWlZXGcdcKIUklfX2wj0JklNYgz39OBqh2cqXvcQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [android]
-
-  '@esbuild/android-x64@0.27.3':
-    resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -7395,12 +7300,6 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-arm64@0.27.3':
-    resolution: {integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [darwin]
-
   '@esbuild/darwin-arm64@0.28.1':
     resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
     engines: {node: '>=18'}
@@ -7421,12 +7320,6 @@ packages:
 
   '@esbuild/darwin-x64@0.25.4':
     resolution: {integrity: sha512-CJsry8ZGM5VFVeyUYB3cdKpd/H69PYez4eJh1W/t38vzutdjEjtP7hB6eLKBoOdxcAlCtEYHzQ/PJ/oU9I4u0A==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@esbuild/darwin-x64@0.27.3':
-    resolution: {integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -7455,12 +7348,6 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-arm64@0.27.3':
-    resolution: {integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [freebsd]
-
   '@esbuild/freebsd-arm64@0.28.1':
     resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
     engines: {node: '>=18'}
@@ -7481,12 +7368,6 @@ packages:
 
   '@esbuild/freebsd-x64@0.25.4':
     resolution: {integrity: sha512-0FgvOJ6UUMflsHSPLzdfDnnBBVoCDtBTVyn/MrWloUNvq/5SFmh13l3dvgRPkDihRxb77Y17MbqbCAa2strMQQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [freebsd]
-
-  '@esbuild/freebsd-x64@0.27.3':
-    resolution: {integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -7515,12 +7396,6 @@ packages:
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm64@0.27.3':
-    resolution: {integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [linux]
-
   '@esbuild/linux-arm64@0.28.1':
     resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
     engines: {node: '>=18'}
@@ -7541,12 +7416,6 @@ packages:
 
   '@esbuild/linux-arm@0.25.4':
     resolution: {integrity: sha512-kro4c0P85GMfFYqW4TWOpvmF8rFShbWGnrLqlzp4X1TNWjRY3JMYUfDCtOxPKOIY8B0WC8HN51hGP4I4hz4AaQ==}
-    engines: {node: '>=18'}
-    cpu: [arm]
-    os: [linux]
-
-  '@esbuild/linux-arm@0.27.3':
-    resolution: {integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -7575,12 +7444,6 @@ packages:
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.27.3':
-    resolution: {integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [linux]
-
   '@esbuild/linux-ia32@0.28.1':
     resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
     engines: {node: '>=18'}
@@ -7601,12 +7464,6 @@ packages:
 
   '@esbuild/linux-loong64@0.25.4':
     resolution: {integrity: sha512-NeqqYkrcGzFwi6CGRGNMOjWGGSYOpqwCjS9fvaUlX5s3zwOtn1qwg1s2iE2svBe4Q/YOG1q6875lcAoQK/F4VA==}
-    engines: {node: '>=18'}
-    cpu: [loong64]
-    os: [linux]
-
-  '@esbuild/linux-loong64@0.27.3':
-    resolution: {integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -7635,12 +7492,6 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.27.3':
-    resolution: {integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==}
-    engines: {node: '>=18'}
-    cpu: [mips64el]
-    os: [linux]
-
   '@esbuild/linux-mips64el@0.28.1':
     resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
     engines: {node: '>=18'}
@@ -7661,12 +7512,6 @@ packages:
 
   '@esbuild/linux-ppc64@0.25.4':
     resolution: {integrity: sha512-HOy0aLTJTVtoTeGZh4HSXaO6M95qu4k5lJcH4gxv56iaycfz1S8GO/5Jh6X4Y1YiI0h7cRyLi+HixMR+88swag==}
-    engines: {node: '>=18'}
-    cpu: [ppc64]
-    os: [linux]
-
-  '@esbuild/linux-ppc64@0.27.3':
-    resolution: {integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -7695,12 +7540,6 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.27.3':
-    resolution: {integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==}
-    engines: {node: '>=18'}
-    cpu: [riscv64]
-    os: [linux]
-
   '@esbuild/linux-riscv64@0.28.1':
     resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
     engines: {node: '>=18'}
@@ -7721,12 +7560,6 @@ packages:
 
   '@esbuild/linux-s390x@0.25.4':
     resolution: {integrity: sha512-jFnu+6UbLlzIjPQpWCNh5QtrcNfMLjgIavnwPQAfoGx4q17ocOU9MsQ2QVvFxwQoWpZT8DvTLooTvmOQXkO51g==}
-    engines: {node: '>=18'}
-    cpu: [s390x]
-    os: [linux]
-
-  '@esbuild/linux-s390x@0.27.3':
-    resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -7755,12 +7588,6 @@ packages:
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/linux-x64@0.27.3':
-    resolution: {integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [linux]
-
   '@esbuild/linux-x64@0.28.1':
     resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
     engines: {node: '>=18'}
@@ -7781,12 +7608,6 @@ packages:
 
   '@esbuild/netbsd-arm64@0.25.4':
     resolution: {integrity: sha512-vUnkBYxZW4hL/ie91hSqaSNjulOnYXE1VSLusnvHg2u3jewJBz3YzB9+oCw8DABeVqZGg94t9tyZFoHma8gWZQ==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [netbsd]
-
-  '@esbuild/netbsd-arm64@0.27.3':
-    resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -7815,12 +7636,6 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.27.3':
-    resolution: {integrity: sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [netbsd]
-
   '@esbuild/netbsd-x64@0.28.1':
     resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
     engines: {node: '>=18'}
@@ -7841,12 +7656,6 @@ packages:
 
   '@esbuild/openbsd-arm64@0.25.4':
     resolution: {integrity: sha512-Ct2WcFEANlFDtp1nVAXSNBPDxyU+j7+tId//iHXU2f/lN5AmO4zLyhDcpR5Cz1r08mVxzt3Jpyt4PmXQ1O6+7A==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openbsd]
-
-  '@esbuild/openbsd-arm64@0.27.3':
-    resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -7875,12 +7684,6 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.27.3':
-    resolution: {integrity: sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [openbsd]
-
   '@esbuild/openbsd-x64@0.28.1':
     resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
     engines: {node: '>=18'}
@@ -7895,12 +7698,6 @@ packages:
 
   '@esbuild/openharmony-arm64@0.25.12':
     resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [openharmony]
-
-  '@esbuild/openharmony-arm64@0.27.3':
-    resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -7929,12 +7726,6 @@ packages:
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/sunos-x64@0.27.3':
-    resolution: {integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [sunos]
-
   '@esbuild/sunos-x64@0.28.1':
     resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
     engines: {node: '>=18'}
@@ -7955,12 +7746,6 @@ packages:
 
   '@esbuild/win32-arm64@0.25.4':
     resolution: {integrity: sha512-AVUP428VQTSddguz9dO9ngb+E5aScyg7nOeJDrF1HPYu555gmza3bDGMPhmVXL8svDSoqPCsCPjb265yG/kLKQ==}
-    engines: {node: '>=18'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@esbuild/win32-arm64@0.27.3':
-    resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -7989,12 +7774,6 @@ packages:
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.27.3':
-    resolution: {integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==}
-    engines: {node: '>=18'}
-    cpu: [ia32]
-    os: [win32]
-
   '@esbuild/win32-ia32@0.28.1':
     resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
     engines: {node: '>=18'}
@@ -8015,12 +7794,6 @@ packages:
 
   '@esbuild/win32-x64@0.25.4':
     resolution: {integrity: sha512-nOT2vZNw6hJ+z43oP1SPea/G/6AbN6X+bGNhNuq8NtRHy4wsMhw765IKLNmnjek7GvjWBYQ8Q5VBoYTFg9y1UQ==}
-    engines: {node: '>=18'}
-    cpu: [x64]
-    os: [win32]
-
-  '@esbuild/win32-x64@0.27.3':
-    resolution: {integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -13200,20 +12973,20 @@ packages:
   caniuse-lite@1.0.30001809:
     resolution: {integrity: sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==}
 
-  capnp-es@0.0.14:
-    resolution: {integrity: sha512-8lWj4GJISiqRSlAJGkWpI4Azib7QY5UDIkqxeHcI7aAnXVk9SFuWxl1Fme+2HhzNANV0WTJqwUZvvXvloc3sBA==}
+  capnp-es@0.0.16:
+    resolution: {integrity: sha512-pqhhnRqGfDdgHa+rz4JVO9j1jnkyqsHRYrD4RBtIwxCknYSRG7Mjs+x3IRfd20u+ZGS0IhW2L7cDv9ZcIkCYhQ==}
     hasBin: true
     peerDependencies:
-      typescript: ^5.7.3
+      typescript: ^5.7.3 || ^6.0.0
     peerDependenciesMeta:
       typescript:
         optional: true
 
+  capnweb@0.12.0:
+    resolution: {integrity: sha512-jgZ/LMtMVTi+RVlooIslH78Gg23XbDTdvcLghWx3oz17D6u5GuJARt+uhZk/wcTo+f81eeabfnow4d3zLBj+JQ==}
+
   capnweb@0.6.1:
     resolution: {integrity: sha512-fmhV26QPd1ewf5R74h55oVZnGwIcSaRMzbfLQUy8+zOBjuTmT3KXoT8wxHvnp1m9Ht9BoUUS5ZwNLoVLfQTyBg==}
-
-  capnweb@0.8.0:
-    resolution: {integrity: sha512-BK/TuXUiyfLSKsmjojn70yN7oYG/JJzoURZ3tckjg5Zj2KcygPm0A5jyOlswK7SYB4f0Gh9tt+RZ132b80iLfA==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -13288,8 +13061,8 @@ packages:
   citty@0.2.2:
     resolution: {integrity: sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==}
 
-  cjs-module-lexer@1.4.3:
-    resolution: {integrity: sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==}
+  cjs-module-lexer@1.2.3:
+    resolution: {integrity: sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==}
 
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
@@ -13738,7 +13511,7 @@ packages:
     resolution: {integrity: sha512-28PVt0PS/+4kPa8eKr4mqP8y/YcbdOgdVcGUa6LGl2Kd2bykNWuf/WUOFoSCoynagblbcRgMO1zChLvRcWD6Tg==}
     peerDependencies:
       '@aws-sdk/client-rds-data': '>=3'
-      '@cloudflare/workers-types': 5.20260812.1
+      '@cloudflare/workers-types': 5.20260901.1
       '@effect/sql-d1': '>=4.0.0-beta.105 || >=4.0.0'
       '@effect/sql-libsql': '>=4.0.0-beta.105 || >=4.0.0'
       '@effect/sql-mysql2': '>=4.0.0-beta.105 || >=4.0.0'
@@ -14061,11 +13834,6 @@ packages:
 
   esbuild@0.25.4:
     resolution: {integrity: sha512-8pgjLUcUjcgDg+2Q4NYXnPbo/vncAY4UmyaCm0jZevERqCHZIaWwdJHkf8XQtu4AxSKCdvrUbT0XUr1IdZzI8Q==}
-    engines: {node: '>=18'}
-    hasBin: true
-
-  esbuild@0.27.3:
-    resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -15625,15 +15393,14 @@ packages:
     resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
     engines: {node: '>=12'}
 
-  miniflare@4.20260317.3:
-    resolution: {integrity: sha512-tK78D3X4q30/SXqVwMhWrUfH+ffRou9dJLC+jkhNy5zh1I7i7T4JH6xihOvYxdCSBavJ5fQXaaxDJz6orh09BA==}
-    engines: {node: '>=18.0.0'}
-    hasBin: true
-
   miniflare@4.20260722.0:
     resolution: {integrity: sha512-LW6ABMhCx/yIEFBLC/DO4yAhdm2T/G7jp7pr5T2kj895+CCIaHZqpMXdW9O6YE48LcYcCJChwWc8aEs1vpbTXw==}
     engines: {node: '>=22.0.0'}
     hasBin: true
+
+  miniflare@5.20260815.0-alpha:
+    resolution: {integrity: sha512-YAaGj4Sh5f4fqHKiMQ8zRHDOOM5IGUVtMhnLIeyjuQfU+9P6hcOTrHUVtbfj/ZPay9Kzik4pWELB39pGgefjiQ==}
+    engines: {node: '>=22.0.0'}
 
   minimatch@10.2.6:
     resolution: {integrity: sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==}
@@ -17909,10 +17676,6 @@ packages:
     resolution: {integrity: sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==}
     engines: {node: '>=18.17'}
 
-  undici@7.24.4:
-    resolution: {integrity: sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==}
-    engines: {node: '>=20.18.1'}
-
   undici@7.28.0:
     resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
@@ -18804,18 +18567,8 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
-  workerd@1.20260317.1:
-    resolution: {integrity: sha512-ZuEq1OdrJBS+NV+L5HMYPCzVn49a2O60slQiiLpG44jqtlOo+S167fWC76kEXteXLLLydeuRrluRel7WdOUa4g==}
-    engines: {node: '>=16'}
-    hasBin: true
-
-  workerd@1.20260722.1:
-    resolution: {integrity: sha512-NycKuc1x2onvsRfGGpM093vRlLFU2zHDAM0+APpccfg4+gZxDGCH27RmdDvkeBuoZyYqgLo3oAfF6re4mvC3vQ==}
-    engines: {node: '>=16'}
-    hasBin: true
-
-  workerd@1.20260831.1:
-    resolution: {integrity: sha512-A2LwrkBel/FnKABPfeBAMiL6v70+rugnunqQRfWsWZjlhsTZoBScWUVunMy/xLCGLjWCQL2zp39AVR6aO0jurQ==}
+  workerd@1.20260901.1:
+    resolution: {integrity: sha512-Z5PVprrPRlV70+RzgbFpzoPpjCLGtErhsQ9Ahe96pe7hJGMsmexTU4+rhUPH+2Sguf7vRAxFFsqXpkIleRFSPA==}
     engines: {node: '>=16'}
     hasBin: true
 
@@ -18824,17 +18577,17 @@ packages:
     engines: {node: '>=22.0.0'}
     hasBin: true
     peerDependencies:
-      '@cloudflare/workers-types': 5.20260812.1
+      '@cloudflare/workers-types': 5.20260901.1
     peerDependenciesMeta:
       '@cloudflare/workers-types':
         optional: true
 
-  wrangler@4.78.0:
-    resolution: {integrity: sha512-He/vUhk4ih0D0eFmtNnlbT6Od8j+BEokaSR+oYjbVsH0SWIrIch+eHqfLRSBjBQaOoh6HCNxcafcIkBm2u0Hag==}
-    engines: {node: '>=20.3.0'}
+  wrangler@4.124.0:
+    resolution: {integrity: sha512-75euoZKjVTJYFy+Xhctt/5JlZL4M6A4xmovZsUlep+6GHcCm14n9VtdGzNIybOW2t8wuNxRj5iMUwjT5E7Ctog==}
+    engines: {node: '>=22.0.0'}
     hasBin: true
     peerDependencies:
-      '@cloudflare/workers-types': 5.20260812.1
+      '@cloudflare/workers-types': 5.20260901.1
     peerDependenciesMeta:
       '@cloudflare/workers-types':
         optional: true
@@ -18867,18 +18620,6 @@ packages:
     peerDependencies:
       bufferutil: ^4.0.1
       utf-8-validate: ^5.0.2
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
-  ws@8.18.0:
-    resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
     peerDependenciesMeta:
       bufferutil:
         optional: true
@@ -19291,13 +19032,13 @@ snapshots:
       hast-util-from-html: 2.0.3
       satteri: 0.9.5
 
-  '@astrojs/mdx@7.0.5(@astrojs/markdown-satteri@0.3.5)(astro@7.2.0(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@3.25.76))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(supports-color@10.2.2)':
+  '@astrojs/mdx@7.0.5(@astrojs/markdown-satteri@0.3.5)(astro@7.2.0(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@3.25.76))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(supports-color@10.2.2)':
     dependencies:
       '@astrojs/internal-helpers': 0.10.2
       '@astrojs/markdown-remark': 7.2.2(supports-color@10.2.2)
       '@mdx-js/mdx': 3.1.1(supports-color@10.2.2)
       acorn: 8.18.0
-      astro: 7.2.0(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@3.25.76))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
+      astro: 7.2.0(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@3.25.76))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
       es-module-lexer: 2.3.1
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
@@ -19355,22 +19096,22 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 4.4.3
 
-  '@astrojs/starlight-tailwind@5.0.0(71dfb54e531903e2eaad60f2f53b349f)':
+  '@astrojs/starlight-tailwind@5.0.0(5ab0907d3c3b25b7906fe7568eb155ee)':
     dependencies:
-      '@astrojs/starlight': 0.41.7(patch_hash=7ab76e506900e9b0f934039b4b3f797fdf6ea76e9668891402a75ef46dd79b8c)(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(astro@7.2.0(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@3.25.76))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(supports-color@10.2.2)(typescript@7.0.2)
+      '@astrojs/starlight': 0.41.7(patch_hash=7ab76e506900e9b0f934039b4b3f797fdf6ea76e9668891402a75ef46dd79b8c)(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(astro@7.2.0(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@3.25.76))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(supports-color@10.2.2)(typescript@7.0.2)
       tailwindcss: 4.3.3
 
-  ? '@astrojs/starlight@0.41.7(patch_hash=7ab76e506900e9b0f934039b4b3f797fdf6ea76e9668891402a75ef46dd79b8c)(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(astro@7.2.0(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@3.25.76))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(supports-color@10.2.2)(typescript@7.0.2)'
+  ? '@astrojs/starlight@0.41.7(patch_hash=7ab76e506900e9b0f934039b4b3f797fdf6ea76e9668891402a75ef46dd79b8c)(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(astro@7.2.0(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@3.25.76))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(supports-color@10.2.2)(typescript@7.0.2)'
   : dependencies:
       '@astrojs/markdown-satteri': 0.3.5
-      '@astrojs/mdx': 7.0.5(@astrojs/markdown-satteri@0.3.5)(astro@7.2.0(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@3.25.76))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(supports-color@10.2.2)
+      '@astrojs/mdx': 7.0.5(@astrojs/markdown-satteri@0.3.5)(astro@7.2.0(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@3.25.76))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(supports-color@10.2.2)
       '@astrojs/sitemap': 3.7.3
       '@pagefind/default-ui': 1.5.2
       '@types/hast': 3.0.5
       '@types/js-yaml': 4.0.9
       '@types/mdast': 4.0.4
-      astro: 7.2.0(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@3.25.76))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
-      astro-expressive-code: 0.44.1(astro@7.2.0(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@3.25.76))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+      astro: 7.2.0(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@3.25.76))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
+      astro-expressive-code: 0.44.1(astro@7.2.0(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@3.25.76))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
       bcp-47: 2.1.1
       hast-util-from-html: 2.0.3
       hast-util-select: 6.0.4
@@ -20268,7 +20009,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.18
 
-  '@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260812.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2)':
+  '@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260901.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2)':
     dependencies:
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
@@ -20280,42 +20021,42 @@ snapshots:
       nanostores: 1.4.2
       zod: 4.4.3
     optionalDependencies:
-      '@cloudflare/workers-types': 5.20260812.1
+      '@cloudflare/workers-types': 5.20260901.1
 
-  '@better-auth/drizzle-adapter@1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260812.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))':
+  '@better-auth/drizzle-adapter@1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260901.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))':
     dependencies:
-      '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260812.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2)
+      '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260901.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2)
       '@better-auth/utils': 0.4.2
     optionalDependencies:
-      drizzle-orm: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3)
+      drizzle-orm: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3)
 
-  '@better-auth/kysely-adapter@1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260812.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(kysely@0.29.5)':
+  '@better-auth/kysely-adapter@1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260901.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(kysely@0.29.5)':
     dependencies:
-      '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260812.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2)
+      '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260901.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2)
       '@better-auth/utils': 0.4.2
     optionalDependencies:
       kysely: 0.29.5
 
-  '@better-auth/memory-adapter@1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260812.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)':
+  '@better-auth/memory-adapter@1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260901.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)':
     dependencies:
-      '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260812.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2)
+      '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260901.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/mongo-adapter@1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260812.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(mongodb@6.21.0(@aws-sdk/credential-providers@3.1095.0)(socks@2.8.9))':
+  '@better-auth/mongo-adapter@1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260901.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(mongodb@6.21.0(@aws-sdk/credential-providers@3.1095.0)(socks@2.8.9))':
     dependencies:
-      '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260812.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2)
+      '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260901.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2)
       '@better-auth/utils': 0.4.2
     optionalDependencies:
       mongodb: 6.21.0(@aws-sdk/credential-providers@3.1095.0)(socks@2.8.9)
 
-  '@better-auth/prisma-adapter@1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260812.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)':
+  '@better-auth/prisma-adapter@1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260901.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)':
     dependencies:
-      '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260812.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2)
+      '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260901.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2)
       '@better-auth/utils': 0.4.2
 
-  '@better-auth/telemetry@1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260812.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)':
+  '@better-auth/telemetry@1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260901.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)':
     dependencies:
-      '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260812.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2)
+      '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260901.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
 
@@ -20413,85 +20154,43 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@cloudflare/unenv-preset@2.16.0(unenv@2.0.0-rc.24)(workerd@1.20260317.1)':
+  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260901.1)':
     dependencies:
       unenv: 2.0.0-rc.24
     optionalDependencies:
-      workerd: 1.20260317.1
+      workerd: 1.20260901.1
 
-  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260722.1)':
-    dependencies:
-      unenv: 2.0.0-rc.24
-    optionalDependencies:
-      workerd: 1.20260722.1
-
-  '@cloudflare/unenv-preset@2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260831.1)':
-    dependencies:
-      unenv: 2.0.0-rc.24
-    optionalDependencies:
-      workerd: 1.20260831.1
-
-  '@cloudflare/vitest-pool-workers@0.13.5(@cloudflare/workers-types@5.20260812.1)(@vitest/runner@4.1.10)(@vitest/snapshot@4.1.10)(vitest@4.1.10(@types/node@26.2.0)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))':
+  '@cloudflare/vitest-pool-workers@0.22.0(@cloudflare/workers-types@5.20260901.1)(@vitest/runner@4.1.10)(@vitest/snapshot@4.1.10)(vitest@4.1.10(@types/node@26.2.0)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))':
     dependencies:
       '@vitest/runner': 4.1.10
       '@vitest/snapshot': 4.1.10
-      cjs-module-lexer: 1.4.3
-      esbuild: 0.27.3
-      miniflare: 4.20260317.3
+      cjs-module-lexer: 1.2.3
+      esbuild: 0.28.1
+      miniflare: 5.20260815.0-alpha
       vitest: 4.1.10(@types/node@26.2.0)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
-      wrangler: 4.78.0(@cloudflare/workers-types@5.20260812.1)
-      zod: 3.25.76
+      wrangler: 4.124.0(@cloudflare/workers-types@5.20260901.1)
+      zod: 4.4.3
     transitivePeerDependencies:
       - '@cloudflare/workers-types'
       - bufferutil
       - utf-8-validate
 
-  '@cloudflare/workerd-darwin-64@1.20260317.1':
+  '@cloudflare/workerd-darwin-64@1.20260901.1':
     optional: true
 
-  '@cloudflare/workerd-darwin-64@1.20260722.1':
+  '@cloudflare/workerd-darwin-arm64@1.20260901.1':
     optional: true
 
-  '@cloudflare/workerd-darwin-64@1.20260831.1':
+  '@cloudflare/workerd-linux-64@1.20260901.1':
     optional: true
 
-  '@cloudflare/workerd-darwin-arm64@1.20260317.1':
+  '@cloudflare/workerd-linux-arm64@1.20260901.1':
     optional: true
 
-  '@cloudflare/workerd-darwin-arm64@1.20260722.1':
+  '@cloudflare/workerd-windows-64@1.20260901.1':
     optional: true
 
-  '@cloudflare/workerd-darwin-arm64@1.20260831.1':
-    optional: true
-
-  '@cloudflare/workerd-linux-64@1.20260317.1':
-    optional: true
-
-  '@cloudflare/workerd-linux-64@1.20260722.1':
-    optional: true
-
-  '@cloudflare/workerd-linux-64@1.20260831.1':
-    optional: true
-
-  '@cloudflare/workerd-linux-arm64@1.20260317.1':
-    optional: true
-
-  '@cloudflare/workerd-linux-arm64@1.20260722.1':
-    optional: true
-
-  '@cloudflare/workerd-linux-arm64@1.20260831.1':
-    optional: true
-
-  '@cloudflare/workerd-windows-64@1.20260317.1':
-    optional: true
-
-  '@cloudflare/workerd-windows-64@1.20260722.1':
-    optional: true
-
-  '@cloudflare/workerd-windows-64@1.20260831.1':
-    optional: true
-
-  '@cloudflare/workers-types@5.20260812.1': {}
+  '@cloudflare/workers-types@5.20260901.1': {}
 
   '@codemirror/autocomplete@6.20.3':
     dependencies:
@@ -20745,7 +20444,7 @@ snapshots:
 
   '@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112)':
     dependencies:
-      '@cloudflare/workers-types': 5.20260812.1
+      '@cloudflare/workers-types': 5.20260901.1
       effect: 4.0.0-rc.112
 
   '@effect/sql-mysql2@4.0.0-rc.112(@types/node@24.13.3)(effect@4.0.0-rc.112)':
@@ -20885,9 +20584,6 @@ snapshots:
   '@esbuild/aix-ppc64@0.25.4':
     optional: true
 
-  '@esbuild/aix-ppc64@0.27.3':
-    optional: true
-
   '@esbuild/aix-ppc64@0.28.1':
     optional: true
 
@@ -20898,9 +20594,6 @@ snapshots:
     optional: true
 
   '@esbuild/android-arm64@0.25.4':
-    optional: true
-
-  '@esbuild/android-arm64@0.27.3':
     optional: true
 
   '@esbuild/android-arm64@0.28.1':
@@ -20915,9 +20608,6 @@ snapshots:
   '@esbuild/android-arm@0.25.4':
     optional: true
 
-  '@esbuild/android-arm@0.27.3':
-    optional: true
-
   '@esbuild/android-arm@0.28.1':
     optional: true
 
@@ -20928,9 +20618,6 @@ snapshots:
     optional: true
 
   '@esbuild/android-x64@0.25.4':
-    optional: true
-
-  '@esbuild/android-x64@0.27.3':
     optional: true
 
   '@esbuild/android-x64@0.28.1':
@@ -20945,9 +20632,6 @@ snapshots:
   '@esbuild/darwin-arm64@0.25.4':
     optional: true
 
-  '@esbuild/darwin-arm64@0.27.3':
-    optional: true
-
   '@esbuild/darwin-arm64@0.28.1':
     optional: true
 
@@ -20958,9 +20642,6 @@ snapshots:
     optional: true
 
   '@esbuild/darwin-x64@0.25.4':
-    optional: true
-
-  '@esbuild/darwin-x64@0.27.3':
     optional: true
 
   '@esbuild/darwin-x64@0.28.1':
@@ -20975,9 +20656,6 @@ snapshots:
   '@esbuild/freebsd-arm64@0.25.4':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.27.3':
-    optional: true
-
   '@esbuild/freebsd-arm64@0.28.1':
     optional: true
 
@@ -20988,9 +20666,6 @@ snapshots:
     optional: true
 
   '@esbuild/freebsd-x64@0.25.4':
-    optional: true
-
-  '@esbuild/freebsd-x64@0.27.3':
     optional: true
 
   '@esbuild/freebsd-x64@0.28.1':
@@ -21005,9 +20680,6 @@ snapshots:
   '@esbuild/linux-arm64@0.25.4':
     optional: true
 
-  '@esbuild/linux-arm64@0.27.3':
-    optional: true
-
   '@esbuild/linux-arm64@0.28.1':
     optional: true
 
@@ -21018,9 +20690,6 @@ snapshots:
     optional: true
 
   '@esbuild/linux-arm@0.25.4':
-    optional: true
-
-  '@esbuild/linux-arm@0.27.3':
     optional: true
 
   '@esbuild/linux-arm@0.28.1':
@@ -21035,9 +20704,6 @@ snapshots:
   '@esbuild/linux-ia32@0.25.4':
     optional: true
 
-  '@esbuild/linux-ia32@0.27.3':
-    optional: true
-
   '@esbuild/linux-ia32@0.28.1':
     optional: true
 
@@ -21048,9 +20714,6 @@ snapshots:
     optional: true
 
   '@esbuild/linux-loong64@0.25.4':
-    optional: true
-
-  '@esbuild/linux-loong64@0.27.3':
     optional: true
 
   '@esbuild/linux-loong64@0.28.1':
@@ -21065,9 +20728,6 @@ snapshots:
   '@esbuild/linux-mips64el@0.25.4':
     optional: true
 
-  '@esbuild/linux-mips64el@0.27.3':
-    optional: true
-
   '@esbuild/linux-mips64el@0.28.1':
     optional: true
 
@@ -21078,9 +20738,6 @@ snapshots:
     optional: true
 
   '@esbuild/linux-ppc64@0.25.4':
-    optional: true
-
-  '@esbuild/linux-ppc64@0.27.3':
     optional: true
 
   '@esbuild/linux-ppc64@0.28.1':
@@ -21095,9 +20752,6 @@ snapshots:
   '@esbuild/linux-riscv64@0.25.4':
     optional: true
 
-  '@esbuild/linux-riscv64@0.27.3':
-    optional: true
-
   '@esbuild/linux-riscv64@0.28.1':
     optional: true
 
@@ -21108,9 +20762,6 @@ snapshots:
     optional: true
 
   '@esbuild/linux-s390x@0.25.4':
-    optional: true
-
-  '@esbuild/linux-s390x@0.27.3':
     optional: true
 
   '@esbuild/linux-s390x@0.28.1':
@@ -21125,9 +20776,6 @@ snapshots:
   '@esbuild/linux-x64@0.25.4':
     optional: true
 
-  '@esbuild/linux-x64@0.27.3':
-    optional: true
-
   '@esbuild/linux-x64@0.28.1':
     optional: true
 
@@ -21138,9 +20786,6 @@ snapshots:
     optional: true
 
   '@esbuild/netbsd-arm64@0.25.4':
-    optional: true
-
-  '@esbuild/netbsd-arm64@0.27.3':
     optional: true
 
   '@esbuild/netbsd-arm64@0.28.1':
@@ -21155,9 +20800,6 @@ snapshots:
   '@esbuild/netbsd-x64@0.25.4':
     optional: true
 
-  '@esbuild/netbsd-x64@0.27.3':
-    optional: true
-
   '@esbuild/netbsd-x64@0.28.1':
     optional: true
 
@@ -21168,9 +20810,6 @@ snapshots:
     optional: true
 
   '@esbuild/openbsd-arm64@0.25.4':
-    optional: true
-
-  '@esbuild/openbsd-arm64@0.27.3':
     optional: true
 
   '@esbuild/openbsd-arm64@0.28.1':
@@ -21185,9 +20824,6 @@ snapshots:
   '@esbuild/openbsd-x64@0.25.4':
     optional: true
 
-  '@esbuild/openbsd-x64@0.27.3':
-    optional: true
-
   '@esbuild/openbsd-x64@0.28.1':
     optional: true
 
@@ -21195,9 +20831,6 @@ snapshots:
     optional: true
 
   '@esbuild/openharmony-arm64@0.25.12':
-    optional: true
-
-  '@esbuild/openharmony-arm64@0.27.3':
     optional: true
 
   '@esbuild/openharmony-arm64@0.28.1':
@@ -21212,9 +20845,6 @@ snapshots:
   '@esbuild/sunos-x64@0.25.4':
     optional: true
 
-  '@esbuild/sunos-x64@0.27.3':
-    optional: true
-
   '@esbuild/sunos-x64@0.28.1':
     optional: true
 
@@ -21225,9 +20855,6 @@ snapshots:
     optional: true
 
   '@esbuild/win32-arm64@0.25.4':
-    optional: true
-
-  '@esbuild/win32-arm64@0.27.3':
     optional: true
 
   '@esbuild/win32-arm64@0.28.1':
@@ -21242,9 +20869,6 @@ snapshots:
   '@esbuild/win32-ia32@0.25.4':
     optional: true
 
-  '@esbuild/win32-ia32@0.27.3':
-    optional: true
-
   '@esbuild/win32-ia32@0.28.1':
     optional: true
 
@@ -21255,9 +20879,6 @@ snapshots:
     optional: true
 
   '@esbuild/win32-x64@0.25.4':
-    optional: true
-
-  '@esbuild/win32-x64@0.27.3':
     optional: true
 
   '@esbuild/win32-x64@0.28.1':
@@ -22177,7 +21798,7 @@ snapshots:
       pkg-types: 2.3.1
       semver: 7.8.5
 
-  '@nuxt/devtools@3.4.1(0f01304e996d82e0188901d54c1d087f)':
+  '@nuxt/devtools@3.4.1(43838925e6dd8e4c5211d688814ddf88)':
     dependencies:
       '@nuxt/devtools-kit': 3.4.1(magic-string@1.1.1)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
       '@nuxt/devtools-wizard': 3.4.1
@@ -22207,7 +21828,7 @@ snapshots:
       sirv: 3.0.2
       structured-clone-es: 2.0.1
       tinyglobby: 0.2.17
-      unstorage: 1.17.5(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))
+      unstorage: 1.17.5(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))
       vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
       vite-plugin-inspect: 11.4.1(@nuxt/kit@4.5.1(magic-string@1.1.1)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
       vite-plugin-vue-tracer: 1.5.0(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(vue@3.5.41(typescript@7.0.2))
@@ -22242,7 +21863,7 @@ snapshots:
       - utf-8-validate
       - vue
 
-  '@nuxt/devtools@3.4.1(b06e89db0111218d09dacaed53684127)':
+  '@nuxt/devtools@3.4.1(ccf5a9ec274278f63e2846585aff94a3)':
     dependencies:
       '@nuxt/devtools-kit': 3.4.1(magic-string@1.1.1)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
       '@nuxt/devtools-wizard': 3.4.1
@@ -22272,7 +21893,7 @@ snapshots:
       sirv: 3.0.2
       structured-clone-es: 2.0.1
       tinyglobby: 0.2.17
-      unstorage: 1.17.5(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@24.13.3)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@24.13.3))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@24.13.3)))(ioredis@5.11.1(supports-color@10.2.2))
+      unstorage: 1.17.5(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@24.13.3)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@24.13.3))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@24.13.3)))(ioredis@5.11.1(supports-color@10.2.2))
       vite: 8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
       vite-plugin-inspect: 11.4.1(@nuxt/kit@4.5.1(magic-string@1.1.1)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
       vite-plugin-vue-tracer: 1.5.0(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(vue@3.5.41(typescript@7.0.2))
@@ -22367,7 +21988,94 @@ snapshots:
       - rolldown
       - unplugin
 
-  '@nuxt/nitro-server@4.5.1(10af6e4963100980c58174bdb5ff7e07)':
+  '@nuxt/nitro-server@4.5.1(3d27890fc752a9e5fee4b61c79d6b3e7)':
+    dependencies:
+      '@nuxt/devalue': 2.0.2
+      '@nuxt/kit': 4.5.1(magic-string@1.1.1)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))
+      '@unhead/vue': 3.3.1(@oxc-project/types@0.146.0)(esbuild@0.28.2)(lightningcss@1.33.0)(oxc-parser@0.141.0)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(vue@3.5.41(typescript@7.0.2))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
+      '@vue/shared': 3.5.41
+      consola: 3.4.2
+      defu: 6.1.7
+      destr: 2.0.5
+      devalue: 5.9.0
+      errx: 0.1.2
+      escape-string-regexp: 5.0.0
+      exsolve: 1.1.1
+      h3: 1.15.11
+      impound: 1.1.6(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
+      klona: 2.0.6
+      mocked-exports: 0.1.1
+      nitropack: 2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
+      nostics: 1.2.0
+      nuxt: 4.5.1(3206fa55841a5479ca4c78edc8ffa76d)
+      nypm: 0.6.9
+      ohash: 2.0.11
+      pathe: 2.0.3
+      rou3: 0.9.2
+      std-env: 4.2.0
+      ufo: 1.6.4
+      unctx: 3.0.0(magic-string@1.1.1)(oxc-parser@0.141.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))
+      unstorage: 1.17.5(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))
+      vue: 3.5.41(typescript@7.0.2)
+      vue-bundle-renderer: 2.3.2
+      vue-devtools-stub: 0.1.0
+    optionalDependencies:
+      '@babel/plugin-proposal-decorators': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@electric-sql/pglite'
+      - '@farmfe/core'
+      - '@libsql/client'
+      - '@netlify/blobs'
+      - '@oxc-project/types'
+      - '@parcel/watcher'
+      - '@planetscale/database'
+      - '@rspack/core'
+      - '@unhead/cli'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - '@vitejs/devtools-kit'
+      - aws4fetch
+      - bare-abort-controller
+      - bare-buffer
+      - better-sqlite3
+      - bun-types-no-globals
+      - db0
+      - drizzle-orm
+      - encoding
+      - esbuild
+      - idb-keyval
+      - ioredis
+      - lightningcss
+      - magic-string
+      - magicast
+      - mysql2
+      - oxc-parser
+      - react-native-b4a
+      - rolldown
+      - rollup
+      - sqlite3
+      - srvx
+      - supports-color
+      - typescript
+      - unloader
+      - unplugin
+      - uploadthing
+      - vite
+      - webpack
+      - xml2js
+
+  '@nuxt/nitro-server@4.5.1(516d1c970fdf1dd30df0f7fc08558cdd)':
     dependencies:
       '@nuxt/devalue': 2.0.2
       '@nuxt/kit': 4.5.1(magic-string@1.1.1)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))
@@ -22384,9 +22092,9 @@ snapshots:
       impound: 1.1.6(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
       klona: 2.0.6
       mocked-exports: 0.1.1
-      nitropack: 2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@24.13.3)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@24.13.3))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@24.13.3))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
+      nitropack: 2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@24.13.3)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@24.13.3))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@24.13.3))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
       nostics: 1.2.0
-      nuxt: 4.5.1(38a0ae7adc2044c05f636f188c0deddc)
+      nuxt: 4.5.1(8afcc381206f858c9998bb23d771b3c2)
       nypm: 0.6.9
       ohash: 2.0.11
       pathe: 2.0.3
@@ -22394,7 +22102,7 @@ snapshots:
       std-env: 4.2.0
       ufo: 1.6.4
       unctx: 3.0.0(magic-string@1.1.1)(oxc-parser@0.141.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))
-      unstorage: 1.17.5(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@24.13.3)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@24.13.3))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@24.13.3)))(ioredis@5.11.1(supports-color@10.2.2))
+      unstorage: 1.17.5(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@24.13.3)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@24.13.3))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@24.13.3)))(ioredis@5.11.1(supports-color@10.2.2))
       vue: 3.5.41(typescript@7.0.2)
       vue-bundle-renderer: 2.3.2
       vue-devtools-stub: 0.1.0
@@ -22454,7 +22162,7 @@ snapshots:
       - webpack
       - xml2js
 
-  '@nuxt/nitro-server@4.5.1(4e6cd610fa0e9c193b5d9c55e3579f88)':
+  '@nuxt/nitro-server@4.5.1(808cd65123b8fff3717bb5ce3ac4d244)':
     dependencies:
       '@nuxt/devalue': 2.0.2
       '@nuxt/kit': 4.5.1(magic-string@1.1.1)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))
@@ -22471,9 +22179,9 @@ snapshots:
       impound: 1.1.6(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
       klona: 2.0.6
       mocked-exports: 0.1.1
-      nitropack: 2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
+      nitropack: 2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
       nostics: 1.2.0
-      nuxt: 4.5.1(6cab6962d170d75e6cc46dcb3ab1fb0a)
+      nuxt: 4.5.1(10f78aabed4c566ba3a2c1702c35888c)
       nypm: 0.6.9
       ohash: 2.0.11
       pathe: 2.0.3
@@ -22481,94 +22189,7 @@ snapshots:
       std-env: 4.2.0
       ufo: 1.6.4
       unctx: 3.0.0(magic-string@1.1.1)(oxc-parser@0.141.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))
-      unstorage: 1.17.5(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))
-      vue: 3.5.41(typescript@7.0.2)
-      vue-bundle-renderer: 2.3.2
-      vue-devtools-stub: 0.1.0
-    optionalDependencies:
-      '@babel/plugin-proposal-decorators': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@electric-sql/pglite'
-      - '@farmfe/core'
-      - '@libsql/client'
-      - '@netlify/blobs'
-      - '@oxc-project/types'
-      - '@parcel/watcher'
-      - '@planetscale/database'
-      - '@rspack/core'
-      - '@unhead/cli'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - '@vitejs/devtools-kit'
-      - aws4fetch
-      - bare-abort-controller
-      - bare-buffer
-      - better-sqlite3
-      - bun-types-no-globals
-      - db0
-      - drizzle-orm
-      - encoding
-      - esbuild
-      - idb-keyval
-      - ioredis
-      - lightningcss
-      - magic-string
-      - magicast
-      - mysql2
-      - oxc-parser
-      - react-native-b4a
-      - rolldown
-      - rollup
-      - sqlite3
-      - srvx
-      - supports-color
-      - typescript
-      - unloader
-      - unplugin
-      - uploadthing
-      - vite
-      - webpack
-      - xml2js
-
-  '@nuxt/nitro-server@4.5.1(f283711819bf0c35ec6a413078787585)':
-    dependencies:
-      '@nuxt/devalue': 2.0.2
-      '@nuxt/kit': 4.5.1(magic-string@1.1.1)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))
-      '@unhead/vue': 3.3.1(@oxc-project/types@0.146.0)(esbuild@0.28.2)(lightningcss@1.33.0)(oxc-parser@0.141.0)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(vue@3.5.41(typescript@7.0.2))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
-      '@vue/shared': 3.5.41
-      consola: 3.4.2
-      defu: 6.1.7
-      destr: 2.0.5
-      devalue: 5.9.0
-      errx: 0.1.2
-      escape-string-regexp: 5.0.0
-      exsolve: 1.1.1
-      h3: 1.15.11
-      impound: 1.1.6(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
-      klona: 2.0.6
-      mocked-exports: 0.1.1
-      nitropack: 2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
-      nostics: 1.2.0
-      nuxt: 4.5.1(0baa57aa261304dcdb12983501874da1)
-      nypm: 0.6.9
-      ohash: 2.0.11
-      pathe: 2.0.3
-      rou3: 0.9.2
-      std-env: 4.2.0
-      ufo: 1.6.4
-      unctx: 3.0.0(magic-string@1.1.1)(oxc-parser@0.141.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))
-      unstorage: 1.17.5(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))
+      unstorage: 1.17.5(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))
       vue: 3.5.41(typescript@7.0.2)
       vue-bundle-renderer: 2.3.2
       vue-devtools-stub: 0.1.0
@@ -22655,7 +22276,7 @@ snapshots:
       rc9: 3.0.1
       std-env: 4.2.0
 
-  '@nuxt/vite-builder@4.5.1(@babel/plugin-proposal-decorators@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@types/node@24.13.3)(esbuild@0.28.2)(magic-string@1.1.1)(magicast@0.5.4)(nuxt@4.5.1(38a0ae7adc2044c05f636f188c0deddc))(oxc-parser@0.141.0)(oxlint@1.80.0)(rolldown@1.2.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.5)(rollup@4.62.4))(rollup@4.62.4)(supports-color@10.2.2)(terser@5.50.0)(tsx@4.23.12)(typescript@7.0.2)(vue-tsc@3.3.9(typescript@7.0.2))(vue@3.5.41(typescript@7.0.2))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))(yaml@2.9.0)':
+  '@nuxt/vite-builder@4.5.1(@babel/plugin-proposal-decorators@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@types/node@24.13.3)(esbuild@0.28.2)(magic-string@1.1.1)(magicast@0.5.4)(nuxt@4.5.1(8afcc381206f858c9998bb23d771b3c2))(oxc-parser@0.141.0)(oxlint@1.80.0)(rolldown@1.2.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.5)(rollup@4.62.4))(rollup@4.62.4)(supports-color@10.2.2)(terser@5.50.0)(tsx@4.23.12)(typescript@7.0.2)(vue-tsc@3.3.9(typescript@7.0.2))(vue@3.5.41(typescript@7.0.2))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))(yaml@2.9.0)':
     dependencies:
       '@nuxt/kit': 4.5.1(magic-string@1.1.1)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))
       '@vitejs/plugin-vue': 6.0.8(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(vue@3.5.41(typescript@7.0.2))
@@ -22673,7 +22294,7 @@ snapshots:
       knitwork: 1.3.0
       mlly: 1.8.2
       mocked-exports: 0.1.1
-      nuxt: 4.5.1(38a0ae7adc2044c05f636f188c0deddc)
+      nuxt: 4.5.1(8afcc381206f858c9998bb23d771b3c2)
       nypm: 0.6.9
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -22725,7 +22346,7 @@ snapshots:
       - webpack
       - yaml
 
-  '@nuxt/vite-builder@4.5.1(@babel/plugin-proposal-decorators@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@types/node@26.2.0)(esbuild@0.28.2)(magic-string@1.1.1)(magicast@0.5.4)(nuxt@4.5.1(0baa57aa261304dcdb12983501874da1))(oxc-parser@0.141.0)(oxlint@1.80.0)(rolldown@1.2.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.5)(rollup@4.62.4))(rollup@4.62.4)(supports-color@10.2.2)(terser@5.50.0)(tsx@4.23.12)(typescript@7.0.2)(vue-tsc@3.3.9(typescript@7.0.2))(vue@3.5.41(typescript@7.0.2))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))(yaml@2.9.0)':
+  '@nuxt/vite-builder@4.5.1(@babel/plugin-proposal-decorators@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@types/node@26.2.0)(esbuild@0.28.2)(magic-string@1.1.1)(magicast@0.5.4)(nuxt@4.5.1(10f78aabed4c566ba3a2c1702c35888c))(oxc-parser@0.141.0)(oxlint@1.80.0)(rolldown@1.2.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.5)(rollup@4.62.4))(rollup@4.62.4)(supports-color@10.2.2)(terser@5.50.0)(tsx@4.23.12)(typescript@7.0.2)(vue-tsc@3.3.9(typescript@7.0.2))(vue@3.5.41(typescript@7.0.2))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))(yaml@2.9.0)':
     dependencies:
       '@nuxt/kit': 4.5.1(magic-string@1.1.1)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))
       '@vitejs/plugin-vue': 6.0.8(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(vue@3.5.41(typescript@7.0.2))
@@ -22743,7 +22364,7 @@ snapshots:
       knitwork: 1.3.0
       mlly: 1.8.2
       mocked-exports: 0.1.1
-      nuxt: 4.5.1(0baa57aa261304dcdb12983501874da1)
+      nuxt: 4.5.1(10f78aabed4c566ba3a2c1702c35888c)
       nypm: 0.6.9
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -22795,7 +22416,7 @@ snapshots:
       - webpack
       - yaml
 
-  '@nuxt/vite-builder@4.5.1(@babel/plugin-proposal-decorators@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@types/node@26.2.0)(esbuild@0.28.2)(magic-string@1.1.1)(magicast@0.5.4)(nuxt@4.5.1(6cab6962d170d75e6cc46dcb3ab1fb0a))(oxc-parser@0.141.0)(oxlint@1.80.0)(rolldown@1.2.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.5)(rollup@4.62.4))(rollup@4.62.4)(supports-color@10.2.2)(terser@5.50.0)(tsx@4.23.12)(typescript@7.0.2)(vue@3.5.41(typescript@7.0.2))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))(yaml@2.9.0)':
+  '@nuxt/vite-builder@4.5.1(@babel/plugin-proposal-decorators@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@types/node@26.2.0)(esbuild@0.28.2)(magic-string@1.1.1)(magicast@0.5.4)(nuxt@4.5.1(3206fa55841a5479ca4c78edc8ffa76d))(oxc-parser@0.141.0)(oxlint@1.80.0)(rolldown@1.2.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.5)(rollup@4.62.4))(rollup@4.62.4)(supports-color@10.2.2)(terser@5.50.0)(tsx@4.23.12)(typescript@7.0.2)(vue@3.5.41(typescript@7.0.2))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))(yaml@2.9.0)':
     dependencies:
       '@nuxt/kit': 4.5.1(magic-string@1.1.1)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))
       '@vitejs/plugin-vue': 6.0.8(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(vue@3.5.41(typescript@7.0.2))
@@ -22813,7 +22434,7 @@ snapshots:
       knitwork: 1.3.0
       mlly: 1.8.2
       mocked-exports: 0.1.1
-      nuxt: 4.5.1(6cab6962d170d75e6cc46dcb3ab1fb0a)
+      nuxt: 4.5.1(3206fa55841a5479ca4c78edc8ffa76d)
       nypm: 0.6.9
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -23115,7 +22736,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@opennextjs/cloudflare@1.20.1(next@16.2.10(@babel/core@7.29.7(supports-color@10.2.2))(@playwright/test@1.62.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@10.2.2)(wrangler@4.114.0(@cloudflare/workers-types@5.20260812.1))':
+  '@opennextjs/cloudflare@1.20.1(next@16.2.10(@babel/core@7.29.7(supports-color@10.2.2))(@playwright/test@1.62.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@10.2.2)(wrangler@4.114.0(@cloudflare/workers-types@5.20260901.1))':
     dependencies:
       '@ast-grep/napi': 0.40.5
       '@dotenvx/dotenvx': 1.31.0
@@ -23127,7 +22748,25 @@ snapshots:
       glob: 12.0.0
       next: 16.2.10(@babel/core@7.29.7(supports-color@10.2.2))(@playwright/test@1.62.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       ts-tqdm: 0.8.6
-      wrangler: 4.114.0(@cloudflare/workers-types@5.20260812.1)
+      wrangler: 4.114.0(@cloudflare/workers-types@5.20260901.1)
+      yargs: 18.1.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@opennextjs/cloudflare@1.20.1(next@16.2.10(@babel/core@7.29.7(supports-color@10.2.2))(@playwright/test@1.62.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@10.2.2)(wrangler@4.124.0(@cloudflare/workers-types@5.20260901.1))':
+    dependencies:
+      '@ast-grep/napi': 0.40.5
+      '@dotenvx/dotenvx': 1.31.0
+      '@opennextjs/aws': 4.0.2(next@16.2.10(@babel/core@7.29.7(supports-color@10.2.2))(@playwright/test@1.62.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@10.2.2)
+      ci-info: 4.4.0
+      cloudflare: 4.5.0
+      comment-json: 4.6.2
+      enquirer: 2.4.1
+      glob: 12.0.0
+      next: 16.2.10(@babel/core@7.29.7(supports-color@10.2.2))(@playwright/test@1.62.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      ts-tqdm: 0.8.6
+      wrangler: 4.124.0(@cloudflare/workers-types@5.20260901.1)
       yargs: 18.1.0
     transitivePeerDependencies:
       - encoding
@@ -23933,7 +23572,7 @@ snapshots:
     dependencies:
       react: 19.2.8
 
-  '@react-router/dev@7.16.0(@types/node@26.2.0)(@vitejs/plugin-rsc@0.5.34(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(react@19.2.8)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))(jiti@2.7.0)(lightningcss@1.33.0)(react-router@7.16.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(supports-color@10.2.2)(terser@5.50.0)(tsx@4.23.12)(typescript@7.0.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(wrangler@4.114.0(@cloudflare/workers-types@5.20260812.1))(yaml@2.9.0)':
+  '@react-router/dev@7.16.0(@types/node@26.2.0)(@vitejs/plugin-rsc@0.5.34(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(react@19.2.8)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))(jiti@2.7.0)(lightningcss@1.33.0)(react-router@7.16.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(supports-color@10.2.2)(terser@5.50.0)(tsx@4.23.12)(typescript@7.0.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(wrangler@4.114.0(@cloudflare/workers-types@5.20260901.1))(yaml@2.9.0)':
     dependencies:
       '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/generator': 7.29.8
@@ -23969,7 +23608,59 @@ snapshots:
       '@vitejs/plugin-rsc': 0.5.34(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(react@19.2.8)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
       react-server-dom-webpack: 19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
       typescript: 7.0.2
-      wrangler: 4.114.0(@cloudflare/workers-types@5.20260812.1)
+      wrangler: 4.114.0(@cloudflare/workers-types@5.20260901.1)
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  '@react-router/dev@7.16.0(@types/node@26.2.0)(@vitejs/plugin-rsc@0.5.34(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(react@19.2.8)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))(jiti@2.7.0)(lightningcss@1.33.0)(react-router@7.16.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(supports-color@10.2.2)(terser@5.50.0)(tsx@4.23.12)(typescript@7.0.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(wrangler@4.124.0(@cloudflare/workers-types@5.20260901.1))(yaml@2.9.0)':
+    dependencies:
+      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/generator': 7.29.8
+      '@babel/parser': 7.29.8
+      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/preset-typescript': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/traverse': 7.29.8(supports-color@10.2.2)
+      '@babel/types': 7.29.8
+      '@react-router/node': 7.16.0(react-router@7.16.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(typescript@7.0.2)
+      '@remix-run/node-fetch-server': 0.13.3
+      arg: 5.0.2
+      babel-dead-code-elimination: 1.0.12(supports-color@10.2.2)
+      chokidar: 4.0.3
+      dedent: 1.7.2
+      es-module-lexer: 1.7.0
+      exit-hook: 2.2.1
+      isbot: 5.2.1
+      jsesc: 3.0.2
+      lodash: 4.18.1
+      p-map: 7.0.6
+      pathe: 1.1.2
+      picocolors: 1.1.1
+      pkg-types: 2.3.1
+      prettier: 3.9.6
+      react-refresh: 0.14.2
+      react-router: 7.16.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      semver: 7.8.5
+      tinyglobby: 0.2.17
+      valibot: 1.2.0(typescript@7.0.2)
+      vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
+      vite-node: 3.2.4(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(supports-color@10.2.2)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
+    optionalDependencies:
+      '@vitejs/plugin-rsc': 0.5.34(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(react@19.2.8)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+      react-server-dom-webpack: 19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
+      typescript: 7.0.2
+      wrangler: 4.124.0(@cloudflare/workers-types@5.20260901.1)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -25096,9 +24787,9 @@ snapshots:
       - crossws
       - supports-color
 
-  '@solidjs/vite-plugin-nitro-2@0.3.2(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))':
+  '@solidjs/vite-plugin-nitro-2@0.3.2(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))':
     dependencies:
-      nitropack: 2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
+      nitropack: 2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
       vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -27676,13 +27367,13 @@ snapshots:
 
   astring@1.9.0: {}
 
-  astro-expressive-code@0.44.1(astro@7.2.0(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@3.25.76))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)):
+  astro-expressive-code@0.44.1(astro@7.2.0(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@3.25.76))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)):
     dependencies:
-      astro: 7.2.0(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@3.25.76))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
+      astro: 7.2.0(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@3.25.76))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
       rehype-expressive-code: 0.44.1
       url-extras: 0.1.0
 
-  astro@7.2.0(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@3.25.76))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0):
+  astro@7.2.0(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@3.25.76))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0):
     dependencies:
       '@astrojs/compiler-rs': 0.3.2(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)
       '@astrojs/internal-helpers': 0.10.2
@@ -27730,7 +27421,7 @@ snapshots:
       tinyglobby: 0.2.17
       ultrahtml: 1.7.0
       unifont: 0.7.5
-      unstorage: 1.17.5(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@3.25.76))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))
+      unstorage: 1.17.5(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@3.25.76))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))
       vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
       vitefu: 1.1.3(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
       xxhash-wasm: 1.1.0
@@ -27773,7 +27464,7 @@ snapshots:
       - uploadthing
       - yaml
 
-  astro@7.2.0(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0):
+  astro@7.2.0(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0):
     dependencies:
       '@astrojs/compiler-rs': 0.3.2(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)
       '@astrojs/internal-helpers': 0.10.2
@@ -27821,7 +27512,7 @@ snapshots:
       tinyglobby: 0.2.17
       ultrahtml: 1.7.0
       unifont: 0.7.5
-      unstorage: 1.17.5(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))
+      unstorage: 1.17.5(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))
       vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
       vitefu: 1.1.3(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
       xxhash-wasm: 1.1.0
@@ -27967,15 +27658,15 @@ snapshots:
 
   before-after-hook@4.0.0: {}
 
-  better-auth@1.6.25(aca4c2f227e13471598301066580e538):
+  better-auth@1.6.25(e20f5e9f480a52fe3a4e9438c63ccf5e):
     dependencies:
-      '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260812.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2)
-      '@better-auth/drizzle-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260812.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))
-      '@better-auth/kysely-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260812.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(kysely@0.29.5)
-      '@better-auth/memory-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260812.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)
-      '@better-auth/mongo-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260812.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(mongodb@6.21.0(@aws-sdk/credential-providers@3.1095.0)(socks@2.8.9))
-      '@better-auth/prisma-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260812.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)
-      '@better-auth/telemetry': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260812.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
+      '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260901.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2)
+      '@better-auth/drizzle-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260901.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))
+      '@better-auth/kysely-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260901.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(kysely@0.29.5)
+      '@better-auth/memory-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260901.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)
+      '@better-auth/mongo-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260901.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(mongodb@6.21.0(@aws-sdk/credential-providers@3.1095.0)(socks@2.8.9))
+      '@better-auth/prisma-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260901.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)
+      '@better-auth/telemetry': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260901.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
       '@noble/ciphers': 2.3.0
@@ -27990,7 +27681,7 @@ snapshots:
       '@tanstack/react-start': 1.168.49(@vitejs/plugin-rsc@0.5.34(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(react@19.2.8)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))(crossws@0.4.10(srvx@0.12.5))(esbuild@0.28.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.5)(rollup@4.62.4)(supports-color@10.2.2)(vite-plugin-solid@2.11.14(solid-js@1.9.15)(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
       '@tanstack/solid-start': 1.168.42(@tanstack/react-router@1.170.32(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(crossws@0.4.10(srvx@0.12.5))(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(solid-js@1.9.15)(supports-color@10.2.2)(vite-plugin-solid@2.11.14(solid-js@1.9.15)(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
       drizzle-kit: 1.0.0-rc.5-ab785fc
-      drizzle-orm: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3)
+      drizzle-orm: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3)
       mongodb: 6.21.0(@aws-sdk/credential-providers@3.1095.0)(socks@2.8.9)
       mysql2: 3.24.2(@types/node@26.2.0)
       next: 16.2.10(@babel/core@7.29.7(supports-color@10.2.2))(@playwright/test@1.62.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -28157,13 +27848,13 @@ snapshots:
 
   caniuse-lite@1.0.30001809: {}
 
-  capnp-es@0.0.14(typescript@7.0.2):
+  capnp-es@0.0.16(typescript@7.0.2):
     optionalDependencies:
       typescript: 7.0.2
 
-  capnweb@0.6.1: {}
+  capnweb@0.12.0: {}
 
-  capnweb@0.8.0: {}
+  capnweb@0.6.1: {}
 
   ccount@2.0.1: {}
 
@@ -28260,7 +27951,7 @@ snapshots:
 
   citty@0.2.2: {}
 
-  cjs-module-lexer@1.4.3: {}
+  cjs-module-lexer@1.2.3: {}
 
   class-variance-authority@0.7.1:
     dependencies:
@@ -28536,26 +28227,26 @@ snapshots:
 
   dayjs@1.11.21: {}
 
-  db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@24.13.3)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@24.13.3))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@24.13.3)):
+  db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@24.13.3)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@24.13.3))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@24.13.3)):
     optionalDependencies:
       '@electric-sql/pglite': 0.3.15
       '@libsql/client': 0.17.4
-      drizzle-orm: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@24.13.3)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@24.13.3))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3)
+      drizzle-orm: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@24.13.3)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@24.13.3))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3)
       mysql2: 3.24.2(@types/node@24.13.3)
 
-  db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@3.25.76))(mysql2@3.24.2(@types/node@26.2.0)):
+  db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@3.25.76))(mysql2@3.24.2(@types/node@26.2.0)):
     optionalDependencies:
       '@electric-sql/pglite': 0.3.15
       '@libsql/client': 0.17.4
-      drizzle-orm: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@3.25.76)
+      drizzle-orm: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@3.25.76)
       mysql2: 3.24.2(@types/node@26.2.0)
     optional: true
 
-  db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)):
+  db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)):
     optionalDependencies:
       '@electric-sql/pglite': 0.3.15
       '@libsql/client': 0.17.4
-      drizzle-orm: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3)
+      drizzle-orm: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3)
       mysql2: 3.24.2(@types/node@26.2.0)
 
   debug@4.4.3(supports-color@10.2.2):
@@ -28662,9 +28353,9 @@ snapshots:
       get-tsconfig: 4.14.2
       jiti: 2.7.0
 
-  drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@24.13.3)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@24.13.3))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3):
+  drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@24.13.3)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@24.13.3))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3):
     optionalDependencies:
-      '@cloudflare/workers-types': 5.20260812.1
+      '@cloudflare/workers-types': 5.20260901.1
       '@effect/sql-d1': 4.0.0-rc.112(effect@4.0.0-rc.112)
       '@effect/sql-mysql2': 4.0.0-rc.112(@types/node@24.13.3)(effect@4.0.0-rc.112)
       '@effect/sql-pg': 4.0.0-rc.112(effect@4.0.0-rc.112)
@@ -28682,9 +28373,9 @@ snapshots:
       zod: 4.4.3
     optional: true
 
-  drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@3.25.76):
+  drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@3.25.76):
     optionalDependencies:
-      '@cloudflare/workers-types': 5.20260812.1
+      '@cloudflare/workers-types': 5.20260901.1
       '@effect/sql-d1': 4.0.0-rc.112(effect@4.0.0-rc.112)
       '@effect/sql-mysql2': 4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112)
       '@effect/sql-pg': 4.0.0-rc.112(effect@4.0.0-rc.112)
@@ -28702,9 +28393,9 @@ snapshots:
       zod: 3.25.76
     optional: true
 
-  drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3):
+  drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3):
     optionalDependencies:
-      '@cloudflare/workers-types': 5.20260812.1
+      '@cloudflare/workers-types': 5.20260901.1
       '@effect/sql-d1': 4.0.0-rc.112(effect@4.0.0-rc.112)
       '@effect/sql-mysql2': 4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112)
       '@effect/sql-pg': 4.0.0-rc.112(effect@4.0.0-rc.112)
@@ -28794,7 +28485,7 @@ snapshots:
 
   entities@8.0.0: {}
 
-  env-runner@0.1.16(miniflare@4.20260722.0)(wrangler@4.114.0(@cloudflare/workers-types@5.20260812.1)):
+  env-runner@0.1.16(miniflare@4.20260722.0)(wrangler@4.124.0(@cloudflare/workers-types@5.20260901.1)):
     dependencies:
       crossws: 0.4.10(srvx@0.11.22)
       exsolve: 1.1.1
@@ -28802,7 +28493,7 @@ snapshots:
       srvx: 0.11.22
     optionalDependencies:
       miniflare: 4.20260722.0
-      wrangler: 4.114.0(@cloudflare/workers-types@5.20260812.1)
+      wrangler: 4.124.0(@cloudflare/workers-types@5.20260901.1)
 
   error-ex@1.3.4:
     dependencies:
@@ -28925,35 +28616,6 @@ snapshots:
       '@esbuild/win32-arm64': 0.25.4
       '@esbuild/win32-ia32': 0.25.4
       '@esbuild/win32-x64': 0.25.4
-
-  esbuild@0.27.3:
-    optionalDependencies:
-      '@esbuild/aix-ppc64': 0.27.3
-      '@esbuild/android-arm': 0.27.3
-      '@esbuild/android-arm64': 0.27.3
-      '@esbuild/android-x64': 0.27.3
-      '@esbuild/darwin-arm64': 0.27.3
-      '@esbuild/darwin-x64': 0.27.3
-      '@esbuild/freebsd-arm64': 0.27.3
-      '@esbuild/freebsd-x64': 0.27.3
-      '@esbuild/linux-arm': 0.27.3
-      '@esbuild/linux-arm64': 0.27.3
-      '@esbuild/linux-ia32': 0.27.3
-      '@esbuild/linux-loong64': 0.27.3
-      '@esbuild/linux-mips64el': 0.27.3
-      '@esbuild/linux-ppc64': 0.27.3
-      '@esbuild/linux-riscv64': 0.27.3
-      '@esbuild/linux-s390x': 0.27.3
-      '@esbuild/linux-x64': 0.27.3
-      '@esbuild/netbsd-arm64': 0.27.3
-      '@esbuild/netbsd-x64': 0.27.3
-      '@esbuild/openbsd-arm64': 0.27.3
-      '@esbuild/openbsd-x64': 0.27.3
-      '@esbuild/openharmony-arm64': 0.27.3
-      '@esbuild/sunos-x64': 0.27.3
-      '@esbuild/win32-arm64': 0.27.3
-      '@esbuild/win32-ia32': 0.27.3
-      '@esbuild/win32-x64': 0.27.3
 
   esbuild@0.28.1:
     optionalDependencies:
@@ -30956,24 +30618,24 @@ snapshots:
 
   mimic-fn@4.0.0: {}
 
-  miniflare@4.20260317.3:
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      sharp: 0.34.5
-      undici: 7.24.4
-      workerd: 1.20260317.1
-      ws: 8.18.0
-      youch: 4.1.0-beta.10
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-
   miniflare@4.20260722.0:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.35.2
       undici: 7.28.0
-      workerd: 1.20260722.1
+      workerd: 1.20260901.1
+      ws: 8.21.0
+      youch: 4.1.0-beta.10
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  miniflare@5.20260815.0-alpha:
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      sharp: 0.35.2
+      undici: 7.29.0
+      workerd: 1.20260901.1
       ws: 8.21.0
       youch: 4.1.0-beta.10
     transitivePeerDependencies:
@@ -31166,12 +30828,12 @@ snapshots:
 
   nf3@0.3.23: {}
 
-  nitro@3.0.260415-beta(3a8120cc95eaa7c634e8c0d4e0c76d72):
+  nitro@3.0.260415-beta(c9f87dee608690d191681cb8190233ef):
     dependencies:
       consola: 3.4.2
       crossws: 0.4.10(srvx@0.11.22)
-      db0: 0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0))
-      env-runner: 0.1.16(miniflare@4.20260722.0)(wrangler@4.114.0(@cloudflare/workers-types@5.20260812.1))
+      db0: 0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0))
+      env-runner: 0.1.16(miniflare@4.20260722.0)(wrangler@4.124.0(@cloudflare/workers-types@5.20260901.1))
       h3: 2.0.1-rc.26(crossws@0.4.10(srvx@0.11.22))
       hookable: 6.1.1
       nf3: 0.3.23
@@ -31181,7 +30843,7 @@ snapshots:
       rolldown: 1.2.5
       srvx: 0.11.22
       unenv: 2.0.0-rc.24
-      unstorage: 2.0.0-alpha.7(aws4fetch@1.0.20)(chokidar@5.0.0)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(lru-cache@11.5.2)(mongodb@6.21.0(@aws-sdk/credential-providers@3.1095.0)(socks@2.8.9))(ofetch@2.0.0-alpha.3)
+      unstorage: 2.0.0-alpha.7(aws4fetch@1.0.20)(chokidar@5.0.0)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(lru-cache@11.5.2)(mongodb@6.21.0(@aws-sdk/credential-providers@3.1095.0)(socks@2.8.9))(ofetch@2.0.0-alpha.3)
     optionalDependencies:
       dotenv: 17.4.2
       giget: 3.3.1
@@ -31220,7 +30882,7 @@ snapshots:
       - uploadthing
       - wrangler
 
-  nitropack@2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@24.13.3)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@24.13.3))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@24.13.3))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)):
+  nitropack@2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@24.13.3)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@24.13.3))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@24.13.3))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.2
       '@rollup/plugin-alias': 6.0.0(rollup@4.62.4)
@@ -31241,7 +30903,7 @@ snapshots:
       cookie-es: 2.0.1
       croner: 10.0.1
       crossws: 0.3.5
-      db0: 0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@24.13.3)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@24.13.3))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@24.13.3))
+      db0: 0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@24.13.3)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@24.13.3))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@24.13.3))
       defu: 6.1.7
       destr: 2.0.5
       dot-prop: 10.2.0
@@ -31287,7 +30949,7 @@ snapshots:
       unenv: 2.0.0-rc.24
       unimport: 6.4.0(esbuild@0.28.2)(oxc-parser@0.141.0)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
       unplugin-utils: 0.3.2
-      unstorage: 1.17.5(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@24.13.3)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@24.13.3))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@24.13.3)))(ioredis@5.11.1(supports-color@10.2.2))
+      unstorage: 1.17.5(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@24.13.3)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@24.13.3))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@24.13.3)))(ioredis@5.11.1(supports-color@10.2.2))
       untyped: 2.0.0
       unwasm: 0.5.3
       youch: 4.1.1
@@ -31332,7 +30994,7 @@ snapshots:
       - vite
       - webpack
 
-  nitropack@2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)):
+  nitropack@2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.2
       '@rollup/plugin-alias': 6.0.0(rollup@4.62.4)
@@ -31353,7 +31015,7 @@ snapshots:
       cookie-es: 2.0.1
       croner: 10.0.1
       crossws: 0.3.5
-      db0: 0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0))
+      db0: 0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0))
       defu: 6.1.7
       destr: 2.0.5
       dot-prop: 10.2.0
@@ -31399,7 +31061,7 @@ snapshots:
       unenv: 2.0.0-rc.24
       unimport: 6.4.0(esbuild@0.28.2)(oxc-parser@0.141.0)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
       unplugin-utils: 0.3.2
-      unstorage: 1.17.5(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))
+      unstorage: 1.17.5(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))
       untyped: 2.0.0
       unwasm: 0.5.3
       youch: 4.1.1
@@ -31465,7 +31127,7 @@ snapshots:
       cookie-es: 2.0.1
       croner: 10.0.1
       crossws: 0.3.5
-      db0: 0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0))
+      db0: 0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0))
       defu: 6.1.7
       destr: 2.0.5
       dot-prop: 10.2.0
@@ -31577,7 +31239,7 @@ snapshots:
       cookie-es: 2.0.1
       croner: 10.0.1
       crossws: 0.3.5
-      db0: 0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0))
+      db0: 0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0))
       defu: 6.1.7
       destr: 2.0.5
       dot-prop: 10.2.0
@@ -31754,16 +31416,16 @@ snapshots:
       next: 16.2.10(@babel/core@7.29.7(supports-color@10.2.2))(@playwright/test@1.62.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react-router: 7.16.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
 
-  nuxt@4.5.1(0baa57aa261304dcdb12983501874da1):
+  nuxt@4.5.1(10f78aabed4c566ba3a2c1702c35888c):
     dependencies:
       '@dxup/nuxt': 0.5.6(esbuild@0.28.2)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
       '@nuxt/cli': 3.37.0(@nuxt/schema@4.5.1)(cac@6.7.14)(commander@14.0.3)(magicast@0.5.4)(supports-color@10.2.2)
-      '@nuxt/devtools': 3.4.1(0f01304e996d82e0188901d54c1d087f)
+      '@nuxt/devtools': 3.4.1(43838925e6dd8e4c5211d688814ddf88)
       '@nuxt/kit': 4.5.1(magic-string@1.1.1)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))
-      '@nuxt/nitro-server': 4.5.1(f283711819bf0c35ec6a413078787585)
+      '@nuxt/nitro-server': 4.5.1(808cd65123b8fff3717bb5ce3ac4d244)
       '@nuxt/schema': 4.5.1
       '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.5.1(magic-string@1.1.1)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))))
-      '@nuxt/vite-builder': 4.5.1(@babel/plugin-proposal-decorators@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@types/node@26.2.0)(esbuild@0.28.2)(magic-string@1.1.1)(magicast@0.5.4)(nuxt@4.5.1(0baa57aa261304dcdb12983501874da1))(oxc-parser@0.141.0)(oxlint@1.80.0)(rolldown@1.2.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.5)(rollup@4.62.4))(rollup@4.62.4)(supports-color@10.2.2)(terser@5.50.0)(tsx@4.23.12)(typescript@7.0.2)(vue-tsc@3.3.9(typescript@7.0.2))(vue@3.5.41(typescript@7.0.2))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))(yaml@2.9.0)
+      '@nuxt/vite-builder': 4.5.1(@babel/plugin-proposal-decorators@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@types/node@26.2.0)(esbuild@0.28.2)(magic-string@1.1.1)(magicast@0.5.4)(nuxt@4.5.1(10f78aabed4c566ba3a2c1702c35888c))(oxc-parser@0.141.0)(oxlint@1.80.0)(rolldown@1.2.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.5)(rollup@4.62.4))(rollup@4.62.4)(supports-color@10.2.2)(terser@5.50.0)(tsx@4.23.12)(typescript@7.0.2)(vue-tsc@3.3.9(typescript@7.0.2))(vue@3.5.41(typescript@7.0.2))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))(yaml@2.9.0)
       '@unhead/vue': 3.3.1(@oxc-project/types@0.146.0)(esbuild@0.28.2)(lightningcss@1.33.0)(oxc-parser@0.141.0)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(vue@3.5.41(typescript@7.0.2))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
       '@vue/shared': 3.5.41
       chokidar: 5.0.0
@@ -31894,16 +31556,156 @@ snapshots:
       - xml2js
       - yaml
 
-  nuxt@4.5.1(38a0ae7adc2044c05f636f188c0deddc):
+  nuxt@4.5.1(3206fa55841a5479ca4c78edc8ffa76d):
+    dependencies:
+      '@dxup/nuxt': 0.5.6(esbuild@0.28.2)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
+      '@nuxt/cli': 3.37.0(@nuxt/schema@4.5.1)(cac@6.7.14)(commander@14.0.3)(magicast@0.5.4)(supports-color@10.2.2)
+      '@nuxt/devtools': 3.4.1(43838925e6dd8e4c5211d688814ddf88)
+      '@nuxt/kit': 4.5.1(magic-string@1.1.1)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))
+      '@nuxt/nitro-server': 4.5.1(3d27890fc752a9e5fee4b61c79d6b3e7)
+      '@nuxt/schema': 4.5.1
+      '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.5.1(magic-string@1.1.1)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))))
+      '@nuxt/vite-builder': 4.5.1(@babel/plugin-proposal-decorators@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@types/node@26.2.0)(esbuild@0.28.2)(magic-string@1.1.1)(magicast@0.5.4)(nuxt@4.5.1(3206fa55841a5479ca4c78edc8ffa76d))(oxc-parser@0.141.0)(oxlint@1.80.0)(rolldown@1.2.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.5)(rollup@4.62.4))(rollup@4.62.4)(supports-color@10.2.2)(terser@5.50.0)(tsx@4.23.12)(typescript@7.0.2)(vue@3.5.41(typescript@7.0.2))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))(yaml@2.9.0)
+      '@unhead/vue': 3.3.1(@oxc-project/types@0.146.0)(esbuild@0.28.2)(lightningcss@1.33.0)(oxc-parser@0.141.0)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(vue@3.5.41(typescript@7.0.2))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
+      '@vue/shared': 3.5.41
+      chokidar: 5.0.0
+      compatx: 0.2.0
+      consola: 3.4.2
+      cookie-es: 3.1.1
+      defu: 6.1.7
+      devalue: 5.9.0
+      errx: 0.1.2
+      escape-string-regexp: 5.0.0
+      exsolve: 1.1.1
+      fnv1a-64: 0.1.2
+      hookable: 6.1.1
+      ignore: 7.0.6
+      impound: 1.1.6(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
+      jiti: 2.7.0
+      klona: 2.0.6
+      knitwork: 1.3.0
+      magic-string: 1.1.1
+      mlly: 1.8.2
+      nanotar: 0.3.0
+      nostics: 1.2.0
+      nypm: 0.6.9
+      object-identity: 0.2.3
+      ofetch: 1.5.1
+      ohash: 2.0.11
+      on-change: 6.0.2
+      oxc-walker: 1.1.1(@oxc-project/types@0.146.0)(oxc-parser@0.141.0)(rolldown@1.2.5)
+      pathe: 2.0.3
+      perfect-debounce: 2.1.0
+      picomatch: 4.0.5
+      pkg-types: 2.3.1
+      rolldown: 1.2.5
+      rolldown-string: 0.3.1(rolldown@1.2.5)
+      rou3: 0.9.2
+      scule: 1.3.0
+      std-env: 4.2.0
+      tinyglobby: 0.2.17
+      ufo: 1.6.4
+      ultrahtml: 1.7.0
+      uncrypto: 0.1.3
+      unctx: 3.0.0(magic-string@1.1.1)(oxc-parser@0.141.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))
+      undici: 8.10.0
+      unhead: 3.3.1(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
+      unimport: 6.4.0(esbuild@0.28.2)(oxc-parser@0.141.0)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
+      unplugin: 3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
+      unrouting: 0.2.3
+      untyped: 2.0.0
+      verkit: 0.2.0
+      vue: 3.5.41(typescript@7.0.2)
+      vue-router: 5.2.0(@vue/compiler-sfc@3.5.41)(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(vue@3.5.41(typescript@7.0.2))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
+    optionalDependencies:
+      '@types/node': 26.2.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@babel/plugin-proposal-decorators'
+      - '@babel/plugin-syntax-jsx'
+      - '@babel/plugin-syntax-typescript'
+      - '@biomejs/biome'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@electric-sql/pglite'
+      - '@farmfe/core'
+      - '@libsql/client'
+      - '@netlify/blobs'
+      - '@oxc-project/types'
+      - '@pinia/colada'
+      - '@planetscale/database'
+      - '@rollup/plugin-babel'
+      - '@rspack/core'
+      - '@unhead/cli'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - '@vitejs/devtools'
+      - '@vitejs/devtools-kit'
+      - '@vue/compiler-sfc'
+      - aws4fetch
+      - bare-abort-controller
+      - bare-buffer
+      - better-sqlite3
+      - bufferutil
+      - bun-types-no-globals
+      - cac
+      - commander
+      - db0
+      - drizzle-orm
+      - encoding
+      - esbuild
+      - eslint
+      - idb-keyval
+      - ioredis
+      - less
+      - lightningcss
+      - magicast
+      - meow
+      - mysql2
+      - optionator
+      - oxc-parser
+      - oxlint
+      - pinia
+      - react-native-b4a
+      - rollup
+      - rollup-plugin-visualizer
+      - sass
+      - sass-embedded
+      - sqlite3
+      - srvx
+      - stylelint
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - typescript
+      - unloader
+      - uploadthing
+      - utf-8-validate
+      - vite
+      - vue-tsc
+      - webpack
+      - xml2js
+      - yaml
+
+  nuxt@4.5.1(8afcc381206f858c9998bb23d771b3c2):
     dependencies:
       '@dxup/nuxt': 0.5.6(esbuild@0.28.2)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
       '@nuxt/cli': 3.37.0(@nuxt/schema@4.5.1)(cac@6.7.14)(commander@14.0.3)(magicast@0.5.4)(supports-color@10.2.2)
-      '@nuxt/devtools': 3.4.1(b06e89db0111218d09dacaed53684127)
+      '@nuxt/devtools': 3.4.1(ccf5a9ec274278f63e2846585aff94a3)
       '@nuxt/kit': 4.5.1(magic-string@1.1.1)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))
-      '@nuxt/nitro-server': 4.5.1(10af6e4963100980c58174bdb5ff7e07)
+      '@nuxt/nitro-server': 4.5.1(516d1c970fdf1dd30df0f7fc08558cdd)
       '@nuxt/schema': 4.5.1
       '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.5.1(magic-string@1.1.1)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))))
-      '@nuxt/vite-builder': 4.5.1(@babel/plugin-proposal-decorators@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@types/node@24.13.3)(esbuild@0.28.2)(magic-string@1.1.1)(magicast@0.5.4)(nuxt@4.5.1(38a0ae7adc2044c05f636f188c0deddc))(oxc-parser@0.141.0)(oxlint@1.80.0)(rolldown@1.2.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.5)(rollup@4.62.4))(rollup@4.62.4)(supports-color@10.2.2)(terser@5.50.0)(tsx@4.23.12)(typescript@7.0.2)(vue-tsc@3.3.9(typescript@7.0.2))(vue@3.5.41(typescript@7.0.2))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))(yaml@2.9.0)
+      '@nuxt/vite-builder': 4.5.1(@babel/plugin-proposal-decorators@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@types/node@24.13.3)(esbuild@0.28.2)(magic-string@1.1.1)(magicast@0.5.4)(nuxt@4.5.1(8afcc381206f858c9998bb23d771b3c2))(oxc-parser@0.141.0)(oxlint@1.80.0)(rolldown@1.2.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.5)(rollup@4.62.4))(rollup@4.62.4)(supports-color@10.2.2)(terser@5.50.0)(tsx@4.23.12)(typescript@7.0.2)(vue-tsc@3.3.9(typescript@7.0.2))(vue@3.5.41(typescript@7.0.2))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))(yaml@2.9.0)
       '@unhead/vue': 3.3.1(@oxc-project/types@0.146.0)(esbuild@0.28.2)(lightningcss@1.33.0)(oxc-parser@0.141.0)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(vue@3.5.41(typescript@7.0.2))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
       '@vue/shared': 3.5.41
       chokidar: 5.0.0
@@ -31957,146 +31759,6 @@ snapshots:
       vue-router: 5.2.0(@vue/compiler-sfc@3.5.41)(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(vue@3.5.41(typescript@7.0.2))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
     optionalDependencies:
       '@types/node': 24.13.3
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@babel/plugin-proposal-decorators'
-      - '@babel/plugin-syntax-jsx'
-      - '@babel/plugin-syntax-typescript'
-      - '@biomejs/biome'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@electric-sql/pglite'
-      - '@farmfe/core'
-      - '@libsql/client'
-      - '@netlify/blobs'
-      - '@oxc-project/types'
-      - '@pinia/colada'
-      - '@planetscale/database'
-      - '@rollup/plugin-babel'
-      - '@rspack/core'
-      - '@unhead/cli'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - '@vitejs/devtools'
-      - '@vitejs/devtools-kit'
-      - '@vue/compiler-sfc'
-      - aws4fetch
-      - bare-abort-controller
-      - bare-buffer
-      - better-sqlite3
-      - bufferutil
-      - bun-types-no-globals
-      - cac
-      - commander
-      - db0
-      - drizzle-orm
-      - encoding
-      - esbuild
-      - eslint
-      - idb-keyval
-      - ioredis
-      - less
-      - lightningcss
-      - magicast
-      - meow
-      - mysql2
-      - optionator
-      - oxc-parser
-      - oxlint
-      - pinia
-      - react-native-b4a
-      - rollup
-      - rollup-plugin-visualizer
-      - sass
-      - sass-embedded
-      - sqlite3
-      - srvx
-      - stylelint
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - typescript
-      - unloader
-      - uploadthing
-      - utf-8-validate
-      - vite
-      - vue-tsc
-      - webpack
-      - xml2js
-      - yaml
-
-  nuxt@4.5.1(6cab6962d170d75e6cc46dcb3ab1fb0a):
-    dependencies:
-      '@dxup/nuxt': 0.5.6(esbuild@0.28.2)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
-      '@nuxt/cli': 3.37.0(@nuxt/schema@4.5.1)(cac@6.7.14)(commander@14.0.3)(magicast@0.5.4)(supports-color@10.2.2)
-      '@nuxt/devtools': 3.4.1(0f01304e996d82e0188901d54c1d087f)
-      '@nuxt/kit': 4.5.1(magic-string@1.1.1)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))
-      '@nuxt/nitro-server': 4.5.1(4e6cd610fa0e9c193b5d9c55e3579f88)
-      '@nuxt/schema': 4.5.1
-      '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.5.1(magic-string@1.1.1)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))))
-      '@nuxt/vite-builder': 4.5.1(@babel/plugin-proposal-decorators@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@types/node@26.2.0)(esbuild@0.28.2)(magic-string@1.1.1)(magicast@0.5.4)(nuxt@4.5.1(6cab6962d170d75e6cc46dcb3ab1fb0a))(oxc-parser@0.141.0)(oxlint@1.80.0)(rolldown@1.2.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.5)(rollup@4.62.4))(rollup@4.62.4)(supports-color@10.2.2)(terser@5.50.0)(tsx@4.23.12)(typescript@7.0.2)(vue@3.5.41(typescript@7.0.2))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))(yaml@2.9.0)
-      '@unhead/vue': 3.3.1(@oxc-project/types@0.146.0)(esbuild@0.28.2)(lightningcss@1.33.0)(oxc-parser@0.141.0)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(vue@3.5.41(typescript@7.0.2))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
-      '@vue/shared': 3.5.41
-      chokidar: 5.0.0
-      compatx: 0.2.0
-      consola: 3.4.2
-      cookie-es: 3.1.1
-      defu: 6.1.7
-      devalue: 5.9.0
-      errx: 0.1.2
-      escape-string-regexp: 5.0.0
-      exsolve: 1.1.1
-      fnv1a-64: 0.1.2
-      hookable: 6.1.1
-      ignore: 7.0.6
-      impound: 1.1.6(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
-      jiti: 2.7.0
-      klona: 2.0.6
-      knitwork: 1.3.0
-      magic-string: 1.1.1
-      mlly: 1.8.2
-      nanotar: 0.3.0
-      nostics: 1.2.0
-      nypm: 0.6.9
-      object-identity: 0.2.3
-      ofetch: 1.5.1
-      ohash: 2.0.11
-      on-change: 6.0.2
-      oxc-walker: 1.1.1(@oxc-project/types@0.146.0)(oxc-parser@0.141.0)(rolldown@1.2.5)
-      pathe: 2.0.3
-      perfect-debounce: 2.1.0
-      picomatch: 4.0.5
-      pkg-types: 2.3.1
-      rolldown: 1.2.5
-      rolldown-string: 0.3.1(rolldown@1.2.5)
-      rou3: 0.9.2
-      scule: 1.3.0
-      std-env: 4.2.0
-      tinyglobby: 0.2.17
-      ufo: 1.6.4
-      ultrahtml: 1.7.0
-      uncrypto: 0.1.3
-      unctx: 3.0.0(magic-string@1.1.1)(oxc-parser@0.141.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))
-      undici: 8.10.0
-      unhead: 3.3.1(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
-      unimport: 6.4.0(esbuild@0.28.2)(oxc-parser@0.141.0)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
-      unplugin: 3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
-      unrouting: 0.2.3
-      untyped: 2.0.0
-      verkit: 0.2.0
-      vue: 3.5.41(typescript@7.0.2)
-      vue-router: 5.2.0(@vue/compiler-sfc@3.5.41)(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(vue@3.5.41(typescript@7.0.2))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
-    optionalDependencies:
-      '@types/node': 26.2.0
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -33657,6 +33319,7 @@ snapshots:
       '@img/sharp-win32-arm64': 0.34.5
       '@img/sharp-win32-ia32': 0.34.5
       '@img/sharp-win32-x64': 0.34.5
+    optional: true
 
   sharp@0.35.2:
     dependencies:
@@ -33920,12 +33583,12 @@ snapshots:
 
   standard-as-callback@2.1.0: {}
 
-  starlight-blog@0.28.0(patch_hash=7b6e57367fab3517e0cfd5e4d0da3459ac1430bf4b6036cf03002c978602c23b)(835c89c84373614fdbf634191ed13edd):
+  starlight-blog@0.28.0(patch_hash=7b6e57367fab3517e0cfd5e4d0da3459ac1430bf4b6036cf03002c978602c23b)(9e6397aee9364e8f624d35dfa7bd21f2):
     dependencies:
       '@astrojs/markdown-remark': 7.2.2(supports-color@10.2.2)
-      '@astrojs/mdx': 7.0.5(@astrojs/markdown-satteri@0.3.5)(astro@7.2.0(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@3.25.76))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(supports-color@10.2.2)
+      '@astrojs/mdx': 7.0.5(@astrojs/markdown-satteri@0.3.5)(astro@7.2.0(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@3.25.76))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(supports-color@10.2.2)
       '@astrojs/rss': 4.0.19
-      '@astrojs/starlight': 0.41.7(patch_hash=7ab76e506900e9b0f934039b4b3f797fdf6ea76e9668891402a75ef46dd79b8c)(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(astro@7.2.0(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@3.25.76))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(supports-color@10.2.2)(typescript@7.0.2)
+      '@astrojs/starlight': 0.41.7(patch_hash=7ab76e506900e9b0f934039b4b3f797fdf6ea76e9668891402a75ef46dd79b8c)(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(astro@7.2.0(@astrojs/markdown-remark@7.2.2(supports-color@10.2.2))(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@3.25.76))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(supports-color@10.2.2)(typescript@7.0.2)
       github-slugger: 2.0.0
       hast-util-from-html: 2.0.3
       hast-util-to-html: 9.0.5
@@ -34495,8 +34158,6 @@ snapshots:
 
   undici@6.28.0: {}
 
-  undici@7.24.4: {}
-
   undici@7.28.0: {}
 
   undici@7.29.0: {}
@@ -34823,7 +34484,7 @@ snapshots:
       escape-string-regexp: 5.0.0
       ufo: 1.6.4
 
-  unstorage@1.17.5(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@24.13.3)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@24.13.3))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@24.13.3)))(ioredis@5.11.1(supports-color@10.2.2)):
+  unstorage@1.17.5(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@24.13.3)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@24.13.3))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@24.13.3)))(ioredis@5.11.1(supports-color@10.2.2)):
     dependencies:
       anymatch: 3.1.3
       chokidar: 5.0.0
@@ -34835,10 +34496,10 @@ snapshots:
       ufo: 1.6.4
     optionalDependencies:
       aws4fetch: 1.0.20
-      db0: 0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@24.13.3)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@24.13.3))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@24.13.3))
+      db0: 0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@24.13.3)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@24.13.3))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@24.13.3))
       ioredis: 5.11.1(supports-color@10.2.2)
 
-  unstorage@1.17.5(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@3.25.76))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2)):
+  unstorage@1.17.5(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@3.25.76))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2)):
     dependencies:
       anymatch: 3.1.3
       chokidar: 5.0.0
@@ -34850,10 +34511,10 @@ snapshots:
       ufo: 1.6.4
     optionalDependencies:
       aws4fetch: 1.0.20
-      db0: 0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@3.25.76))(mysql2@3.24.2(@types/node@26.2.0))
+      db0: 0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@3.25.76))(mysql2@3.24.2(@types/node@26.2.0))
       ioredis: 5.11.1(supports-color@10.2.2)
 
-  unstorage@1.17.5(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2)):
+  unstorage@1.17.5(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2)):
     dependencies:
       anymatch: 3.1.3
       chokidar: 5.0.0
@@ -34865,7 +34526,7 @@ snapshots:
       ufo: 1.6.4
     optionalDependencies:
       aws4fetch: 1.0.20
-      db0: 0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0))
+      db0: 0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0))
       ioredis: 5.11.1(supports-color@10.2.2)
 
   unstorage@1.17.5(db0@0.3.4)(ioredis@5.11.1(supports-color@10.2.2)):
@@ -34879,14 +34540,14 @@ snapshots:
       ofetch: 1.5.1
       ufo: 1.6.4
     optionalDependencies:
-      db0: 0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0))
+      db0: 0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0))
       ioredis: 5.11.1(supports-color@10.2.2)
 
-  unstorage@2.0.0-alpha.7(aws4fetch@1.0.20)(chokidar@5.0.0)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(lru-cache@11.5.2)(mongodb@6.21.0(@aws-sdk/credential-providers@3.1095.0)(socks@2.8.9))(ofetch@2.0.0-alpha.3):
+  unstorage@2.0.0-alpha.7(aws4fetch@1.0.20)(chokidar@5.0.0)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(lru-cache@11.5.2)(mongodb@6.21.0(@aws-sdk/credential-providers@3.1095.0)(socks@2.8.9))(ofetch@2.0.0-alpha.3):
     optionalDependencies:
       aws4fetch: 1.0.20
       chokidar: 5.0.0
-      db0: 0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260812.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0))
+      db0: 0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0))
       ioredis: 5.11.1(supports-color@10.2.2)
       lru-cache: 11.5.2
       mongodb: 6.21.0(@aws-sdk/credential-providers@3.1095.0)(socks@2.8.9)
@@ -36093,59 +35754,43 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
-  workerd@1.20260317.1:
+  workerd@1.20260901.1:
     optionalDependencies:
-      '@cloudflare/workerd-darwin-64': 1.20260317.1
-      '@cloudflare/workerd-darwin-arm64': 1.20260317.1
-      '@cloudflare/workerd-linux-64': 1.20260317.1
-      '@cloudflare/workerd-linux-arm64': 1.20260317.1
-      '@cloudflare/workerd-windows-64': 1.20260317.1
+      '@cloudflare/workerd-darwin-64': 1.20260901.1
+      '@cloudflare/workerd-darwin-arm64': 1.20260901.1
+      '@cloudflare/workerd-linux-64': 1.20260901.1
+      '@cloudflare/workerd-linux-arm64': 1.20260901.1
+      '@cloudflare/workerd-windows-64': 1.20260901.1
 
-  workerd@1.20260722.1:
-    optionalDependencies:
-      '@cloudflare/workerd-darwin-64': 1.20260722.1
-      '@cloudflare/workerd-darwin-arm64': 1.20260722.1
-      '@cloudflare/workerd-linux-64': 1.20260722.1
-      '@cloudflare/workerd-linux-arm64': 1.20260722.1
-      '@cloudflare/workerd-windows-64': 1.20260722.1
-
-  workerd@1.20260831.1:
-    optionalDependencies:
-      '@cloudflare/workerd-darwin-64': 1.20260831.1
-      '@cloudflare/workerd-darwin-arm64': 1.20260831.1
-      '@cloudflare/workerd-linux-64': 1.20260831.1
-      '@cloudflare/workerd-linux-arm64': 1.20260831.1
-      '@cloudflare/workerd-windows-64': 1.20260831.1
-
-  wrangler@4.114.0(@cloudflare/workers-types@5.20260812.1):
+  wrangler@4.114.0(@cloudflare/workers-types@5.20260901.1):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.5.0
-      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260722.1)
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260901.1)
       blake3-wasm: 2.1.5
       esbuild: 0.28.1
       miniflare: 4.20260722.0
       path-to-regexp: 6.3.0
       unenv: 2.0.0-rc.24
-      workerd: 1.20260722.1
+      workerd: 1.20260901.1
     optionalDependencies:
-      '@cloudflare/workers-types': 5.20260812.1
+      '@cloudflare/workers-types': 5.20260901.1
       fsevents: 2.3.3
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  wrangler@4.78.0(@cloudflare/workers-types@5.20260812.1):
+  wrangler@4.124.0(@cloudflare/workers-types@5.20260901.1):
     dependencies:
-      '@cloudflare/kv-asset-handler': 0.4.2
-      '@cloudflare/unenv-preset': 2.16.0(unenv@2.0.0-rc.24)(workerd@1.20260317.1)
+      '@cloudflare/kv-asset-handler': 0.5.0
+      '@cloudflare/unenv-preset': 2.16.1(unenv@2.0.0-rc.24)(workerd@1.20260901.1)
       blake3-wasm: 2.1.5
-      esbuild: 0.27.3
-      miniflare: 4.20260317.3
+      esbuild: 0.28.1
+      miniflare: 5.20260815.0-alpha
       path-to-regexp: 6.3.0
       unenv: 2.0.0-rc.24
-      workerd: 1.20260317.1
+      workerd: 1.20260901.1
     optionalDependencies:
-      '@cloudflare/workers-types': 5.20260812.1
+      '@cloudflare/workers-types': 5.20260901.1
       fsevents: 2.3.3
     transitivePeerDependencies:
       - bufferutil
@@ -36180,8 +35825,6 @@ snapshots:
   wrappy@1.0.2: {}
 
   ws@7.5.13: {}
-
-  ws@8.18.0: {}
 
   ws@8.21.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -46,20 +46,20 @@ catalogs:
     "@cloudflare/containers": ^0.3.7
     "@cloudflare/puppeteer": ^1.1.0
     "@cloudflare/vite-plugin": ^1.13.12
-    "@cloudflare/workers-types": 4.20260702.1
+    "@cloudflare/workers-types": 5.20260901.1
     wrangler: ^4.103.0
   cloudflare-runtime:
-    "@cloudflare/unenv-preset": ^2.16.0
-    "@cloudflare/vitest-pool-workers": ^0.13.0
-    "@cloudflare/workers-types": ^5.20260812.1
+    "@cloudflare/unenv-preset": ^2.16.1
+    "@cloudflare/vitest-pool-workers": ^0.22.0
+    "@cloudflare/workers-types": 5.20260901.1
     "@octanejs/vite-plugin": ">=0.1.22"
     "@puppeteer/browsers": ^3.2.0
     "@sveltejs/kit": ">=3.0.0-next.9"
     "@types/http-cache-semantics": ^4.2.0
     "@types/ws": ^8.18.1
     astro: ^7.0.0
-    capnp-es: ^0.0.14
-    capnweb: ^0.8.0
+    capnp-es: ^0.0.16
+    capnweb: ^0.12.0
     esbuild: ^0.28.1
     fast-glob: ^3.3.2
     heap-js: ^2.5.0
@@ -75,7 +75,7 @@ catalogs:
     toucan-js: 4.0.0
     unenv: ^2.0.0-rc.24
     vite: ^7.0.0 || ^8.0.0
-    workerd: 1.20260831.1
+    workerd: 1.20260901.1
     ws: ^8.21.0
     yauzl: ^3.4.0
   database:
@@ -164,7 +164,8 @@ catalogs:
     pathe: ^2.0.3
     tsx: ^4.20.6
 overrides:
-  "@cloudflare/workers-types": 5.20260812.1
+  "@cloudflare/workers-types": 5.20260901.1
+  workerd: 1.20260901.1
   effect: 4.0.0-rc.112
   "@effect/platform-browser": 4.0.0-rc.112
   drizzle-kit: 1.0.0-rc.5-ab785fc
@@ -174,23 +175,24 @@ patchedDependencies:
   "@astrojs/starlight@0.41.7": patches/@astrojs%2Fstarlight@0.41.7.patch
   starlight-blog@0.28.0: patches/starlight-blog@0.28.0.patch
 minimumReleaseAgeExclude:
-  - '@alchemy.run/sigil@0.0.0-alpha.6'
-  - '@effect/atom-react@4.0.0-rc.112'
-  - '@effect/platform-bun@4.0.0-rc.112'
-  - '@effect/platform-node-shared@4.0.0-rc.112'
-  - '@effect/platform-node@4.0.0-rc.112'
-  - '@effect/sql-d1@4.0.0-rc.112'
-  - '@effect/sql-mysql2@4.0.0-rc.112'
-  - '@effect/sql-pg@4.0.0-rc.112'
-  - '@effect/sql-sqlite-do@4.0.0-rc.112'
-  - '@effect/vitest@4.0.0-rc.112'
-  - '@foldkit/vite-plugin@0.16.1'
+  - "@alchemy.run/sigil@0.0.0-alpha.6"
+  - "@effect/atom-react@4.0.0-rc.112"
+  - "@effect/platform-bun@4.0.0-rc.112"
+  - "@effect/platform-node-shared@4.0.0-rc.112"
+  - "@effect/platform-node@4.0.0-rc.112"
+  - "@effect/sql-d1@4.0.0-rc.112"
+  - "@effect/sql-mysql2@4.0.0-rc.112"
+  - "@effect/sql-pg@4.0.0-rc.112"
+  - "@effect/sql-sqlite-do@4.0.0-rc.112"
+  - "@effect/vitest@4.0.0-rc.112"
+  - "@foldkit/vite-plugin@0.16.1"
   - effect@4.0.0-rc.112
   - foldkit@0.148.2
-  - '@solidjs/start@2.0.4'
-  - '@cloudflare/workerd-darwin-64@1.20260831.1'
-  - '@cloudflare/workerd-darwin-arm64@1.20260831.1'
-  - '@cloudflare/workerd-linux-64@1.20260831.1'
-  - '@cloudflare/workerd-linux-arm64@1.20260831.1'
-  - '@cloudflare/workerd-windows-64@1.20260831.1'
-  - workerd@1.20260831.1
+  - "@solidjs/start@2.0.4"
+  - "@cloudflare/workers-types@5.20260901.1"
+  - "@cloudflare/workerd-darwin-64@1.20260901.1"
+  - "@cloudflare/workerd-darwin-arm64@1.20260901.1"
+  - "@cloudflare/workerd-linux-64@1.20260901.1"
+  - "@cloudflare/workerd-linux-arm64@1.20260901.1"
+  - "@cloudflare/workerd-windows-64@1.20260901.1"
+  - workerd@1.20260901.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -50,7 +50,7 @@ catalogs:
     wrangler: ^4.103.0
   cloudflare-runtime:
     "@cloudflare/unenv-preset": ^2.16.1
-    "@cloudflare/vitest-pool-workers": ^0.22.0
+    "@cloudflare/vitest-plugin": ^1.0.0
     "@cloudflare/workers-types": 5.20260901.1
     "@octanejs/vite-plugin": ">=0.1.22"
     "@puppeteer/browsers": ^3.2.0


### PR DESCRIPTION
## Summary

- update `workerd` and `@cloudflare/workers-types` to `20260901.1`, enforcing one resolved version and exact release-age exceptions
- update the workers-sdk submodule pin and port the matching workers-shared/workflows-shared changes
- retain and document Alchemy-specific behavior such as Effect Schema validation and KV error causes
- migrate from `@cloudflare/vitest-pool-workers` to `@cloudflare/vitest-plugin`