### PR TITLE
fix(cloudflare-runtime): pull the egress interceptor host-native

### DIFF
--- a/packages/cloudflare-runtime/src/core/Docker.ts
+++ b/packages/cloudflare-runtime/src/core/Docker.ts
@@ -404,8 +404,24 @@ export const DockerLive = Layer.effect(
     ): Effect.Effect<void, E> =>
       result.exitCode === 0 ? Effect.void : Effect.fail(onNonZero(result));
 
-    const pull = ({ imageUri }: ContainerImage.Pull) =>
-      run(["pull", toPullRef(imageUri), "--platform", "linux/amd64"]).pipe(
+    /**
+     * `platform` is omitted for the egress interceptor: it is a host-side
+     * sidecar, not a deployable image, so Docker must resolve the
+     * host-native variant. Forcing `linux/amd64` there runs it under
+     * emulation on arm64 hosts, where its transparent-proxy setup dies at
+     * startup with `Fatal error: setsockoptint: protocol not available`.
+     * Deployable user images pass `linux/amd64` explicitly, because that is
+     * the architecture Cloudflare's container runtime executes.
+     */
+    const pull = ({
+      imageUri,
+      platform,
+    }: ContainerImage.Pull & { readonly platform?: string }) =>
+      run([
+        "pull",
+        toPullRef(imageUri),
+        ...(platform ? ["--platform", platform] : []),
+      ]).pipe(
         Effect.mapError(
           (cause) =>
             new SystemError({
@@ -568,7 +584,7 @@ export const DockerLive = Layer.effect(
           );
         }),
       pull: (tag, image) =>
-        pull(image).pipe(
+        pull({ ...image, platform: "linux/amd64" }).pipe(
           Effect.andThen(
             run(["tag", image.imageUri, tag]).pipe(
               Effect.mapError(

--- a/packages/cloudflare-runtime/src/core/test/Docker.test.ts
+++ b/packages/cloudflare-runtime/src/core/test/Docker.test.ts
@@ -326,13 +326,9 @@ layer(
           "--format",
           "{{.Id}}",
         ]);
-        expect(present.spawned).not.toContainEqual([
-          "docker",
-          "pull",
-          PINNED_WITHOUT_TAG,
-          "--platform",
-          "linux/amd64",
-        ]);
+        expect(present.spawned.filter(([, verb]) => verb === "pull")).toEqual(
+          [],
+        );
       }),
   );
 });
@@ -354,12 +350,14 @@ layer(Layer.provide(DockerLive, Layer.merge(NodeServices.layer, absent.layer)))(
             "--format",
             "{{.Id}}",
           ]);
-          expect(absent.spawned).toContainEqual([
-            "docker",
-            "pull",
-            PINNED_WITHOUT_TAG,
-            "--platform",
-            "linux/amd64",
+          // Exactly one pull, with no `--platform`: the interceptor is a
+          // host-side sidecar, so Docker must resolve the host-native variant
+          // of this multi-arch image. Forcing `linux/amd64` here runs it
+          // under emulation on arm64 hosts, where it exits 1 with
+          // `setsockoptint: protocol not available` before workerd can create
+          // the user container.
+          expect(absent.spawned.filter(([, verb]) => verb === "pull")).toEqual([
+            ["docker", "pull", PINNED_WITHOUT_TAG],
           ]);
         }),
     );


### PR DESCRIPTION
## Summary

`DockerLive`'s `pull` helper hardcodes `--platform linux/amd64`, and it is shared by
two callers with opposite requirements:

- `Docker.pull` — **deployable user images**. `linux/amd64` is correct here; that is
  the architecture Cloudflare's container runtime executes, and `build` pins the same
  platform right below.
- the **egress interceptor** (`cloudflare/proxy-everything`) — a **host-side sidecar**
  that workerd runs on the developer's machine. Forcing `linux/amd64` here makes it run
  under emulation on arm64 hosts, where it dies at startup.

This PR gives the helper an optional `platform` (omitted → Docker resolves the
host-native variant) and passes `linux/amd64` explicitly on the `Docker.pull` path.
The interceptor call site is unchanged and now pulls host-native.

## Symptom

On an arm64 host (Apple Silicon, arm64 Linux), once the amd64 variant of the interceptor
is in the local image store, `alchemy dev` cannot start a `Cloudflare.Container`:

```
$ docker ps -a
…-EvalHost-…-proxy   cloudflare/proxy-everything:3cb1195   Exited (1)

$ docker logs …-proxy
2026/09/02 16:29:56 TLS interception enabled, CA written to /ca/ca.crt
Fatal error:  setsockoptint: protocol not available
```

The sidecar exits before workerd reaches `createContainer()`, so the **user container is
never created** — `docker ps -a` shows only the `-proxy` container — and requests through
the DO fail (HTTP 500 for us).

## Why it reproduces intermittently

Two things pull the interceptor: this eager prefetch (forced amd64) and workerd itself when
the image is missing (host-native). They race, so the same repo works on one machine and
fails on another. Worse, the broken state **does not self-heal** — the pull is digest-pinned,
and Docker's containerd store refuses to replace a digest with a different variant:

```
$ docker pull cloudflare/proxy-everything@sha256:0ef6716c…   # host-native, no --platform
cannot overwrite digest sha256:0ef6716c…
$ docker image inspect cloudflare/proxy-everything@sha256:0ef6716c… --format '{{.Architecture}}'
amd64
```

So once the amd64 variant lands in the store, every subsequent `alchemy dev` keeps failing
until the user manually `docker rmi`s it.

## Verification

Reproduced and fixed against a real `Cloudflare.Container` (`enableInternet: true`) under
`alchemy dev` on Docker Desktop 29.7.2 / macOS arm64, `alchemy@2.0.0-beta.76`.

| local store holds | sidecar | user container | request |
| --- | --- | --- | --- |
| amd64 (what the forced pull leaves) | `Exited (1)` — `setsockoptint: protocol not available` | never created | HTTP 500 |
| arm64 (this PR) | `Up`, `uname -m` → `aarch64` | `Up` | served |

The pinned interceptor digest `sha256:0ef6716c…` is already a multi-arch OCI index
(`linux/amd64` + `linux/arm64`), so no image bump is needed — dropping the platform force
is sufficient.

## Tests

`src/core/test/Docker.test.ts` already asserted the exact `docker pull` argv for both
callers, so the change is covered by updating the two interceptor expectations to the
platform-free form. The user-image assertions still require `--platform linux/amd64` and
pass unchanged.

Verified as a regression guard: with the test change alone the suite fails
(`1 failed | 21 passed`); with the source change it is `22 passed`. `tsc --noEmit` and
`oxfmt --check` are clean on both files.
