### PR TITLE
feat(dev): dev relay on Fly — stable public subdomains over one WebSocket

### DIFF
--- a/packages/alchemy/src/ACME/IssueCertificateHttp.ts
+++ b/packages/alchemy/src/ACME/IssueCertificateHttp.ts
@@ -1,5 +1,6 @@
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Redacted from "effect/Redacted";
 import type { Account } from "./Account.ts";
 import {
   accountLayer,
@@ -44,7 +45,7 @@ export const IssueCertificateHttp = Layer.succeed(
     }).pipe(
       Effect.map((bound): AccountCredentials => ({
         ca: { directoryUrl: bound.directoryUrl },
-        accountKey: bound.privateKey,
+        accountKey: normalizeKey(bound.privateKey),
         accountUrl: bound.accountUrl,
       })),
     );
@@ -65,3 +66,14 @@ export const IssueCertificateHttp = Layer.succeed(
     return client;
   }),
 );
+
+/**
+ * The bound account key as `Redacted<string>` whatever the host's env
+ * round-trip made of it: a `Redacted`, the JWK JSON text, or (a host that
+ * unwrapped and re-parsed the JSON) the JWK object itself.
+ */
+const normalizeKey = (value: unknown): Redacted.Redacted<string> => {
+  if (Redacted.isRedacted(value)) return normalizeKey(Redacted.value(value));
+  if (typeof value === "string") return Redacted.make(value);
+  return Redacted.make(JSON.stringify(value));
+};

