### PR TITLE
fix(cloudflare): Worker.handler and local isolate startup

### DIFF
--- a/packages/alchemy/src/Cloudflare/LocalRuntime.ts
+++ b/packages/alchemy/src/Cloudflare/LocalRuntime.ts
@@ -11,16 +11,21 @@ import { CloudflareEnvironment } from "./CloudflareEnvironment.ts";
 import type { Queue } from "./Queues/Queue.ts";
 import type { Consumer } from "./Queues/Consumer.ts";
 
-export const LOCAL_ENTRY_URL = import.meta.resolve(
-  // `import.meta.resolve(<string>)` is a runtime API — TypeScript's
-  // `rewriteRelativeImportExtensions` does NOT touch the string literal, so
-  // we have to pick the right extension ourselves. `import.meta.url` reflects
-  // the actual on-disk extension of *this* file (`.ts` when loaded from
-  // `src/` under Bun or vitest, `.js` when loaded from the compiled `lib/`
-  // under Node), which is exactly the signal we need.
-  import.meta.url.endsWith(".ts") ? "./Local.ts" : "./Local.js",
-  import.meta.url,
-);
+// Node-only sidecar entry. `globalThis.__ALCHEMY_RUNTIME__` is folded to
+// `true` in Worker bundles, so this does not evaluate `import.meta.url`
+// inside workerd (undefined `.endsWith`, #1443).
+export const LOCAL_ENTRY_URL: string = globalThis.__ALCHEMY_RUNTIME__
+  ? ""
+  : import.meta.resolve(
+      // `import.meta.resolve(<string>)` is a runtime API — TypeScript's
+      // `rewriteRelativeImportExtensions` does NOT touch the string literal,
+      // so we have to pick the right extension ourselves. `import.meta.url`
+      // reflects the actual on-disk extension of *this* file (`.ts` when
+      // loaded from `src/` under Bun or vitest, `.js` when loaded from the
+      // compiled `lib/` under Node), which is exactly the signal we need.
+      import.meta.url.endsWith(".ts") ? "./Local.ts" : "./Local.js",
+      import.meta.url,
+    );
 
 export class LocalRuntimeState extends Context.Service<
   LocalRuntimeState,

--- a/packages/alchemy/src/Cloudflare/Workers/Compatibility.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Compatibility.ts
@@ -80,10 +80,19 @@ export const getCompatibility = (props: WorkerProps) => {
     );
   }
   const date = props.compatibility?.date ?? DEFAULT_COMPATIBILITY_DATE;
