### PR TITLE
feat(cloudflare/workers): keep write-only bindings across a script upload

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -611,6 +611,12 @@ export interface WorkerVersionOptions {
   tag?: string;
 }
 
+/**
+ * The write-only binding types a script upload may keep from the live
+ * script. See {@link WorkerProps.keepBindings}.
+ */
+export type WorkerKeepBindingType = "secret_text" | "secret_key";
+
 export interface WorkerProps<
   // PERF: unconstrained for the same reason as `Worker<Bindings>` above —
   // the `extends WorkerBindingProps` proof is expensive for generic mapped
@@ -744,6 +750,28 @@ export interface WorkerProps<
    */
   source?: WorkerSourceDescriptor;
   logpush?: boolean;
+  /**
+   * Binding types Cloudflare keeps from the live script when this Worker
+   * uploads. A script upload replaces the whole binding set, so a secret
+   * written out-of-band (`wrangler secret put`, the dashboard, a rotation
+   * job) is dropped on the next deploy unless its type is listed here.
+   *
+   * Only the two write-only types are accepted: Alchemy cannot read their
+   * values back, so it cannot own them. Every other binding type stays
+   * managed by {@link env} and bindings.
+   *
+   * **Example:** Keep secrets set outside Alchemy
+   *
+   * ```ts
+   * Cloudflare.Worker("api", {
+   *   main: "./src/api.ts",
+   *   keepBindings: ["secret_text"],
+   * });
+   * ```
+   *
+   * @default undefined — the upload owns the full binding set
+   */
+  keepBindings?: readonly WorkerKeepBindingType[];
   /**
    * Cloudflare Workers Observability settings. Controls Workers Logs
    * (`logs`) and Workers Traces (`traces`), each with their own

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
@@ -1114,6 +1114,7 @@ const resolveWorkerMetadataHash = ({
     cache: props.cache,
     limits: props.limits,
     logpush: props.logpush,
+    keepBindings: props.keepBindings,
     observability: props.observability,
     placement: props.placement,
     // The source descriptor is plain JSON data; hashing it means
@@ -3597,7 +3598,7 @@ export const LiveWorkerProvider = () =>
           containers:
             metadataContainers.length > 0 ? metadataContainers : undefined,
           keepAssets,
-          keepBindings: undefined,
+          keepBindings: news.keepBindings ? [...news.keepBindings] : undefined,
           limits: news.limits,
           logpush: news.logpush,
           mainModule: bundle.main,

--- a/packages/alchemy/test/Cloudflare/Workers/KeepBindings.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/KeepBindings.test.ts
@@ -1,0 +1,84 @@
+import { CloudflareEnvironment } from "@/Cloudflare/CloudflareEnvironment";
+import * as Cloudflare from "@/Cloudflare/index.ts";
+import * as Test from "@/Test/Alchemy";
+import * as workers from "@distilled.cloud/cloudflare/workers";
+import { describe, expect } from "alchemy-test";
+import * as Effect from "effect/Effect";
+import { MinimumLogLevel } from "effect/References";
+import * as pathe from "pathe";
+import { waitForWorkerToBeDeleted } from "../Utils/Worker.ts";
+
+const { test } = Test.make({ providers: Cloudflare.providers() });
+
+const logLevel = Effect.provideService(
+  MinimumLogLevel,
+  process.env.DEBUG ? "Debug" : "Info",
+);
+
+const main = pathe.resolve(import.meta.dirname, "fixtures/worker.ts");
+
+describe.concurrent("Cloudflare.Worker keepBindings", () => {
+  // A script upload replaces the whole binding set. A secret written
+  // out-of-band survives the next deploy only when its type is listed in
+  // `keepBindings`; without the prop the upload owns the binding set and
+  // the secret is dropped.
+  test.provider(
+    "keeps out-of-band secret_text bindings across a deploy",
+    (stack) =>
+      Effect.gen(function* () {
+        const { accountId } = yield* yield* CloudflareEnvironment;
+
+        yield* stack.destroy();
+
+        const program = (opts: {
+          flags: string[];
+          keepBindings?: readonly Cloudflare.WorkerKeepBindingType[];
+        }) =>
+          Effect.gen(function* () {
+            return yield* Cloudflare.Worker("KeepBindingsWorker", {
+              main,
+              compatibility: { date: "2024-01-01", flags: opts.flags },
+              env: { GREETING: "hello" },
+              keepBindings: opts.keepBindings,
+            });
+          });
+
+        const secretNames = Effect.fn(function* (scriptName: string) {
+          const secrets = yield* workers.listScriptSecrets({
+            accountId,
+            scriptName,
+          });
+          return secrets.result.map((secret) => secret.name).toSorted();
+        });
+
+        const worker = yield* stack.deploy(program({ flags: [] }));
+
+        // Write a secret the way an operator would: outside Alchemy.
+        yield* workers.putScriptSecret({
+          accountId,
+          scriptName: worker.workerName,
+          name: "OUT_OF_BAND_SECRET",
+          text: "set-outside-alchemy",
+          type: "secret_text",
+        });
+        expect(yield* secretNames(worker.workerName)).toEqual([
+          "OUT_OF_BAND_SECRET",
+        ]);
+
+        // A metadata change with keepBindings deploys and keeps the secret.
+        yield* stack.deploy(
+          program({ flags: ["nodejs_compat"], keepBindings: ["secret_text"] }),
+        );
+        expect(yield* secretNames(worker.workerName)).toEqual([
+          "OUT_OF_BAND_SECRET",
+        ]);
+
+        // Dropping keepBindings hands the binding set back to the upload.
+        yield* stack.deploy(program({ flags: [] }));
+        expect(yield* secretNames(worker.workerName)).toEqual([]);
+
+        yield* stack.destroy();
+        yield* waitForWorkerToBeDeleted(worker.workerName, accountId);
+      }).pipe(logLevel),
+  );
+});


### PR DESCRIPTION
## Summary

- Add an optional `keepBindings` prop to `Cloudflare.Worker`, typed as `readonly ("secret_text" | "secret_key")[]`.
- The provider forwards it as `keep_bindings` on the script upload, so a secret written out-of-band (`wrangler secret put`, the dashboard, a rotation job) survives the next deploy.
- The prop joins the metadata hash, so adding or removing it deploys.
- Add `test/Cloudflare/Workers/KeepBindings.test.ts`: deploy, write a secret through `putScriptSecret`, redeploy with `keepBindings: ["secret_text"]` and assert the secret stays, redeploy without it and assert the secret is gone.

## Why

A script upload replaces the whole binding set. Only the two write-only types are accepted: Alchemy cannot read their values back, so it cannot own them; every other binding type stays managed by `env` and bindings. patronage/paitronage carried this as a pnpm patch (`keepBindings: ["secret_text"]` hard-coded) for a Worker whose one oversized credential lives as a classic Worker secret. This PR retires that patch (patronage/software-factory#985).

## Test plan

- `pnpm exec tsc -b` clean for `packages/alchemy`.
- The new live test was written but not run here: this session has no Cloudflare test profile.

https://claude.ai/code/session_01YJH4cF681uuGMwUjUy2wLy