### PR TITLE
feat(cloudflare/pipelines): forward a declared schema on Sink create

### DIFF
--- a/packages/alchemy/src/Cloudflare/Pipelines/Sink.ts
+++ b/packages/alchemy/src/Cloudflare/Pipelines/Sink.ts
@@ -142,6 +142,23 @@ export type SinkFormat =
       rowGroupBytes?: number;
     };
 
+/**
+ * Optional schema declaration forwarded to the create-sink API.
+ *
+ * Sinks that write typed output (parquet, Iceberg tables in the R2 Data
+ * Catalog) can pin their column layout here instead of relying on
+ * inference. The shape is the wire schema; see the Cloudflare Pipelines
+ * "create sink" reference for the field vocabulary.
+ */
+export interface SinkSchema {
+  /** Column definitions, in the Pipelines schema field format. */
+  fields?: pipelines.SinksCreateRequestSchema["fields"];
+  /** Format-specific schema options (for example parquet compression). */
+  format?: pipelines.SinksCreateRequestSchema["format"];
+  /** Let Pipelines infer the schema from the stream when `true`. */
+  inferred?: boolean;
+}
+
 interface SinkBaseProps {
   /**
    * Name of the sink. Unique per account; must be alphanumeric and
@@ -158,6 +175,11 @@ interface SinkBaseProps {
    * @default { type: "json" }
    */
   format?: SinkFormat;
+  /**
+   * Schema forwarded to the create-sink API. Sinks have no update API, so a
+   * schema change replaces the sink.
+   */
+  schema?: SinkSchema;
 }
 
 export type SinkProps =
@@ -371,6 +393,7 @@ export const SinkProvider = () =>
             type: news.type,
             config: toRequestConfig(accountId, news),
             format: news.format,
+            schema: news.schema,
           })
           .pipe(
             Effect.catchTag("SinkAlreadyExists", (error) =>
@@ -546,6 +569,7 @@ const normalizeProps = (props: SinkProps): unknown => {
     return {
       type: props.type,
       format: props.format,
+      schema: props.schema,
       config: {
         ...props.config,
         credentials: {
@@ -560,6 +584,7 @@ const normalizeProps = (props: SinkProps): unknown => {
   return {
     type: props.type,
     format: props.format,
+    schema: props.schema,
     config: {
       ...props.config,
       token: Redacted.value(props.config.token),

--- a/packages/alchemy/test/Cloudflare/Pipelines/Sink.test.ts
+++ b/packages/alchemy/test/Cloudflare/Pipelines/Sink.test.ts
@@ -2,6 +2,7 @@ import * as Cloudflare from "@/Cloudflare";
 import { CloudflareEnvironment } from "@/Cloudflare/CloudflareEnvironment";
 import * as Provider from "@/Provider";
 import * as Test from "@/Test/Alchemy";
+import * as pipelines from "@distilled.cloud/cloudflare/pipelines";
 import * as user from "@distilled.cloud/cloudflare/user";
 import { expect } from "alchemy-test";
 import * as Effect from "effect/Effect";
@@ -97,6 +98,55 @@ test.provider(
       expect(match?.name).toEqual(deployed.name);
       expect(match?.type).toEqual("r2");
       expect(match?.accountId).toEqual(deployed.accountId);
+
+      yield* stack.destroy();
+    }).pipe(logLevel),
+  { timeout: 300_000 },
+);
+
+test.provider(
+  "create forwards a declared schema to the sink",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const creds = yield* r2Credentials;
+      const fields = [
+        { name: "event_id", type: "string", required: true },
+        { name: "occurred_at", type: "timestamp", required: true },
+      ];
+
+      const deployed = yield* retryAuthBlip(
+        stack.deploy(
+          Effect.gen(function* () {
+            const bucket = yield* Cloudflare.R2.Bucket("SchemaSinkBucket", {
+              forceDestroy: true,
+            });
+            return yield* Cloudflare.Pipelines.Sink("SchemaSink", {
+              type: "r2",
+              format: { type: "parquet" },
+              schema: { fields },
+              config: {
+                bucket: bucket.bucketName,
+                credentials: creds,
+                rollingPolicy: { intervalSeconds: 10 },
+              },
+            });
+          }),
+        ),
+      );
+
+      // The wire schema round-trips: Cloudflare echoes the declared columns
+      // on the created sink instead of an inferred (empty) field list.
+      const observed = yield* pipelines.getSink({
+        accountId: deployed.accountId,
+        sinkId: deployed.sinkId,
+      });
+      expect(
+        (observed.schema?.fields ?? []).map(
+          (field) => (field as { name: string }).name,
+        ),
+      ).toEqual(fields.map((field) => field.name));
 
       yield* stack.destroy();
     }).pipe(logLevel),


### PR DESCRIPTION
## Summary

- Add an optional `schema` prop to `Cloudflare.Pipelines.Sink`.
- The provider forwards it on `createSink` and includes it in change detection, so a schema edit replaces the sink like every other create-only prop.
- Add a live test that deploys a parquet R2 sink with two declared fields and reads them back through `getSink`.

## Why

R2 Data Catalog sinks that write parquet need a declared column layout. The Pipelines create-sink API accepts `schema`, but the resource did not expose it. A wrapper provider cannot add a wire field, so two consumers (patronage/firedup, patronage/paitronage) carried a pnpm patch for this. This PR retires that patch (patronage/software-factory#985).

## Test plan

- `pnpm exec tsc -b` clean for `packages/alchemy`.
- The new live test in `test/Cloudflare/Pipelines/Sink.test.ts` was written but not run here: this session has no Cloudflare test profile. It follows the existing `list enumerates the deployed sink` case.

https://claude.ai/code/session_01YJH4cF681uuGMwUjUy2wLy