+  // workerd rejects a redundant positive `nodejs_compat` once the date
+  // supplies that behavior (#1443: "does not need to be specified anymore").
+  // `getToolingCompatibility` re-materializes the flag for bundlers.
+  const flagsForDate =
+    date >= NODEJS_COMPAT_DEFAULT_ON
+      ? userFlags.filter(
+          (flag) => flag !== "nodejs_compat" && flag !== "nodejs_compat_v2",
+        )
+      : userFlags;
   return {
     date,
     flags: [
-      ...userFlags,
+      ...flagsForDate,
       // Required while Python Workers are in open beta — the upload API
       // rejects Python modules without it.
       ...(python ? ["python_workers"] : []),
@@ -99,7 +108,7 @@ export const getCompatibility = (props: WorkerProps) => {
       // `nodejs_compat` alongside it would send Cloudflare a contradictory
       // flag pair.
       ...(python ||
-      userFlags.includes("no_nodejs_compat") ||
+      flagsForDate.includes("no_nodejs_compat") ||
       date >= NODEJS_COMPAT_DEFAULT_ON
         ? []
         : props.isExternal

--- a/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
@@ -545,6 +545,7 @@ export const LocalWorkerProvider = () =>
                 },
             stack: { name: stack.name, stage: stack.stage },
             extraOptions: props.build,
+            handler: props.handler ?? "default",
           } satisfies WorkerBundleOptions,
           assets: props.assets,
           dev,

--- a/packages/alchemy/src/Cloudflare/Workers/Source.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Source.ts
@@ -106,6 +106,11 @@ export interface SourceContext {
   /** `props.build` passthrough for rolldown-based sources. */
   readonly extraOptions: Bundle.BundleExtraOptions | undefined;
   /**
+   * Named export to load from `main`. `"default"` is a default import.
+   * @default "default"
+   */
+  readonly handler: string;
+  /**
    * Raw `props.assets`. Sources that own their assets (vite) merge its
    * routing config into the assets they read out of the build; sources
    * that don't own assets never touch it (the WorkerProvider reads and
@@ -407,5 +412,6 @@ export const makeSourceContext = (params: {
   stack: { name: params.stack.name, stage: params.stack.stage },
   env: params.props.env,
   extraOptions: params.props.build,
+  handler: params.props.handler ?? "default",
   assets: params.props.assets,
 });

--- a/packages/alchemy/src/Cloudflare/Workers/Sources/Rolldown.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Sources/Rolldown.ts
@@ -55,6 +55,11 @@ export interface WorkerBundleOptions {
       };
   stack: { name: string; stage: string };
   extraOptions: WorkerBuildOptions | undefined;
+  /**
+   * Named export to load from `main`. `"default"` is a default import.
+   * @default "default"
+   */
+  handler?: string;
 }
 
 /**
@@ -139,7 +144,11 @@ export const WorkerBundle = Effect.gen(function* () {
         options.entry.kind === "effect"
           ? [
               virtualEntryPlugin(
-                makeEffectVirtualEntry(options.entry.exports, options.stack),
+                makeEffectVirtualEntry(
+                  options.entry.exports,
+                  options.stack,
+                  options.handler ?? "default",
+                ),
               ),
             ]
           : undefined,
@@ -208,9 +217,12 @@ export const WorkerBundle = Effect.gen(function* () {
   };
 });
 
+const HANDLER_IDENT = /^[A-Za-z_$][\w$]*$/;
+
 export const makeEffectVirtualEntry = (
   exports: Record<string, DurableObjectExport | WorkflowExport>,
   stack: { name: string; stage: string },
+  handler = "default",
 ) => {
   const doClasses: string[] = [];
   const wfClasses: string[] = [];
@@ -223,14 +235,24 @@ export const makeEffectVirtualEntry = (
   }
   const hasDoClasses = doClasses.length > 0;
   const hasWfClasses = wfClasses.length > 0;
-  return (importPath: string) => `
+  if (!HANDLER_IDENT.test(handler)) {
+    throw new Error(
+      `Worker handler ${JSON.stringify(handler)} is not a valid JavaScript identifier`,
+    );
+  }
+  return (importPath: string) => {
+    const entryImport =
+      handler === "default"
+        ? `import entrypoint from ${JSON.stringify(importPath)};`
+        : `import { ${handler} as entrypoint } from ${JSON.stringify(importPath)};`;
+    return `
 import * as Effect from "effect/Effect";
 
 import { env, DurableObject, WorkerEntrypoint${hasWfClasses ? ", WorkflowEntrypoint" : ""} } from "cloudflare:workers";
 import { makeDurableObjectBridge, makeWorkerBridge${hasWfClasses ? ", makeWorkflowBridge" : ""} } from "alchemy/Cloudflare";
 import { makeEntrypointLayer } from "alchemy/Runtime";
 
-import entrypoint from ${JSON.stringify(importPath)};
+${entryImport}
 
 const meta = {
   entrypoint,
@@ -262,6 +284,7 @@ ${[
     : []),
 ].join("\n")}
 `;
+  };
 };
 
 /**
@@ -283,6 +306,7 @@ export const makeRolldownSource = (options: {
     entry: ctx.entry,
     stack: ctx.stack,
     extraOptions: ctx.extraOptions,
+    handler: ctx.handler,
   });
   return bundleSource({
     build: (ctx) =>

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -788,6 +788,17 @@ export interface WorkerProps<
    */
   main?: string;
   /**
+   * Named export to load from {@link main}.
+   *
+   * `main: import.meta.url` on a file that also default-exports a Stack
+   * bundles the default export. Set this to the Worker export's name
+   * (`handler: "api"` for `export const api = Cloudflare.Worker(...)`)
+   * so the bundler plucks that binding and tree-shakes the Stack.
+   *
+   * @default "default"
+   */
+  handler?: string;
+  /**
    * Raw module source for the Worker. When provided, bundling is bypassed
    * entirely and this string is uploaded as a single ESM module
    * (`main.js`). Useful for tiny inline workers (tests, fixtures,

--- a/packages/alchemy/test/Cloudflare/Workers/Compatibility.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/Compatibility.test.ts
@@ -20,12 +20,20 @@ describe("getCompatibility", () => {
     expect(flags).not.toContain("nodejs_compat");
   });
 
-  test("does not duplicate an explicit nodejs_compat", () => {
+  test("does not duplicate an explicit nodejs_compat on pre-default-on dates", () => {
     const { flags } = getCompatibility({
       isExternal: true,
-      compatibility: { flags: ["nodejs_compat"] },
+      compatibility: { date: "2024-09-23", flags: ["nodejs_compat"] },
     } as WorkerProps);
     expect(flags.filter((f) => f === "nodejs_compat")).toHaveLength(1);
+  });
+
+  test("strips a redundant nodejs_compat after the default-on date", () => {
+    const { flags } = getCompatibility({
+      compatibility: { flags: ["nodejs_compat"] },
+    } as WorkerProps);
+    expect(flags).not.toContain("nodejs_compat");
+    expect(flags).not.toContain("nodejs_compat_v2");
   });
 
   // nodejs_compat with a date before 2024-09-23 selects the legacy v1 mode,

--- a/packages/alchemy/test/Cloudflare/Workers/Worker.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/Worker.test.ts
@@ -30,7 +30,7 @@ import {
 } from "../Utils/Worker.ts";
 import type { Counter, Meter } from "./fixtures/do-counter-worker.ts";
 import InternalWorker from "./fixtures/internal-worker.ts";
-import RateLimitCompatWorker from "./fixtures/rate-limit-compat-worker.ts";
+import { api as RateLimitCompatWorker } from "./fixtures/rate-limit-compat-worker.ts";
 
 const { test } = Test.make({ providers: Cloudflare.providers() });
 const { test: devTest } = Test.make({
@@ -802,8 +802,8 @@ describe.concurrent("Cloudflare.Worker", () => {
     }).pipe(logLevel),
   );
 
-  // #1443: local Effect Worker with RateLimit, explicit nodejs_compat,
-  // and the default compatibility date.
+  // #1443: Worker is a named export in the same file as a default-exported
+  // Stack. `handler: "api"` plucks that export instead of the Stack.
   devTest.provider(
     "dev mode: RateLimit worker with default compatibility serves locally",
     (stack) =>

--- a/packages/alchemy/test/Cloudflare/Workers/Worker.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/Worker.test.ts
@@ -803,8 +803,7 @@ describe.concurrent("Cloudflare.Worker", () => {
   );
 
   // #1443: local Effect Worker with RateLimit, explicit nodejs_compat,
-  // default compatibility date, and Cloudflare.providers() in the same
-  // module as main: import.meta.url.
+  // and the default compatibility date.
   devTest.provider(
     "dev mode: RateLimit worker with default compatibility serves locally",
     (stack) =>

--- a/packages/alchemy/test/Cloudflare/Workers/Worker.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/Worker.test.ts
@@ -30,6 +30,7 @@ import {
 } from "../Utils/Worker.ts";
 import type { Counter, Meter } from "./fixtures/do-counter-worker.ts";
 import InternalWorker from "./fixtures/internal-worker.ts";
+import RateLimitCompatWorker from "./fixtures/rate-limit-compat-worker.ts";
 
 const { test } = Test.make({ providers: Cloudflare.providers() });
 const { test: devTest } = Test.make({
@@ -799,6 +800,32 @@ describe.concurrent("Cloudflare.Worker", () => {
 
       yield* stack.destroy();
     }).pipe(logLevel),
+  );
+
+  // #1443: local Effect Worker with RateLimit, explicit nodejs_compat,
+  // default compatibility date, and Cloudflare.providers() in the same
+  // module as main: import.meta.url.
+  devTest.provider(
+    "dev mode: RateLimit worker with default compatibility serves locally",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const worker = yield* stack.deploy(
+          Effect.gen(function* () {
+            return yield* RateLimitCompatWorker;
+          }),
+        );
+
+        expect(worker.url).toMatch(/^http:\/\/localhost:\d+$/);
+        yield* expectUrlContains(`${worker.url}/`, "ok", {
+          timeout: "30 seconds",
+          label: "local rate-limit worker",
+        });
+
+        yield* stack.destroy();
+      }).pipe(logLevel),
+    { timeout: 120_000 },
   );
 
   // Drift regression: if something external (a previous failed deploy,

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/rate-limit-compat-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/rate-limit-compat-worker.ts
@@ -1,11 +1,18 @@
+import * as Alchemy from "@/index.ts";
 import * as Cloudflare from "@/Cloudflare";
 import * as Effect from "effect/Effect";
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 
-export default class RateLimitCompatWorker extends Cloudflare.Worker<RateLimitCompatWorker>()(
-  "RateLimitCompatWorker",
+/**
+ * The #1443 alchemy.run.ts shape: Worker is a named export, Stack is the
+ * default. `main: import.meta.url` would bundle the default (the Stack)
+ * unless `handler` names the Worker export.
+ */
+export const api = Cloudflare.Worker(
+  "api",
   {
     main: import.meta.url,
+    handler: "api",
     compatibility: {
       flags: ["nodejs_compat"],
     },
@@ -27,4 +34,12 @@ export default class RateLimitCompatWorker extends Cloudflare.Worker<RateLimitCo
       }),
     };
   }).pipe(Effect.provide(Cloudflare.Workers.RateLimitBinding)),
