### PR TITLE
feat(cloudflare/workflows): export makeWorkflowName

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workflows/WorkflowName.ts
+++ b/packages/alchemy/src/Cloudflare/Workflows/WorkflowName.ts
@@ -8,7 +8,8 @@ import { sha256 } from "../../Util/sha256.ts";
  * exported class. The hash preserves uniqueness when the readable prefix must
  * be truncated to Cloudflare's 64-character limit.
  *
- * @internal
+ * Exported so a stack can reference a Workflow's physical name, for
+ * example to subscribe a Queue to it, without re-deriving it.
  */
 export const makeWorkflowName = (
   scriptName: Input<string>,

--- a/packages/alchemy/src/Cloudflare/Workflows/index.ts
+++ b/packages/alchemy/src/Cloudflare/Workflows/index.ts
@@ -1,2 +1,3 @@
 export * from "./Workflow.ts";
 export { makeWorkflowBridge } from "./WorkflowBridge.ts";
+export { makeWorkflowName } from "./WorkflowName.ts";


### PR DESCRIPTION
Export `makeWorkflowName` from `Cloudflare/Workflows` and drop its `@internal` marker.

```ts
const workflowName = Cloudflare.Workflows.makeWorkflowName(worker.workerName, "FileUrlIngestionWorkflow")

yield* Cloudflare.Queues.Subscription("terminal-events-subscription", {
  source: { type: "workflows.workflow", workflowName },
  // ...
})
```

A stack that subscribes a Queue to a Workflow registered by an async Worker binding needs the Workflow's physical name in the same deploy pass, where `WorkflowResource.ref` cannot resolve yet. Deriving it through the same function the binding uses keeps both sides in sync.

Closes #1456
