### PR TITLE
feat(fly): support health checks

### DIFF
--- a/packages/alchemy/src/Fly/Machine.ts
+++ b/packages/alchemy/src/Fly/Machine.ts
@@ -27,6 +27,7 @@ import {
   observeReplicaSet,
   reconcileReplicas,
   resolveCount,
+  toFlyService,
   volumeIdsOf,
   type Replica,
   type ReplicaSet,
@@ -105,6 +106,37 @@ export interface MachinePort {
   endPort?: number;
 }
 
+/** A health check attached to a Fly service. */
+export interface MachineServiceCheck {
+  /** Check type. HTTP checks send a request; TCP checks open a connection. */
+  type: "http" | "tcp";
+  /** Port to check. Usually the service's {@link MachineService.internalPort}. */
+  port?: number;
+  /** Time between checks, such as `"15s"`. */
+  interval?: string;
+  /** Maximum time for a check, such as `"2s"`. */
+  timeout?: string;
+  /** Delay after the Machine starts before checks begin, such as `"30s"`. */
+  gracePeriod?: string;
+  /** HTTP method for an `http` check. */
+  method?: string;
+  /** Request path for an `http` check. */
+  path?: string;
+  /** Request protocol for an `http` check. */
+  protocol?: "http" | "https";
+  /** Headers sent by an `http` check. */
+  headers?: Array<{
+    /** Header name. */
+    name: string;
+    /** Header values. */
+    values: string[];
+  }>;
+  /** Hostname used to validate the certificate for an HTTPS check. */
+  tlsServerName?: string;
+  /** Skip certificate verification for an HTTPS check. */
+  tlsSkipVerify?: boolean;
+}
+
 export interface MachineService {
   /**
    * Proxy protocol (`tcp` or `udp`).
@@ -122,6 +154,8 @@ export interface MachineService {
   autostop?: "off" | "stop" | "suspend" | boolean;
   /** Minimum Machines to keep running for this service. */
   minMachinesRunning?: number;
+  /** Health checks for this service. */
+  checks?: MachineServiceCheck[];
 }
 
 export type MachineMount = DiskSpec;
@@ -404,6 +438,39 @@ export type Machine = Resource<
  *       ports: [
  *         { port: 80, handlers: ["http"], forceHttps: true },
  *         { port: 443, handlers: ["tls", "http"] },
+ *       ],
+ *     },
+ *   ],
+ * });
+ * ```
+ *
+ * ### Service health checks
+ * Add HTTP or TCP `checks` to a service. Fly uses their results to
+ * determine whether the service is ready to receive traffic.
+ *
+ * **Example:** HTTP readiness check
+ * ```typescript
+ * const web = yield* Fly.Machine("Web", {
+ *   app: Site,
+ *   region: "iad",
+ *   image: "nginx:alpine",
+ *   services: [
+ *     {
+ *       protocol: "tcp",
+ *       internalPort: 80,
+ *       ports: [{ port: 80, handlers: ["http"] }],
+ *       checks: [
+ *         {
+ *           type: "http",
+ *           port: 80,
+ *           method: "GET",
+ *           path: "/health",
+ *           protocol: "http",
+ *           interval: "15s",
+ *           timeout: "2s",
+ *           gracePeriod: "30s",
+ *           headers: [{ name: "X-Health-Check", values: ["alchemy"] }],
+ *         },
  *       ],
  *     },
  *   ],
@@ -694,26 +761,6 @@ const toFlyInit = (init: MachineInit): FlyMachineInit => ({
 const toFlyRestart = (restart: MachineRestart): FlyMachineRestart => ({
   policy: restart.policy,
   max_retries: restart.maxRetries,
-});
-
-const toFlyService = (service: MachineService): FlyMachineService => ({
-  protocol: service.protocol,
-  internal_port: service.internalPort,
-  autostart: service.autostart,
-  autostop:
-    typeof service.autostop === "boolean"
-      ? service.autostop
-        ? "stop"
-        : "off"
-      : service.autostop,
-  min_machines_running: service.minMachinesRunning,
-  ports: service.ports?.map((port) => ({
-    port: port.port,
-    handlers: port.handlers,
-    force_https: port.forceHttps,
-    start_port: port.startPort,
-    end_port: port.endPort,
-  })),
 });
 
 const desiredEnv = (

--- a/packages/alchemy/src/Fly/Service.ts
+++ b/packages/alchemy/src/Fly/Service.ts
@@ -51,6 +51,7 @@ import {
   observeReplicaSet,
   reconcileReplicas,
   resolveCount,
+  toFlyService,
   volumeIdsOf,
   type Replica,
   type ReplicaSet,
@@ -358,6 +359,49 @@ export type ServiceRuntimeContext = FlyHostRuntimeContext;
  * `https://{appName}.fly.dev` lands on Fly's edge. Fly terminates
  * TLS on 443, picks one started Machine that published this service,
  * and forwards to `port` where `fetch` runs.
+ *
+ * ### Configure routing health checks
+ * The generated service includes a TCP check on `port`. To customize
+ * it, provide `services` and configure each service's `checks` property.
+ *
+ * **Example:** HTTP readiness check
+ * ```typescript
+ * export default class Api extends Fly.Service<Api>()(
+ *   "Api",
+ *   {
+ *     app: Site,
+ *     main: import.meta.url,
+ *     port: 3000,
+ *     services: [
+ *       {
+ *         protocol: "tcp",
+ *         internalPort: 3000,
+ *         ports: [
+ *           { port: 80, handlers: ["http"], forceHttps: true },
+ *           { port: 443, handlers: ["tls", "http"] },
+ *         ],
+ *         checks: [
+ *           {
+ *             type: "http",
+ *             port: 3000,
+ *             method: "GET",
+ *             path: "/health",
+ *             protocol: "http",
+ *             interval: "15s",
+ *             timeout: "2s",
+ *             gracePeriod: "30s",
+ *           },
+ *         ],
+ *       },
+ *     ],
+ *   },
+ *   Effect.gen(function* () {
+ *     return {
+ *       fetch: Effect.succeed(HttpServerResponse.text("hello")),
+ *     };
+ *   }),
+ * ) {}
+ * ```
  *
  * ### An address so it answers
  * `{app}.fly.dev` does not answer over IPv4 until the App has an
@@ -727,26 +771,6 @@ const toFlyGuest = (guest: MachineGuest | undefined): FlyMachineGuest => {
   if (guest?.gpus !== undefined) fly.gpus = guest.gpus;
   return fly;
 };
-
-const toFlyService = (service: MachineService): FlyMachineService => ({
-  protocol: service.protocol,
-  internal_port: service.internalPort,
-  autostart: service.autostart,
-  autostop:
-    typeof service.autostop === "boolean"
-      ? service.autostop
-        ? "stop"
-        : "off"
-      : service.autostop,
-  min_machines_running: service.minMachinesRunning,
-  ports: service.ports?.map((port) => ({
-    port: port.port,
-    handlers: port.handlers,
-    force_https: port.forceHttps,
-    start_port: port.startPort,
-    end_port: port.endPort,
-  })),
-});
 
 const desiredEnv = (
   props: ServiceProps,

--- a/packages/alchemy/src/Fly/replicas.ts
+++ b/packages/alchemy/src/Fly/replicas.ts
@@ -2,6 +2,7 @@ import type {
   FlyMachineConfig,
   FlyMachineMount,
   FlyMachineService,
+  FlyMachineServiceCheck,
   ImageRef as FlyImageRef,
   Machine as FlyMachine,
   Volume as FlyVolume,
@@ -11,7 +12,12 @@ import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Schedule from "effect/Schedule";
 import { listOwnedApps } from "./App.ts";
-import type { MachineGuest, MachineImageRef } from "./Machine.ts";
+import type {
+  MachineGuest,
+  MachineImageRef,
+  MachineService,
+  MachineServiceCheck,
+} from "./Machine.ts";
 import {
   alchemyMetadataKeys,
   createMachineMetadata,
@@ -164,6 +170,46 @@ export const toGuestAttrs = (
     gpus: guest.gpus,
   };
 };
+
+export const toFlyServiceCheck = (
+  check: MachineServiceCheck,
+): FlyMachineServiceCheck => ({
+  type: check.type,
+  port: check.port,
+  interval: check.interval,
+  timeout: check.timeout,
+  grace_period: check.gracePeriod,
+  method: check.method,
+  path: check.path,
+  protocol: check.protocol,
+  headers: check.headers?.map((header) => ({
+    name: header.name,
+    values: header.values,
+  })),
+  tls_server_name: check.tlsServerName,
+  tls_skip_verify: check.tlsSkipVerify,
+});
+
+export const toFlyService = (service: MachineService): FlyMachineService => ({
+  protocol: service.protocol,
+  internal_port: service.internalPort,
+  autostart: service.autostart,
+  autostop:
+    typeof service.autostop === "boolean"
+      ? service.autostop
+        ? "stop"
+        : "off"
+      : service.autostop,
+  min_machines_running: service.minMachinesRunning,
+  ports: service.ports?.map((port) => ({
+    port: port.port,
+    handlers: port.handlers,
+    force_https: port.forceHttps,
+    start_port: port.startPort,
+    end_port: port.endPort,
+  })),
+  checks: service.checks?.map(toFlyServiceCheck),
+});
 
 export const hasPublishedService = (
   services: FlyMachineService[] | undefined,

--- a/packages/alchemy/test/Fly/Machine.test.ts
+++ b/packages/alchemy/test/Fly/Machine.test.ts
@@ -96,6 +96,26 @@ test.provider(
                 protocol: "tcp",
                 internalPort: 80,
                 ports: [{ port: 80, handlers: ["http"] }],
+                checks: [
+                  {
+                    type: "http",
+                    port: 80,
+                    interval: "20s",
+                    timeout: "3s",
+                    gracePeriod: "6s",
+                    method: "HEAD",
+                    path: "/",
+                    protocol: "https",
+                    headers: [
+                      {
+                        name: "X-Alchemy-Check",
+                        values: ["ready", "routing"],
+                      },
+                    ],
+                    tlsServerName: "example.com",
+                    tlsSkipVerify: true,
+                  },
+                ],
               },
             ],
           });
@@ -123,6 +143,19 @@ test.provider(
       expect(refetched.config?.restart?.max_retries).toEqual(3);
       expect(refetched.config?.services?.[0]?.internal_port).toEqual(80);
       expect(refetched.config?.services?.[0]?.ports?.[0]?.port).toEqual(80);
+      const check = refetched.config?.services?.[0]?.checks?.[0];
+      expect(check?.type).toEqual("http");
+      expect(check?.port).toEqual(80);
+      expect(check?.interval).toEqual("20s");
+      expect(check?.timeout).toEqual("3s");
+      expect(check?.grace_period).toEqual("6s");
+      expect(check?.method).toEqual("HEAD");
+      expect(check?.path).toEqual("/");
+      expect(check?.protocol).toEqual("https");
+      expect(check?.headers?.[0]?.name).toEqual("X-Alchemy-Check");
+      expect(check?.headers?.[0]?.values).toEqual(["ready", "routing"]);
+      expect(check?.tls_server_name).toEqual("example.com");
+      expect(check?.tls_skip_verify).toEqual(true);
 
       yield* stack.destroy();
 

--- a/packages/alchemy/test/Fly/Service.test.ts
+++ b/packages/alchemy/test/Fly/Service.test.ts
@@ -8,7 +8,8 @@ import { MinimumLogLevel } from "effect/References";
 import * as Schedule from "effect/Schedule";
 import * as HttpClient from "effect/unstable/http/HttpClient";
 import Api from "./fixtures/api.ts";
-import { MARKER, Site, VOLUME_PATH } from "./fixtures/shared.ts";
+import ChecksApi, { ChecksSite } from "./fixtures/checks-api.ts";
+import { API_PORT, MARKER, Site, VOLUME_PATH } from "./fixtures/shared.ts";
 
 const { test } = Test.make({ providers: Fly.providers() });
 
@@ -31,6 +32,32 @@ const waitUntilGone = (appName: string, machineId: string) =>
       Effect.repeat({
         schedule: Schedule.spaced("2 seconds"),
         until: (status) => status === "gone",
+        times: 10,
+      }),
+    );
+
+const waitForPassingServiceCheck = (appName: string, machineId: string) =>
+  machines
+    .getMachine({
+      app_name: appName,
+      machine_id: machineId,
+    })
+    .pipe(
+      Effect.map((machine) => {
+        const serviceChecks =
+          machine.checks?.filter((check) =>
+            check.name?.startsWith("servicecheck-"),
+          ) ?? [];
+        const check = serviceChecks[0];
+        return serviceChecks.length === 1 &&
+          check?.name === `servicecheck-00-http-${API_PORT}` &&
+          check.status === "passing"
+          ? check
+          : undefined;
+      }),
+      Effect.repeat({
+        schedule: Schedule.spaced("5 seconds"),
+        until: (check) => check !== undefined,
         times: 10,
       }),
     );
@@ -117,6 +144,12 @@ test.provider(
       expect(fetched.config?.metadata?.["alchemy.replica"]).toEqual("0");
       expect(fetched.config?.guest?.cpus).toEqual(1);
       expect(fetched.config?.guest?.memory_mb).toEqual(256);
+      const defaultCheck = fetched.config?.services?.[0]?.checks?.[0];
+      expect(defaultCheck?.type).toEqual("tcp");
+      expect(defaultCheck?.port).toEqual(API_PORT);
+      expect(defaultCheck?.interval).toEqual("10s");
+      expect(defaultCheck?.timeout).toEqual("2s");
+      expect(defaultCheck?.grace_period).toEqual("30s");
 
       const liveVolume = yield* machines.getVolumeById({
         app_name: deployed.api.appName,
@@ -154,6 +187,52 @@ test.provider(
       const gone = yield* waitUntilGone(
         deployed.api.appName,
         deployed.api.machineId,
+      );
+      expect(gone).toEqual("gone");
+    }).pipe(logLevel),
+  { timeout: 120_000 },
+);
+
+test.provider(
+  "creates a custom service check and reports it passing",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const deployed = yield* stack.deploy(
+        Effect.gen(function* () {
+          const app = yield* ChecksSite;
+          const service = yield* ChecksApi;
+          return { app, service };
+        }),
+      );
+
+      const live = yield* machines.getMachine({
+        app_name: deployed.app.appName,
+        machine_id: deployed.service.machineId,
+      });
+      const check = live.config?.services?.[0]?.checks?.[0];
+      expect(check?.type).toEqual("http");
+      expect(check?.port).toEqual(API_PORT);
+      expect(check?.method).toEqual("GET");
+      expect(check?.path).toEqual("/health");
+      expect(check?.protocol).toEqual("http");
+      expect(check?.interval).toEqual("15s");
+      expect(check?.timeout).toEqual("3s");
+      expect(check?.grace_period).toEqual("20s");
+
+      const passingCheck = yield* waitForPassingServiceCheck(
+        deployed.service.appName,
+        deployed.service.machineId,
+      );
+      expect(passingCheck?.name).toEqual(`servicecheck-00-http-${API_PORT}`);
+      expect(passingCheck?.status).toEqual("passing");
+
+      yield* stack.destroy();
+
+      const gone = yield* waitUntilGone(
+        deployed.service.appName,
+        deployed.service.machineId,
       );
       expect(gone).toEqual("gone");
     }).pipe(logLevel),

--- a/packages/alchemy/test/Fly/fixtures/checks-api.ts
+++ b/packages/alchemy/test/Fly/fixtures/checks-api.ts
@@ -1,0 +1,53 @@
+import * as Fly from "@/Fly";
+import * as Effect from "effect/Effect";
+import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+import { API_PORT } from "./shared.ts";
+
+export const ChecksSite = Fly.App("ChecksSite");
+
+export default class ChecksApi extends Fly.Service<ChecksApi>()(
+  "ChecksApi",
+  {
+    app: ChecksSite,
+    main: import.meta.url,
+    region: "iad",
+    port: API_PORT,
+    services: [
+      {
+        protocol: "tcp",
+        internalPort: API_PORT,
+        autostart: true,
+        autostop: "off",
+        minMachinesRunning: 1,
+        ports: [
+          { port: 80, handlers: ["http"], forceHttps: true },
+          { port: 443, handlers: ["tls", "http"] },
+        ],
+        checks: [
+          {
+            type: "http",
+            port: API_PORT,
+            method: "GET",
+            path: "/health",
+            protocol: "http",
+            interval: "15s",
+            timeout: "3s",
+            gracePeriod: "20s",
+          },
+        ],
+      },
+    ],
+  },
+  Effect.gen(function* () {
+    return {
+      fetch: Effect.gen(function* () {
+        const request = yield* HttpServerRequest;
+        const path = new URL(request.url, "http://service").pathname;
+        return path === "/health"
+          ? yield* HttpServerResponse.json({ ok: true })
+          : HttpServerResponse.empty({ status: 404 });
+      }),
+    };
+  }),
+) {}


### PR DESCRIPTION
Add the ability to configure health checks through `services[].checks` for both `Fly.Machine` and `Fly.Service`.

```ts
const machine = yield* Fly.Machine("Web", {
  app,
  region: "iad",
  image: "nginx:alpine",
  services: [
    {
      protocol: "tcp",
      internalPort: 80,
      ports: [{ port: 80, handlers: ["http"] }],
      checks: [
        {
          type: "http",
          port: 80,
          method: "GET",
          path: "/",
          protocol: "http",
          interval: "15s",
          timeout: "2s",
          gracePeriod: "30s",
        },
      ],
    },
  ],
});
```

Health checks are a prerequisite to supporting different [deployment strategies](https://fly.io/docs/reference/configuration/#picking-a-deployment-strategy).