### PR TITLE
feat(cloudflare/workflows): support explicit physical names

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/WorkerAsyncBindings.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerAsyncBindings.ts
@@ -199,7 +199,8 @@ export const bindWorkerAsyncBindings = Effect.fn(function* (
         if (isWorkflowLike(binding)) {
           const className = binding.className ?? binding.name;
           const scriptName = binding.scriptName ?? resource.workerName;
-          const workflowName = makeWorkflowName(scriptName, className);
+          const workflowName =
+            binding.workflowName ?? makeWorkflowName(scriptName, className);
           resolvedBindingMeta = {
             ...resolvedBindingMeta,
             workflowName,
@@ -207,15 +208,20 @@ export const bindWorkerAsyncBindings = Effect.fn(function* (
 
           // A locally-hosted Workflow (no `scriptName`) must be registered
           // with Cloudflare via `putWorkflow` once the host Worker exists.
-          // Cross-script references are binding-only; both sides derive the
-          // same physical workflow name from the host script and class.
+          // Cross-script references are binding-only; both sides use the
+          // explicit physical name when supplied, or derive the same default
+          // from the host script and class.
           if (!binding.scriptName) {
-            yield* WorkflowResource(binding.name, {
-              workflowName,
+            const workflow = yield* WorkflowResource(binding.name, {
+              workflowName: binding.workflowName,
               className,
               scriptName: resource.workerName,
               limits: binding.limits,
             });
+            resolvedBindingMeta = {
+              ...resolvedBindingMeta,
+              workflowName: workflow.workflowName,
+            };
           }
         }
 

--- a/packages/alchemy/src/Cloudflare/Workflows/Workflow.ts
+++ b/packages/alchemy/src/Cloudflare/Workflows/Workflow.ts
@@ -4,6 +4,7 @@ import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import type { Scope } from "effect/Scope";
 import * as Stream from "effect/Stream";
+import { OwnedBySomeoneElse, Unowned } from "../../AdoptPolicy.ts";
 import { isResolved } from "../../Diff.ts";
 import type { Input } from "../../Input.ts";
 import * as ProviderLayer from "../../Local/ProviderLayer.ts";
@@ -20,7 +21,7 @@ import {
   WorkerEnvironment,
   type WorkerServices,
 } from "../Workers/Worker.ts";
-import { makeWorkflowName } from "./WorkflowName.ts";
+import { generateWorkflowName } from "./WorkflowName.ts";
 
 type TypeId = "Cloudflare.Workflow";
 const TypeId = "Cloudflare.Workflow" as const;
@@ -304,6 +305,14 @@ export interface WorkflowLimits {
  */
 export interface WorkflowRefProps {
   /**
+   * Account-global Workflow name. Set this to preserve an existing Workflow;
+   * its first deployment requires `--adopt`. If omitted, Alchemy derives a
+   * stage-scoped name from the hosting Worker and exported class. Fixed names
+   * bypass that default, so they must be unique to each independently managed
+   * stack and stage.
+   */
+  workflowName?: string;
+  /**
    * Name of the exported `WorkflowEntrypoint` class.
    *
    * @default name
@@ -328,6 +337,14 @@ export interface WorkflowRefProps {
  */
 export interface WorkflowProps {
   /**
+   * Account-global Workflow name. Set this to preserve an existing Workflow;
+   * its first deployment requires `--adopt`. If omitted, Alchemy derives a
+   * stage-scoped name from the hosting Worker and exported class. Fixed names
+   * bypass that default, so they must be unique to each independently managed
+   * stack and stage.
+   */
+  workflowName?: string;
+  /**
    * Limits applied to the workflow.
    */
   limits?: WorkflowLimits;
@@ -342,7 +359,7 @@ export interface WorkflowProps {
 export interface WorkflowLike<Params = unknown> {
   kind: TypeId;
   name: string;
-  /** @internal phantom */
+  /** Account-global Workflow name, when explicitly configured. */
   workflowName?: string;
   /** @internal phantom */
   className?: string;
@@ -548,6 +565,24 @@ export class WorkflowScope extends Context.Service<
  * ) {}
  * ```
  *
+ * **Example:** Preserving an existing Workflow name
+ *
+ * An existing Workflow has no ownership marker, so the first deployment must
+ * opt in with `--adopt`. Keep fixed names unique per independently managed
+ * stack and stage; unlike the default, they are not stage-scoped by Alchemy.
+ *
+ * ```typescript
+ * export default class MyWorkflow extends Cloudflare.Workflow<MyWorkflow>()(
+ *   "MyWorkflow",
+ *   { workflowName: "my-existing-workflow" },
+ *   Effect.gen(function* () {
+ *     return Effect.fn(function* (input: { name: string }) {
+ *       return { received: input.name };
+ *     });
+ *   }),
+ * ) {}
+ * ```
+ *
  * **Example:** Setting a step limit
  * ```typescript
  * export default class MyWorkflow extends Cloudflare.Workflow<MyWorkflow>()(
@@ -724,6 +759,7 @@ export class WorkflowScope extends Context.Service<
  *   env: {
  *     MY_WORKFLOW: Cloudflare.Workflow<{ value: string }>("MyWorkflow", {
  *       className: "MyWorkflow",
+ *       workflowName: "my-existing-workflow",
  *     }),
  *   },
  * });
@@ -765,6 +801,9 @@ export class WorkflowScope extends Context.Service<
  *     MY_WORKFLOW: Cloudflare.Workflow("MyWorkflow", {
  *       className: "MyWorkflow",
  *       scriptName: host.workerName,
+ *       // Repeat the host's explicit or preserved physical name when it
+ *       // does not use Alchemy's current generated default.
+ *       workflowName: "my-existing-workflow",
  *     }),
  *   },
  * });
@@ -835,6 +874,7 @@ export const Workflow: WorkflowClass = taggedFunction(WorkflowScope, ((
     return {
       kind: TypeId,
       name,
+      workflowName: refProps?.workflowName,
       className: refProps?.className ?? name,
       scriptName: refProps?.scriptName,
       limits: refProps?.limits,
@@ -845,11 +885,8 @@ export const Workflow: WorkflowClass = taggedFunction(WorkflowScope, ((
     Effect.gen(function* () {
       const worker = yield* Worker;
 
-      // Workflow names are account-global, so derive the physical name from
-      // the already-unique host Worker name and exported class name.
-      const workflowName = makeWorkflowName(worker.workerName, name);
       const workflow = yield* WorkflowResource(name, {
-        workflowName,
+        workflowName: props?.workflowName,
         className: name,
         scriptName: worker.workerName,
         limits: props?.limits,
@@ -934,9 +971,12 @@ export const Workflow: WorkflowClass = taggedFunction(WorkflowScope, ((
 
 export interface WorkflowResourceProps {
   /**
-   * Account-global Workflow name.
+   * Account-global Workflow name. If omitted, a deterministic name is derived
+   * from `scriptName` and `className`.
+   *
+   * @internal
    */
-  workflowName: string;
+  workflowName?: string;
   className: string;
   scriptName: string;
   limits?: WorkflowLimits;
@@ -961,6 +1001,11 @@ export interface WorkflowResource extends Resource<
 export const WorkflowResource = Resource<WorkflowResource>(
   WorkflowResourceTypeId,
 );
+
+const getWorkflowOrUndefined = (accountId: string, workflowName: string) =>
+  workflows
+    .getWorkflow({ accountId, workflowName })
+    .pipe(Effect.catchTag("WorkflowNotFound", () => Effect.succeed(undefined)));
 
 export const ProviderLive = () =>
   Provider.succeed(WorkflowResource, {
@@ -996,37 +1041,107 @@ export const ProviderLive = () =>
           ),
         );
       }),
+    diff: Effect.fn(function* ({ olds, news, output }) {
+      const { accountId } = yield* yield* CloudflareEnvironment;
+      if (output?.accountId !== undefined && output.accountId !== accountId) {
+        return { action: "replace" } as const;
+      }
+
+      const oldName =
+        output?.workflowName ??
+        (typeof olds.workflowName === "string"
+          ? olds.workflowName
+          : isResolved(olds)
+            ? yield* generateWorkflowName(olds.scriptName, olds.className)
+            : undefined);
+      // Compare an explicit physical name independently of other unresolved
+      // props so a rename can never be misclassified as an in-place update.
+      const explicitName = (news as Partial<WorkflowResourceProps>)
+        .workflowName;
+      if (
+        typeof explicitName === "string" &&
+        oldName !== undefined &&
+        explicitName !== oldName
+      ) {
+        return { action: "replace" } as const;
+      }
+      if (!isResolved(news)) return undefined;
+      // Auto-generated names are engine-owned: the deployed name stays
+      // authoritative unless the user supplies a different physical name.
+      const workflowName = news.workflowName ?? oldName;
+      if (oldName !== undefined && workflowName !== oldName) {
+        return { action: "replace" } as const;
+      }
+    }),
     read: Effect.fn(function* ({ output, olds }) {
       const { accountId } = yield* yield* CloudflareEnvironment;
-      const workflowName = output?.workflowName ?? olds?.workflowName;
+      const workflowName =
+        output?.workflowName ??
+        olds?.workflowName ??
+        (olds === undefined
+          ? undefined
+          : yield* generateWorkflowName(olds.scriptName, olds.className));
       if (workflowName === undefined) return undefined;
 
       const acct = output?.accountId ?? accountId;
-      return yield* workflows
-        .getWorkflow({
-          accountId: acct,
-          workflowName,
-        })
-        .pipe(
-          Effect.map((workflow) => ({
-            workflowId: workflow.id,
-            workflowName: workflow.name,
-            className: workflow.className,
-            scriptName: workflow.scriptName,
-            accountId: acct,
-          })),
-          Effect.catchTag("WorkflowNotFound", () => Effect.succeed(undefined)),
-        );
+      const workflow = yield* getWorkflowOrUndefined(acct, workflowName);
+      if (workflow === undefined) return undefined;
+      const attrs = {
+        workflowId: workflow.id,
+        workflowName: workflow.name,
+        className: workflow.className,
+        scriptName: workflow.scriptName,
+        accountId: acct,
+      };
+      // Explicit cold reads target resources that carry no ownership marker.
+      // Require --adopt before Alchemy is allowed to mutate or delete them.
+      return output === undefined && olds?.workflowName !== undefined
+        ? Unowned(attrs)
+        : attrs;
     }),
-    reconcile: Effect.fn(function* ({ news, output }) {
+    reconcile: Effect.fn(function* ({ id, news, output }) {
       const { accountId } = yield* yield* CloudflareEnvironment;
       const acct = output?.accountId ?? accountId;
-      const workflowName = news.workflowName;
+      const workflowName =
+        news.workflowName ??
+        output?.workflowName ??
+        (yield* generateWorkflowName(news.scriptName, news.className));
+
+      if (
+        news.workflowName !== undefined &&
+        output?.workflowName !== undefined &&
+        news.workflowName !== output.workflowName
+      ) {
+        return yield* Effect.fail(
+          new Error(
+            `Workflow physical name changed from '${output.workflowName}' to '${news.workflowName}' during an in-place update; a replacement is required.`,
+          ),
+        );
+      }
+
+      // Explicit names may point at hand-managed or differently managed
+      // Workflows. Re-check immediately before a create/replacement PUT to
+      // prevent a plan/apply race or rename from overwriting another owner.
+      if (news.workflowName !== undefined && output === undefined) {
+        const existing = yield* getWorkflowOrUndefined(acct, workflowName);
+        if (existing !== undefined) {
+          return yield* new OwnedBySomeoneElse({
+            message:
+              `Cannot create Workflow '${workflowName}': an existing ` +
+              "Workflow has that account-global name. Choose an unused name, " +
+              "or adopt it into a resource with no prior state by re-planning " +
+              "with --adopt.",
+            resourceType: WorkflowResourceTypeId,
+            logicalId: id,
+            physicalName: workflowName,
+          });
+        }
+      }
+
       yield* Effect.logInfo(`Cloudflare Workflow reconcile: ${workflowName}`);
       // Cloudflare's `putWorkflow` is a true PUT-as-upsert: identical
       // payloads converge to the same state and a missing workflow is
-      // created on the spot. There is no separate observe step needed
-      // — the API is naturally reconciler-shaped.
+      // created on the spot.
       const result = yield* workflows.putWorkflow({
         accountId: acct,
         workflowName,
@@ -1068,10 +1183,18 @@ export const ProviderLocal = () =>
     diff: Effect.fn(function* ({ news, output }) {
       const { accountId } = yield* yield* CloudflareEnvironment;
       if (!output?.workflowId) return { action: "update" } as const;
-      if (!isResolved(news)) return undefined;
       if (output.accountId !== accountId) {
         return { action: "replace" } as const;
       }
+      const explicitName = (news as Partial<WorkflowResourceProps>)
+        .workflowName;
+      if (
+        typeof explicitName === "string" &&
+        explicitName !== output.workflowName
+      ) {
+        return { action: "replace" } as const;
+      }
+      if (!isResolved(news)) return undefined;
       // Fall through to the engine's default prop diff (className /
       // scriptName changes update in place).
     }),
@@ -1081,9 +1204,23 @@ export const ProviderLocal = () =>
     }),
     reconcile: Effect.fn(function* ({ news, output }) {
       const { accountId } = yield* yield* CloudflareEnvironment;
+      if (
+        news.workflowName !== undefined &&
+        output?.workflowName !== undefined &&
+        news.workflowName !== output.workflowName
+      ) {
+        return yield* Effect.fail(
+          new Error(
+            `Workflow physical name changed from '${output.workflowName}' to '${news.workflowName}' during an in-place update; a replacement is required.`,
+          ),
+        );
+      }
       return {
         workflowId: output?.workflowId ?? generateLocalId(),
-        workflowName: news.workflowName,
+        workflowName:
+          news.workflowName ??
+          output?.workflowName ??
+          (yield* generateWorkflowName(news.scriptName, news.className)),
         className: news.className,
         scriptName: news.scriptName,
         accountId: output?.accountId ?? accountId,

--- a/packages/alchemy/src/Cloudflare/Workflows/WorkflowName.ts
+++ b/packages/alchemy/src/Cloudflare/Workflows/WorkflowName.ts
@@ -4,9 +4,29 @@ import * as Output from "../../Output.ts";
 import { sha256 } from "../../Util/sha256.ts";
 
 /**
- * Derive an account-global Workflow name from its unique host Worker name and
- * exported class. The hash preserves uniqueness when the readable prefix must
- * be truncated to Cloudflare's 64-character limit.
+ * Derive an account-global Workflow name from a resolved host Worker name and
+ * exported class.
+ *
+ * @internal
+ */
+export const generateWorkflowName = Effect.fn(function* (
+  scriptName: string,
+  className: string,
+) {
+  const base = `${scriptName}-${className}`
+    .toLowerCase()
+    .replaceAll(/[^a-z0-9-]/g, "-");
+  const hash = yield* sha256(base);
+  const suffix = `-${hash.slice(0, 8)}`;
+  // Trim trailing dashes left by mid-name truncation so the result never
+  // contains a `--` seam.
+  const head = base.slice(0, 64 - suffix.length).replace(/-+$/, "");
+  return `${head}${suffix}`;
+});
+
+/**
+ * Derive an account-global Workflow name when the host Worker name may still
+ * be an unresolved input.
  *
  * @internal
  */
@@ -23,19 +43,8 @@ export const makeWorkflowName = (
       | Output.Output<string>
       | Effect.Effect<string>,
   ).pipe(
-    Output.mapEffect((scriptName) => {
-      const base = `${scriptName}-${className}`
-        .toLowerCase()
-        .replaceAll(/[^a-z0-9-]/g, "-");
-      return sha256(base).pipe(
-        Effect.map((hash) => {
-          const suffix = `-${hash.slice(0, 8)}`;
-          // Trim trailing dashes left by mid-name truncation so the result
-          // never contains a `--` seam.
-          const head = base.slice(0, 64 - suffix.length).replace(/-+$/, "");
-          return `${head}${suffix}`;
-        }),
-      );
-    }),
+    Output.mapEffect((scriptName) =>
+      generateWorkflowName(scriptName, className),
+    ),
   );
 };

--- a/packages/alchemy/test/Cloudflare/EngineOwnedNames.test.ts
+++ b/packages/alchemy/test/Cloudflare/EngineOwnedNames.test.ts
@@ -15,6 +15,11 @@ import {
   type Index,
   IndexProvider,
 } from "@/Cloudflare/Vectorize/VectorizeIndex.ts";
+import {
+  ProviderLive as WorkflowProviderLive,
+  ProviderLocal as WorkflowProviderLocal,
+  type WorkflowResource,
+} from "@/Cloudflare/Workflows/Workflow.ts";
 import { AlchemyContext } from "@/AlchemyContext.ts";
 import { ArtifactStore, createArtifactStore } from "@/Artifacts.ts";
 import { LocalRuntimeState } from "@/Cloudflare/LocalRuntime.ts";
@@ -32,6 +37,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as MutableHashMap from "effect/MutableHashMap";
 import * as Redacted from "effect/Redacted";
+import * as Output from "@/Output.ts";
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
 
 // Regression tests for the "engine-owned names" invariant: a provider's
@@ -277,5 +283,129 @@ describe("engine-owned names: generator drift never replaces", () => {
         );
         expect(result?.action).not.toBe("replace");
       }).pipe(Effect.provide(ConnectionProvider()), Effect.provide(env)),
+  );
+
+  it.effect("Workflow: drifted auto-generated name does not replace", () =>
+    Effect.gen(function* () {
+      const provider = yield* Provider<WorkflowResource>("Cloudflare.Workflow");
+      const result = yield* provider.diff!(
+        diffInput(
+          "Workflow",
+          {
+            // Legacy state persisted the generated name in props.
+            workflowName: DRIFTED,
+            className: "MyWorkflow",
+            scriptName: "worker",
+          },
+          {
+            className: "MyWorkflow",
+            scriptName: "worker",
+          },
+          {
+            workflowId: "11111111-2222-3333-4444-555555555555",
+            workflowName: DRIFTED,
+            className: "MyWorkflow",
+            scriptName: "worker",
+            accountId: TEST_ACCOUNT,
+          },
+        ),
+      );
+      expect(result?.action).not.toBe("replace");
+    }).pipe(Effect.provide(WorkflowProviderLive()), Effect.provide(env)),
+  );
+
+  it.effect("Workflow: generated-name drift preserves the deployed name", () =>
+    Effect.gen(function* () {
+      const provider = yield* Provider<WorkflowResource>("Cloudflare.Workflow");
+      const output = {
+        workflowId: "dev:11111111-2222-3333-4444-555555555555",
+        workflowName: DRIFTED,
+        className: "MyWorkflow",
+        scriptName: "worker",
+        accountId: TEST_ACCOUNT,
+      };
+      const result = yield* provider.reconcile({
+        ...diffInput(
+          "Workflow",
+          {
+            workflowName: DRIFTED,
+            className: "MyWorkflow",
+            scriptName: "worker",
+          },
+          {
+            className: "MyWorkflow",
+            scriptName: "worker",
+          },
+          output,
+        ),
+        news: {
+          className: "MyWorkflow",
+          scriptName: "worker",
+        },
+        bindings: [],
+        session: {} as never,
+      });
+      expect(result.workflowName).toBe(DRIFTED);
+    }).pipe(Effect.provide(WorkflowProviderLocal()), Effect.provide(env)),
+  );
+
+  it.effect(
+    "Workflow: explicit name change replaces with another prop unresolved",
+    () =>
+      Effect.gen(function* () {
+        const provider = yield* Provider<WorkflowResource>(
+          "Cloudflare.Workflow",
+        );
+        const result = yield* provider.diff!(
+          diffInput(
+            "Workflow",
+            {
+              workflowName: "existing-workflow",
+              className: "MyWorkflow",
+              scriptName: "worker",
+            },
+            {
+              workflowName: "renamed-workflow",
+              className: "MyWorkflow",
+              scriptName: Output.asOutput("worker"),
+            },
+            {
+              workflowId: "11111111-2222-3333-4444-555555555555",
+              workflowName: "existing-workflow",
+              className: "MyWorkflow",
+              scriptName: "worker",
+              accountId: TEST_ACCOUNT,
+            },
+          ),
+        );
+        expect(result).toEqual({ action: "replace" });
+      }).pipe(Effect.provide(WorkflowProviderLive()), Effect.provide(env)),
+  );
+
+  it.effect("Workflow: changing accounts replaces", () =>
+    Effect.gen(function* () {
+      const provider = yield* Provider<WorkflowResource>("Cloudflare.Workflow");
+      const result = yield* provider.diff!(
+        diffInput(
+          "Workflow",
+          {
+            className: "MyWorkflow",
+            scriptName: "worker",
+          },
+          {
+            className: "MyWorkflow",
+            scriptName: "worker",
+          },
+          {
+            workflowId: "11111111-2222-3333-4444-555555555555",
+            workflowName: DRIFTED,
+            className: "MyWorkflow",
+            scriptName: "worker",
+            accountId: "previous-account-id",
+          },
+        ),
+      );
+      expect(result).toEqual({ action: "replace" });
+    }).pipe(Effect.provide(WorkflowProviderLive()), Effect.provide(env)),
   );
 });

--- a/packages/alchemy/test/Cloudflare/Workflows/Workflow.local.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workflows/Workflow.local.test.ts
@@ -1,4 +1,3 @@
-import { CloudflareEnvironment } from "@/Cloudflare/CloudflareEnvironment.ts";
 import * as Cloudflare from "@/Cloudflare/index.ts";
 import * as Alchemy from "@/index.ts";
 import * as State from "@/State/State";
@@ -7,9 +6,13 @@ import * as workflows from "@distilled.cloud/cloudflare/workflows";
 import { expect } from "alchemy-test";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
+import * as Path from "effect/Path";
 import { MinimumLogLevel } from "effect/References";
 import * as Schedule from "effect/Schedule";
 import * as HttpClient from "effect/unstable/http/HttpClient";
+import ExplicitNameWorkflowWorker, {
+  EXPLICIT_WORKFLOW_NAME,
+} from "./fixtures/explicit-name-worker.ts";
 import WorkflowLocalWorker from "./fixtures/workflow-worker.ts";
 
 // `dev: true` runs local providers behind the RPC sidecar proxy by default,
@@ -130,6 +133,42 @@ const readWorkflowRow = (stack: Test.ScratchStack) =>
     return undefined;
   }).pipe(Effect.provide(stack.state));
 
+const readWorkerWorkflowBinding = (stack: Test.ScratchStack) =>
+  Effect.gen(function* () {
+    const state = yield* yield* State.State;
+    const fqns = yield* state.list({ stack: stack.name, stage: "test" });
+    for (const fqn of fqns) {
+      const row = yield* state.get({ stack: stack.name, stage: "test", fqn });
+      if (
+        row &&
+        (row as { resourceType?: string }).resourceType === "Cloudflare.Worker"
+      ) {
+        const contributions = (
+          row as {
+            bindings?: Array<{
+              data?: {
+                bindings?: Array<{
+                  type: string;
+                  workflowName?: string;
+                }>;
+              };
+            }>;
+          }
+        ).bindings;
+        const binding = contributions
+          ?.flatMap((contribution) => contribution.data?.bindings ?? [])
+          .find((binding) => binding.type === "workflow");
+        if (binding) return binding;
+      }
+    }
+    return undefined;
+  }).pipe(Effect.provide(stack.state));
+
+const asyncWorkflowMain = Effect.gen(function* () {
+  const path = yield* Path.Path;
+  return path.resolve(import.meta.dirname, "fixtures/async-workflow-worker.ts");
+});
+
 /**
  * Under `alchemy dev` the Workflow resource is emulated by the local provider
  * (a `dev:` id, no cloud API calls) and the host worker's `workflow` binding
@@ -160,6 +199,8 @@ test.provider(
       expect(row).toBeDefined();
       expect(row!.attr?.workflowId).toMatch(/^dev:/);
       expect(row!.providerMode).toBe("local");
+      const binding = yield* readWorkerWorkflowBinding(stack);
+      expect(binding?.workflowName).toBe(row!.attr?.workflowName);
 
       // Drive the workflow through the binding against local workerd.
       const url = deployed.worker.url!;
@@ -169,6 +210,92 @@ test.provider(
       expect(status.status).toBe("complete");
       expect(status.output?.greeting).toBe("Hello, world!");
       expect(status.output?.instanceId).toBe(instanceId);
+
+      yield* stack.destroy();
+    }).pipe(logLevel),
+  { timeout: 120_000 },
+);
+
+/**
+ * An explicit name must flow through both the local Workflow provider and the
+ * Worker's serialized binding metadata. This stays entirely in local mode, so
+ * it proves the exact-name wiring without creating a Cloudflare Workflow.
+ */
+test.provider(
+  "async Worker binding preserves an explicit physical Workflow name",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const workflowName = "existing-workflow-physical-name";
+      const main = yield* asyncWorkflowMain;
+      yield* stack.deploy(
+        Cloudflare.Worker("ExplicitWorkflowWorker", {
+          main,
+          env: {
+            EXISTING_WORKFLOW: Cloudflare.Workflow("ExistingWorkflow", {
+              workflowName,
+            }),
+          },
+        }),
+      );
+
+      const workflowRow = yield* readWorkflowRow(stack);
+      expect(workflowRow?.providerMode).toBe("local");
+      expect(workflowRow?.attr?.workflowName).toBe(workflowName);
+
+      const binding = yield* readWorkerWorkflowBinding(stack);
+      expect(binding?.workflowName).toBe(workflowName);
+
+      yield* stack.destroy();
+    }).pipe(logLevel),
+  { timeout: 120_000 },
+);
+
+test.provider(
+  "cross-script binding serializes the host's explicit Workflow name",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const workflowName = "existing-cross-script-workflow";
+      const main = yield* asyncWorkflowMain;
+      yield* stack.deploy(
+        Cloudflare.Worker("ExplicitWorkflowConsumer", {
+          main,
+          env: {
+            EXISTING_WORKFLOW: Cloudflare.Workflow("ExistingWorkflow", {
+              scriptName: "existing-workflow-host",
+              workflowName,
+            }),
+          },
+        }),
+      );
+
+      // Cross-script references are binding-only: the consumer must serialize
+      // the host's exact physical name without registering another Workflow.
+      expect(yield* readWorkflowRow(stack)).toBeUndefined();
+      const binding = yield* readWorkerWorkflowBinding(stack);
+      expect(binding?.workflowName).toBe(workflowName);
+
+      yield* stack.destroy();
+    }).pipe(logLevel),
+  { timeout: 120_000 },
+);
+
+test.provider(
+  "Effect-native Worker binding preserves an explicit physical Workflow name",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+      yield* stack.deploy(ExplicitNameWorkflowWorker);
+
+      const workflowRow = yield* readWorkflowRow(stack);
+      expect(workflowRow?.providerMode).toBe("local");
+      expect(workflowRow?.attr?.workflowName).toBe(EXPLICIT_WORKFLOW_NAME);
+
+      const binding = yield* readWorkerWorkflowBinding(stack);
+      expect(binding?.workflowName).toBe(EXPLICIT_WORKFLOW_NAME);
 
       yield* stack.destroy();
     }).pipe(logLevel),

--- a/packages/alchemy/test/Cloudflare/Workflows/Workflow.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workflows/Workflow.test.ts
@@ -1,0 +1,339 @@
+import { OwnedBySomeoneElse, Unowned } from "@/AdoptPolicy.ts";
+import type { CloudflareResolvedCredentials } from "@/Cloudflare/Auth/AuthConfig.ts";
+import { CloudflareEnvironment } from "@/Cloudflare/CloudflareEnvironment.ts";
+import {
+  ProviderLive,
+  Workflow,
+  type WorkflowResource,
+  type WorkflowResourceAttrs,
+  type WorkflowResourceProps,
+} from "@/Cloudflare/Workflows/Workflow.ts";
+import { generateWorkflowName } from "@/Cloudflare/Workflows/WorkflowName.ts";
+import { Provider } from "@/Provider.ts";
+import {
+  apiTokenCredentials,
+  Credentials,
+} from "@distilled.cloud/cloudflare/Credentials";
+import { describe, expect, it } from "alchemy-test";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Redacted from "effect/Redacted";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as HttpClientResponse from "effect/unstable/http/HttpClientResponse";
+
+const ACCOUNT_ID = "test-account";
+const WORKFLOW_ID = "11111111-2222-3333-4444-555555555555";
+const WORKFLOW_NAME = "existing-workflow";
+const CLASS_NAME = "ExistingWorkflow";
+const SCRIPT_NAME = "existing-workflow-host";
+const INSTANCE_ID = "0123456789abcdef0123456789abcdef";
+const BASE_URL = `https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/workflows/${WORKFLOW_NAME}`;
+
+const workflowEnvelope = () => ({
+  success: true,
+  errors: [],
+  messages: [],
+  result: {
+    id: WORKFLOW_ID,
+    name: WORKFLOW_NAME,
+    class_name: CLASS_NAME,
+    script_name: SCRIPT_NAME,
+    created_on: "2026-01-01T00:00:00Z",
+    modified_on: "2026-01-01T00:00:00Z",
+    triggered_on: "2026-01-01T00:00:00Z",
+    instances: {},
+  },
+});
+
+const response = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+
+const notFoundResponse = () =>
+  response(
+    {
+      success: false,
+      errors: [{ code: 10200, message: "Workflow not found" }],
+      messages: [],
+      result: null,
+    },
+    404,
+  );
+
+const credentials: CloudflareResolvedCredentials = {
+  type: "apiToken",
+  apiToken: Redacted.make("test-token"),
+  accountId: ACCOUNT_ID,
+  source: { type: "stored" },
+};
+
+const environment = (
+  handle: (request: { method: string; url: string }) => Response,
+) => {
+  const client = HttpClient.make((request) =>
+    Effect.sync(() => HttpClientResponse.fromWeb(request, handle(request))),
+  );
+  return Layer.mergeAll(
+    Layer.succeed(HttpClient.HttpClient, client),
+    Layer.succeed(
+      Credentials,
+      Effect.succeed(apiTokenCredentials({ apiToken: "test-token" })),
+    ),
+    Layer.succeed(CloudflareEnvironment, Effect.succeed(credentials)),
+  );
+};
+
+const withProvider = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+  effect.pipe(Effect.provide(ProviderLive()));
+
+const resourceProps: WorkflowResourceProps = {
+  workflowName: WORKFLOW_NAME,
+  className: CLASS_NAME,
+  scriptName: SCRIPT_NAME,
+};
+
+const resourceAttrs: WorkflowResourceAttrs = {
+  workflowId: WORKFLOW_ID,
+  workflowName: WORKFLOW_NAME,
+  className: CLASS_NAME,
+  scriptName: SCRIPT_NAME,
+  accountId: ACCOUNT_ID,
+};
+
+describe("Cloudflare.Workflow physical names", () => {
+  it("preserves an explicit physical name on an async Worker reference", () => {
+    const workflow = Workflow(CLASS_NAME, {
+      className: CLASS_NAME,
+      workflowName: WORKFLOW_NAME,
+    });
+
+    expect(workflow.workflowName).toBe(WORKFLOW_NAME);
+  });
+
+  it.effect("derives distinct defaults from stage-scoped Worker names", () =>
+    Effect.gen(function* () {
+      const development = yield* generateWorkflowName(
+        "app-development-worker",
+        CLASS_NAME,
+      );
+      const production = yield* generateWorkflowName(
+        "app-production-worker",
+        CLASS_NAME,
+      );
+
+      expect(development).not.toBe(production);
+      expect(development.length).toBeLessThanOrEqual(64);
+      expect(production.length).toBeLessThanOrEqual(64);
+    }),
+  );
+
+  it.effect("deletes only the selected stage's generated Workflow", () => {
+    const requests: Array<{ method: string; url: string }> = [];
+    return withProvider(
+      Effect.gen(function* () {
+        const development = yield* generateWorkflowName(
+          "app-development-worker",
+          CLASS_NAME,
+        );
+        const production = yield* generateWorkflowName(
+          "app-production-worker",
+          CLASS_NAME,
+        );
+        const provider = yield* Provider<WorkflowResource>(
+          "Cloudflare.Workflow",
+        );
+        yield* provider.delete({
+          id: CLASS_NAME,
+          fqn: CLASS_NAME,
+          instanceId: INSTANCE_ID,
+          olds: {
+            className: CLASS_NAME,
+            scriptName: "app-development-worker",
+          },
+          output: {
+            ...resourceAttrs,
+            workflowName: development,
+            scriptName: "app-development-worker",
+          },
+          bindings: [],
+          session: {} as never,
+        });
+
+        expect(requests).toEqual([
+          {
+            method: "DELETE",
+            url: `https://api.cloudflare.com/client/v4/accounts/${ACCOUNT_ID}/workflows/${development}`,
+          },
+        ]);
+        expect(requests[0]?.url).not.toContain(production);
+      }),
+    ).pipe(
+      Effect.provide(
+        environment((request) => {
+          requests.push({ method: request.method, url: request.url });
+          return response({
+            success: true,
+            errors: [],
+            messages: [],
+            result: null,
+          });
+        }),
+      ),
+    );
+  });
+
+  it.effect(
+    "cold-reads an exact existing name as unowned without writing",
+    () => {
+      const requests: Array<{ method: string; url: string }> = [];
+      return withProvider(
+        Effect.gen(function* () {
+          const provider = yield* Provider<WorkflowResource>(
+            "Cloudflare.Workflow",
+          );
+          const attrs = yield* provider.read!({
+            id: CLASS_NAME,
+            fqn: CLASS_NAME,
+            instanceId: INSTANCE_ID,
+            olds: resourceProps,
+            output: undefined,
+          });
+
+          expect(requests).toEqual([{ method: "GET", url: BASE_URL }]);
+          expect(Unowned.is(attrs)).toBe(true);
+          expect({ ...attrs }).toEqual(resourceAttrs);
+        }),
+      ).pipe(
+        Effect.provide(
+          environment((request) => {
+            requests.push({ method: request.method, url: request.url });
+            return response(workflowEnvelope());
+          }),
+        ),
+      );
+    },
+  );
+
+  it.effect(
+    "creates an unused explicit name through its exact API path",
+    () => {
+      const requests: Array<{ method: string; url: string }> = [];
+      return withProvider(
+        Effect.gen(function* () {
+          const provider = yield* Provider<WorkflowResource>(
+            "Cloudflare.Workflow",
+          );
+          const attrs = yield* provider.reconcile({
+            id: CLASS_NAME,
+            fqn: CLASS_NAME,
+            instanceId: INSTANCE_ID,
+            news: resourceProps,
+            olds: undefined,
+            output: undefined,
+            bindings: [],
+            session: {} as never,
+          });
+
+          expect(attrs).toEqual(resourceAttrs);
+          expect(requests).toEqual([
+            { method: "GET", url: BASE_URL },
+            { method: "PUT", url: BASE_URL },
+          ]);
+        }),
+      ).pipe(
+        Effect.provide(
+          environment((request) => {
+            requests.push({ method: request.method, url: request.url });
+            return request.method === "GET"
+              ? notFoundResponse()
+              : response(workflowEnvelope());
+          }),
+        ),
+      );
+    },
+  );
+
+  it.effect("refuses to replace into an occupied explicit name", () => {
+    const requests: Array<{ method: string; url: string }> = [];
+    return withProvider(
+      Effect.gen(function* () {
+        const provider = yield* Provider<WorkflowResource>(
+          "Cloudflare.Workflow",
+        );
+        const error = yield* provider
+          .reconcile({
+            id: CLASS_NAME,
+            fqn: CLASS_NAME,
+            instanceId: INSTANCE_ID,
+            news: resourceProps,
+            olds: undefined,
+            output: undefined,
+            bindings: [],
+            session: {} as never,
+          })
+          .pipe(Effect.flip);
+
+        expect(error).toBeInstanceOf(OwnedBySomeoneElse);
+        expect(requests).toEqual([{ method: "GET", url: BASE_URL }]);
+      }),
+    ).pipe(
+      Effect.provide(
+        environment((request) => {
+          requests.push({ method: request.method, url: request.url });
+          return response(workflowEnvelope());
+        }),
+      ),
+    );
+  });
+
+  it.effect("updates and deletes an adopted exact name", () => {
+    const requests: Array<{ method: string; url: string }> = [];
+    return withProvider(
+      Effect.gen(function* () {
+        const provider = yield* Provider<WorkflowResource>(
+          "Cloudflare.Workflow",
+        );
+        const attrs = yield* provider.reconcile({
+          id: CLASS_NAME,
+          fqn: CLASS_NAME,
+          instanceId: INSTANCE_ID,
+          news: resourceProps,
+          olds: undefined,
+          output: resourceAttrs,
+          bindings: [],
+          session: {} as never,
+        });
+        yield* provider.delete({
+          id: CLASS_NAME,
+          fqn: CLASS_NAME,
+          instanceId: INSTANCE_ID,
+          olds: resourceProps,
+          output: attrs,
+          bindings: [],
+          session: {} as never,
+        });
+
+        expect(requests).toEqual([
+          { method: "PUT", url: BASE_URL },
+          { method: "DELETE", url: BASE_URL },
+        ]);
+      }),
+    ).pipe(
+      Effect.provide(
+        environment((request) => {
+          requests.push({ method: request.method, url: request.url });
+          return request.method === "DELETE"
+            ? response({
+                success: true,
+                errors: [],
+                messages: [],
+                result: null,
+              })
+            : response(workflowEnvelope());
+        }),
+      ),
+    );
+  });
+});

--- a/packages/alchemy/test/Cloudflare/Workflows/fixtures/async-workflow-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Workflows/fixtures/async-workflow-worker.ts
@@ -1,0 +1,13 @@
+import { WorkflowEntrypoint } from "cloudflare:workers";
+
+export class ExistingWorkflow extends WorkflowEntrypoint {
+  async run() {
+    return "ok";
+  }
+}
+
+export default {
+  async fetch() {
+    return new Response("ok");
+  },
+};

--- a/packages/alchemy/test/Cloudflare/Workflows/fixtures/explicit-name-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Workflows/fixtures/explicit-name-worker.ts
@@ -1,0 +1,26 @@
+import * as Cloudflare from "@/Cloudflare";
+import * as Effect from "effect/Effect";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+
+export const EXPLICIT_WORKFLOW_NAME = "existing-effect-workflow-physical-name";
+
+export class ExplicitNameWorkflow extends Cloudflare.Workflow<ExplicitNameWorkflow>()(
+  "ExplicitNameWorkflow",
+  { workflowName: EXPLICIT_WORKFLOW_NAME },
+  Effect.succeed(
+    Effect.fn(function* () {
+      return "ok";
+    }),
+  ),
+) {}
+
+export default class ExplicitNameWorkflowWorker extends Cloudflare.Worker<ExplicitNameWorkflowWorker>()(
+  "ExplicitNameWorkflowWorker",
+  { main: import.meta.url },
+  Effect.gen(function* () {
+    yield* ExplicitNameWorkflow;
+    return {
+      fetch: Effect.succeed(HttpServerResponse.text("ok")),
+    };
+  }),
+) {}


### PR DESCRIPTION
Allow both Cloudflare Workflow forms to opt into an account-global physical name while keeping generated, stage-scoped names as the default.

```ts
Cloudflare.Workflow("MyWorkflow", {
  className: "MyWorkflow",
  workflowName: "my-existing-workflow",
});
```

Exact-name cold reads require explicit adoption, Worker bindings use the persisted physical name, and explicit renames replace without overwriting occupied targets.

Related to #522.