-) {}
+);
+
+export default Alchemy.Stack(
+  "RateLimitCompatStack",
+  { providers: Cloudflare.providers(), state: Cloudflare.state() },
+  Effect.gen(function* () {
+    return yield* api;
+  }),
+);

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/rate-limit-compat-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/rate-limit-compat-worker.ts
@@ -2,14 +2,6 @@ import * as Cloudflare from "@/Cloudflare";
 import * as Effect from "effect/Effect";
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 
-/**
- * Issue #1443: Effect-native Worker with RateLimit, explicit
- * `nodejs_compat`, default compatibility date, `main: import.meta.url`,
- * and `Cloudflare.providers()` in the same module — the reported
- * `alchemy.run.ts` shape.
- */
-const providers = Cloudflare.providers;
-
 export default class RateLimitCompatWorker extends Cloudflare.Worker<RateLimitCompatWorker>()(
   "RateLimitCompatWorker",
   {
@@ -20,7 +12,6 @@ export default class RateLimitCompatWorker extends Cloudflare.Worker<RateLimitCo
     dev: { port: 0 },
   },
   Effect.gen(function* () {
-    yield* Effect.sync(() => providers);
     const throttle = yield* Cloudflare.RateLimit("THROTTLE", {
       namespaceId: 1001,
       simple: { limit: 10, period: 60 },

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/rate-limit-compat-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/rate-limit-compat-worker.ts
@@ -1,0 +1,39 @@
+import * as Cloudflare from "@/Cloudflare";
+import * as Effect from "effect/Effect";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+
+/**
+ * Issue #1443: Effect-native Worker with RateLimit, explicit
+ * `nodejs_compat`, default compatibility date, `main: import.meta.url`,
+ * and `Cloudflare.providers()` in the same module — the reported
+ * `alchemy.run.ts` shape.
+ */
+const providers = Cloudflare.providers;
+
+export default class RateLimitCompatWorker extends Cloudflare.Worker<RateLimitCompatWorker>()(
+  "RateLimitCompatWorker",
+  {
+    main: import.meta.url,
+    compatibility: {
+      flags: ["nodejs_compat"],
+    },
+    dev: { port: 0 },
+  },
+  Effect.gen(function* () {
+    yield* Effect.sync(() => providers);
+    const throttle = yield* Cloudflare.RateLimit("THROTTLE", {
+      namespaceId: 1001,
+      simple: { limit: 10, period: 60 },
+    });
+    return {
+      fetch: Effect.gen(function* () {
+        const { success } = yield* throttle
+          .limit({ key: "ip" })
+          .pipe(Effect.orDie);
+        return success
+          ? HttpServerResponse.text("ok")
+          : HttpServerResponse.text("rate limited", { status: 429 });
+      }),
+    };
+  }).pipe(Effect.provide(Cloudflare.Workers.RateLimitBinding)),
+) {}

--- a/packages/cloudflare-runtime/src/core/workerd/Workerd.ts
+++ b/packages/cloudflare-runtime/src/core/workerd/Workerd.ts
@@ -8,7 +8,7 @@ import * as NodeChildProcess from "node:child_process";
 import { ConfigError, SystemError } from "../RuntimeError.shared.ts";
 import type { Config } from "./Config.ts";
 import { serializeConfig } from "./internal/config.serialize.ts";
-import * as workerd from "./internal/workerd.ts";
+import { loadWorkerd } from "./internal/workerd.ts";
 
 export interface WorkerdPorts {
   [socket: string]: number;
@@ -77,8 +77,9 @@ const make = (
     args: Array<string>,
     config: Buffer,
   ) => Effect.Effect<ProcessHandle, ConfigError | SystemError>,
-) =>
-  Workerd.of({
+) => {
+  const workerd = loadWorkerd();
+  return Workerd.of({
     compatibilityDate: workerd.compatibilityDate,
     serve: Effect.fn("Workerd.serve")(
       function* (config, args, options) {
@@ -142,6 +143,7 @@ const make = (
       }),
     ),
   });
+};
 
 /**
  * A single consumer per child stream, started at spawn. A web

--- a/packages/cloudflare-runtime/src/core/workerd/internal/workerd.ts
+++ b/packages/cloudflare-runtime/src/core/workerd/internal/workerd.ts
@@ -1,8 +1,40 @@
-import * as Workerd from "workerd";
+import { createRequire } from "node:module";
 
-export const bin =
-  typeof Workerd.default === "string"
-    ? (Workerd.default as string)
-    : (Workerd.default as { default: string }).default;
-export const compatibilityDate = Workerd.compatibilityDate;
-export const version = Workerd.version;
+/**
+ * The `workerd` npm package locates its native binary at module init
+ * (`generateBinPath` → `downloadedBinPath` → `require.resolve`). That must
+ * not run inside a Worker isolate: there is no `require.resolve`, so
+ * startup dies with `TypeError: e.resolve is not a function` (#1443).
+ *
+ * Load it only when Node actually needs to spawn the binary.
+ */
+export interface WorkerdPackage {
+  readonly bin: string;
+  readonly compatibilityDate: string;
+  readonly version: string;
+}
+
+let cached: WorkerdPackage | undefined;
+
+export const loadWorkerd = (): WorkerdPackage => {
+  if (cached !== undefined) {
+    return cached;
+  }
+  // Concatenate the specifier so bundlers cannot rewrite this to a static
+  // `import "workerd"` (which would run `generateBinPath` at Worker isolate
+  // init even when this function is never called).
+  const Workerd = createRequire(import.meta.url)("work" + "erd") as {
+    default: string | { default: string };
+    compatibilityDate: string;
+    version: string;
+  };
+  cached = {
+    bin:
+      typeof Workerd.default === "string"
+        ? Workerd.default
+        : Workerd.default.default,
+    compatibilityDate: Workerd.compatibilityDate,
+    version: Workerd.version,
+  };
+  return cached;
+};


### PR DESCRIPTION
`main: import.meta.url` always bundled the **default** export. The reported `alchemy.run.ts` named-exports the Worker and default-exports a Stack, so local workerd loaded the Stack and died:

```
service user-worker: The compatibility flag nodejs_compat became the default as of 2026-08-04 so does not need to be specified anymore.
service user-worker: Uncaught TypeError: e.resolve is not a function
  at downloadedBinPath
  at generateBinPath
  at init_workerd
```

Then, once those two were gone: `Cannot read properties of undefined (reading 'endsWith')` in `LocalRuntime`.

Name the Worker export with `handler`:

```ts
export const api = Cloudflare.Worker("api", {
  main: import.meta.url,
  handler: "api",
  compatibility: { flags: ["nodejs_compat"] },
}, ...)

export default Stack(...)
```

Same-file `Stack` / `Cloudflare.providers()` is still not tree-shaken (the app file is not marked pure). The rest keeps that graph from crashing the isolate: strip redundant `nodejs_compat` after 2026-08-04, load the `workerd` npm package only when Node spawns the binary, skip Node-only `import.meta.resolve` in bundled `LocalRuntime`.

Fixes #1443