--- a/packages/alchemy/src/AlchemyContext.ts
+++ b/packages/alchemy/src/AlchemyContext.ts
@@ -44,6 +44,22 @@ export interface DevIngressOptions {
   readonly domain: string;
   /** Port the ingress listens on. */
   readonly port: number;
+  /**
+   * Connect to an Alchemy dev relay: one WebSocket from the dev sidecar to
+   * the relay, which routes `https://<name>.<namespace>.<relay domain>`
+   * back down it by `Host`.
+   */
+  readonly relay?: DevRelayOptions;
+}
+
+/** How `alchemy dev` connects to a dev relay (see `Local/Relay`). */
+export interface DevRelayOptions {
+  /** The relay's base URL, e.g. `https://dev.alchemy.run`. */
+  readonly url: string;
+  /** The namespace this session owns: hosts are `<name>.<namespace>.<domain>`. */
+  readonly namespace: string;
+  /** Bearer token presented on connect (`ALCHEMY_DEV_RELAY_TOKEN`). */
+  readonly token?: string;
 }
 
 export const AlchemyContextLive = Layer.effect(

--- a/packages/alchemy/src/AlchemyContext.ts
+++ b/packages/alchemy/src/AlchemyContext.ts
@@ -54,7 +54,7 @@ export interface DevIngressOptions {
 
 /** How `alchemy dev` connects to a dev relay (see `Local/Relay`). */
 export interface DevRelayOptions {
-  /** The relay's base URL, e.g. `https://dev.alchemy.run`. */
+  /** The relay's base URL, e.g. `https://alchemy.town`. */
   readonly url: string;
   /** The namespace this session owns: hosts are `<name>.<namespace>.<domain>`. */
   readonly namespace: string;

--- a/packages/alchemy/src/Cli/DevOptions.ts
+++ b/packages/alchemy/src/Cli/DevOptions.ts
@@ -11,6 +11,10 @@ export const DevOptions = Schema.Struct({
   domain: Schema.String,
   /** Port of the shared dev ingress. */
   port: Schema.Number,
+  /** Dev relay to connect to (`--relay <url>`), if any. */
+  relay: Schema.optional(Schema.String),
+  /** Namespace claimed on the relay (`--relay-namespace`). */
+  relayNamespace: Schema.optional(Schema.String),
 });
 
 export type DevOptions = typeof DevOptions.Type;

--- a/packages/alchemy/src/Cli/commands/dev.ts
+++ b/packages/alchemy/src/Cli/commands/dev.ts
@@ -58,6 +58,22 @@ const port = Flag.integer("port").pipe(
   Flag.withDefault(DEFAULT_INGRESS_PORT),
 );
 
+const relay = Flag.string("relay").pipe(
+  Flag.withDescription(
+    "Dev relay to expose local resources through, e.g. https://dev.alchemy.run — one connection, stable https://<name>.<namespace>.<relay> URLs. Token from $ALCHEMY_DEV_RELAY_TOKEN.",
+  ),
+  Flag.optional,
+  Flag.map(Option.getOrUndefined),
+);
+
+const relayNamespace = Flag.string("relay-namespace").pipe(
+  Flag.withDescription(
+    "Namespace to claim on the relay (hosts are <name>.<namespace>.<relay>). Default: the stage, kebab-cased",
+  ),
+  Flag.optional,
+  Flag.map(Option.getOrUndefined),
+);
+
 export const devCommand = Command.make(
   "dev",
   {
@@ -69,6 +85,8 @@ export const devCommand = Command.make(
     profile,
     domain,
     port,
+    relay,
+    relayNamespace,
   },
   Effect.fn(
     function* (rawArgs) {

--- a/packages/alchemy/src/Cli/commands/dev.ts
+++ b/packages/alchemy/src/Cli/commands/dev.ts
@@ -60,7 +60,7 @@ const port = Flag.integer("port").pipe(
 
 const relay = Flag.string("relay").pipe(
   Flag.withDescription(
-    "Dev relay to expose local resources through, e.g. https://dev.alchemy.run — one connection, stable https://<name>.<namespace>.<relay> URLs. Token from $ALCHEMY_DEV_RELAY_TOKEN.",
+    "Dev relay to expose local resources through, e.g. https://alchemy.town — one connection, stable https://<name>.<namespace>.<relay> URLs. Token from $ALCHEMY_DEV_RELAY_TOKEN.",
   ),
   Flag.optional,
   Flag.map(Option.getOrUndefined),

--- a/packages/alchemy/src/Cli/exec.ts
+++ b/packages/alchemy/src/Cli/exec.ts
@@ -77,6 +77,15 @@ const runDev = Effect.fn(function* (options: DevOptions) {
     ingress: {
       domain: options.domain,
       port: options.port,
+      relay: options.relay
+        ? {
+            url: options.relay,
+            namespace:
+              options.relayNamespace ??
+              options.stage.toLowerCase().replace(/[^a-z0-9-]+/g, "-"),
+            token: process.env.ALCHEMY_DEV_RELAY_TOKEN,
+          }
+        : undefined,
     },
   }).pipe(renderPlanning({ operation: "Dev", stage: options.stage }));
   const once = yield* devOnce;

--- a/packages/alchemy/src/Fly/hosted.ts
+++ b/packages/alchemy/src/Fly/hosted.ts
@@ -123,27 +123,19 @@ const { ${handler}: entrypoint } = await import(${JSON.stringify(importPath)});
 await bootstrap(entrypoint);
 `;
 
-/** Flatten a binding/env leaf into a machine env string. Unwraps Redacted. */
+/**
+ * Flatten a binding/env leaf into a machine env string. A `Redacted`
+ * instance is unwrapped (the Machine sees the plain value). A value the
+ * runtime context already marker-packed (`packEnvValue`, for an Output a
+ * host bound with `yield*`) is kept verbatim: the runtime's
+ * `unpackEnvValue` turns it back into the `Redacted` the accessor
+ * promised — unwrapping it here handed accessors a bare string, and
+ * `Redacted.value` on a string throws.
+ */
 export const plainEnvValue = (value: unknown): string | undefined => {
   if (value === undefined || value === null) return undefined;
   if (Redacted.isRedacted(value)) return plainEnvValue(Redacted.value(value));
   if (typeof value === "string") {
-    if (value.startsWith("{")) {
-      try {
-        const parsed: unknown = JSON.parse(value);
-        if (
-          typeof parsed === "object" &&
-          parsed !== null &&
-          (parsed as { _tag?: unknown })._tag === "Redacted" &&
-          typeof (parsed as { value?: unknown }).value === "string"
-        ) {
-          const inner = (parsed as { value: string }).value;
-          return inner.length > 0 ? inner : undefined;
-        }
-      } catch {
-        // plain string that happens to start with `{`
-      }
-    }
     return value.length > 0 ? value : undefined;
   }
   if (typeof value === "number" || typeof value === "boolean") {

--- a/packages/alchemy/src/Local/DevIngress.ts
+++ b/packages/alchemy/src/Local/DevIngress.ts
@@ -15,6 +15,10 @@ import {
   missingHosts,
   readHostsFile,
 } from "./HostsFile.ts";
+import {
+  RelayConnector,
+  type RelayConnection,
+} from "./Relay/RelayConnector.ts";
 
 export type { DevIngressOptions } from "../AlchemyContext.ts";
 
@@ -51,6 +55,8 @@ export interface Exposure {
   readonly url: string;
   /** Every URL serving the resource, most public first. */
   readonly urls: string[];
+  /** The dev-relay URL (`https://<name>.<namespace>.<relay domain>`), when connected. */
+  readonly relayUrl?: string;
 }
 
 /**
@@ -151,8 +157,8 @@ export const layer = Layer.effect(
     const existing = instances.get(key);
     if (existing !== undefined) return yield* existing;
     // The runtime services of the FIRST session build the shared instance;
-    // the ingress is a process-wide singleton itself.
-    const services = yield* Effect.context<Ingress.Ingress>();
+    // the ingress and relay connector are process-wide singletons themselves.
+    const services = yield* Effect.context<Ingress.Ingress | RelayConnector>();
     const detached = yield* Scope.make();
     const instance = yield* Effect.cached(
       make(options).pipe(
@@ -170,6 +176,7 @@ const make = Effect.fn("DevIngress.make")(function* (
   options: DevIngressOptions,
 ) {
   const ingress = yield* Ingress.Ingress;
+  const relays = yield* RelayConnector;
   const fs = yield* Effect.serviceOption(FileSystem.FileSystem);
 
   // Serve eagerly, before any resource's own proxy claims a port, so the
@@ -221,6 +228,26 @@ const make = Effect.fn("DevIngress.make")(function* (
   yield* Effect.logDebug(
     `Dev ingress serving ${served.url} (domain ${options.domain})`,
   );
+
+  // One relay connection for the whole session: the relay routes
+  // `<label>.<namespace>.<domain>` down it, and the connector answers from
+  // this ingress with the matching local host as the route hint. A relay
+  // that can't be reached is a warning, not a dead dev session.
+  const relay: RelayConnection | undefined = options.relay
+    ? yield* relays
+        .connect({
+          ...options.relay,
+          target: served.url,
+          localHost: (label) => `${label}.${options.domain}`,
+        })
+        .pipe(
+          Effect.catchCause((cause) =>
+            Effect.logWarning(
+              `Could not connect to the dev relay at ${options.relay!.url}; serving locally only.\n${cause}`,
+            ).pipe(Effect.as(undefined)),
+          ),
+        )
+    : undefined;
 
   const registrations = new Map<string, Registration>();
   const hostOwners = new Map<string, string>();
@@ -275,12 +302,15 @@ const make = Effect.fn("DevIngress.make")(function* (
     registrations.set(input.fqn, registration);
     hostOwners.set(host, input.fqn);
 
+    const label = host.slice(0, -(options.domain.length + 1));
+    const relayUrl = relay?.publicUrl(label);
     yield* served
       .set(host, {
         upstream: input.upstream.toString(),
         label: input.fqn.split(FQN_SEPARATOR).at(-1),
         fqn: input.fqn,
         type: input.type,
+        publicUrl: relayUrl,
       })
       .pipe(
         Effect.catchCause((cause) =>
@@ -291,12 +321,16 @@ const make = Effect.fn("DevIngress.make")(function* (
       );
     yield* hostsFileCheck(host);
 
-    const urls = [hostUrl(host, advertisePort)];
+    // Public first: the relay URL is stable across restarts.
+    const urls = [
+      ...(relayUrl ? [relayUrl] : []),
+      hostUrl(host, advertisePort),
+    ];
     if (advertisePort === undefined && served.port !== 80) {
       // Forwarded privileged port: the served port still works too.
       urls.push(hostUrl(host, served.port));
     }
-    return { host, url: urls[0]!, urls } satisfies Exposure;
+    return { host, url: urls[0]!, urls, relayUrl } satisfies Exposure;
   }, lock.withPermits(1));
 
   const unexpose = Effect.fn("DevIngress.unexpose")(function* (
@@ -330,8 +364,13 @@ const probeForward = (port: number, id: string) =>
   );
 
 /**
- * {@link layer} with its runtime dependency, the workerd-backed ingress.
- * Needs `AlchemyContext` plus the platform services (FileSystem, Path).
+ * {@link layer} with its runtime dependencies: the workerd-backed ingress
+ * and the relay connector. Needs `AlchemyContext` plus the platform
+ * services (FileSystem, Path).
  */
 export const layerWithRuntime = () =>
-  layer.pipe(Layer.provide(Ingress.layer()));
+  layer.pipe(
+    Layer.provide(Layer.mergeAll(Ingress.layer(), RelayConnectorLayer)),
+  );
+
+import { layer as RelayConnectorLayer } from "./Relay/RelayConnector.ts";

--- a/packages/alchemy/src/Local/Relay/Relay.ts
+++ b/packages/alchemy/src/Local/Relay/Relay.ts
@@ -1,0 +1,101 @@
+import * as Config from "effect/Config";
+import * as Effect from "effect/Effect";
+import * as ACME from "../../ACME/index.ts";
+import * as Cloudflare from "../../Cloudflare/index.ts";
+import * as Fly from "../../Fly/index.ts";
+import DevRelayService, {
+  RelayApp,
+  RelayCertificateAccount,
+  RelayZone,
+} from "./RelayService.ts";
+
+/**
+ * Deploys an Alchemy dev relay on Fly: the {@link DevRelayService}, its
+ * App, public IPs and session directory, the apex certificate, and the DNS
+ * records (`<domain>` and `*.<domain>`, DNS-only) in the Cloudflare zone —
+ * so `alchemy dev --relay https://<domain>` gives every local resource a
+ * stable `https://<name>.<namespace>.<domain>` URL over one WebSocket from
+ * the dev sidecar. Per-namespace wildcard certificates are issued by the
+ * running service itself.
+ *
+ * Configured through `Config` (env vars / `.env`):
+ *
+ * - `DEV_RELAY_ZONE` — Cloudflare zone name (`example.com`)
+ * - `DEV_RELAY_DOMAIN` — relay domain inside it (`dev.example.com`)
+ * - `DEV_RELAY_SCHEME` — `https` (default) or `http`
+ * - `DEV_RELAY_TOKEN` — optional shared bearer token
+ * - `ZERO_SSL_KEY` — ZeroSSL REST key (certificates)
+ *
+ * ### Deploying a relay
+ * **Example:** In a stack
+ * ```typescript
+ * const relay = yield* DevRelay;
+ * return { url: relay.url }; // alchemy dev --relay <url>
+ * ```
+ *
+ * Put `<domain>` on the Public Suffix List so browsers treat each
+ * namespace as its own site (cookies never cross namespaces).
+ */
+export const DevRelay = Effect.gen(function* () {
+  const domain = yield* Config.string("DEV_RELAY_DOMAIN").pipe(
+    Config.map((value) => value.toLowerCase()),
+  );
+  const scheme = yield* Config.string("DEV_RELAY_SCHEME").pipe(
+    Config.withDefault("https"),
+  );
+  const zone = yield* RelayZone;
+  const app = yield* RelayApp;
+  const v4 = yield* Fly.IpAssignment("DevRelayV4", {
+    app,
+    type: "shared_v4",
+  });
+  const v6 = yield* Fly.IpAssignment("DevRelayV6", {
+    app,
+    type: "v6",
+  });
+  const account = yield* RelayCertificateAccount;
+
+  // The connect endpoint and the index page live on the apex, whose
+  // certificate is issued at deploy time and uploaded to the App.
+  if (scheme === "https") {
+    const apex = yield* ACME.Certificate("DevRelayApexCert", {
+      account,
+      identifiers: [domain],
+      solver: Cloudflare.DNS.acmeSolver(zone),
+    });
+    yield* Fly.Certificate("DevRelayApex", {
+      app,
+      hostname: domain,
+      kind: "custom",
+      fullchain: apex.chain,
+      privateKey: apex.privateKey,
+    });
+  }
+
+  // DNS-only records: TLS terminates at Fly, not Cloudflare. The wildcard
+  // matches every depth (`api.sam.<domain>`) because no closer name exists.
+  const records = [
+    ["DevRelayApexA", domain, "A", v4.ip],
+    ["DevRelayApexAAAA", domain, "AAAA", v6.ip],
+    ["DevRelayWildcardA", `*.${domain}`, "A", v4.ip],
+    ["DevRelayWildcardAAAA", `*.${domain}`, "AAAA", v6.ip],
+  ] as const;
+  for (const [id, name, type, content] of records) {
+    yield* Cloudflare.DNS.Record(id, {
+      zoneId: zone.zoneId,
+      name,
+      type,
+      content,
+      ttl: 60,
+      proxied: false,
+    });
+  }
+
+  const service = yield* DevRelayService;
+  return {
+    app,
+    service,
+    /** Base URL to pass to `alchemy dev --relay`. */
+    url: `${scheme}://${domain}`,
+  };
+});

--- a/packages/alchemy/src/Local/Relay/RelayConnector.ts
+++ b/packages/alchemy/src/Local/Relay/RelayConnector.ts
@@ -1,0 +1,334 @@
+import * as Context from "effect/Context";
+import * as Data from "effect/Data";
+import * as Deferred from "effect/Deferred";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Schedule from "effect/Schedule";
+import * as Scope from "effect/Scope";
+import type { DevRelayOptions } from "../../AlchemyContext.ts";
+import { UserFacingError } from "../../UserFacingError.ts";
+import {
+  AUTH_HEADER,
+  CHUNK_SIZE,
+  CONNECT_PATH,
+  decodeChunk,
+  decodeControl,
+  encodeChunk,
+  encodeControl,
+  forwardableHeaders,
+  NAMESPACE_PARAM,
+  publicHost,
+  type ControlFrame,
+  type HelloFrame,
+  type RequestFrame,
+} from "./RelayProtocol.ts";
+
+/**
+ * The dev-sidecar half of the relay: ONE WebSocket to the relay for the
+ * whole session, answering every public request it delivers from the local
+ * ingress. Reconnects with backoff; a request in flight when the socket
+ * drops is answered with an error by the relay and the client retries.
+ */
+export class RelayConnector extends Context.Service<
+  RelayConnector,
+  {
+    readonly connect: (
+      input: ConnectInput,
+    ) => Effect.Effect<RelayConnection, RelayError, Scope.Scope>;
+  }
+>()("alchemy/Local/RelayConnector") {}
+
+export interface ConnectInput extends DevRelayOptions {
+  /** The local ingress every relayed request is forwarded to. */
+  readonly target: URL;
+  /**
+   * Maps a public label (`api`) to the local ingress host it should be
+   * served as (`api.localhost`), sent as the ingress route hint.
+   */
+  readonly localHost: (label: string) => string;
+}
+
+export interface RelayConnection {
+  /** Handshake data: the relay's domain and public scheme. */
+  readonly hello: HelloFrame;
+  /** The public URL for `label`, e.g. `https://api.sam.dev.alchemy.run`. */
+  readonly publicUrl: (label: string) => string;
+}
+
+export class RelayError extends Data.TaggedError("RelayError")<{
+  readonly message: string;
+  readonly cause?: unknown;
+}> {
+  readonly [UserFacingError] = true;
+}
+
+/** Header the ingress honours to pick a route regardless of `Host`. */
+const ROUTE_HINT_HEADER = "x-alchemy-ingress-host";
+
+const HELLO_TIMEOUT = "15 seconds";
+/** Connect attempts before a never-reachable relay is reported (~30s of backoff). */
+const INITIAL_ATTEMPTS = 8;
+
+interface Inflight {
+  readonly controller: AbortController;
+  bodyWriter?: WritableStreamDefaultWriter<Uint8Array>;
+}
+
+export const layer = Layer.succeed(
+  RelayConnector,
+  RelayConnector.of({
+    connect: Effect.fn("RelayConnector.connect")(function* (input) {
+      const connectUrl = new URL(CONNECT_PATH, input.url);
+      connectUrl.protocol = connectUrl.protocol === "http:" ? "ws:" : "wss:";
+      connectUrl.searchParams.set(NAMESPACE_PARAM, input.namespace);
+
+      // Resolves on the first successful handshake; later reconnects only log.
+      const first = yield* Deferred.make<HelloFrame, RelayError>();
+      let latestHello: HelloFrame | undefined;
+      const onCertificate = (frame: HelloFrame) => {
+        const wildcard = `*.${frame.namespace}.${frame.domain}`;
+        const message =
+          frame.certificate === "ready"
+            ? `TLS certificate for ${wildcard} is ready.`
+            : frame.certificate === "provisioning"
+              ? `Issuing the TLS certificate for ${wildcard} (about a minute; HTTPS works once it is uploaded).`
+              : `The relay could not issue a TLS certificate for ${wildcard}; HTTPS to this namespace will fail until it retries.${frame.certificateError ? `\n${frame.certificateError}` : ""}`;
+        Effect.runFork(
+          frame.certificate === "unavailable"
+            ? Effect.logWarning(message)
+            : Effect.logInfo(message),
+        );
+      };
+
+      const session = Effect.gen(function* () {
+        const socket = yield* Effect.acquireRelease(
+          Effect.try({
+            try: () =>
+              new WebSocket(connectUrl, {
+                // Bun and Node (undici) both accept `headers` here.
+                headers: input.token
+                  ? { [AUTH_HEADER]: `Bearer ${input.token}` }
+                  : {},
+              } as unknown as string[]),
+            catch: (cause) =>
+              new RelayError({
+                message: `Could not open a WebSocket to the dev relay at ${connectUrl}.`,
+                cause,
+              }),
+          }),
+          (socket) =>
+            Effect.sync(() => socket.close(1000, "dev session ended")),
+        );
+        socket.binaryType = "arraybuffer";
+        const closed = yield* Deferred.make<void, RelayError>();
+        const hello = yield* Deferred.make<HelloFrame, RelayError>();
+        const inflight = new Map<number, Inflight>();
+
+        const send = (data: string | Uint8Array) => {
+          if (socket.readyState === WebSocket.OPEN) socket.send(data);
+        };
+
+        const handle = (frame: ControlFrame) => {
+          switch (frame.t) {
+            case "hello":
+              // A relay re-sends hello when the namespace's certificate
+              // state changes (issued after the first connect).
+              if (
+                latestHello &&
+                latestHello.certificate !== frame.certificate
+              ) {
+                onCertificate(frame);
+              }
+              latestHello = frame;
+              Deferred.doneUnsafe(hello, Effect.succeed(frame));
+              return;
+            case "req":
+              void serve(frame);
+              return;
+            case "end": {
+              const entry = inflight.get(frame.id);
+              void entry?.bodyWriter?.close().catch(() => {});
+              return;
+            }
+            case "abort": {
+              const entry = inflight.get(frame.id);
+              if (entry) {
+                inflight.delete(frame.id);
+                entry.controller.abort();
+                void entry.bodyWriter?.abort().catch(() => {});
+              }
+              return;
+            }
+            case "res":
+              return;
+          }
+        };
+
+        const serve = async (frame: RequestFrame): Promise<void> => {
+          const controller = new AbortController();
+          const entry: Inflight = { controller };
+          inflight.set(frame.id, entry);
+          let body: ReadableStream<Uint8Array> | undefined;
+          if (frame.body) {
+            const stream = new TransformStream<Uint8Array, Uint8Array>();
+            entry.bodyWriter = stream.writable.getWriter();
+            body = stream.readable;
+          }
+          const headers = new Headers();
+          for (const [name, value] of frame.headers)
+            headers.append(name, value);
+          headers.set(ROUTE_HINT_HEADER, input.localHost(frame.label));
+          try {
+            const response = await fetch(new URL(frame.url, input.target), {
+              method: frame.method,
+              headers,
+              body,
+              redirect: "manual",
+              signal: controller.signal,
+              // Streaming request bodies need half-duplex mode in undici.
+              ...(body ? { duplex: "half" } : {}),
+            } as RequestInit);
+            const hasBody = response.body !== null;
+            send(
+              encodeControl({
+                t: "res",
+                id: frame.id,
+                status: response.status,
+                headers: forwardableHeaders(response.headers),
+                body: hasBody,
+              }),
+            );
+            if (hasBody) {
+              const reader = response.body!.getReader();
+              for (;;) {
+                const { done, value } = await reader.read();
+                if (done) break;
+                for (let o = 0; o < value.byteLength; o += CHUNK_SIZE) {
+                  send(
+                    encodeChunk(frame.id, value.subarray(o, o + CHUNK_SIZE)),
+                  );
+                }
+              }
+              send(encodeControl({ t: "end", id: frame.id }));
+            }
+          } catch (error) {
+            if (!controller.signal.aborted) {
+              send(
+                encodeControl({
+                  t: "abort",
+                  id: frame.id,
+                  message: `alchemy dev could not reach ${frame.label}: ${
+                    error instanceof Error ? error.message : String(error)
+                  }`,
+                }),
+              );
+            }
+          } finally {
+            inflight.delete(frame.id);
+          }
+        };
+
+        socket.addEventListener("message", (event) => {
+          const data = (event as MessageEvent).data as string | ArrayBuffer;
+          if (typeof data === "string") {
+            handle(decodeControl(data));
+          } else {
+            const { id, chunk } = decodeChunk(data);
+            const entry = inflight.get(id);
+            void entry?.bodyWriter
+              ?.write(new Uint8Array(chunk))
+              .catch(() => {});
+          }
+        });
+        socket.addEventListener("close", (event) => {
+          const { code, reason } = event as CloseEvent;
+          const error = new RelayError({
+            message: `Dev relay connection closed (${code}${reason ? `: ${reason}` : ""}).`,
+          });
+          Deferred.doneUnsafe(hello, Effect.fail(error));
+          Deferred.doneUnsafe(
+            closed,
+            code === 1000 ? Effect.void : Effect.fail(error),
+          );
+        });
+        socket.addEventListener("error", (event) => {
+          const detail = (event as { message?: string; error?: unknown })
+            .message;
+          const error = new RelayError({
+            message: `Dev relay connection to ${connectUrl} failed${detail ? `: ${detail}` : "."}`,
+            cause: (event as { error?: unknown }).error,
+          });
+          Deferred.doneUnsafe(hello, Effect.fail(error));
+          Deferred.doneUnsafe(closed, Effect.fail(error));
+        });
+
+        const greeted = yield* Deferred.await(hello).pipe(
+          Effect.timeoutOrElse({
+            duration: HELLO_TIMEOUT,
+            orElse: () =>
+              Effect.fail(
+                new RelayError({
+                  message: `The dev relay at ${connectUrl} did not complete the handshake within ${HELLO_TIMEOUT}.`,
+                }),
+              ),
+          }),
+        );
+        yield* Deferred.succeed(first, greeted);
+        yield* Effect.logInfo(
+          `Connected to the dev relay: ${greeted.scheme}://<name>.${greeted.namespace}.${greeted.domain}`,
+        );
+        if (
+          greeted.certificate !== undefined &&
+          greeted.certificate !== "ready"
+        ) {
+          onCertificate(greeted);
+        }
+        // Serve until the socket closes.
+        yield* Deferred.await(closed);
+      }).pipe(Effect.scoped);
+
+      // Keep the connection alive for the whole dev session: reconnect with
+      // backoff on drops. Before the first handshake, failures are retried a
+      // bounded number of times (a relay whose route/DNS was just created
+      // takes a moment to answer) and then surface to the caller — a bad URL
+      // or token must not retry forever silently.
+      let initialFailures = 0;
+      let initialGivenUp = false;
+      yield* session.pipe(
+        Effect.tapError((error) =>
+          Effect.gen(function* () {
+            if (yield* Deferred.isDone(first)) {
+              yield* Effect.logWarning(`${error.message} Reconnecting…`);
+            } else if (++initialFailures >= INITIAL_ATTEMPTS) {
+              initialGivenUp = true;
+              yield* Deferred.fail(first, error);
+            } else {
+              yield* Effect.logDebug(
+                `${error.message} Retrying (${initialFailures}/${INITIAL_ATTEMPTS})…`,
+              );
+            }
+          }),
+        ),
+        Effect.retry({
+          // Stop only once the initial handshake has been given up on.
+          while: () => !initialGivenUp,
+          schedule: Schedule.min([
+            Schedule.exponential("500 millis"),
+            Schedule.spaced("10 seconds"),
+          ]),
+        }),
+        Effect.catch(() => Effect.void),
+        Effect.forkScoped,
+      );
+
+      const hello = yield* Deferred.await(first);
+      return {
+        hello,
+        publicUrl: (label) => {
+          const h = latestHello ?? hello;
+          return `${h.scheme}://${publicHost(label, h.namespace, h.domain)}`;
+        },
+      } satisfies RelayConnection;
+    }),
+  }),
+);

--- a/packages/alchemy/src/Local/Relay/RelayConnector.ts
+++ b/packages/alchemy/src/Local/Relay/RelayConnector.ts
@@ -51,7 +51,7 @@ export interface ConnectInput extends DevRelayOptions {
 export interface RelayConnection {
   /** Handshake data: the relay's domain and public scheme. */
   readonly hello: HelloFrame;
-  /** The public URL for `label`, e.g. `https://api.sam.dev.alchemy.run`. */
+  /** The public URL for `label`, e.g. `https://api.sam.alchemy.town`. */
   readonly publicUrl: (label: string) => string;
 }
 

--- a/packages/alchemy/src/Local/Relay/RelayProtocol.ts
+++ b/packages/alchemy/src/Local/Relay/RelayProtocol.ts
@@ -67,7 +67,7 @@ export interface RequestFrame {
   readonly method: string;
   /** Path and query, e.g. `/echo?x=1`. */
   readonly url: string;
-  /** The public host the client dialed, e.g. `api.sam.dev.alchemy.run`. */
+  /** The public host the client dialed, e.g. `api.sam.alchemy.town`. */
   readonly host: string;
   /** The label routed to (`api`). */
   readonly label: string;

--- a/packages/alchemy/src/Local/Relay/RelayProtocol.ts
+++ b/packages/alchemy/src/Local/Relay/RelayProtocol.ts
@@ -1,0 +1,161 @@
+/**
+ * Wire protocol between the dev relay (a Fly Service, see `RelayService.ts`)
+ * and the connector running in the `alchemy dev` sidecar. One WebSocket per
+ * namespace carries many concurrent HTTP exchanges, multiplexed by a stream
+ * id:
+ *
+ * - **Text frames** are JSON {@link ControlFrame}s: request/response heads,
+ *   end-of-body markers, aborts, and the hello handshake.
+ * - **Binary frames** are body chunks: a 4-byte big-endian stream id followed
+ *   by the bytes. Chunks stay well under the 1 MiB WebSocket message limit.
+ *
+ * Shared by the relay (bundled for Fly) and the Node/Bun connector, so it
+ * must stay free of platform imports.
+ */
+
+/** Largest body chunk sent in one binary frame. */
+export const CHUNK_SIZE = 64 * 1024;
+
+/** Path on the relay host the connector dials. */
+export const CONNECT_PATH = "/__relay/connect";
+
+/** Header carrying the connector's bearer token on connect. */
+export const AUTH_HEADER = "authorization";
+
+/** Query parameter naming the namespace a connector claims. */
+export const NAMESPACE_PARAM = "namespace";
+
+/** Hop-by-hop / framing headers that must not be forwarded either way. */
+export const STRIPPED_HEADERS: ReadonlySet<string> = new Set([
+  "connection",
+  "keep-alive",
+  "transfer-encoding",
+  "content-length",
+  "upgrade",
+  "te",
+  "trailer",
+  "proxy-connection",
+  "expect",
+]);
+
+export type HeaderList = ReadonlyArray<readonly [string, string]>;
+
+/** Relay → connector, right after the socket opens. */
+export interface HelloFrame {
+  readonly t: "hello";
+  /** Namespace the socket serves. */
+  readonly namespace: string;
+  /** Relay domain: public hosts are `<label>.<namespace>.<domain>`. */
+  readonly domain: string;
+  /** Public scheme (`https`, or `http` on relays without TLS). */
+  readonly scheme: string;
+  /**
+   * State of the namespace's TLS certificate (`*.<namespace>.<domain>`):
+   * `ready`, `provisioning` (being issued — the relay sends a fresh hello
+   * when it is uploaded), or `unavailable` (issuance failed; HTTPS to the
+   * namespace will not work until the relay retries).
+   */
+  readonly certificate?: "ready" | "provisioning" | "unavailable";
+  /** Why the certificate is `unavailable`, for the developer's terminal. */
+  readonly certificateError?: string;
+}
+
+/** Relay → connector: a public request arrived for `label`. */
+export interface RequestFrame {
+  readonly t: "req";
+  readonly id: number;
+  readonly method: string;
+  /** Path and query, e.g. `/echo?x=1`. */
+  readonly url: string;
+  /** The public host the client dialed, e.g. `api.sam.dev.alchemy.run`. */
+  readonly host: string;
+  /** The label routed to (`api`). */
+  readonly label: string;
+  readonly headers: HeaderList;
+  /** Whether body chunks follow (ended by an `end` frame). */
+  readonly body: boolean;
+}
+
+/** Connector → relay: the response head for `id`. */
+export interface ResponseFrame {
+  readonly t: "res";
+  readonly id: number;
+  readonly status: number;
+  readonly headers: HeaderList;
+  /** Whether body chunks follow (ended by an `end` frame). */
+  readonly body: boolean;
+}
+
+/** Either direction: no more body chunks for `id`. */
+export interface EndFrame {
+  readonly t: "end";
+  readonly id: number;
+}
+
+/** Either direction: give up on `id` (client went away, upstream failed). */
+export interface AbortFrame {
+  readonly t: "abort";
+  readonly id: number;
+  readonly message?: string;
+}
+
+export type ControlFrame =
+  | HelloFrame
+  | RequestFrame
+  | ResponseFrame
+  | EndFrame
+  | AbortFrame;
+
+export const encodeControl = (frame: ControlFrame): string =>
+  JSON.stringify(frame);
+
+export const decodeControl = (text: string): ControlFrame =>
+  JSON.parse(text) as ControlFrame;
+
+/** Prefix a body chunk with its stream id. */
+export const encodeChunk = (id: number, chunk: Uint8Array): Uint8Array => {
+  const out = new Uint8Array(4 + chunk.byteLength);
+  new DataView(out.buffer).setUint32(0, id);
+  out.set(chunk, 4);
+  return out;
+};
+
+/** Split a binary frame back into its stream id and bytes. */
+export const decodeChunk = (
+  data: ArrayBuffer | Uint8Array,
+): { readonly id: number; readonly chunk: Uint8Array } => {
+  const bytes = data instanceof Uint8Array ? data : new Uint8Array(data);
+  const id = new DataView(bytes.buffer, bytes.byteOffset, 4).getUint32(0);
+  return { id, chunk: bytes.subarray(4) };
+};
+
+/** Headers worth forwarding, as a plain list (Headers objects don't serialize). */
+export const forwardableHeaders = (
+  headers: Iterable<readonly [string, string]>,
+): HeaderList => {
+  const out: Array<readonly [string, string]> = [];
+  for (const [name, value] of headers) {
+    if (!STRIPPED_HEADERS.has(name.toLowerCase())) out.push([name, value]);
+  }
+  return out;
+};
+
+/** Split `host` into `{ label, namespace }` under `domain`, or `undefined`. */
+export const parsePublicHost = (
+  host: string,
+  domain: string,
+): { readonly label: string; readonly namespace: string } | undefined => {
+  const hostname = host.split(":")[0]!.toLowerCase();
+  const suffix = `.${domain.toLowerCase()}`;
+  if (!hostname.endsWith(suffix)) return undefined;
+  const labels = hostname.slice(0, -suffix.length).split(".");
+  if (labels.length !== 2 || labels.some((l) => l === "")) return undefined;
+  return { label: labels[0]!, namespace: labels[1]! };
+};
+
+/** The public host for `label` in `namespace`. */
+export const publicHost = (
+  label: string,
+  namespace: string,
+  domain: string,
+): string => `${label}.${namespace}.${domain}`;

--- a/packages/alchemy/src/Local/Relay/RelayService.ts
+++ b/packages/alchemy/src/Local/Relay/RelayService.ts
@@ -1,0 +1,731 @@
+import * as ZeroSsl from "@distilled.cloud/zerossl";
+import * as Cause from "effect/Cause";
+import * as Config from "effect/Config";
+import * as Deferred from "effect/Deferred";
+import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
+import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
+import * as Redacted from "effect/Redacted";
+import * as Schedule from "effect/Schedule";
+import * as Stream from "effect/Stream";
+import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
+import * as Headers from "effect/unstable/http/Headers";
+import * as HttpServerRequest from "effect/unstable/http/HttpServerRequest";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+import * as Socket from "effect/unstable/socket/Socket";
+import * as ACME from "../../ACME/index.ts";
+import * as AdoptPolicy from "../../AdoptPolicy.ts";
+import * as Cloudflare from "../../Cloudflare/index.ts";
+import * as Fly from "../../Fly/index.ts";
+import * as Output from "../../Output.ts";
+import {
+  AUTH_HEADER,
+  CHUNK_SIZE,
+  CONNECT_PATH,
+  decodeChunk,
+  decodeControl,
+  encodeChunk,
+  encodeControl,
+  forwardableHeaders,
+  NAMESPACE_PARAM,
+  parsePublicHost,
+  type ControlFrame,
+  type HelloFrame,
+  type RequestFrame,
+} from "./RelayProtocol.ts";
+
+/**
+ * The Alchemy dev relay — a public front door for `alchemy dev` sessions,
+ * as a Fly Service.
+ *
+ * - The dev sidecar dials `wss://<domain>/__relay/connect?namespace=<ns>`
+ *   once and keeps the socket open; the Machine that accepted it owns the
+ *   namespace and records itself in the {@link RelayDirectory} (Redis).
+ * - Every request for `https://<label>.<ns>.<domain>` lands on some Machine
+ *   (Fly's proxy load-balances); a Machine that doesn't hold the socket
+ *   answers with `fly-replay: instance=<owner>` and Fly's proxy re-sends the
+ *   request to the owner, which forwards it down the socket as a multiplexed
+ *   stream (see `RelayProtocol.ts`). The connector answers it from the local
+ *   ingress.
+ * - TLS ends at Fly's proxy. Each namespace gets its own wildcard
+ *   certificate (`*.<ns>.<domain>`), issued from ZeroSSL over DNS-01 through
+ *   the zone's Cloudflare records the first time the namespace connects and
+ *   uploaded to the App with {@link Fly.WriteCertificates}; a background
+ *   loop renews them. Let's Encrypt is not an option here only because it
+ *   is unreachable from Cloudflare Workers — on Fly it would work too.
+ *
+ * Configured with `Config` at init — Alchemy captures the values at deploy
+ * and re-resolves them from the Machine's environment at runtime:
+ *
+ * - `DEV_RELAY_DOMAIN` — public domain, hosts are `<label>.<ns>.<domain>`
+ * - `DEV_RELAY_ZONE` — the Cloudflare zone `<domain>` lives in
+ * - `DEV_RELAY_SCHEME` — `https` (default) or `http` on a TLS-less relay
+ * - `DEV_RELAY_TOKEN` — optional shared bearer token connectors must present
+ * - `ZERO_SSL_KEY` — ZeroSSL REST key the ACME account's EAB is minted from
+ *
+ * Deploy it with Alchemy itself: see `Relay.ts` and `stacks/dev-relay.ts`.
+ */
+
+const domain = Config.string("DEV_RELAY_DOMAIN").pipe(
+  Config.map((value) => value.toLowerCase()),
+);
+const scheme = Config.string("DEV_RELAY_SCHEME").pipe(
+  Config.withDefault("https"),
+);
+const token = Config.option(Config.redacted("DEV_RELAY_TOKEN"));
+
+/** The Fly App the relay runs in. */
+export const RelayApp = Fly.App("DevRelayApp", { enableSubdomains: true });
+
+/** Namespace → owning Machine, and the set of namespaces to keep certificates for. */
+export const RelayDirectory = Fly.Redis("DevRelayDirectory");
+
+/** The Cloudflare zone `DEV_RELAY_DOMAIN` lives in (existing; adopted, never deleted). */
+export const RelayZone = Cloudflare.Zone.Zone("DevRelayZone", {
+  name: Config.string("DEV_RELAY_ZONE"),
+}).pipe(AdoptPolicy.adopt());
+
+/**
+ * External Account Binding minted from `ZERO_SSL_KEY` when the stack is
+ * evaluated (cached so both halves come from one pair). Only the first
+ * `newAccount` consumes it; later deploys reuse the stored account.
+ */
+const zeroSslEab = Effect.runSync(
+  Effect.cached(
+    ZeroSsl.zerossl
+      .generateEabCredentials({})
+      .pipe(
+        Effect.provide(
+          Layer.mergeAll(ZeroSsl.CredentialsFromEnv, FetchHttpClient.layer),
+        ),
+        Effect.orDie,
+      ),
+  ),
+);
+
+/** The ACME account every relay certificate is issued with. */
+export const RelayCertificateAccount = ACME.Account("DevRelayZeroSSL", {
+  ca: ACME.ZeroSSL,
+  eab: {
+    keyId: Output.fromEffect(zeroSslEab.pipe(Effect.map((e) => e.eab_kid!))),
+    hmacKey: Output.fromEffect(
+      zeroSslEab.pipe(Effect.map((e) => e.eab_hmac_key!)),
+    ),
+  },
+  termsOfServiceAgreed: true,
+});
+
+/** How long a public request waits for the dev session's response head. */
+const RESPONSE_TIMEOUT = "30 seconds";
+/** Re-issue a namespace certificate when less than this remains. */
+const RENEW_BEFORE_MS = 30 * 86_400_000;
+/** How often the renewal loop looks at every namespace's certificate. */
+const RENEWAL_INTERVAL = "6 hours";
+/** Directory entries expire unless the owner is still around to refresh them. */
+const OWNER_TTL_SECONDS = 24 * 3600;
+
+const ownerKey = (namespace: string) => `relay:owner:${namespace}`;
+const NAMESPACES_KEY = "relay:namespaces";
+const wildcardOf = (namespace: string, relayDomain: string) =>
+  `*.${namespace}.${relayDomain}`;
+
+interface Pending {
+  readonly head: Deferred.Deferred<
+    HttpServerResponse.HttpServerResponse,
+    Error
+  >;
+  writer?: WritableStreamDefaultWriter<Uint8Array>;
+}
+
+interface Session {
+  readonly namespace: string;
+  readonly pending: Map<number, Pending>;
+  nextId: number;
+  write: (
+    chunk: string | Uint8Array | Socket.CloseEvent,
+  ) => Effect.Effect<void, Socket.SocketError>;
+}
+
+const page = (status: number, title: string, body: string) =>
+  HttpServerResponse.text(
+    `<!doctype html><html lang="en"><head><meta charset="utf-8"><title>${title}</title>
+<style>body{margin:0;padding:3rem 1.5rem;font:15px/1.5 ui-sans-serif,system-ui,sans-serif;background:#f6f6f7;color:#1c1c1e}main{max-width:40rem;margin:0 auto}h1{font-size:1.25rem;font-weight:600}code{font:.9em ui-monospace,Menlo,monospace}small{color:#6b6b70}@media(prefers-color-scheme:dark){body{background:#111113;color:#ececef}small{color:#8c8c93}}</style>
+</head><body><main><h1>${title}</h1><p>${body}</p><p><small>alchemy dev relay · ${status}</small></p></main></body></html>`,
+    { status, contentType: "text/html; charset=utf-8" },
+  );
+
+const escape = (value: string): string =>
+  value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;");
+
+const timingSafeEqual = (a: string, b: string): boolean => {
+  const encoder = new TextEncoder();
+  const x = encoder.encode(a);
+  const y = encoder.encode(b);
+  if (x.byteLength !== y.byteLength) return false;
+  let diff = 0;
+  for (let i = 0; i < x.byteLength; i++) diff |= x[i]! ^ y[i]!;
+  return diff === 0;
+};
+
+const NAMESPACE_PATTERN = /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$/;
+
+export default class DevRelayService extends Fly.Service<DevRelayService>()(
+  "DevRelay",
+  {
+    app: RelayApp,
+    main: import.meta.url,
+    port: 3000,
+    guest: { cpuKind: "shared", cpus: 1, memoryMb: 512 },
+  },
+  Effect.gen(function* () {
+    const relayDomain = yield* domain;
+    const relayScheme = yield* scheme;
+    const relayToken = yield* token;
+    const acme = yield* ACME.IssueCertificate(RelayCertificateAccount);
+    const dns = yield* Cloudflare.DNS.ReadWriteDns(RelayZone);
+    const certs = yield* Fly.WriteCertificates(RelayApp);
+    const directory = yield* Fly.ReadWriteRedis(RelayDirectory);
+    const solver = Cloudflare.DNS.acmeDnsSolver(dns);
+
+    /** This Machine's id — what the directory records and `fly-replay` targets. */
+    const machineId = Effect.sync(() => process.env.FLY_MACHINE_ID ?? "local");
+
+    // Namespaces whose connector socket this Machine holds.
+    const sessions = new Map<string, Session>();
+    // Namespaces whose certificate is being issued right now (per Machine).
+    const issuing = new Set<string>();
+
+    const authorized = (
+      request: HttpServerRequest.HttpServerRequest,
+    ): boolean => {
+      if (Option.isNone(relayToken)) return true;
+      const presented = request.headers[AUTH_HEADER]?.replace(
+        /^Bearer\s+/i,
+        "",
+      );
+      return (
+        presented !== undefined &&
+        timingSafeEqual(presented, Redacted.value(relayToken.value))
+      );
+    };
+
+    // -------------------------------------------------------------------
+    // Certificates
+    // -------------------------------------------------------------------
+
+    /** `ready` when a custom certificate for the namespace's wildcard is uploaded and not due. */
+    const certificateState = (namespace: string) =>
+      certs.get(wildcardOf(namespace, relayDomain)).pipe(
+        Effect.map((detail) => {
+          const custom = (detail?.certificates ?? []).filter(
+            (c) => c.source === "custom",
+          );
+          if (custom.length === 0 || detail?.configured !== true) {
+            return "missing" as const;
+          }
+          const expiresAt = Math.max(
+            ...custom.map((c) => Date.parse(c.expires_at ?? "") || 0),
+          );
+          return expiresAt - Date.now() < RENEW_BEFORE_MS
+            ? ("due" as const)
+            : ("ready" as const);
+        }),
+        Effect.orElseSucceed(() => "missing" as const),
+      );
+
+    /**
+     * Fly serves a certificate only once the hostname is "configured". It
+     * cannot probe a wildcard, so proof of ownership is the
+     * `_fly-ownership.<ns>.<domain>` TXT it names in `dns_requirements`:
+     * publish it (idempotently) and re-run Fly's check until it passes.
+     */
+    const configureOwnership = (namespace: string, hostname: string) =>
+      Effect.gen(function* () {
+        const detail = yield* certs.get(hostname);
+        const ownership = detail?.dns_requirements?.ownership;
+        if (
+          ownership?.name === undefined ||
+          ownership.app_value === undefined
+        ) {
+          return yield* Effect.fail(
+            new Error(`Fly reported no ownership record for ${hostname}`),
+          );
+        }
+        const existing = yield* dns.listDnsRecords({
+          type: "TXT",
+          name: { exact: ownership.name },
+        });
+        const present = (existing.result ?? []).some(
+          (r) =>
+            r.name === ownership.name &&
+            (r.content ?? "").replace(/^"|"$/g, "") === ownership.app_value,
+        );
+        if (!present) {
+          yield* dns.createDnsRecord({
+            type: "TXT",
+            name: ownership.name,
+            content: ownership.app_value,
+            ttl: 60,
+          });
+          yield* Effect.logInfo(
+            `[${namespace}] published ${ownership.name} = ${ownership.app_value}`,
+          );
+        }
+        const configured = yield* certs.check(hostname).pipe(
+          Effect.map((checked) => checked.configured === true),
+          Effect.orElseSucceed(() => false),
+          Effect.repeat({
+            schedule: Schedule.spaced("3 seconds"),
+            until: (ok) => ok,
+            times: 40,
+          }),
+        );
+        if (!configured) {
+          return yield* Effect.fail(
+            new Error(
+              `Fly did not accept ownership of ${hostname} within the wait budget`,
+            ),
+          );
+        }
+      });
+
+    /** Issue and upload the namespace's wildcard certificate. */
+    const issueCertificate = (namespace: string) =>
+      Effect.gen(function* () {
+        const hostname = wildcardOf(namespace, relayDomain);
+        yield* Effect.logInfo(`[${namespace}] issuing ${hostname}`);
+        const issued = yield* acme.issue({
+          identifiers: [hostname],
+          solver,
+        });
+        yield* certs.upload({
+          hostname,
+          fullchain: issued.chain,
+          privateKey: issued.privateKey,
+        });
+        yield* configureOwnership(namespace, hostname);
+        yield* Effect.logInfo(
+          `[${namespace}] ${hostname} uploaded (expires ${issued.notAfter})`,
+        );
+      });
+
+    // Last issuance failure per namespace, echoed in hello so the developer
+    // sees why HTTPS is not working instead of hunting for Machine logs.
+    const certificateErrors = new Map<string, string>();
+
+    const hello = (
+      namespace: string,
+      certificate: HelloFrame["certificate"],
+    ): HelloFrame => ({
+      t: "hello",
+      namespace,
+      domain: relayDomain,
+      scheme: relayScheme,
+      certificate,
+      certificateError:
+        certificate === "unavailable"
+          ? certificateErrors.get(namespace)
+          : undefined,
+    });
+
+    /**
+     * Make sure the namespace has a certificate: `ready` now, or
+     * `provisioning` with issuance running in the background — the session
+     * gets a fresh hello when it lands.
+     */
+    const ensureCertificate = (namespace: string) =>
+      Effect.gen(function* () {
+        if (relayScheme !== "https") return undefined;
+        const state = yield* certificateState(namespace);
+        if (state === "ready") return "ready" as const;
+        if (!issuing.has(namespace)) {
+          issuing.add(namespace);
+          yield* issueCertificate(namespace).pipe(
+            Effect.map(() => {
+              certificateErrors.delete(namespace);
+              return "ready" as const;
+            }),
+            Effect.catchCause((cause) =>
+              Effect.logError(
+                `[${namespace}] certificate issuance failed:\n${cause}`,
+              ).pipe(
+                Effect.tap(() =>
+                  Effect.sync(() =>
+                    certificateErrors.set(
+                      namespace,
+                      Cause.pretty(cause).slice(0, 2000),
+                    ),
+                  ),
+                ),
+                Effect.as("unavailable" as const),
+              ),
+            ),
+            Effect.tap((result) =>
+              Effect.gen(function* () {
+                issuing.delete(namespace);
+                const session = sessions.get(namespace);
+                if (session) {
+                  yield* session
+                    .write(encodeControl(hello(namespace, result)))
+                    .pipe(Effect.ignore);
+                }
+              }),
+            ),
+            Effect.forkDetach,
+          );
+        }
+        // A certificate that is merely due keeps serving while it renews.
+        return state === "due" ? ("ready" as const) : ("provisioning" as const);
+      });
+
+    /** Renew every namespace's certificate that is due. Runs forever. */
+    const renewalLoop = Effect.gen(function* () {
+      const namespaces = yield* directory
+        .smembers(NAMESPACES_KEY)
+        .pipe(Effect.orElseSucceed(() => [] as string[]));
+      for (const namespace of namespaces) {
+        const state = yield* certificateState(namespace);
+        if (state !== "due") continue;
+        yield* issueCertificate(namespace).pipe(
+          Effect.catchCause((cause) =>
+            Effect.logError(`[${namespace}] renewal failed:\n${cause}`),
+          ),
+        );
+      }
+    }).pipe(
+      Effect.catchCause((cause) => Effect.logError(`renewal loop:\n${cause}`)),
+      Effect.repeat(Schedule.spaced(RENEWAL_INTERVAL)),
+      Effect.asVoid,
+    );
+
+    // -------------------------------------------------------------------
+    // Sessions
+    // -------------------------------------------------------------------
+
+    const settle = (session: Session, frame: ControlFrame) =>
+      Effect.sync(() => {
+        const { pending } = session;
+        switch (frame.t) {
+          case "res": {
+            const entry = pending.get(frame.id);
+            if (!entry) return;
+            const headers = Headers.fromInput(frame.headers);
+            if (!frame.body) {
+              pending.delete(frame.id);
+              Deferred.doneUnsafe(
+                entry.head,
+                Effect.succeed(
+                  HttpServerResponse.empty({ status: frame.status, headers }),
+                ),
+              );
+              return;
+            }
+            const { readable, writable } = new TransformStream<
+              Uint8Array,
+              Uint8Array
+            >();
+            entry.writer = writable.getWriter();
+            Deferred.doneUnsafe(
+              entry.head,
+              Effect.succeed(
+                HttpServerResponse.stream(
+                  Stream.fromReadableStream({
+                    evaluate: () => readable,
+                    onError: (error) => error,
+                  }),
+                  { status: frame.status, headers },
+                ),
+              ),
+            );
+            return;
+          }
+          case "end": {
+            const entry = pending.get(frame.id);
+            if (!entry) return;
+            pending.delete(frame.id);
+            void entry.writer?.close().catch(() => {});
+            return;
+          }
+          case "abort": {
+            const entry = pending.get(frame.id);
+            if (!entry) return;
+            pending.delete(frame.id);
+            const error = new Error(
+              frame.message ?? "aborted by the dev session",
+            );
+            if (entry.writer) void entry.writer.abort(error).catch(() => {});
+            else Deferred.doneUnsafe(entry.head, Effect.fail(error));
+            return;
+          }
+          case "hello":
+          case "req":
+            return;
+        }
+      });
+
+    const failAll = (session: Session, message: string) =>
+      Effect.sync(() => {
+        for (const [id, entry] of session.pending) {
+          session.pending.delete(id);
+          const error = new Error(message);
+          if (entry.writer) void entry.writer.abort(error).catch(() => {});
+          else Deferred.doneUnsafe(entry.head, Effect.fail(error));
+        }
+      });
+
+    /** Accept a connector socket and serve it until it closes. */
+    const connect = Effect.fn("DevRelay.connect")(function* (
+      request: HttpServerRequest.HttpServerRequest,
+      namespace: string,
+    ) {
+      const self = yield* machineId;
+      const socket = yield* request.upgrade;
+      const session: Session = {
+        namespace,
+        pending: new Map(),
+        nextId: 1,
+        // Filled in once the socket is running (below).
+        write: () => Effect.void,
+      };
+      // `run` is what completes the handshake and drives the socket: start
+      // it first, then write. Node hands every frame over as bytes, so a
+      // control frame (JSON, starts with `{`) is told apart from a body
+      // chunk (4-byte stream id, first byte 0) by its first byte.
+      const reader = yield* socket
+        .runRaw((data) => {
+          const bytes = typeof data === "string" ? undefined : data;
+          if (typeof data === "string" || bytes![0] === 0x7b) {
+            const text =
+              typeof data === "string" ? data : new TextDecoder().decode(bytes);
+            return settle(session, decodeControl(text));
+          }
+          return Effect.sync(() => {
+            const { id, chunk } = decodeChunk(bytes!);
+            const entry = session.pending.get(id);
+            // Copy: the frame's buffer is reused by the runtime.
+            void entry?.writer?.write(new Uint8Array(chunk)).catch(() => {});
+          });
+        })
+        .pipe(Effect.ignore, Effect.forkScoped);
+      const write = yield* socket.writer;
+      session.write = write;
+      // A new connector replaces the previous (restarted) session.
+      const previous = sessions.get(namespace);
+      if (previous) {
+        yield* failAll(previous, "replaced by a newer connector");
+        yield* previous
+          .write(new Socket.CloseEvent(4000, "replaced by a newer connector"))
+          .pipe(Effect.ignore);
+      }
+      sessions.set(namespace, session);
+      yield* directory
+        .set(ownerKey(namespace), self, { ex: OWNER_TTL_SECONDS })
+        .pipe(Effect.ignore);
+      yield* directory.sadd(NAMESPACES_KEY, namespace).pipe(Effect.ignore);
+
+      const certificate = yield* ensureCertificate(namespace);
+      yield* write(encodeControl(hello(namespace, certificate))).pipe(
+        Effect.ignore,
+      );
+      yield* Effect.logInfo(`[${namespace}] connector attached to ${self}`);
+
+      // Serve until the socket closes; refresh the directory lease meanwhile.
+      const lease = directory
+        .expire(ownerKey(namespace), OWNER_TTL_SECONDS)
+        .pipe(
+          Effect.ignore,
+          Effect.repeat(Schedule.spaced("1 hour")),
+          Effect.forkScoped,
+        );
+      yield* lease;
+      yield* Fiber.join(reader);
+
+      yield* failAll(session, "the dev session disconnected");
+      if (sessions.get(namespace) === session) {
+        sessions.delete(namespace);
+        // Only the owner clears its own entry; a replacement elsewhere
+        // already overwrote it.
+        const owner = yield* directory
+          .get(ownerKey(namespace))
+          .pipe(Effect.orElseSucceed(() => null));
+        if (owner === self) {
+          yield* directory.del(ownerKey(namespace)).pipe(Effect.ignore);
+        }
+      }
+      yield* Effect.logInfo(`[${namespace}] connector detached`);
+      return HttpServerResponse.empty();
+    });
+
+    /** Forward one public request down the session's socket and await its response. */
+    const relay = Effect.fn("DevRelay.relay")(function* (
+      request: HttpServerRequest.HttpServerRequest,
+      session: Session,
+      host: string,
+      label: string,
+    ) {
+      const id = session.nextId++;
+      const url = new URL(request.url, "http://relay");
+      const headers = Headers.setAll(request.headers, {
+        "x-forwarded-host": host,
+        "x-forwarded-proto": relayScheme,
+      });
+      const hasBody = request.method !== "GET" && request.method !== "HEAD";
+      const frame: RequestFrame = {
+        t: "req",
+        id,
+        method: request.method,
+        url: `${url.pathname}${url.search}`,
+        host,
+        label,
+        headers: forwardableHeaders(Object.entries(headers)),
+        body: hasBody,
+      };
+      const head = yield* Deferred.make<
+        HttpServerResponse.HttpServerResponse,
+        Error
+      >();
+      session.pending.set(id, { head });
+      yield* session.write(encodeControl(frame)).pipe(
+        Effect.catch((error) =>
+          Effect.sync(() => {
+            session.pending.delete(id);
+            Deferred.doneUnsafe(head, Effect.fail(new Error(String(error))));
+          }),
+        ),
+      );
+      if (hasBody) {
+        // Pump the body in bounded chunks; the response head can arrive
+        // before the body finishes, so this runs detached from the request.
+        yield* request.stream.pipe(
+          Stream.flatMap((bytes) => {
+            const chunks: Uint8Array[] = [];
+            for (let o = 0; o < bytes.byteLength; o += CHUNK_SIZE) {
+              chunks.push(bytes.subarray(o, o + CHUNK_SIZE));
+            }
+            return Stream.fromIterable(chunks);
+          }),
+          Stream.runForEach((chunk) => session.write(encodeChunk(id, chunk))),
+          Effect.andThen(session.write(encodeControl({ t: "end", id }))),
+          Effect.catch((error) =>
+            session.write(
+              encodeControl({ t: "abort", id, message: String(error) }),
+            ),
+          ),
+          Effect.ignore,
+          Effect.forkDetach,
+        );
+      }
+      return yield* Deferred.await(head).pipe(
+        Effect.timeoutOrElse({
+          duration: RESPONSE_TIMEOUT,
+          orElse: () =>
+            Effect.sync(() => {
+              session.pending.delete(id);
+              return page(
+                504,
+                "No response from alchemy dev",
+                "The dev session did not answer in time.",
+              );
+            }),
+        }),
+        Effect.catch((error) =>
+          Effect.succeed(
+            page(504, "No response from alchemy dev", escape(error.message)),
+          ),
+        ),
+      );
+    });
+
+    let renewing = false;
+
+    return {
+      fetch: Effect.gen(function* () {
+        if (!renewing) {
+          // Init also runs at deploy time; only a serving Machine renews.
+          renewing = true;
+          yield* renewalLoop.pipe(Effect.forkDetach);
+        }
+        const request = yield* HttpServerRequest.HttpServerRequest;
+        const host = request.headers.host ?? "";
+        const hostname = host.split(":")[0]!.toLowerCase();
+        const url = new URL(request.url, "http://relay");
+
+        if (hostname === relayDomain && url.pathname === CONNECT_PATH) {
+          if (request.headers.upgrade?.toLowerCase() !== "websocket") {
+            return page(
+              426,
+              "Upgrade required",
+              "Connect with a WebSocket client.",
+            );
+          }
+          if (!authorized(request)) {
+            return HttpServerResponse.text("unauthorized", { status: 401 });
+          }
+          const namespace = url.searchParams
+            .get(NAMESPACE_PARAM)
+            ?.toLowerCase();
+          if (!namespace || !NAMESPACE_PATTERN.test(namespace)) {
+            return HttpServerResponse.text("invalid or missing namespace", {
+              status: 400,
+            });
+          }
+          return yield* connect(request, namespace);
+        }
+
+        if (hostname === relayDomain) {
+          return page(
+            200,
+            "alchemy dev relay",
+            `Run <code>alchemy dev --relay ${escape(`${relayScheme}://${relayDomain}`)}</code> to get stable <code>https://&lt;name&gt;.&lt;namespace&gt;.${escape(relayDomain)}</code> URLs for your local resources.`,
+          );
+        }
+
+        const target = parsePublicHost(host, relayDomain);
+        if (target === undefined) {
+          return page(
+            404,
+            "Unknown host",
+            `Nothing is served at <code>${escape(host)}</code>.`,
+          );
+        }
+        if (request.headers.upgrade?.toLowerCase() === "websocket") {
+          return page(
+            501,
+            "WebSockets are not relayed yet",
+            "The dev relay forwards HTTP requests; WebSocket passthrough is on its way.",
+          );
+        }
+        const session = sessions.get(target.namespace);
+        if (session !== undefined) {
+          return yield* relay(request, session, host, target.label);
+        }
+        // Not ours: the owning Machine (if any) gets the request replayed.
+        const self = yield* machineId;
+        const owner = yield* directory
+          .get(ownerKey(target.namespace))
+          .pipe(Effect.orElseSucceed(() => null));
+        if (owner !== null && owner !== self) {
+          return HttpServerResponse.empty({
+            status: 200,
+            headers: Headers.fromInput({ "fly-replay": `instance=${owner}` }),
+          });
+        }
+        return page(
+          502,
+          "alchemy dev is not connected",
+          `No dev session is connected for <code>${escape(host)}</code>. Start <code>alchemy dev</code> with the relay enabled and retry.`,
+        );
+      }),
+    };
+  }).pipe(
+    Effect.provide(ACME.IssueCertificateHttp),
+    Effect.provide(Cloudflare.DNS.ReadWriteDnsHttp),
+    Effect.provide(Fly.WriteCertificatesHttp),
+    Effect.provide(Fly.ReadWriteRedisHttp),
+  ),
+) {}

--- a/packages/alchemy/src/Platform.ts
+++ b/packages/alchemy/src/Platform.ts
@@ -29,7 +29,7 @@ import {
   sanitizeKey,
   type BaseRuntimeContext,
 } from "./RuntimeContext.ts";
-import { Self } from "./Self.ts";
+import { Self, type Self as SelfService } from "./Self.ts";
 import { ServerHost, type ProcessContext } from "./Server/Process.ts";
 import type { Stack, StackServices } from "./Stack.ts";
 import type { Stage } from "./Stage.ts";
@@ -196,7 +196,11 @@ export interface Platform<
       const Id extends string,
       Shape extends MainShape,
       PropsReq = never,
-      InitReq extends Services | PlatformServices | Resource = never,
+      // Unconstrained: an init that binds another provider's resources
+      // (a Fly Service issuing certificates through Cloudflare DNS) needs
+      // that provider's collection, which the Stack supplies. The platform
+      // itself provides `Self` and its own services while building the init.
+      InitReq = never,
     >(
       id: Id,
       props:
@@ -212,7 +216,10 @@ export interface Platform<
       never,
       | Resource["Providers"]
       | Exclude<PropsReq, Services | PlatformServices | Resource>
-      | Exclude<InitReq, Services | PlatformServices | Resource>
+      | Exclude<
+          InitReq,
+          Services | PlatformServices | Resource | SelfService<any>
+        >
     > &
       Named<Id> & {
         new (
@@ -224,10 +231,7 @@ export interface Platform<
       id: Id,
     ): Effect.Effect<Resource & Rpc<Self>, never, Resource["Providers"]> &
       Named<Id> & {
-        make<
-          PropsReq = never,
-          InitReq extends Services | PlatformServices | Resource = never,
-        >(
+        make<PropsReq = never, InitReq = never>(
           props:
             | InputProps<InlineProps>
             | Effect.Effect<
@@ -240,7 +244,10 @@ export interface Platform<
           Self,
           never,
           | Resource["Providers"]
-          | Exclude<PropsReq | InitReq, Services | PlatformServices | Resource>
+          | Exclude<
+              PropsReq | InitReq,
+              Services | PlatformServices | Resource | SelfService<any>
+            >
         >;
         new (_: never): BaseShape & Named<Id> & Tag<Resource["Type"]>;
       };

--- a/packages/alchemy/test/Local/Relay.test.ts
+++ b/packages/alchemy/test/Local/Relay.test.ts
@@ -1,0 +1,216 @@
+import * as ACME from "@/ACME";
+import * as Cloudflare from "@/Cloudflare";
+import * as Fly from "@/Fly";
+import * as Alchemy from "@/index.ts";
+import { DevRelay } from "@/Local/Relay/Relay.ts";
+import * as Test from "@/Test/Alchemy";
+import { expect } from "alchemy-test";
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import { MinimumLogLevel } from "effect/References";
+import * as Schedule from "effect/Schedule";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
+import * as Dns from "node:dns/promises";
+import IngressApiWorker from "../Cloudflare/Workers/fixtures/ingress/api-worker.ts";
+
+/**
+ * End to end through Fly: the dev relay service is deployed with its apex
+ * certificate and DNS records on the standing test zone, a local dev
+ * session connects to it over one WebSocket (the relay issues the
+ * namespace's `*.<ns>.<domain>` certificate from ZeroSSL on that first
+ * connect), and a public request for
+ * `https://api.<namespace>.relay.alchemy-test-2.us` is answered by the
+ * local Worker behind the dev ingress.
+ *
+ * Needs Fly + Cloudflare credentials and `ZERO_SSL_KEY`.
+ */
+const ZONE = process.env.CLOUDFLARE_TEST_DNS_ZONE_NAME ?? "alchemy-test-2.us";
+const RELAY_DOMAIN = `${process.env.ALCHEMY_TEST_RELAY_SUBDOMAIN ?? "relay"}.${ZONE}`;
+const RELAY_URL = `https://${RELAY_DOMAIN}`;
+const NAMESPACE = "reltest";
+const PORT = 13385;
+
+const enabled =
+  process.env.ZERO_SSL_KEY !== undefined ||
+  process.env.ZEROSSL_ACCESS_KEY !== undefined;
+
+const logLevel = Effect.provideService(
+  MinimumLogLevel,
+  process.env.DEBUG ? "Debug" : "Info",
+);
+
+const providers = () =>
+  Layer.mergeAll(Fly.providers(), Cloudflare.providers(), ACME.providers());
+
+// The relay itself deploys for real.
+const live = Test.make({ providers: providers() });
+
+// The dev session runs locally behind the sidecar with the relay enabled.
+const dev = Test.make({
+  providers: Cloudflare.providers(),
+  dev: true,
+  ingress: {
+    domain: "localhost",
+    port: PORT,
+    relay: { url: RELAY_URL, namespace: NAMESPACE },
+  },
+});
+
+// The relay reads its configuration through `Config`; set it before the
+// stack is planned (the test process resolves the live stack's Config).
+process.env.DEV_RELAY_ZONE = ZONE;
+process.env.DEV_RELAY_DOMAIN = RELAY_DOMAIN;
+process.env.DEV_RELAY_SCHEME = "https";
+
+const RelayStack = Alchemy.Stack(
+  "DevRelayTestStack",
+  { providers: providers(), state: Cloudflare.state() },
+  Effect.gen(function* () {
+    const relay = yield* DevRelay;
+    return { url: relay.url, appName: relay.app.appName };
+  }),
+);
+
+class NotReady extends Data.TaggedError("NotReady")<{
+  status: number;
+  body: string;
+}> {}
+
+const waitForDns = (hostname: string) =>
+  Effect.tryPromise(() => {
+    const resolver = new Dns.Resolver();
+    resolver.setServers(["1.1.1.1", "1.0.0.1"]);
+    return resolver.resolve4(hostname);
+  }).pipe(
+    Effect.retry({
+      schedule: Schedule.max([
+        Schedule.spaced("2 seconds"),
+        Schedule.recurs(45),
+      ]),
+    }),
+    Effect.orDie,
+  );
+
+/** GET a public relay URL, retrying while DNS, TLS and the session settle. */
+const getPublic = (
+  url: string,
+  ok: (status: number) => boolean = (status) => status === 200,
+  headers: Record<string, string> = {},
+  attempts = 45,
+) =>
+  Effect.gen(function* () {
+    const client = yield* HttpClient.HttpClient;
+    return yield* client
+      .execute(
+        HttpClientRequest.get(url).pipe(HttpClientRequest.setHeaders(headers)),
+      )
+      .pipe(
+        Effect.flatMap((res) =>
+          ok(res.status)
+            ? Effect.succeed(res)
+            : res.text.pipe(
+                Effect.flatMap((body) =>
+                  Effect.fail(new NotReady({ status: res.status, body })),
+                ),
+              ),
+        ),
+        Effect.retry({
+          schedule: Schedule.max([
+            Schedule.spaced("3 seconds"),
+            Schedule.recurs(attempts),
+          ]),
+        }),
+        Effect.catchTag("NotReady", (e) =>
+          Effect.die(
+            new Error(`relay answered ${e.status}: ${e.body.slice(0, 400)}`),
+          ),
+        ),
+      );
+  }).pipe(Effect.orDie);
+
+// Deploy the relay, then wait until it actually answers: fresh DNS records
+// and the apex certificate take a moment, and the connector's first attempt
+// must not race that.
+const relay = live.beforeAll(
+  enabled
+    ? Effect.gen(function* () {
+        const deployed = yield* live.deploy(RelayStack);
+        // Ask public DNS directly first: resolving through the OS before the
+        // fresh record exists caches NXDOMAIN locally for minutes.
+        yield* waitForDns(RELAY_DOMAIN);
+        const res = yield* getPublic(
+          `${RELAY_URL}/__relay/connect`,
+          (status) => status === 426,
+        );
+        expect(res.status).toBe(426);
+        return deployed;
+      })
+    : Effect.succeed({ url: "", appName: "" } as {
+        url: string;
+        appName: string;
+      }),
+);
+live.afterAll.skipIf(!enabled || !!process.env.NO_DESTROY)(
+  live.destroy(RelayStack),
+);
+
+dev.test.provider.skipIf(!enabled)(
+  "a public relay URL is answered by the local Worker over one WebSocket",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* relay;
+      yield* stack.destroy();
+
+      const { api } = yield* stack.deploy(
+        Effect.gen(function* () {
+          const api = yield* IngressApiWorker;
+          return { api };
+        }),
+      );
+      const publicUrl = `https://api.${NAMESPACE}.${RELAY_DOMAIN}`;
+      // The relay URL is the primary one; the local ingress URL follows.
+      expect(api.url).toBe(publicUrl);
+      expect(api.urls).toContain(`http://api.localhost:${PORT}`);
+
+      // The namespace's wildcard certificate is issued on first connect
+      // (~a minute) and then propagates to Fly's edges (a few more); TLS
+      // failures are retried until it serves.
+      const res = yield* getPublic(
+        `${publicUrl}/echo?x=1`,
+        undefined,
+        { origin: "http://web.example.com" },
+        120,
+      );
+      const echo = (yield* res.json) as unknown as {
+        method: string;
+        forwardedHost: string | null;
+        forwardedProto: string | null;
+        origin: string | null;
+      };
+      expect(echo.method).toBe("GET");
+      expect(echo.forwardedHost).toBe(`api.${NAMESPACE}.${RELAY_DOMAIN}`);
+      expect(echo.forwardedProto).toBe("https");
+      expect(echo.origin).toBe("http://web.example.com");
+      // CORS headers come back through the relay untouched.
+      expect(res.headers["access-control-allow-origin"]).toBe(
+        "http://web.example.com",
+      );
+
+      // Destroying the Worker withdraws its route: the relay still forwards
+      // (the sidecar keeps the session open for the whole test process) and
+      // the local ingress answers 404 for the gone host — proof that
+      // `unexpose` reaches through the relay. A 502 needs the session
+      // itself to disconnect, which only happens when the sidecar exits.
+      yield* stack.destroy();
+      const gone = yield* getPublic(
+        `${publicUrl}/`,
+        (status) => status === 404,
+        {},
+        20,
+      );
+      expect(gone.status).toBe(404);
+    }).pipe(logLevel),
+  { timeout: 600_000 },
+);

--- a/packages/cloudflare-runtime/src/core/proxy/Ingress.worker.ts
+++ b/packages/cloudflare-runtime/src/core/proxy/Ingress.worker.ts
@@ -33,9 +33,13 @@ export interface IngressRoute {
   readonly fqn?: string;
   /** Resource type (`Cloudflare.Worker`, `Command.Dev`, …). */
   readonly type?: string;
+  /** Public URL exposing this host (a dev relay), when one is connected. */
+  readonly publicUrl?: string;
 }
 
 const CONTROLLER_PREFIX = "/cdn-cgi/ingress/";
+/** Header a trusted local hop sets to pick the route regardless of `Host`. */
+const ROUTE_HINT_HEADER = "x-alchemy-ingress-host";
 
 export default {
   fetch(request: Request, env: Env): Promise<Response> {
@@ -129,7 +133,13 @@ export class Ingress extends DurableObject<Env> {
   }
 
   private async handleRouted(request: Request, url: URL): Promise<Response> {
-    const host = normalizeHost(request.headers.get("host") ?? url.host);
+    // A relay connector in front of the ingress names the local host it
+    // wants explicitly (its own `Host` is the public one, and it may not be
+    // able to override the header at all) — honour that first.
+    const hinted = request.headers.get(ROUTE_HINT_HEADER);
+    const host = normalizeHost(
+      hinted ?? request.headers.get("host") ?? url.host,
+    );
     const route = this.routes.get(host);
     if (route) {
       return await this.forward(request, url, route);
@@ -156,6 +166,7 @@ export class Ingress extends DurableObject<Env> {
     proxied.pathname = original.pathname;
     proxied.search = original.search;
     const headers = new Headers(request.headers);
+    headers.delete(ROUTE_HINT_HEADER);
     // Preserve what a hop in front of us said (a proxy reports the public
     // hostname) — otherwise the public host is the one the client dialed.
     if (!headers.has("x-forwarded-host")) {
@@ -200,11 +211,17 @@ export class Ingress extends DurableObject<Env> {
     const items = routes
       .map(([host, route]) => {
         const href = `${url.protocol}//${host}${port ? `:${port}` : ""}`;
+        const publicLink = route.publicUrl
+          ? `<a class="public" href="${escapeHtml(route.publicUrl)}">${escapeHtml(
+              route.publicUrl,
+            )}</a>`
+          : "";
         return `<li>
   <div class="name">${escapeHtml(route.label ?? host)}<span class="type">${escapeHtml(
     route.type ?? "",
   )}</span></div>
   <a href="${escapeHtml(href)}">${escapeHtml(href)}</a>
+  ${publicLink}
   <div class="upstream">→ ${escapeHtml(route.upstream)}</div>
 </li>`;
       })
@@ -304,13 +321,14 @@ const renderPage = (title: string, body: string): string => `<!doctype html>
   .type { font-weight: 400; color: #6b6b70; font-size: .8rem; margin-left: .5rem; }
   a { color: #1a5fd6; text-decoration: none; word-break: break-all; }
   a:hover { text-decoration: underline; }
+  .public { display: block; color: #0b7a4b; }
   .upstream, .muted { color: #6b6b70; font-size: .85rem; }
   code { font: .9em ui-monospace, SFMono-Regular, Menlo, monospace; }
   .hosts li { margin: .25rem 0; }
   @media (prefers-color-scheme: dark) {
     body { background: #111113; color: #ececef; }
     .routes li { background: #1b1b1f; border-color: #2b2b31; }
-    a { color: #7aa7ff; }
+    a { color: #7aa7ff; } .public { color: #4cc38a; }
     .type, .upstream, .muted { color: #8c8c93; }
   }
 </style>

--- a/stacks/dev-relay.ts
+++ b/stacks/dev-relay.ts
@@ -7,12 +7,13 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 
 /**
- * Alchemy's hosted dev relay: `alchemy dev --relay https://<DEV_RELAY_DOMAIN>`
- * gives every local resource a stable `https://<name>.<namespace>.<domain>`
- * URL over one WebSocket from the dev sidecar.
+ * Alchemy's hosted dev relay at `alchemy.town`: `alchemy dev --relay
+ * https://alchemy.town` gives every local resource a stable
+ * `https://<name>.<namespace>.alchemy.town` URL over one WebSocket from the
+ * dev sidecar. User content lives on its own domain, never on alchemy.run.
  *
  * ```sh
- * DEV_RELAY_ZONE=alchemy.run DEV_RELAY_DOMAIN=dev.alchemy.run \
+ * DEV_RELAY_ZONE=alchemy.town DEV_RELAY_DOMAIN=alchemy.town \
  * DEV_RELAY_TOKEN=… ZERO_SSL_KEY=… alchemy deploy --config stacks/dev-relay.ts --stage prod
  * ```
  *

--- a/stacks/dev-relay.ts
+++ b/stacks/dev-relay.ts
@@ -1,0 +1,37 @@
+import * as Alchemy from "alchemy";
+import * as ACME from "alchemy/ACME";
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Fly from "alchemy/Fly";
+import { DevRelay } from "alchemy/Local/Relay/Relay";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+
+/**
+ * Alchemy's hosted dev relay: `alchemy dev --relay https://<DEV_RELAY_DOMAIN>`
+ * gives every local resource a stable `https://<name>.<namespace>.<domain>`
+ * URL over one WebSocket from the dev sidecar.
+ *
+ * ```sh
+ * DEV_RELAY_ZONE=alchemy.run DEV_RELAY_DOMAIN=dev.alchemy.run \
+ * DEV_RELAY_TOKEN=… ZERO_SSL_KEY=… alchemy deploy --config stacks/dev-relay.ts --stage prod
+ * ```
+ *
+ * Runs on Fly (TLS ends at Fly's proxy, one wildcard certificate per
+ * namespace issued by the service itself). Put `<domain>` on the Public
+ * Suffix List so browsers treat each namespace as its own site.
+ */
+export default Alchemy.Stack(
+  "DevRelay",
+  {
+    providers: Layer.mergeAll(
+      Fly.providers(),
+      Cloudflare.providers(),
+      ACME.providers(),
+    ),
+    state: Cloudflare.state(),
+  },
+  Effect.gen(function* () {
+    const relay = yield* DevRelay;
+    return { url: relay.url };
+  }),
+);

--- a/website/src/content/docs/cli/dev.mdx
+++ b/website/src/content/docs/cli/dev.mdx
@@ -28,6 +28,8 @@ A failed apply keeps dev alive so healthy resources keep serving — fix the err
 | `--config, -c <file>`            | Stack file to run (defaults to `alchemy.run.ts`)                   |
 | `--domain <domain>` | Domain local resources are served under as `<name>.<domain>` (defaults to `localhost`) |
 | `--port <port>`     | Port of the shared dev ingress every `<name>.<domain>` host is served on (defaults to `1337`) |
+| `--relay <url>`     | Expose local resources through a dev relay (one connection, stable `https://<name>.<namespace>.<relay>` URLs); token from `$ALCHEMY_DEV_RELAY_TOKEN` |
+| `--relay-namespace <name>` | Namespace to claim on the relay (defaults to the stage, kebab-cased) |
 
 `alchemy deploy` defaults to `live_$USER`. Using a different default
 here means a bare `alchemy dev` will not replace a stage you deployed.
@@ -61,6 +63,24 @@ See [hosts](/cli/hosts).
 
 Binding port 80 needs privileges too. `alchemy dev --port 80` falls back to `1337` when it cannot bind, then checks whether the OS forwards `:80` to the ingress; if not, it prints the one-time forwarding command for your platform (`pfctl` on macOS, `iptables` on Linux). Once forwarded, URLs are advertised without a port: `http://api.myapp.test`.
 
+## Relay
+
+```sh
+alchemy dev --relay https://dev.alchemy.run
+```
+
+```
+Connected to the dev relay: https://<name>.dev-sam.dev.alchemy.run
+[Api] → https://api.dev-sam.dev.alchemy.run
+[Web] → https://web.dev-sam.dev.alchemy.run
+```
+
+A relay is a small service on a domain the relay operator owns. `alchemy dev` opens **one** WebSocket to it and keeps it open for the session; the relay routes every `https://<name>.<namespace>.<domain>` request down that socket by `Host`, and the local ingress answers it. Real subdomains, stable names across restarts, no extra process per resource. The namespace is yours for the session (the stage name by default) and each resource keeps its ingress name under it, so cookies scoped to `<namespace>.<domain>` work across your resources like they will in production.
+
+The first time a namespace connects, the relay issues a `*.<namespace>.<domain>` certificate for it (about a minute — `alchemy dev` says when it is uploaded; Fly's edges pick it up over the next few minutes) and renews it in the background.
+
+Anyone can host a relay with Alchemy itself — `yield* DevRelay` (from `alchemy/Local/Relay/Relay`) deploys the Fly service, its App, IPs, session directory, apex certificate and DNS records onto a Cloudflare zone, configured by `DEV_RELAY_ZONE`, `DEV_RELAY_DOMAIN`, `DEV_RELAY_TOKEN` and `ZERO_SSL_KEY` (see `stacks/dev-relay.ts`). Connectors present the relay's bearer token from `$ALCHEMY_DEV_RELAY_TOKEN`. WebSocket passthrough (HMR sockets through the relay) is not supported yet; the local URLs keep working for that.
+
 ## Examples
 
 ```sh
@@ -72,6 +92,9 @@ alchemy dev --stage prod
 
 # Serve resources as http://<name>.myapp.test (after `sudo alchemy hosts add …`)
 alchemy dev --domain myapp.test
+
+# Expose every local resource through a dev relay at stable subdomains
+ALCHEMY_DEV_RELAY_TOKEN=… alchemy dev --relay https://dev.alchemy.run
 ```
 
 ## Where next

--- a/website/src/content/docs/cli/dev.mdx
+++ b/website/src/content/docs/cli/dev.mdx
@@ -66,16 +66,16 @@ Binding port 80 needs privileges too. `alchemy dev --port 80` falls back to `133
 ## Relay
 
 ```sh
-alchemy dev --relay https://dev.alchemy.run
+alchemy dev --relay https://alchemy.town
 ```
 
 ```
-Connected to the dev relay: https://<name>.dev-sam.dev.alchemy.run
-[Api] → https://api.dev-sam.dev.alchemy.run
-[Web] → https://web.dev-sam.dev.alchemy.run
+Connected to the dev relay: https://<name>.dev-sam.alchemy.town
+[Api] → https://api.dev-sam.alchemy.town
+[Web] → https://web.dev-sam.alchemy.town
 ```
 
-A relay is a small service on a domain the relay operator owns. `alchemy dev` opens **one** WebSocket to it and keeps it open for the session; the relay routes every `https://<name>.<namespace>.<domain>` request down that socket by `Host`, and the local ingress answers it. Real subdomains, stable names across restarts, no extra process per resource. The namespace is yours for the session (the stage name by default) and each resource keeps its ingress name under it, so cookies scoped to `<namespace>.<domain>` work across your resources like they will in production.
+Alchemy hosts one at `alchemy.town`, a domain that carries only dev traffic — nothing on it is ours, and nothing of ours is on it. A relay is a small service on a domain the relay operator owns. `alchemy dev` opens **one** WebSocket to it and keeps it open for the session; the relay routes every `https://<name>.<namespace>.<domain>` request down that socket by `Host`, and the local ingress answers it. Real subdomains, stable names across restarts, no extra process per resource. The namespace is yours for the session (the stage name by default) and each resource keeps its ingress name under it, so cookies scoped to `<namespace>.<domain>` work across your resources like they will in production.
 
 The first time a namespace connects, the relay issues a `*.<namespace>.<domain>` certificate for it (about a minute — `alchemy dev` says when it is uploaded; Fly's edges pick it up over the next few minutes) and renews it in the background.
 
@@ -94,7 +94,7 @@ alchemy dev --stage prod
 alchemy dev --domain myapp.test
 
 # Expose every local resource through a dev relay at stable subdomains
-ALCHEMY_DEV_RELAY_TOKEN=… alchemy dev --relay https://dev.alchemy.run
+ALCHEMY_DEV_RELAY_TOKEN=… alchemy dev --relay https://alchemy.town
 ```
 
 ## Where next


### PR DESCRIPTION
`alchemy dev --relay https://alchemy.town` gives every local resource a stable public `https://<name>.<namespace>.alchemy.town` URL over one WebSocket from the dev sidecar. The relay is a Fly Service on `alchemy.town`, a domain that carries only user dev traffic — nothing of ours lives there, and no user content lives on alchemy.run.

```sh
alchemy dev --relay https://alchemy.town
# Connected to the dev relay: https://<name>.dev-sam.alchemy.town
# [Api] → https://api.dev-sam.alchemy.town
```

- **One connection, many resources.** The sidecar dials `wss://<domain>/__relay/connect?namespace=<ns>` once; the relay routes every `https://<label>.<ns>.<domain>` request down that socket as a multiplexed stream (JSON control frames + 4-byte-id binary chunks), and the connector answers it from the local ingress with a route hint header. Names are stable across restarts; the namespace defaults to the stage.
- **TLS per namespace.** Fly's proxy terminates TLS. On a namespace's first connect the service issues `*.<ns>.<domain>` from ZeroSSL over DNS-01 through the zone's Cloudflare records (`ACME.IssueCertificate` + `Cloudflare.DNS.acmeDnsSolver`), uploads it with `Fly.WriteCertificates`, publishes the `_fly-ownership` TXT Fly needs to serve a wildcard it cannot probe, and waits for Fly to report it configured (~40s end to end; edges pick it up over the next few minutes). A background loop renews. The connector reports `provisioning` → `ready`, with the failure reason when it isn't. Each namespace is its own registrable site once `alchemy.town` is on the Public Suffix List, so cookies never cross namespaces.
- **Session locality across Machines.** The Machine holding a namespace's socket records itself in Redis (`Fly.Redis` + `ReadWriteRedis`); any other Machine answers that namespace's requests with `fly-replay: instance=<owner>` and Fly's proxy re-sends them.
- **Deploy it with Alchemy.** `yield* DevRelay` (from `alchemy/Local/Relay/Relay`) composes the App, IPs, directory, ZeroSSL account, apex certificate, DNS-only records (`<domain>` and `*.<domain>`, a wildcard matches every depth) and the service; `stacks/dev-relay.ts` is the hosted one. Configured by `DEV_RELAY_ZONE`, `DEV_RELAY_DOMAIN`, `DEV_RELAY_TOKEN`, `ZERO_SSL_KEY`.

Two engine fixes this surfaced:

- Fly hosts unwrapped every runtime-packed secret marker into a bare string, so any `Redacted` output a binding read back through its accessor (`yield* token.value`) threw `Unable to get redacted value` at runtime. `plainEnvValue` now keeps the marker, as the `RuntimeContext` contract requires.
- `Platform`'s inline constructor no longer constrains the init effect's requirements to the platform's own services — leftover requirements (another provider's collection) flow to the Stack, as the Worker platform already allows. A Fly Service can now bind Cloudflare DNS and ACME.

Not yet: WebSocket passthrough to local resources (HMR sockets); the local URLs keep working for that.

Stacked on #1466 (certificates) and #1449 (ingress).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
