### PR TITLE
feat(cli): unify plan and dev output presentation

### DIFF
--- a/packages/alchemy/package.json
+++ b/packages/alchemy/package.json
@@ -423,7 +423,7 @@
     "@alchemy.run/cloudflare-runtime": "workspace:*",
     "@alchemy.run/floci": "workspace:*",
     "@alchemy.run/node-utils": "workspace:*",
-    "@alchemy.run/sigil": "0.0.0-alpha.6",
+    "@alchemy.run/sigil": "0.0.0-alpha.8",
     "@aws-sdk/credential-providers": "catalog:aws",
     "@distilled.cloud/aws": "workspace:*",
     "@distilled.cloud/axiom": "workspace:*",

--- a/packages/alchemy/src/Cli/NamespaceTree.ts
+++ b/packages/alchemy/src/Cli/NamespaceTree.ts
@@ -16,11 +16,6 @@ import {
 export type ActionTreeItem = ActionApply | ActionDelete;
 export type ActionVerb = ActionTreeItem["action"]; // "run" | "noop" | "delete"
 
-/** A resource belongs in a review/progress view only when it or a binding changes. */
-export const resourceHasPlannedWork = (item: CRUD): boolean =>
-  item.action !== "noop" ||
-  item.bindings.some((binding) => binding.action !== "noop");
-
 /** No-op actions are dependency markers, not work the user needs to review. */
 export const actionHasPlannedWork = (item: ActionTreeItem): boolean =>
   item.action !== "noop";
@@ -40,7 +35,7 @@ export interface PlanSummaryCounts {
   readonly bindingChanges: number;
 }
 
-/** Count the reviewable work in a plan — one tally behind every summary line. */
+/** Count every resource and task, plus binding changes, for the Plan summary. */
 export const buildPlanSummary = (plan: Plan): PlanSummaryCounts => {
   const allItems = [
     ...Object.values(plan.resources),
@@ -55,16 +50,14 @@ export const buildPlanSummary = (plan: Plan): PlanSummaryCounts => {
     noop: 0,
     replace: 0,
   };
-  for (const item of allItems.filter(resourceHasPlannedWork)) {
+  for (const item of allItems) {
     counts[item.action]++;
   }
   const taskCounts = { run: 0, noop: 0, delete: 0 };
   for (const item of [
     ...Object.values(plan.actions ?? {}),
     ...Object.values(plan.actionDeletions ?? {}),
-  ]
-    .filter((task): task is ActionTreeItem => task !== undefined)
-    .filter(actionHasPlannedWork)) {
+  ].filter((task): task is ActionTreeItem => task !== undefined)) {
     taskCounts[item.action]++;
   }
   const bindingChanges = allItems.reduce(

--- a/packages/alchemy/src/Cli/commands/dev.ts
+++ b/packages/alchemy/src/Cli/commands/dev.ts
@@ -22,10 +22,7 @@ import {
   profile,
   resolveStackArgs,
 } from "./flags.ts";
-import {
-  installShutdownFeedback,
-  suppressInterruptMessages,
-} from "./errors.ts";
+import { suppressInterruptMessages } from "./errors.ts";
 
 /**
  * Trust the Floci emulator CA in `alchemy dev` so cross-cloud data planes
@@ -56,9 +53,6 @@ export const devCommand = Command.make(
       // terminal and announces the Ctrl+C shutdown. Without this, a SIGINT
       // hits both processes and the interrupt message prints twice.
       yield* suppressInterruptMessages;
-      // Feedback stays silent here (suppressed — the exec child owns the
-      // terminal); this install is for the force-quit on a second Ctrl+C.
-      yield* installShutdownFeedback;
       const options = yield* Schema.encodeEffect(DevOptions)(args);
       const fs = yield* FileSystem.FileSystem;
       // Set on THIS process too, so the RPC spawner's sidecars (and the workerd
@@ -120,11 +114,6 @@ export const devCommand = Command.make(
         // Same process group as this supervisor: the exec child owns the
         // terminal (TUI stdin), so the tty's Ctrl+C must reach it directly.
         detached: false,
-        // The watcher won't die while its inner exec child is still shutting
-        // down — it forwards SIGTERM to the child and lingers. Without this
-        // bound the kill finalizer waits on it forever (the double-Ctrl+C
-        // hang); with it, a stuck shutdown escalates to SIGKILL.
-        forceKillAfter: "3 seconds",
       });
       yield* child.exitCode;
     },

--- a/packages/alchemy/src/Cli/commands/errors.ts
+++ b/packages/alchemy/src/Cli/commands/errors.ts
@@ -12,7 +12,6 @@ import {
   ansiFg,
   colorsEnabled,
   glyphsFor,
-  spinnerFramesFor,
   theme,
   unicodeEnabled,
 } from "../CliKit/index.ts";
@@ -50,56 +49,24 @@ export const suppressInterruptMessages = Effect.sync(() => {
   interruptMessagesSuppressed = true;
 });
 
-const SHUTDOWN_FEEDBACK_DELAY_MS = 200;
+const SHUTDOWN_FEEDBACK_DELAY_MS = 500;
 
 /**
- * Shutdown feedback on SIGINT/SIGTERM: silent when teardown finishes within
- * 200ms, otherwise a spinner (TTY) or periodic log lines (plain). A second
- * signal force-quits. Raw stderr + unref'd timers on purpose — the Effect
- * runtime (and any `Runtime.Teardown` hook) only settles after finalizers,
- * which is exactly the window this has to render through.
+ * Keep quick shutdowns quiet, but acknowledge cleanup that takes long enough
+ * to be noticeable. The Effect runtime continues to own signal handling and
+ * teardown; this listener only writes delayed feedback.
  */
 export const installShutdownFeedback = Effect.sync(() => {
-  let firstSignalAt: number | undefined;
+  let scheduled = false;
   const onSignal = () => {
-    if (firstSignalAt !== undefined) {
-      // Watchers and runners in the chain (`node --watch`, pnpm) forward the
-      // tty's SIGINT to their children, so ONE ^C can be delivered twice
-      // within milliseconds. Only a press after the feedback delay — when the
-      // "Ctrl+C again" hint can even be visible — means "force quit".
-      if (Date.now() - firstSignalAt < SHUTDOWN_FEEDBACK_DELAY_MS) return;
-      if (!interruptMessagesSuppressed) {
-        process.stderr.write(
-          colorsEnabled()
-            ? `\n${ANSI_DIM}Force quitting.${ANSI_RESET}\n`
-            : "\nForce quitting.\n",
-        );
-      }
-      process.exit(EXIT_CANCELLED);
-    }
-    firstSignalAt = Date.now();
-    if (interruptMessagesSuppressed) return;
-    const startedAt = firstSignalAt;
-    const elapsed = () => Math.round((Date.now() - startedAt) / 1000);
+    if (scheduled || interruptMessagesSuppressed) return;
+    scheduled = true;
     const timer = setTimeout(() => {
-      if (process.stderr.isTTY) {
-        const frames = spinnerFramesFor(unicodeEnabled());
-        let frame = 0;
-        const spin = setInterval(() => {
-          process.stderr.write(
-            `\r${frames[frame++ % frames.length]} Shutting down... (Ctrl+C again to force quit) `,
-          );
-        }, 80);
-        spin.unref();
-      } else {
-        process.stderr.write(
-          "Shutting down — waiting for cleanup to finish (Ctrl+C again to force quit)\n",
-        );
-        const report = setInterval(() => {
-          process.stderr.write(`Still shutting down (${elapsed()}s)\n`);
-        }, 5000);
-        report.unref();
-      }
+      process.stderr.write(
+        colorsEnabled()
+          ? `\n${ANSI_DIM}Shutting down${ANSI_RESET}\n`
+          : "\nShutting down\n",
+      );
     }, SHUTDOWN_FEEDBACK_DELAY_MS);
     timer.unref();
   };

--- a/packages/alchemy/src/Cli/commands/render.ts
+++ b/packages/alchemy/src/Cli/commands/render.ts
@@ -94,6 +94,11 @@ export const renderApply =
             ? session.emit(event)
             : Effect.void,
         ),
+        Effect.tap((value) =>
+          options?.dev && session.setOutput !== undefined
+            ? session.setOutput(value)
+            : Effect.void,
+        ),
         Effect.onExit((exit) =>
           Exit.isSuccess(exit)
             ? session.done("success")

--- a/packages/alchemy/src/Cli/commands/render.ts
+++ b/packages/alchemy/src/Cli/commands/render.ts
@@ -1,6 +1,8 @@
 import * as Cause from "effect/Cause";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
+import * as Option from "effect/Option";
+import * as Scope from "effect/Scope";
 import { Progress } from "../../Alchemist/Progress.ts";
 import type { Plan } from "../../Plan.ts";
 import * as Report from "../../Report.ts";
@@ -87,6 +89,15 @@ export const renderApply =
     Effect.gen(function* () {
       const cli = yield* Report.Cli;
       const session = yield* cli.startApplySession(plan, options);
+      // Dev keeps the widget mounted after apply settles and parks in the
+      // ambient scope; bind the widget's teardown to that scope so a reload
+      // or Ctrl+C removes it instead of stacking it under the next one.
+      if (options?.dev && session.close !== undefined) {
+        const scope = yield* Effect.serviceOption(Scope.Scope);
+        if (Option.isSome(scope)) {
+          yield* Scope.addFinalizer(scope.value, session.close);
+        }
+      }
       return yield* effect.pipe(
         Effect.provideService(Progress, (event) =>
           event._tag === "apply.resource.status" ||

--- a/packages/alchemy/src/Cli/components/ui/Feedback.tsx
+++ b/packages/alchemy/src/Cli/components/ui/Feedback.tsx
@@ -95,30 +95,77 @@ export function Alert({
   );
 }
 
-type KeyBarProps = {
+export interface KeyBarProps {
   readonly keys: ReadonlyArray<readonly [key: string, label: string]>;
   readonly marginTop?: number;
-};
+  readonly inline?: boolean;
+  /** Widget rendered before the key hints. */
+  readonly before?: ReactNode;
+  /** Widget rendered after the key hints. */
+  readonly after?: ReactNode;
+  /** Draw border rails between populated widget/key sections. */
+  readonly divider?: boolean;
+}
 
-export function KeyBar({ keys, marginTop = 1 }: KeyBarProps) {
+export function KeyBar({
+  keys,
+  marginTop = 1,
+  inline = false,
+  before,
+  after,
+  divider = false,
+}: KeyBarProps) {
+  const borderStyle = useBorderStyle();
+  const sectionBorder = {
+    borderStyle,
+    borderLeft: true,
+    borderRight: false,
+    borderTop: false,
+    borderBottom: false,
+    borderColor: theme.color.muted,
+    borderDimColor: true,
+    marginLeft: 1,
+    paddingLeft: 1,
+  } as const;
   return (
     <Box
-      width="100%"
+      width={inline ? undefined : "100%"}
       flexWrap="wrap"
       marginTop={marginTop}
-      paddingLeft={theme.space.indent}
+      paddingLeft={before === undefined ? theme.space.indent : 0}
     >
-      {keys.map(([key, label], index) => (
-        <Box key={`${key}:${label}`}>
-          {index === 0 ? null : <Text tone="muted"> • </Text>}
-          <Text>
-            <Text bold color={theme.color.brand}>
-              {key}
+      {before === undefined ? null : <Box>{before}</Box>}
+      <Box
+        flexWrap="wrap"
+        {...(divider && before !== undefined
+          ? sectionBorder
+          : before === undefined
+            ? {}
+            : { marginLeft: 1 })}
+      >
+        {keys.map(([key, label], index) => (
+          <Box key={`${key}:${label}`}>
+            {index === 0 ? null : <Text tone="muted"> • </Text>}
+            <Text>
+              <Text bold color={theme.color.brand}>
+                {key}
+              </Text>
+              <Text tone="muted"> {label}</Text>
             </Text>
-            <Text tone="muted"> {label}</Text>
-          </Text>
+          </Box>
+        ))}
+      </Box>
+      {after === undefined ? null : (
+        <Box
+          {...(divider
+            ? sectionBorder
+            : {
+                marginLeft: 1,
+              })}
+        >
+          {after}
         </Box>
-      ))}
+      )}
     </Box>
   );
 }

--- a/packages/alchemy/src/Cli/components/view/ApprovePlan.tsx
+++ b/packages/alchemy/src/Cli/components/view/ApprovePlan.tsx
@@ -11,7 +11,7 @@ import {
 } from "../ui/index.ts";
 import { Screen, theme, type ScreenController } from "../../CliKit/index.ts";
 import type { Plan as AlchemyPlan } from "../../../Plan.ts";
-import { Plan, PlanView, PlanViewStore } from "./PlanView.tsx";
+import { Plan, PlanTree } from "./PlanView.tsx";
 
 export interface ApprovePlanProps {
   plan: AlchemyPlan;
@@ -32,9 +32,24 @@ export function ApprovePlan(props: ApprovePlanProps): JSX.Element {
   const action = plan.destroy ? "Destroy" : "Deploy";
   const glyphs = useGlyphs();
   const keys = useKeyGlyphs();
-  const store = useMemo(
-    () => new PlanViewStore(plan, { detailed }),
-    [plan, detailed],
+  const tree = useMemo(
+    () =>
+      new PlanTree(plan, {
+        detailed,
+        mode: "review",
+        label: action,
+      }),
+    [plan, detailed, action],
+  );
+  const staticTree = useMemo(
+    () =>
+      new PlanTree(plan, {
+        detailed,
+        mode: "review",
+        label: action,
+        viewport: "full",
+      }),
+    [plan, detailed, action],
   );
 
   const complete = (answer: boolean) => {
@@ -50,7 +65,7 @@ export function ApprovePlan(props: ApprovePlanProps): JSX.Element {
       verdict
     ) : (
       <Box flexDirection="column">
-        <Plan plan={plan} detailed={detailed} />
+        <Plan tree={staticTree} />
         {verdict}
       </Box>
     );
@@ -65,35 +80,29 @@ export function ApprovePlan(props: ApprovePlanProps): JSX.Element {
     else if (input.toLowerCase() === "n") complete(false);
   });
 
-  return (
-    <Box flexDirection="column" gap={1}>
-      <PlanView
-        store={store}
-        mode="review"
-        detailed={detailed}
-        viewport="virtual"
+  const prompt = (
+    <Box flexDirection="column">
+      <Text bold>{action}?</Text>
+      <ChoiceGroup
+        value={approved}
+        choices={[
+          { value: true, label: action },
+          { value: false, label: "Cancel" },
+        ]}
+        onChange={setApproved}
       />
-      <Box flexDirection="column" marginTop={1}>
-        <Text bold>{action}?</Text>
-        <ChoiceGroup
-          value={approved}
-          choices={[
-            { value: true, label: action },
-            { value: false, label: "Cancel" },
-          ]}
-          onChange={setApproved}
-        />
-        <KeyBar
-          keys={[
-            [keys.upDown, "scroll plan"],
-            [keys.leftRight, "choose"],
-            [keys.enter, "confirm"],
-            [keys.escape, "cancel"],
-          ]}
-        />
-      </Box>
+      <KeyBar
+        keys={[
+          [keys.upDown, "scroll plan"],
+          [keys.leftRight, "choose"],
+          [keys.enter, "confirm"],
+          [keys.escape, "cancel"],
+        ]}
+      />
     </Box>
   );
+
+  return <Plan tree={tree} footer={prompt} />;
 }
 
 export const approvePlanScreen = (plan: AlchemyPlan, detailed = false) =>

--- a/packages/alchemy/src/Cli/components/view/ApprovePlan.tsx
+++ b/packages/alchemy/src/Cli/components/view/ApprovePlan.tsx
@@ -41,17 +41,6 @@ export function ApprovePlan(props: ApprovePlanProps): JSX.Element {
       }),
     [plan, detailed, action],
   );
-  const staticTree = useMemo(
-    () =>
-      new PlanTree(plan, {
-        detailed,
-        mode: "review",
-        label: action,
-        viewport: "full",
-      }),
-    [plan, detailed, action],
-  );
-
   const complete = (answer: boolean) => {
     const verdict = (
       <Text color={answer ? theme.color.success : theme.color.danger}>
@@ -61,11 +50,12 @@ export function ApprovePlan(props: ApprovePlanProps): JSX.Element {
     // On approval the plan disappears — the apply progress that follows
     // shows every row again. A declined plan stays on screen (complete,
     // unscrolled) so the user can review what they just turned down.
+    if (!answer) tree.setViewport("full");
     const summary = answer ? (
       verdict
     ) : (
       <Box flexDirection="column">
-        <Plan tree={staticTree} />
+        <Plan tree={tree} />
         {verdict}
       </Box>
     );

--- a/packages/alchemy/src/Cli/components/view/PlanDecision.tsx
+++ b/packages/alchemy/src/Cli/components/view/PlanDecision.tsx
@@ -2,14 +2,13 @@
 import { useMemo, useState, type JSX } from "react";
 import type { Plan } from "../../../Plan.ts";
 import {
-  Box,
   PromptFrame,
   ChoiceGroup,
   useKeyGlyphs,
   useTerminalInput,
 } from "../ui/index.ts";
 import { Screen, type ScreenController } from "../../CliKit/index.ts";
-import { PlanView, PlanViewStore } from "./PlanView.tsx";
+import { Plan as PlanComponent, PlanTree } from "./PlanView.tsx";
 
 export interface PlanDecisionChoice<Value> {
   readonly value: Value;
@@ -18,13 +17,24 @@ export interface PlanDecisionChoice<Value> {
 
 function PlanDecision<Value>(props: {
   readonly plan: Plan;
+  readonly label?: string;
   readonly message: string;
   readonly choices: ReadonlyArray<PlanDecisionChoice<Value>>;
   readonly initialValue: Value;
   readonly controller: ScreenController<Value>;
 }): JSX.Element {
-  const { plan, message, choices, initialValue, controller } = props;
-  const store = useMemo(() => new PlanViewStore(plan), [plan]);
+  const {
+    plan,
+    label = "Plan",
+    message,
+    choices,
+    initialValue,
+    controller,
+  } = props;
+  const tree = useMemo(
+    () => new PlanTree(plan, { mode: "review", label }),
+    [plan, label],
+  );
   const [selected, setSelected] = useState(initialValue);
   const keys = useKeyGlyphs();
 
@@ -34,29 +44,32 @@ function PlanDecision<Value>(props: {
   });
 
   return (
-    <Box flexDirection="column" gap={1}>
-      <PlanView store={store} mode="review" viewport="virtual" />
-      <PromptFrame
-        message={message}
-        keys={[
-          [keys.upDown, "scroll plan"],
-          [keys.leftRight, "choose"],
-          [keys.enter, "confirm"],
-          [keys.escape, "cancel"],
-        ]}
-      >
-        <ChoiceGroup
-          choices={choices}
-          value={selected}
-          onChange={setSelected}
-        />
-      </PromptFrame>
-    </Box>
+    <PlanComponent
+      tree={tree}
+      footer={
+        <PromptFrame
+          message={message}
+          keys={[
+            [keys.upDown, "scroll plan"],
+            [keys.leftRight, "choose"],
+            [keys.enter, "confirm"],
+            [keys.escape, "cancel"],
+          ]}
+        >
+          <ChoiceGroup
+            choices={choices}
+            value={selected}
+            onChange={setSelected}
+          />
+        </PromptFrame>
+      }
+    />
   );
 }
 
 export const planDecisionScreen = <Value,>(options: {
   readonly plan: Plan;
+  readonly label?: string;
   readonly message: string;
   readonly choices: ReadonlyArray<PlanDecisionChoice<Value>>;
   readonly initialValue: Value;

--- a/packages/alchemy/src/Cli/components/view/PlanRow.tsx
+++ b/packages/alchemy/src/Cli/components/view/PlanRow.tsx
@@ -1,8 +1,7 @@
 /** @jsxImportSource react */
 /**
- * Shared row shapes for the plan tree. Both the approved plan (Plan.tsx) and
- * the applying plan render namespaces through PlanView, this one
- * component so the two views look like the same tree.
+ * Shared rows for the Plan tree. Review and apply modes both render
+ * namespaces through this component so they look like the same tree.
  */
 import type { JSX } from "react";
 import { Row, Text, useGlyphs } from "../ui/index.ts";

--- a/packages/alchemy/src/Cli/components/view/PlanTree.ts
+++ b/packages/alchemy/src/Cli/components/view/PlanTree.ts
@@ -1,0 +1,355 @@
+import * as Predicate from "effect/Predicate";
+import type { ActionApply, ActionDelete, CRUD, Plan } from "../../../Plan.ts";
+import type {
+  ApplyEvent,
+  ApplyStatus,
+  ResourceStatusChanged,
+} from "../../../Report.ts";
+import type { ProviderMode } from "../../../ProviderMode.ts";
+import {
+  buildNamespaceTree,
+  buildPlanSummary,
+  flattenTree,
+  type ActionVerb,
+  type FlattenedItem,
+  type PlanSummaryCounts,
+} from "../../NamespaceTree.ts";
+import type { DeclaredPropertyYaml } from "../../PropertyDiff.ts";
+import { isInProgress, isTerminalStatus } from "./statusStyle.ts";
+
+export type PlanRow =
+  | {
+      key: string;
+      type: "namespace";
+      id: string;
+      depth: number;
+      action: FlattenedItem["action"];
+    }
+  | {
+      key: string;
+      type: "resource";
+      id: string;
+      resourceType: string;
+      depth: number;
+      action: CRUD["action"];
+      persistedApplyStatus?: "created" | "updated";
+      providerMode?: ProviderMode;
+      fromProviderMode?: ProviderMode;
+      propertyYaml?: DeclaredPropertyYaml;
+    }
+  | {
+      key: string;
+      type: "binding";
+      id: string;
+      depth: number;
+      action: "create" | "update" | "delete" | "noop";
+    }
+  | {
+      key: string;
+      type: "task";
+      id: string;
+      depth: number;
+      action: ActionVerb;
+    };
+
+export type ResourceRow = Extract<PlanRow, { type: "resource" }>;
+
+const isProgressRow = Predicate.not(
+  (row: PlanRow) =>
+    row.type === "namespace" ||
+    (row.type === "binding" && row.action === "noop"),
+);
+
+export interface RowState extends Required<
+  Pick<ResourceStatusChanged, "id" | "status">
+> {
+  key: string;
+  message?: string;
+  startedAt?: number;
+  elapsedMs?: number;
+}
+
+export type PlanViewport = "full" | "virtual";
+export type PlanView = "plan" | "output";
+export type PlanOutcome = "success" | "failure";
+
+export interface PlanProgress {
+  readonly completed: number;
+  readonly failures: number;
+  readonly total: number;
+}
+
+export interface PlanTreeState {
+  readonly tasks: Map<string, RowState>;
+  readonly label: string;
+  readonly visible: boolean;
+  readonly expanded: boolean;
+  readonly viewport: PlanViewport;
+  readonly busy: boolean;
+  readonly outcome: PlanOutcome | undefined;
+  readonly output: unknown;
+  readonly view: PlanView;
+}
+
+export interface PlanTreeOptions {
+  readonly detailed?: boolean;
+  readonly mode?: "review" | "apply";
+  readonly label?: string;
+  readonly titleDetail?: string;
+  readonly expanded?: boolean;
+  readonly visible?: boolean;
+  readonly viewport?: PlanViewport;
+  readonly busy?: boolean;
+  readonly outcome?: PlanOutcome;
+  readonly output?: unknown;
+}
+
+const getRowKey = (item: FlattenedItem) => item.path.join("/");
+
+const findCrudByLogicalId = (plan: Plan, id: string): CRUD | undefined =>
+  [...Object.values(plan.resources), ...Object.values(plan.deletions)].find(
+    (item): item is CRUD => item?.resource.LogicalId === id,
+  );
+
+const buildRows = (plan: Plan, detailed: boolean): PlanRow[] => {
+  const resources = [
+    ...Object.values(plan.resources),
+    ...Object.values(plan.deletions).filter(
+      (item): item is NonNullable<Plan["deletions"][string]> =>
+        item !== undefined,
+    ),
+  ] as CRUD[];
+  const actions = [
+    ...Object.values(plan.actions ?? {}),
+    ...Object.values(plan.actionDeletions ?? {}),
+  ].filter((task): task is ActionApply | ActionDelete => task !== undefined);
+
+  return flattenTree(buildNamespaceTree(resources, actions), {
+    includePropertyYaml: detailed,
+  }).map((item) => {
+    if (item.type === "namespace") {
+      return {
+        key: getRowKey(item),
+        type: "namespace" as const,
+        id: item.id,
+        depth: item.depth,
+        action: item.action,
+      };
+    }
+    if (item.type === "binding") {
+      return {
+        key: getRowKey(item),
+        type: "binding" as const,
+        id: item.bindingSid ?? item.id,
+        depth: item.depth,
+        action: item.action as "create" | "update" | "delete" | "noop",
+      };
+    }
+    if (item.type === "action") {
+      return {
+        key: getRowKey(item),
+        type: "task" as const,
+        id: item.id,
+        depth: item.depth,
+        action: item.action as ActionVerb,
+      };
+    }
+    return {
+      key: getRowKey(item),
+      type: "resource" as const,
+      id: item.id,
+      resourceType: item.resourceType ?? "Unknown",
+      depth: item.depth,
+      action: item.action as CRUD["action"],
+      providerMode: item.providerMode,
+      fromProviderMode: item.fromProviderMode,
+      propertyYaml: item.propertyYaml,
+      persistedApplyStatus:
+        item.action === "noop"
+          ? (() => {
+              const crud = findCrudByLogicalId(plan, item.id);
+              return crud?.action === "noop" ? crud.state.status : undefined;
+            })()
+          : undefined,
+    };
+  });
+};
+
+export const initialResourceState = (row: ResourceRow): RowState => ({
+  key: row.key,
+  id: row.id,
+  status:
+    row.action === "noop" ? (row.persistedApplyStatus ?? "created") : "pending",
+});
+
+const buildInitialTasks = (rows: readonly PlanRow[]) =>
+  new Map(
+    rows.flatMap((row): Array<[string, RowState]> => {
+      if (row.type === "resource")
+        return [[row.key, initialResourceState(row)]];
+      if (row.type === "binding") {
+        return [
+          [
+            row.key,
+            {
+              key: row.key,
+              id: row.id,
+              status: row.action === "noop" ? "created" : "pending",
+            },
+          ],
+        ];
+      }
+      if (row.type === "task") {
+        return [
+          [
+            row.key,
+            {
+              key: row.key,
+              id: row.id,
+              status: row.action === "noop" ? "skipped" : "pending",
+            },
+          ],
+        ];
+      }
+      return [];
+    }),
+  );
+
+export class PlanTree {
+  readonly rows: readonly PlanRow[];
+  readonly progressRows: readonly PlanRow[];
+  readonly summary: PlanSummaryCounts;
+  readonly mode: "review" | "apply";
+  readonly detailed: boolean;
+  readonly titleDetail?: string;
+  private state: PlanTreeState;
+  private readonly listeners = new Set<() => void>();
+
+  constructor(
+    readonly plan: Plan,
+    options: PlanTreeOptions = {},
+  ) {
+    this.detailed = options.detailed ?? false;
+    this.mode = options.mode ?? "review";
+    this.titleDetail = options.titleDetail;
+    this.rows = buildRows(plan, this.detailed);
+    this.progressRows = this.rows.filter(isProgressRow);
+    this.summary = buildPlanSummary(plan);
+    this.state = {
+      tasks: buildInitialTasks(this.rows),
+      label: options.label ?? "Plan",
+      visible: options.visible ?? true,
+      expanded: options.expanded ?? true,
+      viewport: options.viewport ?? "virtual",
+      busy: options.busy ?? false,
+      outcome: options.outcome,
+      output: options.output,
+      view: "plan",
+    };
+  }
+
+  subscribe(listener: () => void) {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  snapshot() {
+    return this.state;
+  }
+
+  progress(): PlanProgress {
+    let completed = 0;
+    let failures = 0;
+    let total = 0;
+    for (const row of this.progressRows) {
+      const status = this.state.tasks.get(row.key)?.status;
+      if (row.action !== "noop") {
+        total++;
+        if (status !== undefined && isTerminalStatus(status)) completed++;
+      }
+      if (status === "fail") failures++;
+    }
+    return { completed, failures, total };
+  }
+
+  setLabel(label: string) {
+    this.update({ label });
+  }
+
+  setExpanded(expanded: boolean) {
+    this.update({ expanded });
+  }
+
+  setVisible(visible: boolean) {
+    this.update({ visible });
+  }
+
+  setViewport(viewport: PlanViewport) {
+    this.update({ viewport });
+  }
+
+  setBusy(busy: boolean) {
+    this.update({
+      busy,
+      outcome: busy ? undefined : this.state.outcome,
+      view: busy ? "plan" : this.state.view,
+    });
+  }
+
+  finish(
+    outcome: PlanOutcome,
+    label: string,
+    view: PlanView = this.state.view,
+  ) {
+    this.update({ busy: false, outcome, label, view });
+  }
+
+  setOutput(output: unknown) {
+    this.update({ output });
+  }
+
+  setView(view: PlanView) {
+    this.update({ view });
+  }
+
+  emit(event: ApplyEvent) {
+    const tasks = new Map(this.state.tasks);
+    const key = event.fqn;
+    const now = Date.now();
+    const timing = (current: RowState | undefined, status: ApplyStatus) => {
+      const startedAt =
+        current?.startedAt ?? (isInProgress(status) ? now : undefined);
+      return {
+        startedAt,
+        elapsedMs:
+          isTerminalStatus(status) && startedAt !== undefined
+            ? now - startedAt
+            : current?.elapsedMs,
+      };
+    };
+
+    if (event._tag === "apply.resource.status") {
+      const rowKey = event.bindingId ? `${key}/${event.bindingId}` : key;
+      const current = tasks.get(rowKey);
+      if (current) {
+        tasks.set(rowKey, {
+          key: rowKey,
+          id: event.bindingId ?? event.id,
+          status: event.status,
+          message: event.message ?? current.message,
+          ...timing(current, event.status),
+        });
+      }
+    } else {
+      const current = tasks.get(key);
+      if (current) tasks.set(key, { ...current, message: event.message });
+    }
+
+    this.update({ tasks });
+  }
+
+  private update(patch: Partial<PlanTreeState>) {
+    this.state = { ...this.state, ...patch };
+    for (const listener of this.listeners) listener();
+  }
+}

--- a/packages/alchemy/src/Cli/components/view/PlanTree.ts
+++ b/packages/alchemy/src/Cli/components/view/PlanTree.ts
@@ -82,7 +82,6 @@ export interface PlanProgress {
 export interface PlanTreeState {
   readonly tasks: Map<string, RowState>;
   readonly label: string;
-  readonly visible: boolean;
   readonly expanded: boolean;
   readonly viewport: PlanViewport;
   readonly busy: boolean;
@@ -96,12 +95,8 @@ export interface PlanTreeOptions {
   readonly mode?: "review" | "apply";
   readonly label?: string;
   readonly titleDetail?: string;
-  readonly expanded?: boolean;
-  readonly visible?: boolean;
   readonly viewport?: PlanViewport;
   readonly busy?: boolean;
-  readonly outcome?: PlanOutcome;
-  readonly output?: unknown;
 }
 
 const getRowKey = (item: FlattenedItem) => item.path.join("/");
@@ -238,12 +233,11 @@ export class PlanTree {
     this.state = {
       tasks: buildInitialTasks(this.rows),
       label: options.label ?? "Plan",
-      visible: options.visible ?? true,
-      expanded: options.expanded ?? true,
+      expanded: true,
       viewport: options.viewport ?? "virtual",
       busy: options.busy ?? false,
-      outcome: options.outcome,
-      output: options.output,
+      outcome: undefined,
+      output: undefined,
       view: "plan",
     };
   }
@@ -272,16 +266,8 @@ export class PlanTree {
     return { completed, failures, total };
   }
 
-  setLabel(label: string) {
-    this.update({ label });
-  }
-
   setExpanded(expanded: boolean) {
     this.update({ expanded });
-  }
-
-  setVisible(visible: boolean) {
-    this.update({ visible });
   }
 
   setViewport(viewport: PlanViewport) {

--- a/packages/alchemy/src/Cli/components/view/PlanView.tsx
+++ b/packages/alchemy/src/Cli/components/view/PlanView.tsx
@@ -80,8 +80,6 @@ const rowDetail = (status: ApplyStatus, message: string | undefined) =>
 export interface PlanProps {
   /** Reactive tree containing rows, statuses, label, and presentation state. */
   tree: PlanTree;
-  /** Override the tree's reactive busy state. */
-  busy?: boolean;
   /** Allow the tree to collapse behind `p`. */
   collapsible?: boolean;
   /** Widget rendered before the summary block. */
@@ -105,7 +103,6 @@ const usePlanTree = (tree: PlanTree): PlanTreeState => {
 export function Plan(props: PlanProps): JSX.Element {
   const {
     tree,
-    busy: busyOverride,
     collapsible = false,
     before,
     summaryBefore,
@@ -117,8 +114,7 @@ export function Plan(props: PlanProps): JSX.Element {
   const keyGlyphs = useKeyGlyphs();
   const borderStyle = useBorderStyle();
   const state = usePlanTree(tree);
-  const { tasks, label, visible, viewport, busy: treeBusy } = state;
-  const busy = busyOverride ?? treeBusy;
+  const { tasks, label, viewport, busy } = state;
   const {
     progress: { completed, total: workRows },
     collapsed,
@@ -187,8 +183,6 @@ export function Plan(props: PlanProps): JSX.Element {
     ["p", collapsed ? "show plan/output" : "hide widget"],
     ["Ctrl+C", "exit"],
   ];
-
-  if (!visible) return <></>;
 
   return (
     <Box flexDirection="column">

--- a/packages/alchemy/src/Cli/components/view/PlanView.tsx
+++ b/packages/alchemy/src/Cli/components/view/PlanView.tsx
@@ -5,137 +5,63 @@
  * renders through this one state-driven component, so a plan always looks
  * the same wherever it appears.
  *
- * - One {@link PlanViewStore} holds the flattened tree (namespaces,
+ * - One {@link PlanTree} holds the flattened tree (namespaces,
  *   resources, bindings, actions) plus per-row runtime state (apply status
  *   and the row's latest log message), updated from engine
  *   {@link ApplyEvent}s.
  * - Two presentation `mode`s: `review` renders action glyphs (`+ ~ - ±`),
  *   `apply` renders live statuses with spinners and per-row messages.
- * - Two `viewport`s: `full` height or `virtual` (a terminal-sized, line-based
- *   window that follows the active row and supports keyboard scrolling).
+ * - `virtual` viewports follow the active row and support keyboard scrolling;
+ *   `full` viewports produce static terminal scrollback. This choice is
+ *   independent of whether the tree will receive more events.
  * - Property diffs (`detailed`) render in every mode, and the window is
  *   line-budget aware so multi-line rows never overflow the terminal.
  */
-import {
-  useMemo,
-  useState,
-  useSyncExternalStore,
-  type JSX,
-  type ReactNode,
-} from "react";
-import { useProgress, useTitle } from "@alchemy.run/sigil";
+import { useMemo, useSyncExternalStore, type JSX, type ReactNode } from "react";
 import {
   Box,
+  KeyBar,
   Row,
   SectionHeading,
-  Spinner,
-  Status,
+  SpinnerGlyph,
   TaskRow,
   Text,
   useBorderStyle,
   useGlyphs,
-  useTerminalInput,
-  useTerminalSize,
+  useKeyGlyphs,
 } from "../ui/index.ts";
-import type {
-  CRUD,
-  Plan as AlchemyPlan,
-  ActionApply,
-  ActionDelete,
-} from "../../../Plan.ts";
-import type {
-  ApplyEvent,
-  ApplyStatus,
-  ResourceStatusChanged,
-} from "../../../Report.ts";
-import {
-  buildNamespaceTree,
-  buildPlanSummary,
-  flattenTree,
-  type ActionVerb,
-  type FlattenedItem,
-  type PlanSummaryCounts,
-} from "../../NamespaceTree.ts";
+import type { Plan as AlchemyPlan } from "../../../Plan.ts";
+import type { ApplyStatus } from "../../../Report.ts";
+import type { ActionVerb, PlanSummaryCounts } from "../../NamespaceTree.ts";
 import { formatModeNote } from "../../ModeTag.ts";
 import { theme } from "../../CliKit/index.ts";
-import type { ProviderMode } from "../../../ProviderMode.ts";
 import { formatElapsed } from "../../Format.ts";
-import {
-  actionStyle,
-  applyStatusColor,
-  isInProgress,
-  isTerminalStatus,
-} from "./statusStyle.ts";
-import {
-  matchYamlChange,
-  matchYamlKey,
-  type DeclaredPropertyYaml,
-} from "../../PropertyDiff.ts";
+import { actionStyle, applyStatusColor, isInProgress } from "./statusStyle.ts";
+import { matchYamlChange, matchYamlKey } from "../../PropertyDiff.ts";
 import { NamespaceRow, namespaceStyle } from "./PlanRow.tsx";
+import { StackOutputs } from "./StackOutputs.tsx";
+import {
+  PlanTree,
+  initialResourceState,
+  type PlanRow,
+  type PlanTreeState,
+  type ResourceRow,
+  type RowState,
+} from "./PlanTree.ts";
+import { usePlanViewport } from "./usePlanViewport.ts";
+import { usePlanPresentation } from "./usePlanPresentation.ts";
 
-// ── Row model ─────────────────────────────────────────────────────────────
-
-export type PlanRow =
-  | {
-      key: string;
-      type: "namespace";
-      id: string;
-      depth: number;
-      action: FlattenedItem["action"];
-    }
-  | {
-      key: string;
-      type: "resource";
-      id: string;
-      resourceType: string;
-      depth: number;
-      action: CRUD["action"];
-      /** For `noop` resources, persisted state status to show instead of `pending`. */
-      persistedApplyStatus?: "created" | "updated";
-      /** Resolved provider mode; `undefined` for mode-agnostic providers. */
-      providerMode?: ProviderMode;
-      /** On mode-switch replacements, the old generation's stamped mode. */
-      fromProviderMode?: ProviderMode;
-      /** Declared property diff, present when the store was built `detailed`. */
-      propertyYaml?: DeclaredPropertyYaml;
-    }
-  | {
-      key: string;
-      type: "binding";
-      /** The binding sid, nested under its host resource. */
-      id: string;
-      depth: number;
-      action: "create" | "update" | "delete" | "noop";
-    }
-  | {
-      key: string;
-      type: "task";
-      id: string;
-      depth: number;
-      action: ActionVerb;
-    };
-
-type ResourceRow = Extract<PlanRow, { type: "resource" }>;
-
-/** Runtime state of one row: latest apply status + its own log line. */
-interface RowState extends Required<
-  Pick<ResourceStatusChanged, "id" | "status">
-> {
-  key: string;
-  message?: string;
-  /** When the row first went in-progress, for the settled-duration suffix. */
-  startedAt?: number;
-  /** Wall-clock duration once the row settles. */
-  elapsedMs?: number;
-}
-
-interface PlanViewState {
-  readonly tasks: Map<string, RowState>;
-  readonly outcome?: "success" | "failure";
-  /** Total apply duration, set when the session settles. */
-  readonly elapsedMs?: number;
-}
-
+export { PlanTree } from "./PlanTree.ts";
+export type {
+  PlanOutcome,
+  PlanProgress,
+  PlanRow,
+  PlanTreeOptions,
+  PlanTreeState,
+  PlanView,
+  PlanViewport,
+  RowState,
+} from "./PlanTree.ts";
 export type { PlanSummaryCounts } from "../../NamespaceTree.ts";
 
 /**
@@ -149,480 +75,263 @@ const rowDetail = (status: ApplyStatus, message: string | undefined) =>
     message
   );
 
-const getRowKey = (item: FlattenedItem) => item.path.join("/");
-
-const buildRows = (plan: AlchemyPlan, detailed: boolean): PlanRow[] => {
-  const items = [
-    ...Object.values(plan.resources),
-    ...Object.values(plan.deletions).filter(
-      (item): item is NonNullable<AlchemyPlan["deletions"][string]> =>
-        item !== undefined,
-    ),
-  ] as CRUD[];
-  const taskItems = [
-    ...Object.values(plan.actions ?? {}),
-    ...Object.values(plan.actionDeletions ?? {}),
-  ].filter((task): task is ActionApply | ActionDelete => task !== undefined);
-  const tree = buildNamespaceTree(items, taskItems);
-  return flattenTree(tree, { includePropertyYaml: detailed }).map((item) => {
-    if (item.type === "namespace") {
-      return {
-        key: getRowKey(item),
-        type: "namespace" as const,
-        id: item.id,
-        depth: item.depth,
-        action: item.action,
-      };
-    }
-    if (item.type === "binding") {
-      return {
-        key: getRowKey(item),
-        type: "binding" as const,
-        id: item.bindingSid ?? item.id,
-        depth: item.depth,
-        action: item.action as "create" | "update" | "delete" | "noop",
-      };
-    }
-    if (item.type === "action") {
-      return {
-        key: getRowKey(item),
-        type: "task" as const,
-        id: item.id,
-        depth: item.depth,
-        action: item.action as ActionVerb,
-      };
-    }
-    return {
-      key: getRowKey(item),
-      type: "resource" as const,
-      id: item.id,
-      resourceType: item.resourceType ?? "Unknown",
-      depth: item.depth,
-      action: item.action as CRUD["action"],
-      providerMode: item.providerMode,
-      fromProviderMode: item.fromProviderMode,
-      propertyYaml: item.propertyYaml,
-      persistedApplyStatus:
-        item.action === "noop"
-          ? (() => {
-              const crud = findCrudByLogicalId(plan, item.id);
-              return crud?.action === "noop" ? crud.state.status : undefined;
-            })()
-          : undefined,
-    };
-  });
-};
-
-const initialResourceState = (row: ResourceRow): RowState => ({
-  key: row.key,
-  id: row.id,
-  status:
-    row.action === "noop" ? (row.persistedApplyStatus ?? "created") : "pending",
-});
-
-const buildInitialTasks = (rows: PlanRow[]) =>
-  new Map(
-    rows.flatMap((row): Array<[string, RowState]> => {
-      if (row.type === "resource")
-        return [[row.key, initialResourceState(row)]];
-      if (row.type === "binding") {
-        // `noop` bindings render as "no change" from the start.
-        return [
-          [
-            row.key,
-            {
-              key: row.key,
-              id: row.id,
-              status: row.action === "noop" ? "created" : "pending",
-            },
-          ],
-        ];
-      }
-      if (row.type === "task") {
-        // `noop` tasks are skipped — render as gray `•` from the start
-        // rather than briefly flashing the `ran` cyan styling.
-        return [
-          [
-            row.key,
-            {
-              key: row.key,
-              id: row.id,
-              status: row.action === "noop" ? "skipped" : "pending",
-            },
-          ],
-        ];
-      }
-      return [];
-    }),
-  );
-
-// ── Store ─────────────────────────────────────────────────────────────────
-
-/**
- * The state behind a rendered plan: the flattened rows plus each row's live
- * status and log message. A static review is simply a store nobody emits to.
- */
-export class PlanViewStore {
-  readonly rows: PlanRow[];
-  readonly summary: PlanSummaryCounts;
-  private readonly startedAtMs = Date.now();
-  private state: PlanViewState;
-  private readonly listeners = new Set<() => void>();
-
-  constructor(
-    readonly plan: AlchemyPlan,
-    options: { detailed?: boolean } = {},
-  ) {
-    this.rows = buildRows(plan, options.detailed ?? false);
-    this.summary = buildPlanSummary(plan);
-    this.state = { tasks: buildInitialTasks(this.rows) };
-  }
-
-  readonly subscribe = (listener: () => void) => {
-    this.listeners.add(listener);
-    return () => this.listeners.delete(listener);
-  };
-
-  readonly snapshot = () => this.state;
-
-  readonly finish = (outcome: "success" | "failure") => {
-    this.state = {
-      ...this.state,
-      outcome,
-      elapsedMs: Date.now() - this.startedAtMs,
-    };
-    for (const listener of this.listeners) listener();
-  };
-
-  emit(event: ApplyEvent) {
-    const next = new Map(this.state.tasks);
-    const key = event.fqn;
-    const now = Date.now();
-    // First in-progress status starts the row's clock; the settling status
-    // stops it. Renderer-side timing keeps the events themselves pure.
-    const timing = (current: RowState | undefined, status: ApplyStatus) => {
-      const startedAt =
-        current?.startedAt ?? (isInProgress(status) ? now : undefined);
-      return {
-        startedAt,
-        elapsedMs:
-          isTerminalStatus(status) && startedAt !== undefined
-            ? now - startedAt
-            : current?.elapsedMs,
-      };
-    };
-
-    if (event._tag === "apply.resource.status") {
-      if (event.bindingId) {
-        // Binding rows key as `<host resource key>/<sid>`.
-        const bindingId = event.bindingId;
-        const bindingKey = `${key}/${bindingId}`;
-        const current = next.get(bindingKey);
-        if (current) {
-          next.set(bindingKey, {
-            key: bindingKey,
-            id: bindingId,
-            status: event.status,
-            message: event.message ?? current.message,
-            ...timing(current, event.status),
-          });
-        }
-      } else {
-        const current = next.get(key);
-        if (current)
-          next.set(key, {
-            key,
-            id: event.id,
-            status: event.status,
-            message: event.message ?? current.message,
-            ...timing(current, event.status),
-          });
-      }
-    } else {
-      const current = next.get(key);
-      if (current) next.set(key, { ...current, message: event.message });
-    }
-
-    this.state = { ...this.state, tasks: next };
-    for (const listener of this.listeners) listener();
-  }
-}
-
-// ── Viewport ──────────────────────────────────────────────────────────────
-
-export type PlanViewport =
-  /** Render every row. */
-  | "full"
-  /** Terminal-sized window that follows the active row; ↑/↓ scroll. */
-  | "virtual";
-
-type VirtualPlanLine =
-  | { readonly kind: "row"; readonly row: PlanRow }
-  | {
-      readonly kind: "yaml";
-      readonly key: string;
-      readonly line: string;
-      readonly paddingLeft: number;
-    }
-  | {
-      readonly kind: "note";
-      readonly key: string;
-      readonly paddingLeft: number;
-    };
-
-const virtualPlanLines = (
-  rows: ReadonlyArray<PlanRow>,
-  detailed: boolean,
-): VirtualPlanLine[] =>
-  rows.flatMap((row): VirtualPlanLine[] => {
-    const lines: VirtualPlanLine[] = [{ kind: "row", row }];
-    if (row.type !== "resource") return lines;
-    const showYaml = detailed || row.propertyYaml?.kind === "drift";
-    if (!showYaml) return lines;
-    if (row.propertyYaml !== undefined) {
-      lines.push(
-        ...row.propertyYaml.lines.map((line, index) => ({
-          kind: "yaml" as const,
-          key: `${row.key}:yaml:${index}`,
-          line,
-          paddingLeft: row.depth * 2 + 2,
-        })),
-      );
-    } else if (
-      row.action === "update" ||
-      row.action === "adopted" ||
-      row.action === "replace"
-    ) {
-      lines.push({
-        kind: "note",
-        key: `${row.key}:note`,
-        paddingLeft: row.depth * 2 + 2,
-      });
-    }
-    return lines;
-  });
-
 // ── Component ─────────────────────────────────────────────────────────────
 
-export interface PlanViewProps {
-  store: PlanViewStore;
-  /** `review` renders action glyphs; `apply` renders live statuses. */
-  mode: "review" | "apply";
-  /** @default "full" for review, "virtual" for apply */
-  viewport?: PlanViewport;
-  /** Render property diffs beneath changed resources. */
-  detailed?: boolean;
-  /** Stage shown in the apply title. */
-  stage?: string;
+export interface PlanProps {
+  /** Reactive tree containing rows, statuses, label, and presentation state. */
+  tree: PlanTree;
+  /** Override the tree's reactive busy state. */
+  busy?: boolean;
+  /** Allow the tree to collapse behind `p`. */
+  collapsible?: boolean;
+  /** Widget rendered before the summary block. */
+  before?: ReactNode;
+  /** Widget rendered on the summary row before the summary. */
+  summaryBefore?: ReactNode;
+  /** Widget rendered on the summary row after the summary. */
+  summaryAfter?: ReactNode;
+  /** Widget rendered below the virtualized rows. */
+  footer?: ReactNode;
+  /** Widget rendered after the complete Plan. */
+  after?: ReactNode;
 }
 
-export function PlanView(props: PlanViewProps): JSX.Element {
-  const { store, mode, detailed = false, stage } = props;
-  const viewport = props.viewport ?? (mode === "apply" ? "virtual" : "full");
-  const { rows } = store;
-  const glyphs = useGlyphs();
+const usePlanTree = (tree: PlanTree): PlanTreeState => {
+  const subscribe = useMemo(() => tree.subscribe.bind(tree), [tree]);
+  const snapshot = useMemo(() => tree.snapshot.bind(tree), [tree]);
+  return useSyncExternalStore(subscribe, snapshot);
+};
+
+export function Plan(props: PlanProps): JSX.Element {
+  const {
+    tree,
+    busy: busyOverride,
+    collapsible = false,
+    before,
+    summaryBefore,
+    summaryAfter,
+    footer,
+    after,
+  } = props;
+  const { mode } = tree;
+  const keyGlyphs = useKeyGlyphs();
   const borderStyle = useBorderStyle();
-  const { rows: terminalRows } = useTerminalSize();
-  const { tasks, outcome, elapsedMs } = useSyncExternalStore(
-    store.subscribe,
-    store.snapshot,
-  );
-
-  // ── Progress accounting (apply header + sigil progress/title) ─────────
-  let completed = 0;
-  let failures = 0;
-  let noops = 0;
-  let workRows = 0;
-  for (const row of rows) {
-    if (row.type !== "resource" && row.type !== "task") continue;
-    const status = tasks.get(row.key)?.status;
-    if (row.action !== "noop") {
-      workRows++;
-      if (status !== undefined && isTerminalStatus(status)) completed++;
-    } else {
-      noops++;
-    }
-    if (status === "fail") failures++;
-  }
-  const failed = outcome === "failure" || failures > 0;
-  const finished = outcome !== undefined;
-
-  useProgress(
-    mode === "apply"
-      ? {
-          state: failed
-            ? "error"
-            : finished || workRows === 0
-              ? "inactive"
-              : "normal",
-          value: workRows === 0 ? undefined : (completed / workRows) * 100,
-        }
-      : { state: "inactive" },
-  );
-  const applyLabel =
-    workRows === 0 && !failed
-      ? "No changes"
-      : runLabel(store.plan, failed, finished);
-  const titleProgress = finished ? "" : ` ${completed}/${workRows}`;
-  useTitle(
-    mode === "apply"
-      ? stage === undefined
-        ? `${applyLabel}${titleProgress}`
-        : `${applyLabel}${titleProgress} · ${stage}`
-      : undefined,
-  );
-
-  // ── Windowing ─────────────────────────────────────────────────────────
-  const lineBudget =
-    viewport === "virtual"
-      ? Math.max(4, terminalRows - 8)
-      : Number.POSITIVE_INFINITY;
-  const budgetRows =
-    lineBudget === Number.POSITIVE_INFINITY
-      ? rows.length
-      : Math.max(1, Math.floor(lineBudget));
-  const expandedLines = useMemo(
-    () => virtualPlanLines(rows, detailed),
-    [rows, detailed],
-  );
-  const virtualizing = viewport === "virtual" && !finished;
-  const scrollLength = virtualizing ? expandedLines.length : rows.length;
-  const maxOffset = Math.max(0, scrollLength - budgetRows);
-  const activeRowIndex = rows.findIndex((row) => {
-    if (row.type !== "resource" && row.type !== "task") return false;
-    const status = tasks.get(row.key)?.status;
-    return status !== undefined && !isTerminalStatus(status);
+  const state = usePlanTree(tree);
+  const { tasks, label, visible, viewport, busy: treeBusy } = state;
+  const busy = busyOverride ?? treeBusy;
+  const {
+    progress: { completed, total: workRows },
+    collapsed,
+    showControls,
+    lineBudget,
+    refs: { beforeRef, summaryRef, controlsRef, afterRef },
+  } = usePlanPresentation({
+    tree,
+    state,
+    busy,
+    collapsible,
+    hasFooter: footer !== undefined,
   });
-  const activeIndex = virtualizing
-    ? expandedLines.findIndex(
-        (line) => line.kind === "row" && line.row === rows[activeRowIndex],
-      )
-    : activeRowIndex;
-  const followedOffset = Math.min(
-    maxOffset,
-    Math.max(
-      0,
-      (activeIndex < 0 ? rows.length : activeIndex) -
-        Math.floor(budgetRows / 3),
-    ),
-  );
-  const [manualOffset, setManualOffset] = useState<number>();
-  const offset =
-    viewport === "full"
-      ? 0
-      : Math.min(maxOffset, manualOffset ?? followedOffset);
-  const visibleRows = rows;
-  const visibleLines = virtualizing
-    ? expandedLines.slice(offset, offset + budgetRows)
-    : undefined;
-  const shownOffset = virtualizing ? offset : 0;
-  const hiddenBelow = virtualizing
-    ? expandedLines.length - shownOffset - (visibleLines?.length ?? 0)
-    : 0;
-
-  useTerminalInput((_input, key) => {
-    if (viewport !== "virtual" || finished) return;
-    const page = Math.max(1, Math.floor(lineBudget));
-    if (key.up)
-      setManualOffset((current) => Math.max(0, (current ?? offset) - 1));
-    else if (key.down)
-      setManualOffset((current) =>
-        Math.min(maxOffset, (current ?? offset) + 1),
-      );
-    else if (key.pageUp)
-      setManualOffset((current) => Math.max(0, (current ?? offset) - page));
-    else if (key.pageDown)
-      setManualOffset((current) =>
-        Math.min(maxOffset, (current ?? offset) + page),
-      );
-    else if (key.home) setManualOffset(0);
-    else if (key.end) setManualOffset(undefined);
+  const {
+    selectedView,
+    hasOutput,
+    virtual: virtualizing,
+    budget: budgetRows,
+    offset: shownOffset,
+    hiddenBelow,
+    planLines: visibleLines,
+  } = usePlanViewport({
+    tree,
+    state,
+    lineBudget,
+    collapsible,
+    collapsed,
   });
 
-  // ── Header ────────────────────────────────────────────────────────────
-  const summary =
+  // ── Summary and operation bar ─────────────────────────────────────────
+  const operationProgress =
     mode === "apply" ? (
-      finished ? (
-        <Status
-          variant={failed ? "error" : "success"}
-          detail={applySummary(completed, workRows, noops, failures, elapsedMs)}
-        >
-          {applyLabel}
-        </Status>
-      ) : (
-        <Spinner
-          label={applyLabel}
-          detail={applySummary(completed, workRows, noops, failures)}
-        />
-      )
+      <>
+        {busy ? (
+          <>
+            <SpinnerGlyph color={theme.color.brand} />
+            <Text> </Text>
+          </>
+        ) : null}
+        <SectionHeading>{label}</SectionHeading>
+        <Text tone="muted">
+          {workRows === 0 ? "" : ` (${completed}/${workRows})`}
+        </Text>
+      </>
+    ) : null;
+  const planSummary =
+    selectedView === "output" ? (
+      <SectionHeading>Output</SectionHeading>
+    ) : mode === "apply" ? (
+      <ApplySummary label="Plan" rows={tree.progressRows} tasks={tasks} />
     ) : (
-      <ReviewSummary summary={store.summary} />
+      <ReviewSummary label={label} summary={tree.summary} />
     );
+  const planKeys: ReadonlyArray<readonly [string, string]> = [
+    ...(!collapsed && viewport === "virtual"
+      ? [[keyGlyphs.upDown, `scroll ${selectedView}`] as const]
+      : []),
+    ...(!collapsed && hasOutput
+      ? [
+          [
+            keyGlyphs.leftRight,
+            selectedView === "plan" ? "show output" : "show plan",
+          ] as const,
+        ]
+      : []),
+    ["p", collapsed ? "show plan/output" : "hide widget"],
+    ["Ctrl+C", "exit"],
+  ];
+
+  if (!visible) return <></>;
 
   return (
     <Box flexDirection="column">
-      <Box
-        marginBottom={1}
-        borderStyle={borderStyle}
-        borderBottom
-        borderTop={false}
-        borderLeft={false}
-        borderRight={false}
-        borderColor={theme.color.muted}
-        borderDimColor
-      >
-        {summary}
+      <Box ref={beforeRef} flexDirection="column">
+        {before}
       </Box>
-      <Box flexDirection="column">
-        {shownOffset > 0 ? (
-          <Text tone="muted">
-            {glyphs.overflowUp} {shownOffset} earlier{" "}
-            {virtualizing ? "lines" : "rows"}
-          </Text>
-        ) : null}
-        {visibleLines === undefined
-          ? visibleRows.map((row) => (
-              <PlanRowView
-                key={row.key}
-                row={row}
-                mode={mode}
-                detailed={detailed}
-                state={tasks.get(row.key)}
-                defaultMode={store.plan.defaultMode}
-              />
-            ))
-          : visibleLines.map((line) =>
-              line.kind === "row" ? (
-                <PlanRowView
-                  key={line.row.key}
-                  row={line.row}
-                  mode={mode}
-                  detailed={detailed}
-                  includeYaml={false}
-                  state={tasks.get(line.row.key)}
-                  defaultMode={store.plan.defaultMode}
-                />
-              ) : line.kind === "yaml" ? (
-                <YamlLine
-                  key={line.key}
-                  line={line.line}
-                  paddingLeft={line.paddingLeft}
-                />
-              ) : (
-                <DetailLine key={line.key} paddingLeft={line.paddingLeft}>
-                  <Text tone="muted" dimColor>
-                    no declared property changes
-                  </Text>
-                </DetailLine>
-              ),
-            )}
-        {hiddenBelow > 0 ? (
-          <Text tone="muted">
-            {glyphs.overflowDown} {hiddenBelow} more{" "}
-            {virtualizing ? "lines" : "rows"}
-          </Text>
-        ) : null}
+      {collapsed ? null : (
+        <Box
+          ref={summaryRef}
+          marginBottom={1}
+          borderStyle={borderStyle}
+          borderTop
+          borderBottom={false}
+          borderLeft={false}
+          borderRight={false}
+          borderColor={theme.color.muted}
+          borderDimColor
+        >
+          {summaryBefore}
+          {planSummary}
+          {summaryAfter}
+        </Box>
+      )}
+      {collapsed ? null : (
+        <PlanContent
+          tree={tree}
+          state={state}
+          selectedView={selectedView}
+          virtual={virtualizing}
+          budget={budgetRows}
+          offset={shownOffset}
+          hiddenBelow={hiddenBelow}
+          lines={visibleLines}
+        />
+      )}
+      {showControls ? (
+        <Box
+          ref={controlsRef}
+          marginTop={collapsed ? 0 : 1}
+          borderStyle={borderStyle}
+          borderTop
+          borderBottom={false}
+          borderLeft={false}
+          borderRight={false}
+          borderColor={theme.color.muted}
+          borderDimColor
+        >
+          {collapsible ? (
+            <KeyBar
+              inline
+              marginTop={0}
+              before={operationProgress}
+              keys={planKeys}
+              after={footer}
+              divider={mode === "apply" || footer !== undefined}
+            />
+          ) : mode === "apply" ? (
+            <>
+              {operationProgress}
+              {footer}
+            </>
+          ) : (
+            footer
+          )}
+        </Box>
+      ) : null}
+      <Box ref={afterRef} flexDirection="column">
+        {after}
       </Box>
+    </Box>
+  );
+}
+
+function PlanContent(props: {
+  readonly tree: PlanTree;
+  readonly state: PlanTreeState;
+  readonly selectedView: "plan" | "output";
+  readonly virtual: boolean;
+  readonly budget: number;
+  readonly offset: number;
+  readonly hiddenBelow: number;
+  readonly lines: ReturnType<typeof usePlanViewport>["planLines"];
+}) {
+  const { tree, state, selectedView, virtual, budget, offset, hiddenBelow } =
+    props;
+  const glyphs = useGlyphs();
+  const overflowUnit = virtual ? "lines" : "rows";
+  return (
+    <Box flexDirection="column">
+      {offset > 0 ? (
+        <Text tone="muted">
+          {glyphs.overflowUp} {offset} earlier {overflowUnit}
+        </Text>
+      ) : null}
+      {selectedView === "output" ? (
+        <StackOutputs
+          value={state.output}
+          offset={offset}
+          limit={virtual ? budget : undefined}
+        />
+      ) : props.lines === undefined ? (
+        tree.rows.map((row) => (
+          <PlanRowView
+            key={row.key}
+            row={row}
+            mode={tree.mode}
+            detailed={tree.detailed}
+            state={state.tasks.get(row.key)}
+            defaultMode={tree.plan.defaultMode}
+          />
+        ))
+      ) : (
+        props.lines.map((line) =>
+          line.kind === "row" ? (
+            <PlanRowView
+              key={line.row.key}
+              row={line.row}
+              mode={tree.mode}
+              detailed={tree.detailed}
+              includeYaml={false}
+              state={state.tasks.get(line.row.key)}
+              defaultMode={tree.plan.defaultMode}
+            />
+          ) : line.kind === "yaml" ? (
+            <YamlLine
+              key={line.key}
+              line={line.line}
+              paddingLeft={line.paddingLeft}
+            />
+          ) : (
+            <DetailLine key={line.key} paddingLeft={line.paddingLeft}>
+              <Text tone="muted" dimColor>
+                no declared property changes
+              </Text>
+            </DetailLine>
+          ),
+        )
+      )}
+      {hiddenBelow > 0 ? (
+        <Text tone="muted">
+          {glyphs.overflowDown} {hiddenBelow} more {overflowUnit}
+        </Text>
+      ) : null}
     </Box>
   );
 }
@@ -847,7 +556,10 @@ function PlanRowView(props: {
 
 // ── Headers ───────────────────────────────────────────────────────────────
 
-function ReviewSummary(props: { summary: PlanSummaryCounts }): JSX.Element {
+function ReviewSummary(props: {
+  label: string;
+  summary: PlanSummaryCounts;
+}): JSX.Element {
   const { counts, taskCounts, bindingChanges } = props.summary;
   const parts = [
     ...(
@@ -859,6 +571,15 @@ function ReviewSummary(props: { summary: PlanSummaryCounts }): JSX.Element {
         label: `${counts[action]} to ${action}`,
         color: namespaceStyle(action).color,
       })),
+    ...(counts.noop > 0
+      ? [
+          {
+            key: "noop",
+            label: `${counts.noop} no change`,
+            color: theme.color.muted,
+          },
+        ]
+      : []),
     ...(taskCounts.run > 0
       ? [
           {
@@ -877,6 +598,15 @@ function ReviewSummary(props: { summary: PlanSummaryCounts }): JSX.Element {
           },
         ]
       : []),
+    ...(taskCounts.noop > 0
+      ? [
+          {
+            key: "task-noop",
+            label: `${taskCounts.noop} tasks no change`,
+            color: theme.color.muted,
+          },
+        ]
+      : []),
     ...(bindingChanges > 0
       ? [
           {
@@ -889,7 +619,7 @@ function ReviewSummary(props: { summary: PlanSummaryCounts }): JSX.Element {
   ];
   return (
     <>
-      <SectionHeading>Plan</SectionHeading>
+      <SectionHeading>{props.label}</SectionHeading>
       <Text tone="muted"> · </Text>
       {parts.length === 0 ? (
         <Text tone="muted">no changes</Text>
@@ -905,28 +635,68 @@ function ReviewSummary(props: { summary: PlanSummaryCounts }): JSX.Element {
   );
 }
 
-const applySummary = (
-  completed: number,
-  workRows: number,
-  noops: number,
-  failures: number,
-  elapsedMs?: number,
-) =>
-  `(${completed}/${workRows}) · ${completed} done · ${noops} noop${failures > 0 ? ` · ${failures} failed` : ""}${elapsedMs === undefined ? "" : ` · ${formatElapsed(elapsedMs)}`}`;
+const applySummaryOrder: readonly (ApplyStatus | "no change")[] = [
+  "fail",
+  "attaching",
+  "post-attach",
+  "pre-creating",
+  "creating",
+  "creating replacement",
+  "updating",
+  "adopting",
+  "deleting",
+  "orphaning",
+  "replacing",
+  "running",
+  "pending",
+  "created",
+  "updated",
+  "adopted",
+  "deleted",
+  "orphaned",
+  "replaced",
+  "ran",
+  "skipped",
+  "no change",
+];
 
-const runLabel = (plan: AlchemyPlan, failed: boolean, finished: boolean) => {
-  if (failed) {
-    if (plan.destroy) return "Destroy failed";
-    return plan.defaultMode === "local"
-      ? "Dev startup failed"
-      : "Deploy failed";
+function ApplySummary(props: {
+  label: string;
+  rows: readonly PlanRow[];
+  tasks: ReadonlyMap<string, RowState>;
+}): JSX.Element {
+  const counts = new Map<ApplyStatus | "no change", number>();
+  for (const row of props.rows) {
+    const status = props.tasks.get(row.key)?.status ?? "pending";
+    const displayStatus = row.action === "noop" ? "no change" : status;
+    counts.set(displayStatus, (counts.get(displayStatus) ?? 0) + 1);
   }
-  if (plan.destroy) return finished ? "Stack destroyed" : "Destroying stack";
-  if (plan.defaultMode === "local") {
-    return finished ? "Dev stack ready" : "Starting dev stack";
-  }
-  return finished ? "Stack deployed" : "Deploying stack";
-};
+  const parts = applySummaryOrder
+    .filter((status) => counts.has(status))
+    .map((status) => ({
+      status,
+      count: counts.get(status) ?? 0,
+    }));
+
+  return (
+    <>
+      <SectionHeading>{props.label}</SectionHeading>
+      <Text tone="muted"> · </Text>
+      {parts.length === 0 ? (
+        <Text tone="muted">no resources</Text>
+      ) : (
+        parts.map((part, index) => (
+          <Box key={part.status}>
+            {index === 0 ? null : <Text tone="muted"> · </Text>}
+            <Text color={applyStatusColor(part.status)}>
+              {part.count} {part.status}
+            </Text>
+          </Box>
+        ))
+      )}
+    </>
+  );
+}
 
 // ── Status helpers ────────────────────────────────────────────────────────
 
@@ -1048,38 +818,4 @@ function DetailLine({
   );
 }
 
-const findCrudByLogicalId = (
-  plan: AlchemyPlan,
-  logicalId: string,
-): CRUD | undefined => {
-  for (const node of Object.values(plan.resources)) {
-    if (node.resource.LogicalId === logicalId) {
-      return node;
-    }
-  }
-  for (const node of Object.values(plan.deletions)) {
-    if (node?.resource.LogicalId === logicalId) {
-      return node;
-    }
-  }
-  return undefined;
-};
-
 // ── Static convenience ────────────────────────────────────────────────────
-
-export interface PlanProps {
-  plan: AlchemyPlan;
-  /** Include declared resource inputs as YAML beneath each changed row. */
-  detailed?: boolean;
-}
-
-/** A static plan review — {@link PlanView} over a store nobody emits to. */
-export function Plan({ plan, detailed = false }: PlanProps): JSX.Element {
-  const store = useMemo(
-    () => new PlanViewStore(plan, { detailed }),
-    [plan, detailed],
-  );
-  return (
-    <PlanView store={store} mode="review" detailed={detailed} viewport="full" />
-  );
-}

--- a/packages/alchemy/src/Cli/components/view/Runtime.tsx
+++ b/packages/alchemy/src/Cli/components/view/Runtime.tsx
@@ -273,9 +273,8 @@ function TerminalRoot({ store }: TerminalRootProps) {
   const state = useSyncExternalStore(store.subscribe, store.snapshot);
   useTerminalInput(
     (input, key) => {
-      // Ctrl-C while raw-mode rendering has no active prompt: surface it as a
-      // regular SIGINT so the process-level handler owns shutdown.
-      if (key.ctrl && input === "c") process.kill(process.pid, "SIGINT");
+      if (!key.ctrl || input !== "c") return;
+      process.kill(process.pid, "SIGINT");
     },
     { active: state.active === undefined },
   );

--- a/packages/alchemy/src/Cli/components/view/SigilCli.tsx
+++ b/packages/alchemy/src/Cli/components/view/SigilCli.tsx
@@ -10,7 +10,7 @@ import { CliKit } from "../../CliKit/index.ts";
 import type { ApplyEvent } from "../../../Report.ts";
 import { formatElapsed } from "../../Format.ts";
 import { approvePlanScreen } from "./ApprovePlan.tsx";
-import { Plan as PlanComponent, PlanView, PlanViewStore } from "./PlanView.tsx";
+import { Plan as PlanComponent, PlanTree } from "./PlanView.tsx";
 
 export const sigilCli = () =>
   Layer.effect(
@@ -44,9 +44,13 @@ const displayPlan = Effect.fn(function* <P extends Plan>(
   plan: P,
   options?: import("../../../Report.ts").PlanDisplayOptions,
 ) {
-  yield* cli.output.print(
-    <PlanComponent plan={plan} detailed={options?.detailed} />,
-  );
+  const tree = new PlanTree(plan, {
+    detailed: options?.detailed,
+    mode: "review",
+    label: "Plan",
+    viewport: "full",
+  });
+  yield* cli.output.print(<PlanComponent tree={tree} />);
 });
 
 const startPlanningSession = Effect.fn(function* (
@@ -105,33 +109,63 @@ const startApplySession = Effect.fn(function* <P extends Plan>(
   plan: P,
   options?: import("../../../Report.ts").PlanDisplayOptions,
 ) {
-  // Detailed applies render their YAML diffs inline in the progress tree;
-  // persistOnClose keeps the final full render (diffs included) in
-  // scrollback, covering --yes deployments too.
-  const progress = new PlanViewStore(plan, { detailed: options?.detailed });
+  // Detailed applies render their YAML diffs inline in the progress tree.
+  // One-shot operations persist the final render; dev keeps its live block
+  // mounted so logs remain static above the collapsible plan and keybar.
+  const labels = plan.destroy
+    ? {
+        active: "Destroying stack",
+        success: "Stack destroyed",
+        failure: "Destroy failed",
+      }
+    : plan.defaultMode === "local"
+      ? {
+          active: "Starting dev stack",
+          success: "Dev stack ready",
+          failure: "Dev startup failed",
+        }
+      : {
+          active: "Deploying stack",
+          success: "Stack deployed",
+          failure: "Deploy failed",
+        };
+  const progress = new PlanTree(plan, {
+    detailed: options?.detailed,
+    mode: "apply",
+    label: labels.active,
+    titleDetail: options?.stage,
+    busy: true,
+  });
   // The session outlives this effect — the caller settles it via `done` on
   // every exit path (Apply.ts's onExit). live.open is Scope-bound, so give
-  // it a manually managed scope that `done` closes; Apply deliberately runs
-  // the session in the ambient scope, so we cannot lean on Effect.scoped
-  // here.
+  // it a manually managed scope. One-shot operations close it in `done`;
+  // dev deliberately retains it for the lifetime of its watch process.
   const scope = yield* Scope.make();
   const live = yield* cli.live
-    .open(
-      <PlanView
-        store={progress}
-        mode="apply"
-        detailed={options?.detailed}
-        stage={options?.stage}
-      />,
-      { persistOnClose: true },
-    )
+    .open(<PlanComponent tree={progress} collapsible={options?.dev} />, {
+      persistOnClose: !options?.dev,
+    })
     .pipe(Scope.provide(scope));
   return {
     done: (outcome) =>
-      Effect.sync(() => progress.finish(outcome)).pipe(
-        Effect.andThen(live.close),
-        Effect.ensuring(Scope.close(scope, Exit.void)),
+      Effect.sync(() => {
+        const outputReady = progress.snapshot().output !== undefined;
+        progress.finish(
+          outcome,
+          labels[outcome],
+          options?.dev && outcome === "success" && outputReady
+            ? "output"
+            : "plan",
+        );
+        if (!options?.dev) progress.setViewport("full");
+      }).pipe(
+        Effect.andThen(
+          options?.dev
+            ? Effect.void
+            : live.close.pipe(Effect.ensuring(Scope.close(scope, Exit.void))),
+        ),
       ),
     emit: (event: ApplyEvent) => Effect.sync(() => progress.emit(event)),
+    setOutput: (value: unknown) => Effect.sync(() => progress.setOutput(value)),
   } satisfies PlanStatusSession;
 });

--- a/packages/alchemy/src/Cli/components/view/SigilCli.tsx
+++ b/packages/alchemy/src/Cli/components/view/SigilCli.tsx
@@ -139,13 +139,16 @@ const startApplySession = Effect.fn(function* <P extends Plan>(
   // The session outlives this effect — the caller settles it via `done` on
   // every exit path (Apply.ts's onExit). live.open is Scope-bound, so give
   // it a manually managed scope. One-shot operations close it in `done`;
-  // dev deliberately retains it for the lifetime of its watch process.
+  // dev retains it after `done` and tears it down through `close` when the
+  // generation is interrupted (a reload or Ctrl+C), so a replaced
+  // generation never leaves its widget behind.
   const scope = yield* Scope.make();
   const live = yield* cli.live
     .open(<PlanComponent tree={progress} collapsible={options?.dev} />, {
       persistOnClose: !options?.dev,
     })
     .pipe(Scope.provide(scope));
+  const close = live.close.pipe(Effect.ensuring(Scope.close(scope, Exit.void)));
   return {
     done: (outcome) =>
       Effect.sync(() => {
@@ -158,13 +161,8 @@ const startApplySession = Effect.fn(function* <P extends Plan>(
             : "plan",
         );
         if (!options?.dev) progress.setViewport("full");
-      }).pipe(
-        Effect.andThen(
-          options?.dev
-            ? Effect.void
-            : live.close.pipe(Effect.ensuring(Scope.close(scope, Exit.void))),
-        ),
-      ),
+      }).pipe(Effect.andThen(options?.dev ? Effect.void : close)),
+    close,
     emit: (event: ApplyEvent) => Effect.sync(() => progress.emit(event)),
     setOutput: (value: unknown) => Effect.sync(() => progress.setOutput(value)),
   } satisfies PlanStatusSession;

--- a/packages/alchemy/src/Cli/components/view/StackOutputs.tsx
+++ b/packages/alchemy/src/Cli/components/view/StackOutputs.tsx
@@ -4,22 +4,34 @@ import { inspect } from "node:util";
 import type { ReactNode } from "react";
 import { Box, useCliEnvironment } from "../ui/index.ts";
 
-type StackOutputsProps = { readonly value: unknown };
+export interface StackOutputsProps {
+  readonly value: unknown;
+  readonly offset?: number;
+  readonly limit?: number;
+}
 
-function StackOutputs({ value }: StackOutputsProps) {
+export function StackOutputs({
+  value,
+  offset = 0,
+  limit = Number.POSITIVE_INFINITY,
+}: StackOutputsProps) {
   const { colors } = useCliEnvironment();
   const output = inspect(value, { colors });
+  const lines = output.split("\n").slice(offset, offset + limit);
 
   return (
     <Box flexDirection="column">
-      {output.split("\n").map((line, index) => (
-        <AnsiText key={index} wrap="none">
+      {lines.map((line, index) => (
+        <AnsiText key={offset + index} wrap="none">
           {line || " "}
         </AnsiText>
       ))}
     </Box>
   );
 }
+
+export const stackOutputLineCount = (value: unknown): number =>
+  inspect(value, { colors: false }).split("\n").length;
 
 export const stackOutputsView = (value: unknown): ReactNode => (
   <StackOutputs value={value} />

--- a/packages/alchemy/src/Cli/components/view/usePlanPresentation.ts
+++ b/packages/alchemy/src/Cli/components/view/usePlanPresentation.ts
@@ -1,0 +1,84 @@
+import {
+  measureElement,
+  useProgress,
+  useTitle,
+  type DOMElement,
+} from "@alchemy.run/sigil";
+import { useLayoutEffect, useRef, useState } from "react";
+import { useTerminalSize } from "../ui/index.ts";
+import type { PlanTree, PlanTreeState } from "./PlanTree.ts";
+
+export const usePlanPresentation = (options: {
+  readonly tree: PlanTree;
+  readonly state: PlanTreeState;
+  readonly busy: boolean;
+  readonly collapsible: boolean;
+  readonly hasFooter: boolean;
+}) => {
+  const { tree, state, busy, collapsible, hasFooter } = options;
+  const { mode } = tree;
+  const { label, visible, expanded, viewport, outcome } = state;
+  const { completed, failures, total } = tree.progress();
+  const collapsed = collapsible && !expanded;
+  const settled = !busy && completed >= total;
+
+  useProgress(
+    visible && mode === "apply"
+      ? {
+          state:
+            outcome === "failure" || failures > 0
+              ? "error"
+              : busy
+                ? "normal"
+                : "inactive",
+          value: total === 0 ? undefined : (completed / total) * 100,
+        }
+      : { state: "inactive" },
+  );
+  const titleProgress = settled || total === 0 ? "" : ` ${completed}/${total}`;
+  const titleDetail = tree.titleDetail ? ` · ${tree.titleDetail}` : "";
+  useTitle(
+    visible && mode === "apply"
+      ? `${label}${titleProgress}${titleDetail}`
+      : undefined,
+  );
+
+  const beforeRef = useRef<DOMElement>(null);
+  const summaryRef = useRef<DOMElement>(null);
+  const controlsRef = useRef<DOMElement>(null);
+  const afterRef = useRef<DOMElement>(null);
+  const [chromeRows, setChromeRows] = useState<number>();
+  const { rows: terminalRows } = useTerminalSize();
+  const showControls =
+    mode === "apply" || (!collapsed && (collapsible || hasFooter));
+
+  useLayoutEffect(() => {
+    if (!visible || collapsed || viewport !== "virtual") return;
+    const height = (ref: { readonly current: DOMElement | null }) =>
+      ref.current === null ? 0 : measureElement(ref.current).height;
+    const measured =
+      height(beforeRef) +
+      height(summaryRef) +
+      height(controlsRef) +
+      height(afterRef) +
+      1 +
+      (showControls ? 1 : 0);
+    setChromeRows((current) => (current === measured ? current : measured));
+  });
+
+  const lineBudget =
+    viewport === "virtual"
+      ? Math.max(
+          1,
+          terminalRows - (mode === "apply" ? 3 : 0) - (chromeRows ?? 8),
+        )
+      : Number.POSITIVE_INFINITY;
+
+  return {
+    progress: { completed, failures, total },
+    collapsed,
+    showControls,
+    lineBudget,
+    refs: { beforeRef, summaryRef, controlsRef, afterRef },
+  } as const;
+};

--- a/packages/alchemy/src/Cli/components/view/usePlanPresentation.ts
+++ b/packages/alchemy/src/Cli/components/view/usePlanPresentation.ts
@@ -17,13 +17,13 @@ export const usePlanPresentation = (options: {
 }) => {
   const { tree, state, busy, collapsible, hasFooter } = options;
   const { mode } = tree;
-  const { label, visible, expanded, viewport, outcome } = state;
+  const { label, expanded, viewport, outcome } = state;
   const { completed, failures, total } = tree.progress();
   const collapsed = collapsible && !expanded;
   const settled = !busy && completed >= total;
 
   useProgress(
-    visible && mode === "apply"
+    mode === "apply"
       ? {
           state:
             outcome === "failure" || failures > 0
@@ -38,9 +38,7 @@ export const usePlanPresentation = (options: {
   const titleProgress = settled || total === 0 ? "" : ` ${completed}/${total}`;
   const titleDetail = tree.titleDetail ? ` · ${tree.titleDetail}` : "";
   useTitle(
-    visible && mode === "apply"
-      ? `${label}${titleProgress}${titleDetail}`
-      : undefined,
+    mode === "apply" ? `${label}${titleProgress}${titleDetail}` : undefined,
   );
 
   const beforeRef = useRef<DOMElement>(null);
@@ -53,7 +51,7 @@ export const usePlanPresentation = (options: {
     mode === "apply" || (!collapsed && (collapsible || hasFooter));
 
   useLayoutEffect(() => {
-    if (!visible || collapsed || viewport !== "virtual") return;
+    if (collapsed || viewport !== "virtual") return;
     const height = (ref: { readonly current: DOMElement | null }) =>
       ref.current === null ? 0 : measureElement(ref.current).height;
     const measured =

--- a/packages/alchemy/src/Cli/components/view/usePlanViewport.ts
+++ b/packages/alchemy/src/Cli/components/view/usePlanViewport.ts
@@ -74,7 +74,7 @@ export const usePlanViewport = (options: {
 }): PlanWindow => {
   const { tree, state, lineBudget, collapsible, collapsed } = options;
   const { rows, detailed } = tree;
-  const { tasks, output, view, viewport, visible } = state;
+  const { tasks, output, view, viewport } = state;
   const hasOutput = output !== undefined;
   const selectedView = view === "output" && hasOutput ? "output" : "plan";
   const virtual = viewport === "virtual";
@@ -135,7 +135,6 @@ export const usePlanViewport = (options: {
     }));
 
   useTerminalInput((input, key) => {
-    if (!visible) return;
     if (collapsible && !key.ctrl && !key.meta && input.toLowerCase() === "p") {
       tree.setExpanded(collapsed);
       return;

--- a/packages/alchemy/src/Cli/components/view/usePlanViewport.ts
+++ b/packages/alchemy/src/Cli/components/view/usePlanViewport.ts
@@ -1,0 +1,173 @@
+import { useMemo, useState } from "react";
+import { useTerminalInput } from "../ui/index.ts";
+import { stackOutputLineCount } from "./StackOutputs.tsx";
+import {
+  type PlanRow,
+  type PlanTree,
+  type PlanTreeState,
+  type PlanView,
+} from "./PlanTree.ts";
+import { isTerminalStatus } from "./statusStyle.ts";
+
+export type VirtualPlanLine =
+  | { readonly kind: "row"; readonly row: PlanRow }
+  | {
+      readonly kind: "yaml";
+      readonly key: string;
+      readonly line: string;
+      readonly paddingLeft: number;
+    }
+  | {
+      readonly kind: "note";
+      readonly key: string;
+      readonly paddingLeft: number;
+    };
+
+const planLines = (
+  rows: readonly PlanRow[],
+  detailed: boolean,
+): VirtualPlanLine[] =>
+  rows.flatMap((row): VirtualPlanLine[] => {
+    const lines: VirtualPlanLine[] = [{ kind: "row", row }];
+    if (row.type !== "resource") return lines;
+    const showYaml = detailed || row.propertyYaml?.kind === "drift";
+    if (!showYaml) return lines;
+    if (row.propertyYaml !== undefined) {
+      lines.push(
+        ...row.propertyYaml.lines.map((line, index) => ({
+          kind: "yaml" as const,
+          key: `${row.key}:yaml:${index}`,
+          line,
+          paddingLeft: row.depth * 2 + 2,
+        })),
+      );
+    } else if (
+      row.action === "update" ||
+      row.action === "adopted" ||
+      row.action === "replace"
+    ) {
+      lines.push({
+        kind: "note",
+        key: `${row.key}:note`,
+        paddingLeft: row.depth * 2 + 2,
+      });
+    }
+    return lines;
+  });
+
+export interface PlanWindow {
+  readonly selectedView: PlanView;
+  readonly hasOutput: boolean;
+  readonly virtual: boolean;
+  readonly budget: number;
+  readonly offset: number;
+  readonly hiddenBelow: number;
+  readonly planLines: readonly VirtualPlanLine[] | undefined;
+}
+
+export const usePlanViewport = (options: {
+  readonly tree: PlanTree;
+  readonly state: PlanTreeState;
+  readonly lineBudget: number;
+  readonly collapsible: boolean;
+  readonly collapsed: boolean;
+}): PlanWindow => {
+  const { tree, state, lineBudget, collapsible, collapsed } = options;
+  const { rows, detailed } = tree;
+  const { tasks, output, view, viewport, visible } = state;
+  const hasOutput = output !== undefined;
+  const selectedView = view === "output" && hasOutput ? "output" : "plan";
+  const virtual = viewport === "virtual";
+  const expandedLines = useMemo(
+    () => planLines(rows, detailed),
+    [rows, detailed],
+  );
+  const available =
+    lineBudget === Number.POSITIVE_INFINITY
+      ? rows.length
+      : Math.max(1, Math.floor(lineBudget));
+  const length =
+    selectedView === "output"
+      ? stackOutputLineCount(output)
+      : virtual
+        ? expandedLines.length
+        : rows.length;
+  // Overflow markers render above and below the content window, so they must
+  // consume its budget rather than extending the complete widget. Reserve
+  // both even when following the end (where only the upper marker is shown),
+  // because manual scrolling can make both visible without changing height.
+  const budget =
+    virtual && length > available ? Math.max(1, available - 2) : available;
+  const maxOffset = Math.max(0, length - budget);
+  const activeRow = tree.progressRows.find((row) => {
+    const status = tasks.get(row.key)?.status;
+    return status !== undefined && !isTerminalStatus(status);
+  });
+  const activeRowIndex = activeRow === undefined ? -1 : rows.indexOf(activeRow);
+  const activeLineIndex = virtual
+    ? expandedLines.findIndex(
+        (line) => line.kind === "row" && line.row === rows[activeRowIndex],
+      )
+    : activeRowIndex;
+  const followedOffset =
+    selectedView === "output"
+      ? maxOffset
+      : Math.min(
+          maxOffset,
+          Math.max(
+            0,
+            (activeLineIndex < 0 ? length : activeLineIndex) -
+              Math.floor(budget / 3),
+          ),
+        );
+  const [manualOffsets, setManualOffsets] = useState<
+    Record<PlanView, number | undefined>
+  >({ plan: undefined, output: undefined });
+  const offset = virtual
+    ? Math.min(maxOffset, manualOffsets[selectedView] ?? followedOffset)
+    : 0;
+  const setOffset = (
+    update: (current: number | undefined) => number | undefined,
+  ) =>
+    setManualOffsets((current) => ({
+      ...current,
+      [selectedView]: update(current[selectedView]),
+    }));
+
+  useTerminalInput((input, key) => {
+    if (!visible) return;
+    if (collapsible && !key.ctrl && !key.meta && input.toLowerCase() === "p") {
+      tree.setExpanded(collapsed);
+      return;
+    }
+    if (collapsed) return;
+    if (hasOutput && (key.left || key.right)) {
+      tree.setView(selectedView === "plan" ? "output" : "plan");
+      return;
+    }
+    if (!virtual) return;
+    const page = Math.max(1, Math.floor(lineBudget));
+    if (key.up) setOffset((current) => Math.max(0, (current ?? offset) - 1));
+    else if (key.down)
+      setOffset((current) => Math.min(maxOffset, (current ?? offset) + 1));
+    else if (key.pageUp)
+      setOffset((current) => Math.max(0, (current ?? offset) - page));
+    else if (key.pageDown)
+      setOffset((current) => Math.min(maxOffset, (current ?? offset) + page));
+    else if (key.home) setOffset(() => 0);
+    else if (key.end) setOffset(() => undefined);
+  });
+
+  return {
+    selectedView,
+    hasOutput,
+    virtual,
+    budget,
+    offset,
+    hiddenBelow: virtual ? Math.max(0, length - offset - budget) : 0,
+    planLines:
+      virtual && selectedView === "plan"
+        ? expandedLines.slice(offset, offset + budget)
+        : undefined,
+  };
+};

--- a/packages/alchemy/src/Cli/exec.ts
+++ b/packages/alchemy/src/Cli/exec.ts
@@ -23,6 +23,7 @@ import { ConsoleLogLive } from "./GlobalLog.ts";
 import { handleCliErrors, installShutdownFeedback } from "./commands/errors.ts";
 import { renderApply, renderPlanning } from "./commands/render.ts";
 import * as CliKit from "./CliKit/index.ts";
+import { stackOutputsView } from "./components/view/StackOutputs.tsx";
 import { selectCliServices } from "./selectCli.ts";
 
 // Interactive dev/deploy runs use the Sigil progress UI; CI, redirected output,
@@ -79,6 +80,7 @@ const runDev = Effect.fn(function* (options: DevOptions) {
   const applyPlan = Stacks.apply(snapshot).pipe(
     renderApply(snapshot.native, {
       stage: options.stage,
+      dev: !once,
     }),
   );
   const result = yield* once
@@ -92,7 +94,10 @@ const runDev = Effect.fn(function* (options: DevOptions) {
               ).pipe(Effect.as(undefined)),
         ),
       );
-  if (result !== undefined) yield* Console.log(result);
+  if (result !== undefined && once) {
+    const kit = yield* CliKit.CliKit;
+    yield* kit.output.print(stackOutputsView(result));
+  }
   return once ? undefined : yield* Effect.never;
 });
 

--- a/packages/alchemy/src/Local/RpcSpawner.ts
+++ b/packages/alchemy/src/Local/RpcSpawner.ts
@@ -289,7 +289,14 @@ export const make = Effect.fn(function* ({
 export const layerServer = (
   environment: Pick<RpcServerEnvironment, "profile" | "envFile">,
 ) =>
-  Layer.effect(RpcSpawner, make(environment)).pipe(Layer.provide(httpServer()));
+  Layer.effect(RpcSpawner, make(environment)).pipe(
+    // `/logs` is deliberately long-lived. On shutdown the exec child still
+    // owns that response while this scope owns the exec child, so waiting for
+    // Node's default 20-second graceful HTTP drain creates a finalizer cycle.
+    // Stop accepting/serving immediately so the watcher finalizer can close
+    // the child; all actual sidecars still use their own bounded finalizers.
+    Layer.provide(httpServer(0, "127.0.0.1", { gracefulShutdownTimeout: 0 })),
+  );
 
 const RPC_ADDRESS_REGEX =
   /(<ALCHEMY_RPC_ADDRESS>)(.+)(<\/ALCHEMY_RPC_ADDRESS>)/;

--- a/packages/alchemy/src/Report.ts
+++ b/packages/alchemy/src/Report.ts
@@ -270,6 +270,8 @@ export const Progress = Context.Reference<ProgressReporter>(
 export interface PlanStatusSession {
   emit: (event: ApplyEvent) => Effect.Effect<void>;
   done: (outcome: "success" | "failure") => Effect.Effect<void>;
+  /** Replace the dev widget's stack output view without writing scrollback. */
+  setOutput?: (value: unknown) => Effect.Effect<void>;
 }
 
 /** A session that drops everything — the default when no renderer is ambient. */
@@ -309,6 +311,8 @@ export interface PlanDisplayOptions {
   detailed?: boolean;
   /** Stage displayed in terminal lifecycle updates. */
   stage?: string;
+  /** Keep the dev plan mounted as a collapsible widget below static logs. */
+  dev?: boolean;
 }
 
 export interface CLIService {

--- a/packages/alchemy/src/Report.ts
+++ b/packages/alchemy/src/Report.ts
@@ -272,6 +272,12 @@ export interface PlanStatusSession {
   done: (outcome: "success" | "failure") => Effect.Effect<void>;
   /** Replace the dev widget's stack output view without writing scrollback. */
   setOutput?: (value: unknown) => Effect.Effect<void>;
+  /**
+   * Tear down the session's live presentation without settling it. Dev keeps
+   * its widget mounted after `done`; an interrupted generation (reload,
+   * Ctrl+C) must remove it so the next generation does not stack another.
+   */
+  close?: Effect.Effect<void>;
 }
 
 /** A session that drops everything — the default when no renderer is ambient. */

--- a/packages/alchemy/src/Util/PlatformServices.ts
+++ b/packages/alchemy/src/Util/PlatformServices.ts
@@ -1,4 +1,5 @@
 import type { Crypto } from "effect/Crypto";
+import type { Input as DurationInput } from "effect/Duration";
 import * as Effect from "effect/Effect";
 import type { FileSystem } from "effect/FileSystem";
 import * as Layer from "effect/Layer";
@@ -136,6 +137,9 @@ export const runMain = <E, A>(
 export const httpServer = (
   port: number = 0,
   host: string = "127.0.0.1",
+  options?: {
+    readonly gracefulShutdownTimeout?: DurationInput | undefined;
+  },
 ): Layer.Layer<HttpServer, ServeError> =>
   platformLayer({
     bun: async () => {
@@ -157,6 +161,10 @@ export const httpServer = (
         ),
         import("node:http"),
       ]);
-      return NodeHttpServer.layerServer(Http.createServer, { host, port });
+      return NodeHttpServer.layerServer(Http.createServer, {
+        host,
+        port,
+        gracefulShutdownTimeout: options?.gracefulShutdownTimeout,
+      });
     },
   });

--- a/packages/alchemy/test/Cli/CliKit.test.tsx
+++ b/packages/alchemy/test/Cli/CliKit.test.tsx
@@ -30,6 +30,8 @@ import {
 } from "@/Cli/components/ui/index.ts";
 import { tabsWindow } from "@/Cli/components/ui/Layout.tsx";
 import { makeRuntime } from "@/Cli/components/view/Runtime.tsx";
+import { sigilCli } from "@/Cli/components/view/SigilCli.tsx";
+import { renderApply } from "@/Cli/commands/render.ts";
 import { isInProgress } from "@/Cli/components/view/statusStyle.ts";
 import { spinnerFramesFor } from "@/Util/Theme.ts";
 import {
@@ -49,6 +51,7 @@ import {
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
 import * as Fiber from "effect/Fiber";
+import * as Layer from "effect/Layer";
 import * as Logger from "effect/Logger";
 import { expect, it } from "alchemy-test";
 import { deleteNode, noopNode, planWith, updateNode } from "./PlanTestNodes.ts";
@@ -510,6 +513,35 @@ it.effect("renders completed dev plans as a hideable output view", () =>
     expect(hiddenOutput).toContain("Dev stack ready (0/1)");
     expect(hiddenOutput).toContain("p show plan/output");
     yield* live.close;
+  }),
+);
+
+// A dev generation keeps its widget mounted after apply settles and parks
+// until a reload (or Ctrl+C) closes its scope. Closing that scope must remove
+// the widget: leaving it behind stacks one stale "Dev stack ready" bar per
+// reload under the live one.
+it.effect("removes the dev apply widget when its generation scope closes", () =>
+  Effect.gen(function* () {
+    const { service, stdout } = yield* makeLive();
+    const plan = {
+      ...planWith([updateNode({ version: 1 }, { version: 2 })]),
+      defaultMode: "local" as const,
+    };
+    const cli = sigilCli().pipe(Layer.provide(Layer.succeed(CliKit, service)));
+    let settledAt = 0;
+    yield* Effect.scoped(
+      Effect.gen(function* () {
+        yield* Effect.succeed({ endpoint: "http://localhost:3000" }).pipe(
+          renderApply(plan, { dev: true }),
+        );
+        yield* Effect.promise(() => stdout.waitFor("Dev stack ready"));
+        settledAt = stdout.output.length;
+      }),
+    ).pipe(Effect.provide(cli));
+
+    // Nothing else is live once the generation is gone, so the renderer
+    // unmounts and restores the cursor.
+    expect(stdout.output.slice(settledAt)).toContain("[?25h");
   }),
 );
 

--- a/packages/alchemy/test/Cli/CliKit.test.tsx
+++ b/packages/alchemy/test/Cli/CliKit.test.tsx
@@ -15,6 +15,7 @@ import {
   ChoiceGroup,
   DescriptionList,
   Heading,
+  KeyBar,
   LiveStore,
   PromptFrame,
   ProgressGroup,
@@ -30,12 +31,14 @@ import {
 import { tabsWindow } from "@/Cli/components/ui/Layout.tsx";
 import { makeRuntime } from "@/Cli/components/view/Runtime.tsx";
 import { isInProgress } from "@/Cli/components/view/statusStyle.ts";
+import { spinnerFramesFor } from "@/Util/Theme.ts";
 import {
   makeResourceLogger,
   makeResourceOutput,
 } from "@/Util/ResourceOutput.ts";
 import { stackOutputsView } from "@/Cli/components/view/StackOutputs.tsx";
-import { Plan } from "@/Cli/components/view/PlanView.tsx";
+import { Plan, PlanTree } from "@/Cli/components/view/PlanView.tsx";
+import { ApprovePlan } from "@/Cli/components/view/ApprovePlan.tsx";
 import { ProfileDetailsBody } from "@/Cli/components/view/Profile.tsx";
 import {
   buildStageNodes,
@@ -48,7 +51,7 @@ import * as Exit from "effect/Exit";
 import * as Fiber from "effect/Fiber";
 import * as Logger from "effect/Logger";
 import { expect, it } from "alchemy-test";
-import { planWith, updateNode } from "./PlanTestNodes.ts";
+import { deleteNode, noopNode, planWith, updateNode } from "./PlanTestNodes.ts";
 
 class CaptureStream extends PassThrough {
   readonly columns = 80;
@@ -258,21 +261,280 @@ it("prints stack outputs using inspect without wrapping long lines", () => {
 
 it("renders detailed plans as nested YAML", () => {
   const { service } = makeStatic();
-  const output = service.output.format(
-    <Plan
-      plan={planWith([
-        updateNode({ config: { retries: 2 } }, { config: { retries: 3 } }),
-      ])}
-      detailed
-    />,
-    { columns: 80 },
+  const tree = new PlanTree(
+    planWith([
+      updateNode({ config: { retries: 2 } }, { config: { retries: 3 } }),
+    ]),
+    { detailed: true, viewport: "full" },
   );
+  const output = service.output.format(<Plan tree={tree} />, { columns: 80 });
 
   expect(output).toContain("properties:");
   expect(output).toContain("config:");
   expect(output).toContain("│ -     retries: 2");
   expect(output).toContain("│ +     retries: 3");
   expect(output).toContain("(Test.Resource)");
+});
+
+it("keeps the plan summary visible and updates it during apply", () => {
+  const { service } = makeStatic();
+  const plan = {
+    ...planWith([
+      updateNode({ version: 1 }, { version: 2 }),
+      noopNode({ version: 1 }, "Stable"),
+    ]),
+    defaultMode: "local" as const,
+  };
+  const reviewTree = new PlanTree(plan, { viewport: "full" });
+  const reviewOutput = service.output.format(<Plan tree={reviewTree} />, {
+    columns: 80,
+  });
+  const tree = new PlanTree(plan, {
+    mode: "apply",
+    label: "Starting dev stack",
+    busy: true,
+  });
+  const output = service.output.format(<Plan tree={tree} collapsible />, {
+    columns: 160,
+  });
+
+  expect(reviewOutput).toContain("1 to update");
+  expect(reviewOutput).toContain("1 no change");
+  expect(output.indexOf("─")).toBeLessThan(
+    output.indexOf("Starting dev stack"),
+  );
+  expect(output.indexOf("Plan")).toBeLessThan(output.indexOf("Worker"));
+  expect(output.indexOf("Starting dev stack")).toBeGreaterThan(
+    output.indexOf("Worker"),
+  );
+  expect(output).toContain("1 pending");
+  expect(output).toContain("1 no change");
+  expect(
+    spinnerFramesFor(true).some((frame) =>
+      output.includes(`${frame} Starting dev stack`),
+    ),
+  ).toBe(true);
+  const keybarLine = output
+    .split("\n")
+    .find((line) => line.includes("p hide widget"));
+  expect(keybarLine).toContain("p hide widget");
+  expect(keybarLine).toContain("Ctrl+C exit");
+  expect(keybarLine).toContain("↑/↓ scroll plan");
+  expect(keybarLine).toContain("Starting dev stack");
+
+  tree.emit({
+    _tag: "apply.resource.status",
+    fqn: "Worker",
+    id: "Worker",
+    type: "Test.Resource",
+    status: "updating",
+  });
+  tree.setBusy(false);
+  tree.setViewport("full");
+  const updatingOutput = service.output.format(<Plan tree={tree} />, {
+    columns: 80,
+  });
+  expect(updatingOutput).toContain("1 updating");
+  expect(updatingOutput).not.toContain("1 pending");
+  expect(updatingOutput).toContain("1 no change");
+  expect(
+    spinnerFramesFor(true).some((frame) =>
+      updatingOutput.includes(`${frame} Starting dev stack`),
+    ),
+  ).toBe(false);
+});
+
+it("keeps a large destroy summary and confirmation visible", () => {
+  const { service } = makeStatic();
+  const deletions = Array.from({ length: 40 }, (_, index) =>
+    deleteNode({}, `Resource${index}`),
+  );
+  const plan = { ...planWith([], deletions), destroy: true };
+  const output = service.output.format(
+    <ApprovePlan
+      plan={plan}
+      controller={{ submit: () => undefined, cancel: () => undefined }}
+    />,
+    { columns: 80 },
+  );
+
+  expect(output).toContain("Destroy");
+  expect(output).toContain("40 to delete");
+  expect(output).toContain("Destroy?");
+  expect(output).toContain("more lines");
+  expect(output).toContain("↑/↓ scroll plan");
+});
+
+it("keeps apply totals on top and destroy progress on the last row", () => {
+  const { service } = makeStatic();
+  const plan = {
+    ...planWith(
+      [],
+      Array.from({ length: 10 }, (_, index) =>
+        deleteNode({}, `Resource${index}`),
+      ),
+    ),
+    destroy: true,
+  };
+  const tree = new PlanTree(plan, {
+    mode: "apply",
+    label: "Destroying stack",
+    busy: true,
+  });
+  tree.emit({
+    _tag: "apply.resource.status",
+    fqn: "Resource0",
+    id: "Resource0",
+    type: "Test.Resource",
+    status: "deleted",
+  });
+
+  const output = service.output.format(<Plan tree={tree} />, {
+    columns: 120,
+  });
+  const lines = output.split("\n");
+  const summaryLine = lines.find((line) => line.includes("Plan ·"));
+  const progressLine = lines.find((line) => line.includes("Destroying stack"));
+
+  expect(summaryLine).toContain("1 deleted");
+  expect(summaryLine).toContain("9 pending");
+  expect(progressLine).toContain("Destroying stack (1/10)");
+  expect(
+    spinnerFramesFor(true).some((frame) => progressLine?.includes(frame)),
+  ).toBe(true);
+  expect(output.indexOf("Plan ·")).toBeLessThan(output.indexOf("Resource0"));
+  expect(output.indexOf("Destroying stack")).toBeGreaterThan(
+    output.indexOf("Resource9"),
+  );
+});
+
+it("includes binding work in apply totals and failures", () => {
+  const { service } = makeStatic();
+  const worker = {
+    ...noopNode({}, "Worker"),
+    bindings: [
+      { sid: "BUCKET", action: "update" as const, data: {} },
+      { sid: "STABLE", action: "noop" as const, data: {} },
+    ],
+  };
+  const tree = new PlanTree(planWith([worker]), {
+    mode: "apply",
+    label: "Deploying stack",
+    busy: true,
+  });
+  tree.emit({
+    _tag: "apply.resource.status",
+    fqn: "Worker",
+    id: "Worker",
+    type: "Test.Resource",
+    bindingId: "BUCKET",
+    status: "fail",
+    message: "binding failed",
+  });
+
+  const output = service.output.format(<Plan tree={tree} />, { columns: 80 });
+  expect(output).toContain("1 fail");
+  expect(output).toContain("1 no change");
+  expect(output).not.toContain("2 no change");
+  expect(output).toContain("Deploying stack (1/1)");
+  expect(output).toContain("binding failed");
+});
+
+it.effect("keeps native progress active until the apply outcome settles", () =>
+  Effect.gen(function* () {
+    const { service, stdout } = yield* makeLive();
+    const tree = new PlanTree(
+      planWith([updateNode({ version: 1 }, { version: 2 })]),
+      {
+        mode: "apply",
+        label: "Deploying stack",
+        busy: true,
+      },
+    );
+    tree.emit({
+      _tag: "apply.resource.status",
+      fqn: "Worker",
+      id: "Worker",
+      type: "Test.Resource",
+      status: "updated",
+    });
+    const live = yield* service.live.open(<Plan tree={tree} />);
+    yield* Effect.promise(flushEffects);
+    expect(stdout.output).toContain("\u001B]9;4;1;100\u001B\\");
+
+    const settledAt = stdout.output.length;
+    tree.finish("failure", "Deploy failed");
+    yield* Effect.promise(flushEffects);
+    expect(stdout.output.slice(settledAt)).toContain(
+      "\u001B]9;4;2;100\u001B\\",
+    );
+    yield* live.close;
+  }),
+);
+
+it.effect("renders completed dev plans as a hideable output view", () =>
+  Effect.gen(function* () {
+    const { service, stdout } = yield* makeLive();
+    const plan = {
+      ...planWith([updateNode({ version: 1 }, { version: 2 })]),
+      defaultMode: "local" as const,
+    };
+    const tree = new PlanTree(plan, {
+      mode: "apply",
+      label: "Starting dev stack",
+    });
+    const live = yield* service.live.open(<Plan tree={tree} collapsible />);
+
+    yield* Effect.promise(() => stdout.waitFor("p hide widget"));
+    yield* Effect.sync(() => {
+      tree.setOutput({ endpoint: "http://localhost:3000" });
+      tree.finish("success", "Dev stack ready", "output");
+    });
+    yield* Effect.promise(() => stdout.waitFor("http://localhost:3000"));
+    expect(stdout.output).toContain("←/→ show plan");
+
+    tree.setView("plan");
+    expect(tree.snapshot().view).toBe("plan");
+
+    tree.setExpanded(false);
+    yield* Effect.promise(() => stdout.waitFor("p show plan/output"));
+
+    const { service: staticService } = makeStatic();
+    const hiddenOutput = staticService.output.format(
+      <Plan tree={tree} collapsible />,
+      { columns: 80 },
+    );
+    expect(hiddenOutput).not.toContain("Plan ·");
+    expect(hiddenOutput).not.toContain("Worker");
+    expect(hiddenOutput).not.toContain("http://localhost:3000");
+    expect(hiddenOutput).toContain("Dev stack ready (0/1)");
+    expect(hiddenOutput).toContain("p show plan/output");
+    yield* live.close;
+  }),
+);
+
+it("virtualizes dev stack output", () => {
+  const { service } = makeStatic();
+  const tree = new PlanTree(planWith([updateNode({}, {})]), {
+    mode: "apply",
+    label: "Dev stack ready",
+  });
+  tree.setOutput(
+    Object.fromEntries(
+      Array.from({ length: 40 }, (_, index) => [`output${index}`, index]),
+    ),
+  );
+  tree.setView("output");
+
+  const output = service.output.format(<Plan tree={tree} collapsible />, {
+    columns: 80,
+  });
+  expect(output).toContain("Output");
+  expect(output).toContain("earlier lines");
+  expect(output).not.toContain("Worker");
+  expect(output).toContain("←/→ show plan");
+  expect(output).toContain("↑/↓ scroll output");
+  expect(output.split("\n").length).toBeLessThanOrEqual(21);
 });
 
 it("renders drift details without detailed mode", () => {
@@ -282,7 +544,8 @@ it("renders drift details without detailed mode", () => {
     expected: { value: "declared" },
     actual: { value: "changed-out-of-band" },
   };
-  const output = service.output.format(<Plan plan={planWith([node])} />, {
+  const tree = new PlanTree(planWith([node]), { viewport: "full" });
+  const output = service.output.format(<Plan tree={tree} />, {
     columns: 80,
   });
 
@@ -1498,6 +1761,49 @@ it.effect(
       expect(rendered).toContain("2/4");
     }),
 );
+
+it.effect("composes widgets before and after divided key hints", () =>
+  Effect.gen(function* () {
+    const { service } = makeStatic();
+    const rendered = yield* service.output.render(
+      <KeyBar
+        inline
+        marginTop={0}
+        divider
+        before={<Text>Plan summary</Text>}
+        keys={[["p", "show plan"]]}
+        after={<Text>ready</Text>}
+      />,
+    );
+
+    expect(rendered.trim().split("\n")).toHaveLength(1);
+    expect(rendered).toContain("Plan summary");
+    expect(rendered.match(/│/g)).toHaveLength(2);
+    expect(rendered).toContain("p show plan");
+    expect(rendered).toContain("ready");
+  }),
+);
+
+it("wraps individual key hints in narrow terminals", () => {
+  const { service } = makeStatic();
+  const rendered = service.output.format(
+    <KeyBar
+      inline
+      marginTop={0}
+      divider
+      before={<Text>Ready</Text>}
+      keys={[
+        ["p", "show plan"],
+        ["Ctrl+C", "exit"],
+      ]}
+    />,
+    { columns: 20 },
+  );
+
+  expect(rendered).toContain("p show plan");
+  expect(rendered).toContain("Ctrl+C exit");
+  expect(rendered.trimEnd().split("\n").length).toBeGreaterThan(1);
+});
 
 it.effect("tabs scroll horizontally instead of wrapping when overflowing", () =>
   Effect.gen(function* () {

--- a/packages/alchemy/test/Cli/ModeTag.test.ts
+++ b/packages/alchemy/test/Cli/ModeTag.test.ts
@@ -14,7 +14,7 @@
  */
 import { formatModeNote, modeLabel } from "@/Cli/ModeTag.ts";
 import { formatPlanLines } from "@/Cli/LoggingCli.ts";
-import { PlanViewStore } from "@/Cli/components/view/PlanView.tsx";
+import { PlanTree } from "@/Cli/components/view/PlanView.tsx";
 import type { CRUD, Plan } from "@/Plan.ts";
 import type { ProviderMode } from "@/ProviderMode.ts";
 import { describe, expect, test } from "alchemy-test";
@@ -180,7 +180,7 @@ describe("compact plan output", () => {
   });
 
   test("targets live status updates by FQN when logical IDs repeat", () => {
-    const store = new PlanViewStore(
+    const store = new PlanTree(
       makePlan({
         resources: {
           "claude/toolchain": crud({
@@ -226,7 +226,7 @@ describe("compact plan output", () => {
     expect(lineFor(lines, "Stable")).toContain("noop");
     expect(lineFor(lines, "Changed")).toContain("update");
     expect(lines).not.toContain("1 unchanged hidden");
-    const rows = new PlanViewStore(plan).rows;
+    const rows = new PlanTree(plan).rows;
     expect(
       rows.some((row) => row.type === "resource" && row.id === "Stable"),
     ).toBe(true);
@@ -236,7 +236,7 @@ describe("compact plan output", () => {
   });
 
   test("an all-noop plan keeps typed resource rows", () => {
-    const rows = new PlanViewStore(
+    const rows = new PlanTree(
       makePlan({
         defaultMode: "live",
         resources: {

--- a/packages/alchemy/test/Cli/PlanTestNodes.ts
+++ b/packages/alchemy/test/Cli/PlanTestNodes.ts
@@ -1,4 +1,12 @@
-import type { Apply, Create, Delete, Plan, Replace, Update } from "@/Plan.ts";
+import type {
+  Apply,
+  Create,
+  Delete,
+  NoopUpdate,
+  Plan,
+  Replace,
+  Update,
+} from "@/Plan.ts";
 import type { ProviderService } from "@/Provider.ts";
 import type { ResourceLike } from "@/Resource.ts";
 import type { CreatedResourceState } from "@/State/index.ts";
@@ -65,6 +73,12 @@ export const createNode = (props: object, id = "Worker"): Create => ({
   action: "create",
   props,
   state: undefined,
+});
+
+export const noopNode = (props: object, id = "Worker"): NoopUpdate => ({
+  ...baseNode(id, props),
+  action: "noop",
+  state: state(id, props),
 });
 
 export const replaceNode = (

--- a/packages/alchemy/test/Cli/shutdownFeedback.test.ts
+++ b/packages/alchemy/test/Cli/shutdownFeedback.test.ts
@@ -72,41 +72,18 @@ const waitForStderr = (read: () => string, text: string) =>
 
 describe("shutdown feedback", () => {
   it.live(
-    "a hanging shutdown surfaces feedback and a second SIGINT force-quits with 130",
+    "a slow shutdown prints one delayed status line",
     () =>
       Effect.gen(function* () {
-        const fixture = yield* spawnFixture();
+        const fixture = yield* spawnFixture({
+          SHUTDOWN_FIXTURE_EXIT_AFTER_MS: "800",
+        });
         yield* fixture.sigint;
-        yield* waitForStderr(
-          fixture.stderr,
-          "Shutting down — waiting for cleanup",
-        );
-        yield* fixture.sigint;
-        expect(yield* fixture.handle.exitCode).toBe(130);
-        expect(fixture.stderr()).toContain("Force quitting.");
-      }).pipe(Effect.scoped, Effect.provide(PlatformServices)),
-    { timeout: 30_000 },
-  );
-
-  it.live(
-    "a duplicate SIGINT within the feedback delay does not force-quit",
-    () =>
-      Effect.gen(function* () {
-        // `node --watch` and pnpm forward the tty's SIGINT to their children,
-        // so one ^C can be delivered twice back-to-back — that must read as
-        // ONE press, not a force-quit.
-        const fixture = yield* spawnFixture();
-        yield* fixture.sigint;
-        yield* fixture.sigint;
-        yield* waitForStderr(
-          fixture.stderr,
-          "Shutting down — waiting for cleanup",
-        );
-        expect(fixture.stderr()).not.toContain("Force quitting");
-        // A distinct press after the hint is visible still force-quits.
-        yield* fixture.sigint;
-        expect(yield* fixture.handle.exitCode).toBe(130);
-        expect(fixture.stderr()).toContain("Force quitting.");
+        yield* Effect.sleep(Duration.millis(300));
+        expect(fixture.stderr()).not.toContain("Shutting down");
+        yield* waitForStderr(fixture.stderr, "Shutting down");
+        expect(yield* fixture.handle.exitCode).toBe(0);
+        expect(fixture.stderr().match(/Shutting down/g)).toHaveLength(1);
       }).pipe(Effect.scoped, Effect.provide(PlatformServices)),
     { timeout: 30_000 },
   );
@@ -126,19 +103,16 @@ describe("shutdown feedback", () => {
   );
 
   it.live(
-    "a suppressed process (dev supervisor) stays silent but still force-quits",
+    "a suppressed process stays silent",
     () =>
       Effect.gen(function* () {
         const fixture = yield* spawnFixture({
           SHUTDOWN_FIXTURE_SUPPRESS: "1",
+          SHUTDOWN_FIXTURE_EXIT_AFTER_MS: "800",
         });
         yield* fixture.sigint;
-        // Past the 200ms feedback delay — suppression must keep this quiet.
-        yield* Effect.sleep(Duration.millis(500));
+        expect(yield* fixture.handle.exitCode).toBe(0);
         expect(fixture.stderr()).not.toContain("Shutting down");
-        yield* fixture.sigint;
-        expect(yield* fixture.handle.exitCode).toBe(130);
-        expect(fixture.stderr()).not.toContain("Force quitting");
       }).pipe(Effect.scoped, Effect.provide(PlatformServices)),
     { timeout: 30_000 },
   );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5342,8 +5342,8 @@ importers:
         specifier: workspace:*
         version: link:../node-utils
       '@alchemy.run/sigil':
-        specifier: 0.0.0-alpha.6
-        version: 0.0.0-alpha.6(@types/react@19.2.18)(react-devtools-core@7.0.1)(react@19.2.8)
+        specifier: 0.0.0-alpha.8
+        version: 0.0.0-alpha.8(@types/react@19.2.18)(react-devtools-core@7.0.1)(react@19.2.8)
       '@aws-sdk/credential-providers':
         specifier: catalog:aws
         version: 3.1095.0
@@ -6058,8 +6058,8 @@ packages:
   '@actions/io@1.1.3':
     resolution: {integrity: sha512-wi9JjgKLYS7U/z8PPbco+PvTb/nRWjeoFlJ1Qer83k/3C5PHQi28hiVdeE2kHXmIL99mQFawx8qt/JPjZilJ8Q==}
 
-  '@alchemy.run/sigil@0.0.0-alpha.6':
-    resolution: {integrity: sha512-kbFZCNxVv1rIkuJcq23hELB3aF63zZDKMgrBLRzOtVaweAJ2ZCEKfRqC1iWgaUh/J4vERDvFE/tnNiipfwOHyQ==}
+  '@alchemy.run/sigil@0.0.0-alpha.8':
+    resolution: {integrity: sha512-RFMxcEjgHk9QkUpPhsZTBuV2PnD5vZtVnjHaTiSh4heg/ULSaPx6Lxw4qA/55p4XralAZ3ecXPIzVURcGFPhcw==}
     engines: {node: '>=22'}
     peerDependencies:
       '@types/react': '>=19.2.0'
@@ -18811,7 +18811,7 @@ snapshots:
 
   '@actions/io@1.1.3': {}
 
-  '@alchemy.run/sigil@0.0.0-alpha.6(@types/react@19.2.18)(react-devtools-core@7.0.1)(react@19.2.8)':
+  '@alchemy.run/sigil@0.0.0-alpha.8(@types/react@19.2.18)(react-devtools-core@7.0.1)(react@19.2.8)':
     dependencies:
       react: 19.2.8
       react-reconciler: 0.33.0(react@19.2.8)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -175,7 +175,7 @@ patchedDependencies:
   "@astrojs/starlight@0.41.7": patches/@astrojs%2Fstarlight@0.41.7.patch
   starlight-blog@0.28.0: patches/starlight-blog@0.28.0.patch
 minimumReleaseAgeExclude:
-  - "@alchemy.run/sigil@0.0.0-alpha.6"
+  - "@alchemy.run/sigil@0.0.0-alpha.8"
   - "@effect/atom-react@4.0.0-rc.112"
   - "@effect/platform-bun@4.0.0-rc.112"
   - "@effect/platform-node-shared@4.0.0-rc.112"


### PR DESCRIPTION
## Summary

Unify plan review, apply progress, and dev output around one composable terminal presentation.

- Render review, approval, deploy, destroy, and dev plans through a shared reactive `PlanTree`.
- Keep resource totals at the top, bounded or virtualized plan content in the middle, and operation progress or controls at the bottom.
- Include binding work in progress and failure totals without counting unchanged binding details as resources.
- Support detailed property output, active-work following, arrow-key scrolling, and switchable Plan and Output views.
- Keep ordinary dev logs in scrollback while changing output stays inside a hideable live widget.
- Render stack outputs through the CLI view system so ANSI colors and long lines are preserved.
- Improve terminal input, resize handling, and delayed shutdown feedback.
- Bind each dev apply widget to its generation scope so reload or Ctrl+C removes it before the next widget starts.

## Result

Every command now presents plans with the same structure, and each dev generation owns exactly one live widget without sacrificing terminal scrollback.
