### PR TITLE
fix(package): include agent instruction files

### DIFF
--- a/packages/alchemy/package.json
+++ b/packages/alchemy/package.json
@@ -26,6 +26,8 @@
     "!bin/register-dev-mode.js",
     "lib",
     "src",
+    "AGENTS.md",
+    "CLAUDE.md",
     "NOTICE",
     "THIRD_PARTY_LICENSES.md"
   ],

--- a/scripts/copy-package-files.ts
+++ b/scripts/copy-package-files.ts
@@ -10,6 +10,7 @@ const thirdPartyPackages: Array<string> = [
   "node-utils",
 ];
 const readmePackages: Array<string> = ["alchemy"];
+const agentInstructionPackages: Array<string> = ["alchemy"];
 
 const packageNames = await readdir(packagesDirectory, {
   withFileTypes: true,
@@ -46,6 +47,17 @@ for (const packageName of targets) {
     await copyFile(
       path.join(root, "README.md"),
       path.join(packageDirectory, "README.md"),
+    );
+  }
+
+  if (agentInstructionPackages.includes(packageName)) {
+    await copyFile(
+      path.join(root, "AGENTS.md"),
+      path.join(packageDirectory, "AGENTS.md"),
+    );
+    await copyFile(
+      path.join(root, "CLAUDE.md"),
+      path.join(packageDirectory, "CLAUDE.md"),
     );
   }
 }


### PR DESCRIPTION
Copy the repository's agent instructions into the published `alchemy` package so installed copies expose the same guidance as the source checkout.

```diff
+ AGENTS.md
+ CLAUDE.md
```

Both files are copied by the existing package-file build step and explicitly included in the npm `files` allowlist.

Fixes #1286
