### PR TITLE
docs: onboarding funnel and Cloudflare Workers docs in the narrative style

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -1459,11 +1459,11 @@ export const isSelf = (value: unknown): value is Self =>
  *
  * ```typescript
  * Effect.gen(function* () {
- *   // Phase 1: bind resources (runs at deploy time)
+ *   // Construction: bind resources (deploy time and cold start)
  *   const kv = yield* Cloudflare.KV.ReadWriteNamespace(MyKV);
  *
  *   return {
- *     // Phase 2: runtime handlers (runs on each request)
+ *     // Runtime: handlers, once per request
  *     fetch: Effect.gen(function* () {
  *       const value = yield* kv.get("key");
  *       return HttpServerResponse.text(value ?? "not found");
@@ -1580,6 +1580,37 @@ export const isSelf = (value: unknown): value is Self =>
  * };
  * ```
  *
+ * **Example:** Binding a named entrypoint
+ *
+ * `env: { TARGET: worker }` targets the Worker's default entrypoint.
+ * `Cloudflare.WorkerEntrypoint` binds one of its named
+ * `WorkerEntrypoint` class exports instead; `InferEnv` types the entry
+ * as a `Fetcher` stub whose RPC methods are called directly.
+ * ```typescript
+ * const caller = yield* Cloudflare.Worker("Caller", {
+ *   main: "./src/caller.ts",
+ *   env: {
+ *     API: Cloudflare.WorkerEntrypoint(target, "Api"), // env.API.greet("alice")
+ *   },
+ * });
+ * ```
+ *
+ * **Example:** Entrypoint props
+ *
+ * The options form attaches properties the target entrypoint reads from
+ * `this.ctx.props`. `Output` values resolve at deploy time. `alchemy dev`
+ * delivers `props` to the local workerd; the deploy API's binding schema
+ * does not carry the field yet, so `props` are dropped at upload while the
+ * binding itself deploys correctly.
+ * ```typescript
+ * env: {
+ *   VENDOR: Cloudflare.WorkerEntrypoint(vendorWorker, {
+ *     entrypoint: "Vendor",
+ *     props: { baseUrl: site.url },
+ *   }),
+ * }
+ * ```
+ *
  * ### Python Workers
  * Point `main` at a `.py` file to deploy a
  * [Python Worker](https://developers.cloudflare.com/workers/languages/python/)
@@ -1643,11 +1674,11 @@ export const isSelf = (value: unknown): value is Self =>
  *   "MyWorker",
  *   { main: import.meta.url },
  *   Effect.gen(function* () {
- *     // init: bind resources
+ *     // Construction: bind resources
  *     const kv = yield* Cloudflare.KV.ReadWriteNamespace(MyKV);
  *
  *     return {
- *       // runtime: use them
+ *       // Runtime: use them
  *       fetch: Effect.gen(function* () {
  *         const value = yield* kv.get("key");
  *         return HttpServerResponse.text(value ?? "not found");
@@ -1683,11 +1714,11 @@ export const isSelf = (value: unknown): value is Self =>
  * export default WorkerB.make(
  *   { main: import.meta.url },
  *   Effect.gen(function* () {
- *     // init: bind resources
+ *     // Construction: bind resources
  *     const kv = yield* Cloudflare.KV.ReadWriteNamespace(MyKV);
  *
  *     return {
- *       // runtime: use them
+ *       // Runtime: use them
  *       greet: (name: string) =>
  *         Effect.gen(function* () {
  *           yield* kv.put("last-greeted", name);
@@ -1737,6 +1768,25 @@ export const isSelf = (value: unknown): value is Self =>
  * {
  *   main: import.meta.url,
  *   assets: "./public",
+ * }
+ * ```
+ *
+ * **Example:** Run the Worker before the asset layer
+ *
+ * A path that matches no asset already falls through to the Worker.
+ * `runWorkerFirst` routes the listed paths (or, with `true`, every
+ * request) through the Worker ahead of asset matching, for an asset
+ * that would otherwise shadow a route or an SPA fallback that would
+ * answer an API call. A `_headers` or `_redirects` file in the
+ * directory is applied automatically and `.assetsignore` excludes
+ * files from the upload.
+ * ```typescript
+ * {
+ *   main: import.meta.url,
+ *   assets: {
+ *     directory: "./public",
+ *     runWorkerFirst: ["/api/*", "/admin/*"],
+ *   },
  * }
  * ```
  *
@@ -1951,10 +2001,10 @@ export const isSelf = (value: unknown): value is Self =>
  *     return {
  *       fetch: Effect.gen(function* () {
  *         const publicUrl = yield* url;
- *         return Response.json({ url: publicUrl });
+ *         return yield* HttpServerResponse.json({ url: publicUrl });
  *       }),
  *     };
- *   }).pipe(Effect.provide(Cloudflare.Workers.URLBinding)),
+ *   }),
  * );
  * ```
  *
@@ -2058,7 +2108,7 @@ export const isSelf = (value: unknown): value is Self =>
  * Workers Cache puts a regionally tiered cache in front of the Worker —
  * cache hits are served from the edge without invoking the Worker (and
  * without billing CPU time). In an Effect-native Worker, enable it by
- * yielding `Cloudflare.cache()` in the init phase, which also returns the
+ * yielding `Cloudflare.cache()` in the Construction phase, which also returns the
  * runtime purge client; async Workers use the `cache` prop instead. Control
  * what gets cached from your handlers via standard response headers:
  * `Cache-Control` (including `stale-while-revalidate`), `Cache-Tag` for
@@ -2071,7 +2121,7 @@ export const isSelf = (value: unknown): value is Self =>
  * **Example:** Enabling and purging the cache in an Effect Worker
  * ```typescript
  * Effect.gen(function* () {
- *   // init: enable Workers Cache on this Worker
+ *   // Construction: enable Workers Cache on this Worker
  *   const { purge } = yield* Cloudflare.cache({ crossVersionCache: true });
  *
  *   return {
@@ -2114,17 +2164,17 @@ export const isSelf = (value: unknown): value is Self =>
  *
  * For ad-hoc background work, `WorkerExecutionContext.waitUntil(effect)`
  * forks an Effect with the caller's full context and keeps the invocation
- * alive until it settles. The context can be yielded once in the init
- * closure and used from any handler; its methods are `RuntimeContext`-
+ * alive until it settles. The context can be yielded once in the
+ * constructor and used from any handler; its methods are `RuntimeContext`-
  * colored, so they can only run inside a handler.
  *
- * The init closure is evaluated once per isolate: the bridge builds the
+ * The constructor is evaluated once per isolate: the bridge builds the
  * Worker's layer stack on the first event and every later event reuses the
  * built services. Resolve services, bind resources, build handlers there —
  * one-shot I/O that caches a plain value (e.g. fetching a secret for a
  * client) is fine, but nothing disposable: the build scope is never closed
- * (workerd has no isolate-teardown hook), so a finalizer added in the init
- * closure never runs, and I/O-backed objects (sockets, response bodies) are
+ * (workerd has no isolate-teardown hook), so a finalizer added in the
+ * constructor never runs, and I/O-backed objects (sockets, response bodies) are
  * pinned to the request that created them. Anything that needs cleanup
  * belongs in a handler, where `Effect.addFinalizer` attaches to the
  * per-event scope.
@@ -2142,7 +2192,7 @@ export const isSelf = (value: unknown): value is Self =>
  *
  * **Example:** Background work with waitUntil
  * ```typescript
- * // init
+ * // Construction
  * const exec = yield* Cloudflare.WorkerExecutionContext;
  *
  * return {
@@ -2155,13 +2205,13 @@ export const isSelf = (value: unknown): value is Self =>
  * ```
  *
  * ### R2 Bucket
- * Bind an R2 bucket in the init phase with `Cloudflare.R2.ReadWriteBucket`.
+ * Bind an R2 bucket in the Construction phase with `Cloudflare.R2.ReadWriteBucket`.
  * The returned handle exposes `get`, `put`, `delete`, and `list`
  * methods you can call in your runtime handlers.
  *
  * **Example:** Binding and using R2
  * ```typescript
- * // init
+ * // Construction
  * const bucket = yield* Cloudflare.R2.ReadWriteBucket(MyBucket);
  *
  * return {
@@ -2189,7 +2239,7 @@ export const isSelf = (value: unknown): value is Self =>
  *
  * **Example:** Binding and using KV
  * ```typescript
- * // init
+ * // Construction
  * const kv = yield* Cloudflare.KV.ReadWriteNamespace(MyKV);
  *
  * return {
@@ -2207,7 +2257,7 @@ export const isSelf = (value: unknown): value is Self =>
  *
  * **Example:** Binding and querying D1
  * ```typescript
- * // init
+ * // Construction
  * const db = yield* Cloudflare.D1.QueryDatabase(MyDatabase);
  *
  * return {
@@ -2222,13 +2272,13 @@ export const isSelf = (value: unknown): value is Self =>
  * ```
  *
  * ### Durable Objects
- * Yield a `DurableObject` class in the init phase to get a
+ * Yield a `DurableObject` class in the Construction phase to get a
  * namespace handle. Call `getByName` or `getById` to get a typed RPC
  * stub, then call its methods from your runtime handlers.
  *
  * **Example:** Using a Durable Object
  * ```typescript
- * // init
+ * // Construction
  * const counters = yield* Counter;
  *
  * return {
@@ -2242,7 +2292,7 @@ export const isSelf = (value: unknown): value is Self =>
  *
  * ### Containers
  * Containers run long-lived processes alongside Durable Objects.
- * Provide `Cloudflare.Containers.layer(Sandbox, …)` on a DO's init to
+ * Provide `Cloudflare.Containers.layer(Sandbox, …)` on a DO's constructor to
  * bind, start, and monitor the container; then `yield* Sandbox`
  * resolves the **running** instance. Call its typed methods or use
  * `getTcpPort` to make HTTP requests to its exposed ports.
@@ -2282,7 +2332,7 @@ export const isSelf = (value: unknown): value is Self =>
  *
  * **Example:** Loading a dynamic Worker
  * ```typescript
- * // init
+ * // Construction
  * const loader = yield* Cloudflare.WorkerLoader("Loader");
  *
  * return {

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -456,7 +456,6 @@ export default defineConfig({
           items: [
             { label: "What is Alchemy?", link: "/what-is-alchemy" },
             { label: "Getting started", link: "/getting-started" },
-            { label: "Migrating from v1", link: "/migrating-from-v1" },
             {
               label: "Infrastructure as Code",
               items: [
@@ -669,6 +668,7 @@ export default defineConfig({
                 { label: "cloudflare", link: "/cli/cloudflare" },
               ],
             },
+            { label: "Migrating from v1", link: "/migrating-from-v1" },
           ],
         },
         {

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -696,25 +696,15 @@ export default defineConfig({
                   label: "Python Workers",
                   link: "/cloudflare/compute/python-workers",
                 },
-                {
-                  label: "Durable Objects",
-                  link: "/cloudflare/compute/durable-objects",
-                },
-                { label: "Containers", link: "/cloudflare/compute/containers" },
-                { label: "Workflows", link: "/cloudflare/compute/workflows" },
-                {
-                  label: "Cross-worker DOs",
-                  link: "/cloudflare/compute/cross-worker-durable-object",
-                },
-                {
-                  label: "WebSockets",
-                  link: "/cloudflare/compute/hibernatable-websockets",
-                },
+                { label: "Workers Cache", link: "/cloudflare/compute/cache" },
                 {
                   label: "Rate limiting",
                   link: "/cloudflare/compute/rate-limiting",
                 },
-                { label: "Workers Cache", link: "/cloudflare/compute/cache" },
+                {
+                  label: "Browser rendering",
+                  link: "/cloudflare/compute/browser-rendering",
+                },
                 {
                   label: "Worker Loader",
                   link: "/cloudflare/compute/worker-loader",
@@ -724,9 +714,19 @@ export default defineConfig({
                   link: "/cloudflare/compute/workers-for-platforms",
                 },
                 {
-                  label: "Browser rendering",
-                  link: "/cloudflare/compute/browser-rendering",
+                  label: "Durable Objects",
+                  link: "/cloudflare/compute/durable-objects",
                 },
+                {
+                  label: "Cross-worker DOs",
+                  link: "/cloudflare/compute/cross-worker-durable-object",
+                },
+                {
+                  label: "WebSockets",
+                  link: "/cloudflare/compute/hibernatable-websockets",
+                },
+                { label: "Containers", link: "/cloudflare/compute/containers" },
+                { label: "Workflows", link: "/cloudflare/compute/workflows" },
               ],
             },
             {

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -454,8 +454,8 @@ export default defineConfig({
         {
           label: "Core",
           items: [
-            { label: "What is Alchemy?", link: "/what-is-alchemy" },
             { label: "Getting started", link: "/getting-started" },
+            { label: "What is Alchemy?", link: "/what-is-alchemy" },
             {
               label: "Infrastructure as Code",
               items: [

--- a/website/public/llms.txt
+++ b/website/public/llms.txt
@@ -38,7 +38,7 @@ The noun graph and its semantics: Stacks of Resources and Actions, data flow via
 - [Actions](https://alchemy.run/infrastructure-as-code/action) — A node in the dependency graph that runs an Effect during apply when its inputs change.
 - [Inputs & Outputs](https://alchemy.run/infrastructure-as-code/outputs) — Output<T> is alchemy's lazy reference type — the lazy values that flow between resources, get composed with .pipe, mapped, interpolated, and resolved during deploy.
 - [References](https://alchemy.run/infrastructure-as-code/references) — Read an already-deployed Resource or Stack at plan time — Resource.ref by Logical ID with optional stack/stage props, or import a Stack tag and depend on its outputs.
-- [Resource lifecycle](https://alchemy.run/infrastructure-as-code/resource-lifecycle) — How alchemy plans, applies, replaces, and destroys resources — and how to think about idempotency and recovery.
+- [Resource Lifecycle](https://alchemy.run/infrastructure-as-code/resource-lifecycle) — How alchemy plans, applies, replaces, and destroys resources — and how to think about idempotency and recovery.
 - [Providers](https://alchemy.run/infrastructure-as-code/provider) — Providers implement the lifecycle operations for a resource type — reconcile, delete, diff, read, and more.
 - [Custom Provider](https://alchemy.run/infrastructure-as-code/custom-provider) — Add support for a new cloud or third-party API by declaring a Resource type and implementing its lifecycle as an Effect Layer.
 
@@ -131,7 +131,7 @@ A linear five-part walkthrough from zero to a tested, locally-developed, CI-depl
 - [Durable Objects](https://alchemy.run/cloudflare/compute/durable-objects) — Durable Objects are globally-unique stateful instances with transactional storage — define one as an Effect, persist state per key, expose typed RPC methods, and stream values back to the caller.
 - [Gradual deployments](https://alchemy.run/cloudflare/compute/gradual-deployments) — Roll out Worker deploys incrementally — upload preview versions, canary a percentage of live traffic, ramp to 100%, pin users to a version during the rollout, and verify which version served each request.
 - [Python Workers](https://alchemy.run/cloudflare/compute/python-workers) — Deploy Cloudflare Python Workers by pointing main at a .py file — alchemy uploads the modules, vendors pyproject.toml dependencies with uv, and serves them locally through workerd's built-in Pyodide.
-- [Workers](https://alchemy.run/cloudflare/compute/workers) — Cloudflare Workers are the compute runtime of every alchemy app — define infrastructure and runtime behavior in one Effect program, bind resources with full type safety, and call other Workers over schemaless RPC.
+- [Workers](https://alchemy.run/cloudflare/compute/workers) — Cloudflare Workers are the compute Runtime of every Alchemy app — declare the Worker and its handler in one file, bind resources with full type safety, and call other Workers over schemaless RPC.
 - [Workflows](https://alchemy.run/cloudflare/compute/workflows) — Cloudflare Workflows run durable multi-step jobs — define a typed workflow class, checkpoint steps with task and sleep, trigger instances from a Worker, and poll status until completion.
 
 ## Cloudflare — Frontend

--- a/website/src/components/ProviderIcons.astro
+++ b/website/src/components/ProviderIcons.astro
@@ -1,0 +1,46 @@
+---
+/**
+ * A row of provider brand marks, for cards that point at the provider
+ * directory. Icons come from the same table the docs tab bar uses, so
+ * they stay in sync with the providers Alchemy ships.
+ */
+import { TAB_ICONS } from "../docs-icons";
+
+interface Props {
+  /** Tab labels from `TAB_ICONS`, in display order. */
+  names?: string[];
+}
+
+const {
+  names = [
+    "Hetzner",
+    "Fly",
+    "Railway",
+    "Kubernetes",
+    "Docker",
+    "Neon",
+    "PlanetScale",
+    "Prisma",
+    "Drizzle",
+    "GitHub",
+  ],
+} = Astro.props;
+
+const icons = names
+  .map((name) => ({ name, body: TAB_ICONS[name] }))
+  .filter((i): i is { name: string; body: string } => Boolean(i.body));
+---
+
+<span class="provider-icons" aria-label={names.join(", ")}>
+  {
+    icons.map((icon) => (
+      <svg
+        aria-hidden="true"
+        width="22"
+        height="22"
+        viewBox="0 0 24 24"
+        set:html={icon.body}
+      />
+    ))
+  }
+</span>

--- a/website/src/content/docs/blog/2026-05-29-beta-45.md
+++ b/website/src/content/docs/blog/2026-05-29-beta-45.md
@@ -163,7 +163,7 @@ binding rather than the public network.
 The full walkthrough — schema, handlers, deploy, integration
 test, cross-Worker binding, and the modular `Class.make(impl)`
 form — lives in the new
-[RpcWorker tutorial](/cloudflare/compute/workers#schemaless-rpc).
+[RpcWorker tutorial](/cloudflare/compute/workers#call-another-worker).
 ([#387](https://github.com/alchemy-run/alchemy/pull/387))
 
 ## `Cloudflare.RpcDurableObject`
@@ -273,7 +273,7 @@ types. See the changelog for the full list.
 ## Where to go next
 
 - [Concepts › Secrets and Config](/environments/secrets)
-- [RpcWorker tutorial](/cloudflare/compute/workers#schemaless-rpc)
+- [RpcWorker tutorial](/cloudflare/compute/workers#call-another-worker)
 - [RpcDurableObject tutorial](/cloudflare/compute/durable-objects#schemaless-rpc)
 - [Effect RPC guide](/cloudflare/apis/effect-rpc)
 - [CHANGELOG](https://github.com/alchemy-run/alchemy/blob/main/CHANGELOG.md#v200-beta45)

--- a/website/src/content/docs/cloudflare/apis/effect-http-api.mdx
+++ b/website/src/content/docs/cloudflare/apis/effect-http-api.mdx
@@ -624,5 +624,5 @@ backends behind the scenes.
   Effect HTTP.
 - [Effect RPC on Workers](/cloudflare/apis/effect-rpc) — the
   schema-first RPC shape for Effect/TypeScript consumers.
-- [Schemaless RPC](/cloudflare/compute/workers#schemaless-rpc) — the
+- [Schemaless RPC](/cloudflare/compute/workers#call-another-worker) — the
   default for internal Worker-to-Worker calls.

--- a/website/src/content/docs/cloudflare/apis/effect-rpc.mdx
+++ b/website/src/content/docs/cloudflare/apis/effect-rpc.mdx
@@ -445,7 +445,7 @@ internet) and the client is typed by `TaskWorker`'s declared schema.
 A `Proxy` defers each call's underlying `RpcClient` construction so
 Cloudflare's "no cross-request I/O" rule is satisfied transparently.
 For internal Worker-to-Worker calls that don't need a schema at all,
-see [Schemaless RPC on Workers](/cloudflare/compute/workers#schemaless-rpc).
+see [Schemaless RPC on Workers](/cloudflare/compute/workers#call-another-worker).
 
 `RpcWorker` also supports a **modular form** that separates the
 class declaration from its runtime — useful when a consumer Worker

--- a/website/src/content/docs/cloudflare/apis/schemaless-rpc.mdx
+++ b/website/src/content/docs/cloudflare/apis/schemaless-rpc.mdx
@@ -62,7 +62,7 @@ export default class BindingEffectCaller extends Cloudflare.Worker<BindingEffect
 ) {}
 ```
 
-`bindWorker(BindingTargetWorker)` registers a service Binding at deploy time and returns a stub typed as the target's Shape — `target.greet(name)` is fully inferred from the target class, and every call rides native JSRPC. Service bindings in depth: [Workers](/cloudflare/compute/workers#schemaless-rpc).
+`bindWorker(BindingTargetWorker)` registers a service Binding at deploy time and returns a stub typed as the target's Shape — `target.greet(name)` is fully inferred from the target class, and every call rides native JSRPC. Service bindings in depth: [Workers](/cloudflare/compute/workers#call-another-worker).
 
 ## Worker → Durable Object
 

--- a/website/src/content/docs/cloudflare/compute/browser-rendering.mdx
+++ b/website/src/content/docs/cloudflare/compute/browser-rendering.mdx
@@ -51,8 +51,8 @@ converted Markdown; failures surface as a typed `BrowserError`.
 
 ## Scrape elements by selector
 
-The other JSON quick actions follow the same shape — pass a URL plus
-action-specific options, get the parsed result back:
+The other JSON quick actions follow the same shape. Pass a URL plus
+action-specific options and get the parsed result back:
 
 ```typescript
 const scrape = yield* browser.scrape({
@@ -101,7 +101,7 @@ export type WorkerEnv = Cloudflare.InferEnv<typeof Worker>;
 //   { BROWSER: BrowserRun }
 ```
 
-`InferEnv` types the `env` your handler receives — `BROWSER` flows
+`InferEnv` types the `env` your handler receives. `BROWSER` flows
 through as Cloudflare's native `BrowserRun` binding. The
 `nodejs_compat` flag is required for `@cloudflare/puppeteer`.
 

--- a/website/src/content/docs/cloudflare/compute/cache.mdx
+++ b/website/src/content/docs/cloudflare/compute/cache.mdx
@@ -8,15 +8,15 @@ sidebar:
 Workers Cache sits in front of a Worker: when it's enabled, Cloudflare
 checks the cache before invoking the Worker at all, and a hit is
 served straight from the edge. What gets cached is controlled by
-standard response headers — `Cache-Control` (including
+standard response headers: `Cache-Control` (including
 `stale-while-revalidate`), `Cache-Tag` for tag-based purging, and
 `Vary` for content negotiation.
 
 ## Enable the cache on a Worker
 
 `yield*` `Cloudflare.cache()` in the Worker's Construction phase. It turns
-Workers Cache on at deploy time and returns the runtime client — no
-layer to provide:
+Workers Cache on at deploy time and returns the runtime client. There
+is no layer to provide:
 
 ```typescript
 // src/worker.ts
@@ -87,8 +87,8 @@ const { purge } = yield* Cloudflare.cache({ crossVersionCache: true });
 ```
 
 `enabled: false` keeps the binding's purge client available while
-turning the read-through cache off — useful for toggling cache
-behavior per stage.
+turning the read-through cache off, which is useful for toggling
+cache behavior per stage.
 
 ## Enable the cache with the `cache` prop
 
@@ -103,7 +103,7 @@ export const Worker = Cloudflare.Worker("Worker", {
 });
 ```
 
-The handler shapes cache behavior the same way — through
+The handler shapes cache behavior the same way, through
 `Cache-Control`, `Cache-Tag`, and `Vary` headers on its responses.
 
 ## Where next

--- a/website/src/content/docs/cloudflare/compute/containers.mdx
+++ b/website/src/content/docs/cloudflare/compute/containers.mdx
@@ -462,7 +462,7 @@ The Durable Object class name defaults to the binding name (the
 differently. The type parameter (`Container<Sandbox>`) is the class
 from `worker.ts` above — it types `env.Sandbox` as
 `DurableObjectNamespace<Sandbox>` through
-[`InferEnv`](/cloudflare/compute/workers#typed-env-for-async-workers),
+[`InferEnv`](/cloudflare/compute/workers#async-workers),
 so the handler reaches the container with full types:
 
 ```typescript

--- a/website/src/content/docs/cloudflare/compute/gradual-deployments.mdx
+++ b/website/src/content/docs/cloudflare/compute/gradual-deployments.mdx
@@ -288,7 +288,7 @@ export default Cloudflare.Worker(
 );
 ```
 
-See [Version metadata](/cloudflare/compute/workers#version-metadata)
+See [Version metadata](/cloudflare/compute/workers#versions)
 for the async-Worker variant.
 
 ## What a version carries

--- a/website/src/content/docs/cloudflare/compute/gradual-deployments.mdx
+++ b/website/src/content/docs/cloudflare/compute/gradual-deployments.mdx
@@ -4,8 +4,8 @@ description: Roll out Worker deploys incrementally — upload preview versions, 
 ---
 
 Every deploy of a Worker uploads an immutable
-[version](https://developers.cloudflare.com/workers/configuration/versions-and-deployments/)
-— a snapshot of code, bindings, and compatibility settings — and a
+[version](https://developers.cloudflare.com/workers/configuration/versions-and-deployments/),
+a snapshot of code, bindings, and compatibility settings. A
 *deployment* routes traffic across up to two versions by percentage.
 By default alchemy deploys each new version at 100%. The `version`
 prop unlocks the other shapes: gradual rollouts, canaries, and
@@ -33,15 +33,15 @@ yield* Cloudflare.Worker("Api", {
 Each request is routed independently by percentage. Raise the number
 and re-deploy to ramp; remove the prop (or set `100`) to promote.
 
-The first deploy of a script always goes to 100% — there is nothing
+The first deploy of a script always goes to 100%, since there is nothing
 to split with. `traffic: 0` uploads the version without deploying it
 (the equivalent of `wrangler versions upload`).
 
 ## Percentages replace, they never add
 
 A deployment is a complete routing table, and each versioned deploy
-splits its new version against the *stable* side — the majority
-holder — of the current one:
+splits its new version against the *stable* side of the current one,
+the majority holder:
 
 ```typescript
 version: { traffic: 10 }  // deploys: v2 10%, v1 90%
@@ -89,7 +89,7 @@ jobs:
 ```
 
 Deploy at `10`, watch your metrics, re-run at `50`, promote at the
-default `100`. Run every step from the same ref — a re-run from a
+default `100`. Run every step from the same ref. A re-run from a
 moving branch ships whatever landed since, which is a new rollout,
 not a ramp.
 
@@ -97,7 +97,7 @@ not a ramp.
 
 Rolling back is another deploy: re-deploy the previous code and it
 goes out as a new version at 100%. Versions are immutable snapshots,
-so the previous behavior comes back exactly — bindings and
+so the previous behavior comes back exactly, bindings and
 compatibility settings included.
 
 ## Canary another stage's Worker
@@ -118,8 +118,8 @@ Destroying the canary restores 100% of traffic to the live version.
 
 ## Preview versions
 
-With `parent` set and no `traffic`, the version receives no traffic —
-it is reachable only at its preview URL. This is the PR-preview
+With `parent` set and no `traffic`, the version receives no traffic.
+It is reachable only at its preview URL. This is the PR-preview
 workflow:
 
 ```typescript
@@ -144,7 +144,7 @@ keeps previews working with the stable URL off.
 
 ### Preview version or preview stage?
 
-Deploying the stack to its own stage is also a preview — a fully
+Deploying the stack to its own stage is also a preview, a fully
 independent one, with its own script and its own copies of every
 resource. A preview *version* rides the parent's script, settings, and
 version history, and adds no scripts to the account. Use a stage to
@@ -173,7 +173,7 @@ curl -s https://api.example.com/health \
 
 The dictionary is keyed by the *physical script name*; an unknown
 version or malformed header falls back to the percentages. Overrides
-also apply to `fetch()`-based service binding calls — forward the
+also apply to `fetch()`-based service binding calls. Forward the
 incoming request to keep cooperating Workers on matching versions. If
 the smoke test fails, re-deploy the last good ref at the default 100
 ([Roll back](#roll-back)).
@@ -200,7 +200,7 @@ yield* Cloudflare.Worker("Api", {
 
 Alchemy provisions a transform rule on each zone the Worker serves on
 (custom domains and routes), scoped to the Worker's hostnames, that
-fills the header from the cookie — and, for requests that don't carry
+fills the header from the cookie, and for requests that don't carry
 the cookie yet, from the client IP. The rule updates in place as the
 config changes and is removed when `affinity` is removed or the
 Worker is destroyed. On a [canary of another stage's
@@ -209,8 +209,8 @@ lands on the parent's zones, pinning users across the canary split.
 
 Besides `cookie`, the key can come from a request `header` (a tenant
 or user id your edge already stamps), the client IP alone
-(`{ ip: true }`), or — for anything else, like a JWT claim via API
-Shield — a raw
+(`{ ip: true }`), or, for anything else like a JWT claim via API
+Shield, a raw
 [Rules-language](https://developers.cloudflare.com/ruleset-engine/rules-language/)
 expression:
 
@@ -230,8 +230,8 @@ curl -s https://api.example.com -H 'Cloudflare-Workers-Version-Key: user-123'
 
 Pinned users only move forward as percentages rise, never back.
 
-For full control over the rule — custom match conditions, keys
-composed from several fields, rules spanning Workers — drop down to a
+For full control over the rule, such as custom match conditions, keys
+composed from several fields, or rules spanning Workers, drop down to a
 manual `Ruleset` in the same phase, which is exactly what the sugar
 manages for you:
 
@@ -294,14 +294,14 @@ for the async-Worker variant.
 ## What a version carries
 
 A version snapshots code, bindings, compatibility settings, and cache
-configuration. Script-level settings — routes, custom domains, crons,
+configuration. Script-level settings (routes, custom domains, crons,
 tags, observability, logpush, placement, limits, and the workers.dev
-subdomain — apply immediately to *all* versions: they are rejected on
+subdomain) apply immediately to *all* versions: they are rejected on
 a version worker, and during a gradual rollout they keep their live
 values until the next full deploy.
 
-Anything the Worker *calls* — Durable Objects, Workflows, service
-bindings — sits outside the version too, so both versions talk to it
+Anything the Worker *calls*, Durable Objects, Workflows, and service
+bindings, sits outside the version too, so both versions talk to it
 during the rollout. Ship those changes expand-and-contract:
 
 1. Deploy the new DO handler / Workflow / RPC method at 100%,
@@ -318,10 +318,10 @@ Platform limits to plan around:
 
 - A deployment splits between at most two versions, and only the last
   100 uploaded versions are deployable.
-- Each Durable Object is assigned one version by the percentages —
-  a single object never splits across versions. Class migrations
+- Each Durable Object is assigned one version by the percentages,
+  so a single object never splits across versions. Class migrations
   cannot ride a rollout (deploy them at 100% first), and a version
-  worker cannot host DO or Workflow classes — host them on the parent
+  worker cannot host DO or Workflow classes. Host them on the parent
   and reference them
   [cross-script](/cloudflare/compute/cross-worker-durable-object).
 - Workers that implement Durable Objects do not get preview URLs.
@@ -332,7 +332,7 @@ Platform limits to plan around:
 ## Containers roll out by instance, not by request
 
 [Containers](/cloudflare/compute/containers) shift gradually by
-replacing running *instances* with the new image in steps — there is
+replacing running *instances* with the new image in steps. There is
 no request-level split between two images:
 
 ```typescript

--- a/website/src/content/docs/cloudflare/compute/python-workers.mdx
+++ b/website/src/content/docs/cloudflare/compute/python-workers.mdx
@@ -6,8 +6,8 @@ description: Deploy Cloudflare Python Workers by pointing main at a .py file —
 Cloudflare [Python Workers](https://developers.cloudflare.com/workers/languages/python/)
 (open beta) run CPython inside the Workers runtime via Pyodide. In
 alchemy, a Python Worker is a regular `Cloudflare.Worker` whose `main`
-points at a `.py` file — the infrastructure is still defined in
-TypeScript, only the runtime code is Python.
+points at a `.py` file. The infrastructure is still defined in
+TypeScript. Only the runtime code is Python.
 
 There is no bundling step: the entry and every sibling `.py` module
 upload as-is, the `python_workers` compatibility flag is added
@@ -86,7 +86,7 @@ from util import slugify
 
 Put a `pyproject.toml` next to the entry module. On deploy, alchemy
 vendors `[project.dependencies]` with uv and uploads them under
-`python_modules/` — the same layout Wrangler and
+`python_modules/`, the same layout Wrangler and
 [pywrangler](https://github.com/cloudflare/workers-py) use:
 
 ```toml
@@ -117,7 +117,7 @@ Under the hood, alchemy runs the same steps `pywrangler sync` does:
 
 1. `uv pip compile` resolves the dependencies against the
    [Pyodide wheel index](https://index.pyodide.org) for the runtime's
-   Python version into a `pylock.toml` (prebuilt wheels only —
+   Python version into a `pylock.toml` (prebuilt wheels only, since
    Pyodide-platformed wheels can't be built locally).
 2. `uv venv` + `uv pip install --no-build` install the locked wheels
    into an `emscripten-wasm32` cross-venv.
@@ -135,13 +135,13 @@ must be installed for dependency vendoring. Workers without a
 `pyproject.toml` deploy without uv. Only pure-Python packages,
 packages with `emscripten-wasm32` wheels, and
 [packages built into Pyodide](https://pyodide.org/en/stable/usage/packages-in-pyodide.html)
-resolve — and HTTP clients must be async (`httpx`, `aiohttp`, or JS
+resolve, and HTTP clients must be async (`httpx`, `aiohttp`, or JS
 `fetch` via the FFI).
 :::
 
 ### ASGI apps (FastAPI)
 
-The runtime ships an `asgi` module that serves any ASGI application —
+The runtime ships an `asgi` module that serves any ASGI application,
 so FastAPI (with pydantic validation) works out of the box. Bindings
 and env vars reach your routes through `request.scope["env"]`:
 
@@ -192,14 +192,14 @@ dependencies = ["fastapi"]
 Compiled-extension packages with Pyodide wheels (numpy, pydantic-core,
 and the rest of the
 [Pyodide package set](https://pyodide.org/en/stable/usage/packages-in-pyodide.html))
-vendor the emscripten-wasm32 binary wheel matching the runtime's ABI —
-no build step on your side.
+vendor the emscripten-wasm32 binary wheel matching the runtime's ABI.
+There is no build step on your side.
 
 ### Bring your own python_modules
 
 If the entry's directory already contains a `python_modules/`
-directory — produced by `pywrangler sync` or any other tool that
-emits Wrangler's vendored layout — alchemy uploads it byte-for-byte
+directory, produced by `pywrangler sync` or any other tool that
+emits Wrangler's vendored layout, alchemy uploads it byte-for-byte
 and never invokes uv. This is the escape hatch for teams that manage
 Python dependencies outside of alchemy.
 
@@ -225,8 +225,8 @@ const worker = yield* Cloudflare.Worker("Worker", {
 ## Local dev
 
 `alchemy dev` serves Python Workers from local
-[workerd](https://github.com/cloudflare/workerd), which embeds Pyodide
-— the same module graph that would upload runs locally, bindings
+[workerd](https://github.com/cloudflare/workerd), which embeds Pyodide.
+The same module graph that would upload runs locally, bindings
 included. Edits to any `.py` file under the entry's directory (or to
 `pyproject.toml`, which re-vendors) restart the local Worker.
 
@@ -238,7 +238,7 @@ included. Edits to any `.py` file under the entry's directory (or to
   legacy top-level `on_fetch` style requires an extra compatibility
   flag and is not recommended.
 - Cold starts are mitigated server-side: Cloudflare snapshots the
-  Worker's memory after top-level imports at deploy time — there is
+  Worker's memory after top-level imports at deploy time. There is
   nothing to configure.
 - Vendored `python_modules/` files count toward the Worker size limit
   (3 MiB free / 10 MiB paid, gzipped).

--- a/website/src/content/docs/cloudflare/compute/rate-limiting.mdx
+++ b/website/src/content/docs/cloudflare/compute/rate-limiting.mdx
@@ -6,8 +6,8 @@ sidebar:
 ---
 
 The Rate Limiting binding gives a Worker a counter it can consult on
-every request: pass a key — an IP, a user id, an API token — and get
-back whether that key is within its budget. There is no backing cloud
+every request. Pass a key, such as an IP, a user id, or an API token,
+and get back whether that key is within its budget. There is no backing cloud
 resource to deploy; the limit configuration lives on the binding
 itself and ships with the Worker.
 
@@ -51,7 +51,7 @@ export default Cloudflare.Worker(
 ```
 
 `simple.limit` is the number of requests allowed per `simple.period`
-seconds — the period must be `10` or `60`. `namespaceId` is a number
+seconds. The period must be `10` or `60`. `namespaceId` is a number
 or string that uniquely identifies this limit configuration within
 the account; reuse the same id to share one budget across Workers,
 use distinct ids for independent limits.
@@ -70,7 +70,7 @@ const b1 = yield* throttle.limit({ key: "bob" });   // { success: true }
 ```
 
 Counting is approximate and local to the Cloudflare location serving
-the request — the binding is built for cheap, fast abuse protection,
+the request. The binding is built for cheap, fast abuse protection,
 not globally consistent quotas. For exact global counting, put the
 counter in a [Durable Object](/cloudflare/compute/durable-objects).
 
@@ -93,7 +93,7 @@ const { success } = yield* throttle.limit({ key }).pipe(
 ## Declare the binding as env metadata
 
 Workers whose `main` module exports a plain async `fetch` handler
-declare the limit on `env` instead — `InferEnv` types it as
+declare the limit on `env` instead. `InferEnv` types it as
 Cloudflare's native `RateLimit` binding:
 
 ```typescript

--- a/website/src/content/docs/cloudflare/compute/rate-limiting.mdx
+++ b/website/src/content/docs/cloudflare/compute/rate-limiting.mdx
@@ -13,7 +13,7 @@ itself and ships with the Worker.
 
 ## Bind a rate limit to a Worker
 
-`yield*` `Cloudflare.RateLimit(name, props)` in the Worker's constructor
+`yield*` `Cloudflare.RateLimit(name, props)` in the Worker's Construction
 phase and provide `RateLimitBinding` as a layer:
 
 ```typescript

--- a/website/src/content/docs/cloudflare/compute/worker-loader.mdx
+++ b/website/src/content/docs/cloudflare/compute/worker-loader.mdx
@@ -15,7 +15,7 @@ untrusted plugins, or executing Workers an AI agent just wrote.
 
 `yield*` `Cloudflare.WorkerLoader(name)` in the Worker's Construction phase.
 It registers the `worker_loader` binding on the deployed Worker and
-returns the runtime handle in one step — no layer to provide:
+returns the runtime handle in one step. There is no layer to provide:
 
 ```typescript
 // src/worker.ts
@@ -54,8 +54,8 @@ export default Cloudflare.Worker(
 
 `loader.load()` takes a compatibility date, a main module name, and a
 map of module names to source strings, and returns a stub for the
-freshly loaded Worker. `worker.fetch` speaks Effect-native HTTP —
-it accepts an `HttpClientRequest` (or, as here, forwards the incoming
+freshly loaded Worker. `worker.fetch` speaks Effect-native HTTP. It
+accepts an `HttpClientRequest` (or, as here, forwards the incoming
 server request) and resolves to an `HttpClientResponse`.
 
 ## Sandbox the loaded Worker
@@ -101,8 +101,8 @@ const worker = yield* loader.get("tenant-42", () => ({
 }));
 ```
 
-`getCode` may also return an `Effect` — useful when the source lives
-in R2 or KV and fetching it is itself effectful.
+`getCode` may also return an `Effect`, which is useful when the source
+lives in R2 or KV and fetching it is itself effectful.
 
 ## Call typed entrypoints
 
@@ -121,8 +121,8 @@ const greeting = yield* api.greet("world");
 ```
 
 The caller supplies the shape as a type argument since there is no
-statically bound class to infer it from. The full pattern — what
-makes a member callable and what crosses the wire — is covered in
+statically bound class to infer it from. What makes a member callable
+and what crosses the wire is covered in
 [Schemaless RPC](/cloudflare/apis/schemaless-rpc).
 
 ## Declare the binding as env metadata

--- a/website/src/content/docs/cloudflare/compute/workers-for-platforms.mdx
+++ b/website/src/content/docs/cloudflare/compute/workers-for-platforms.mdx
@@ -7,7 +7,7 @@ sidebar:
 
 Workers for Platforms lets you run your customers' code on Cloudflare's
 edge inside your own account. Customer ("user") Workers live in a
-**dispatch namespace** — they get no routes or URLs of their own.
+**dispatch namespace** and get no routes or URLs of their own.
 Instead, a **platform Worker** you control receives every request and
 forwards it to the right user Worker by script name.
 
@@ -31,7 +31,7 @@ export const Customers = Cloudflare.WorkersForPlatforms.DispatchNamespace(
 );
 ```
 
-The `name` is the namespace's identity — there is no rename API, so
+The `name` is the namespace's identity. There is no rename API, so
 changing it triggers a replacement (omit it to get a generated name).
 Deleting a namespace also deletes every script uploaded into it.
 
@@ -72,8 +72,8 @@ export default Alchemy.Stack(
 Referencing the namespace's `name` output establishes the dependency
 edge, so the namespace is created before the user Worker is uploaded
 into it (and the script is deleted first on destroy). The `script`
-form takes raw ESM source — typically whatever code your customer
-uploaded — but `main` with a local entrypoint works too.
+form takes raw ESM source, typically whatever code your customer
+uploaded. `main` with a local entrypoint works too.
 
 ## Dispatch from the platform Worker
 
@@ -127,7 +127,7 @@ edge, never a user-Worker response.
 ## Or bind on `env`
 
 For a plain async handler, pass the namespace on the Worker's `env`
-instead — `InferEnv` types it as the native runtime binding:
+instead. `InferEnv` types it as the native runtime binding:
 
 ```typescript
 const platform = Cloudflare.Worker("Platform", {
@@ -146,7 +146,7 @@ export default {
 ```
 
 `env.DISPATCH.get(name)` returns the same `Fetcher` the Effect-native
-client wraps — pick whichever style matches the rest of the Worker.
+client wraps. Pick whichever style matches the rest of the Worker.
 
 ## Where next
 

--- a/website/src/content/docs/cloudflare/compute/workers.mdx
+++ b/website/src/content/docs/cloudflare/compute/workers.mdx
@@ -113,6 +113,11 @@ Every building block binds the same way. See
 [Durable Objects](/cloudflare/compute/durable-objects), or walk
 through it step by step in [tutorial part 2](/cloudflare/tutorial/part-2).
 
+:::note
+[Bindings](/infrastructure-as-effects/binding) explains what a binding
+generates at deploy time and how the Layer you provide implements it.
+:::
+
 ## Call another Worker
 
 Workers call each other's methods directly. No HTTP routes, no schema,
@@ -171,12 +176,15 @@ against `Greeter`'s declared shape end to end.
 
 Importing the `Greeter` class pulls in no runtime code. Alchemy marks
 `.make()` as pure, so the bundler drops the implementation from every
-Worker that only binds it. [Runtime](/infrastructure-as-effects/runtime#three-ways-to-declare-one)
+Worker that only binds it. For external clients across a trust
+boundary, where payloads need schema validation before they touch your
+code, reach for [Effect RPC](/cloudflare/apis/effect-rpc) instead.
+
+:::note
+[Runtime](/infrastructure-as-effects/runtime#three-ways-to-declare-one)
 covers the three declaration forms, and
-[Schemaless RPC](/apis/schemaless) the calling convention. For
-external clients across a trust boundary, where payloads need schema
-validation before they touch your code, reach for
-[Effect RPC](/cloudflare/apis/effect-rpc) instead.
+[Schemaless RPC](/apis/schemaless) the calling convention.
+:::
 
 ## Serve static assets
 

--- a/website/src/content/docs/cloudflare/compute/workers.mdx
+++ b/website/src/content/docs/cloudflare/compute/workers.mdx
@@ -65,7 +65,7 @@ by binding it.
 
 ## Bind a resource
 
-Declare a bucket next to the Worker and bind it. The
+Declare a Bucket next to the Worker and bind it. The
 [Binding](/infrastructure-as-effects/binding) hands back a typed
 client, and the Layer you provide decides how the binding is
 implemented, here as a native `r2_bucket` binding on the Worker:

--- a/website/src/content/docs/cloudflare/compute/workers.mdx
+++ b/website/src/content/docs/cloudflare/compute/workers.mdx
@@ -1,25 +1,13 @@
 ---
 title: Workers
-description: Cloudflare Workers are the compute runtime of every alchemy app — define infrastructure and runtime behavior in one Effect program, bind resources with full type safety, and call other Workers over schemaless RPC.
+description: Cloudflare Workers are the compute Runtime of every Alchemy app — declare the Worker and its handler in one file, bind resources with full type safety, and call other Workers over schemaless RPC.
 ---
 
-A Cloudflare Worker is serverless JavaScript running in every
-Cloudflare data center. In alchemy, a Worker is a special kind of
-Resource: it has both an infrastructure definition (name, bundle,
-compatibility flags) and a runtime implementation expressed as an
-Effect — one program describes what to deploy *and* what it does.
-
-Reach for a Worker whenever you need compute: HTTP APIs, frontends,
-queue consumers, cron jobs, RPC services. Every other building block
-— [Durable Objects](/cloudflare/compute/durable-objects), [D1](/cloudflare/data/d1),
-[R2](/cloudflare/data/r2), [Queues](/cloudflare/messaging/queues) — is reached
-*through* a Worker via bindings.
-
-## Deploy a Worker
-
-A Worker follows a two-phase pattern: the outer `Effect.gen` is the
-**Construction phase** (binds resources at deploy time), and the handlers it
-returns are the **Runtime phase** (run on each request).
+In Alchemy, a Cloudflare Worker is a
+[Runtime](/infrastructure-as-effects/runtime): a
+[Resource](/infrastructure-as-code/resource) that carries the code it
+runs. The name and props describe the Worker to deploy. The Effect is
+what it does:
 
 ```typescript
 // src/worker.ts
@@ -40,7 +28,9 @@ export default Cloudflare.Worker(
 );
 ```
 
-Wire it into a Stack and expose its URL:
+`main: import.meta.url` tells Alchemy to bundle this file's default
+export, the Worker itself, as the script. Yield the Worker from a
+Stack and expose its URL:
 
 ```typescript
 // alchemy.run.ts
@@ -51,13 +41,9 @@ import Worker from "./src/worker.ts";
 
 export default Alchemy.Stack(
   "MyApp",
-  {
-    providers: Cloudflare.providers(),
-    state: Cloudflare.state(),
-  },
+  { providers: Cloudflare.providers(), state: Cloudflare.state() },
   Effect.gen(function* () {
     const worker = yield* Worker;
-
     return { url: worker.url };
   }),
 );
@@ -70,40 +56,43 @@ bun alchemy deploy
 Alchemy bundles the file, uploads it, enables the `workers.dev`
 subdomain, and prints the URL as a stack output.
 
-## Bindings
+Reach for a Worker whenever you need compute: HTTP APIs, frontends,
+queue consumers, cron jobs, RPC services. Every other building block,
+[Durable Objects](/cloudflare/compute/durable-objects),
+[D1](/cloudflare/data/d1), [R2](/cloudflare/data/r2),
+[Queues](/cloudflare/messaging/queues), is reached through a Worker
+by binding it.
 
-Workers reach other resources through **bindings** — typed clients
-resolved in the Construction phase. Given an R2 bucket declared in its own
-file (`export const Bucket = Cloudflare.R2.Bucket("Bucket")`), bind
-it by yielding `Cloudflare.R2.ReadWriteBucket(...)` and providing
-its binding layer:
+## Bind a resource
+
+Declare a bucket next to the Worker and bind it. The
+[Binding](/infrastructure-as-effects/binding) hands back a typed
+client, and the Layer you provide decides how the binding is
+implemented, here as a native `r2_bucket` binding on the Worker:
 
 ```typescript
 // src/worker.ts
 import * as Cloudflare from "alchemy/Cloudflare";
 import * as Effect from "effect/Effect";
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
-import { Bucket } from "./bucket.ts";
+
+export const Uploads = Cloudflare.R2.Bucket("Uploads");
 
 export default Cloudflare.Worker(
   "Worker",
   { main: import.meta.url },
   Effect.gen(function* () {
-    // Construction: register the binding, get a typed client
-    const bucket = yield* Cloudflare.R2.ReadWriteBucket(Bucket);
+    const bucket = yield* Cloudflare.R2.ReadWriteBucket(Uploads);
 
     return {
       fetch: Effect.gen(function* () {
-        // runtime: use it
-        const object = yield* bucket.get("hello.txt");
-        return HttpServerResponse.text(
-          object === null ? "Not found" : yield* object.text(),
-        );
+        const obj = yield* bucket.get("hello.txt");
+        return obj
+          ? HttpServerResponse.text(yield* obj.text())
+          : HttpServerResponse.text("Not found", { status: 404 });
       }).pipe(
         Effect.catchTag("R2Error", (error) =>
-          Effect.succeed(
-            HttpServerResponse.text(error.message, { status: 500 }),
-          ),
+          Effect.succeed(HttpServerResponse.text(error.message, { status: 500 })),
         ),
       ),
     };
@@ -111,46 +100,36 @@ export default Cloudflare.Worker(
 );
 ```
 
-Three things make this different from a `wrangler.toml` binding:
+The binding is declared where it's used, so deploying the Worker
+deploys the wiring. The client's errors, like `R2Error`, live in the
+Effect type system, so you can't forget to handle them. And the access
+level is in the name: `ReadBucket`, `WriteBucket`, or
+`ReadWriteBucket`, depending on what the Worker actually needs.
 
-- The binding is declared where it's used — deploying the Worker
-  deploys the wiring.
-- The client is fully typed, and its errors (like `R2Error`) live in
-  the Effect type system, so you can't forget to handle them.
-- Access is scoped: request `ReadBucket`, `WriteBucket`, or
-  `ReadWriteBucket` depending on what the Worker actually needs.
+Every building block binds the same way. See
+[KV](/cloudflare/data/kv), [D1](/cloudflare/data/d1),
+[Queues](/cloudflare/messaging/queues),
+[Hyperdrive](/cloudflare/data/hyperdrive), and
+[Durable Objects](/cloudflare/compute/durable-objects), or walk
+through it step by step in [tutorial part 2](/cloudflare/tutorial/part-2).
 
-Every building block follows the same shape — see
-[D1](/cloudflare/data/d1), [Queues](/cloudflare/messaging/queues), and
-[Hyperdrive](/cloudflare/data/hyperdrive), or walk through it step by step
-in [tutorial part 2](/cloudflare/tutorial/part-2).
+## Call another Worker
 
-## Schemaless RPC
-
-This is the Cloudflare shape of [Schemaless RPC](/apis/schemaless) —
-see that page for the full concept.
-
-Workers can call each other's methods directly — no HTTP routes, no
-schema declarations, no public URL. Declare the Worker as a class
-whose type carries its RPC shape, and any method returning an
-`Effect` becomes callable from other Workers. This is the
-recommended way to do Worker-to-Worker RPC.
-
-Define the callee with the class + `.make()` form (the class is a
-lightweight identifier; `.make()` provides the runtime, and bundlers
-tree-shake it out of consumers):
+Workers call each other's methods directly. No HTTP routes, no schema,
+no public URL. Declare the callee as a class whose type carries its
+RPC shape, and attach its implementation with `.make()`:
 
 ```typescript
-// src/WorkerB.ts — the tag carries the name + RPC shape
+// src/Greeter.ts
 import * as Cloudflare from "alchemy/Cloudflare";
 import * as Effect from "effect/Effect";
 
-export class WorkerB extends Cloudflare.Worker<
-  WorkerB,
+export class Greeter extends Cloudflare.Worker<
+  Greeter,
   { greet: (name: string) => Effect.Effect<string> }
->()("WorkerB") {}
+>()("Greeter") {}
 
-export default WorkerB.make(
+export default Greeter.make(
   { main: import.meta.url },
   Effect.gen(function* () {
     return {
@@ -160,176 +139,79 @@ export default WorkerB.make(
 );
 ```
 
-Bind it from another Worker with `Cloudflare.Workers.bindWorker` and
-call its methods through the typed stub:
+Bind it from another Worker with `bindWorker` and call `greet` through
+the typed stub:
 
 ```typescript
-// src/WorkerA.ts
+// src/Api.ts
 import * as Cloudflare from "alchemy/Cloudflare";
 import * as Effect from "effect/Effect";
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
-import WorkerB from "./WorkerB.ts";
+import { Greeter } from "./Greeter.ts";
 
-export default class WorkerA extends Cloudflare.Worker<WorkerA>()(
-  "WorkerA",
+export default Cloudflare.Worker(
+  "Api",
   { main: import.meta.url },
   Effect.gen(function* () {
-    const b = yield* Cloudflare.Workers.bindWorker(WorkerB);
+    const greeter = yield* Cloudflare.Workers.bindWorker(Greeter);
 
     return {
       fetch: Effect.gen(function* () {
-        const greeting = yield* b.greet("world");
-        return HttpServerResponse.text(greeting);
+        return HttpServerResponse.text(yield* greeter.greet("world"));
       }),
     };
   }),
-) {}
+);
 ```
 
-`bindWorker(WorkerB)` registers a service binding on WorkerA, so
-each call travels over Cloudflare's in-account service-binding
-fabric — never the public internet — and `b.greet("world")` is
-type-checked against WorkerB's declared shape end-to-end.
+`bindWorker(Greeter)` registers a service binding on `Api`, so each
+call travels over Cloudflare's in-account service-binding fabric and
+never the public internet. `greeter.greet("world")` is type-checked
+against `Greeter`'s declared shape end to end.
 
-The same pattern works for [Durable
-Objects](/cloudflare/compute/durable-objects#schemaless-rpc). For external
-clients across a trust boundary — where payloads need schema
-validation before they touch your code — reach for
+Importing the `Greeter` class pulls in no runtime code. Alchemy marks
+`.make()` as pure, so the bundler drops the implementation from every
+Worker that only binds it. [Runtime](/infrastructure-as-effects/runtime#three-ways-to-declare-one)
+covers the three declaration forms, and
+[Schemaless RPC](/apis/schemaless) the calling convention. For
+external clients across a trust boundary, where payloads need schema
+validation before they touch your code, reach for
 [Effect RPC](/cloudflare/apis/effect-rpc) instead.
 
-## Isolate scope vs request scope
+## Serve static assets
 
-The Worker's constructor runs **once per isolate**: the bridge
-builds your layers on the first event, and every later event —
-fetch, RPC, cron, queue — reuses them. Each event then runs with a
-**fresh `Scope`** that the bridge closes after the response via
-`ctx.waitUntil`, so `Effect.addFinalizer` in a handler runs after
-the response is sent without blocking it:
-
-```typescript
-fetch: Effect.gen(function* () {
-  yield* Effect.addFinalizer(() => flushMetrics().pipe(Effect.ignore));
-  return HttpServerResponse.text("ok");
-}),
-```
-
-Streaming responses and WebSocket upgrades transfer ownership of the
-request scope to the stream — its finalizers run when the stream
-completes instead of when the handler returns.
-
-workerd has no isolate-teardown hook, so a finalizer added in the
-constructor **never runs** — acquire anything that needs cleanup
-(connections, pools) inside handlers, where it's scoped to the
-event. `Drizzle.Postgres` follows this pattern: one pool per event,
-opened on the first query, closed when the event settles — the
-[SQL connection lifecycle](/sql/effect-sql/lifecycle) spells out the
-contract. See
-[Instance scope vs request scope](/infrastructure-as-effects/runtime#instance-scope-vs-request-scope)
-for the model across all runtimes.
-
-## URLs & domains
-
-`worker.urls` is every URL that serves the Worker, most significant
-first — and `worker.url` is always `urls[0]`:
-
-```typescript
-const worker = yield* Cloudflare.Worker("Api", {
-  main: "./src/api.ts",
-  domain: {
-    name: "example.com",
-    aliases: ["www.example.com"],
-    redirects: ["old.example.com"], // 301 → https://example.com
-  },
-});
-// worker.url    === "https://example.com"
-// worker.urls   === ["https://example.com", "https://www.example.com",
-//                    "https://<name>.<account>.workers.dev"]
-// worker.domain === { name: "example.com", aliases: ["www.example.com"],
-//                     redirects: ["old.example.com"] }
-```
-
-Every hostname is attached as a Cloudflare custom domain — DNS records
-and edge certificates are managed for you (the zone must already exist
-in the account). A bare string is shorthand for `{ name }`. Redirect
-hostnames answer with a permanent redirect (path and query preserved)
-before the Worker runs, so they never appear in `urls`.
-
-`workersDev` controls the `workers.dev` surface:
-
-```typescript
-workersDev: false, // no workers.dev URLs — url is the custom domain
-workersDev: { enabled: false, previewsEnabled: true }, // preview URLs only
-```
-
-Under `alchemy dev`, `urls` is the dev server's actual surface:
-
-```typescript
-// worker.url  === "http://localhost:1337"
-// worker.urls === ["http://localhost:1337", "http://192.168.0.12:1337"]
-```
-
-Pass `urls` wholesale wherever a list of origins is needed:
-
-```typescript
-const api = yield* Cloudflare.Worker("Api", {
-  main: "./src/api.ts",
-  env: { ALLOWED_ORIGINS: site.urls }, // CORS allow-list
-});
-```
-
-For zone setup, DNS records, and route patterns, see the
-[custom domains guide](/cloudflare/networking/custom-domains).
-
-## Static assets
-
-A Worker can serve a directory of static files alongside its code.
 Pass `assets` and Cloudflare serves matching requests from its asset
-layer; everything else invokes your handlers:
+layer. Everything else invokes your handlers:
 
 ```typescript
 export default Cloudflare.Worker(
   "Worker",
-  {
-    main: import.meta.url,
-    assets: "./public",
-  },
+  { main: import.meta.url, assets: "./public" },
   // ...
 );
 ```
 
-Set `assets.runWorkerFirst` to route requests through the Worker
-*before* asset matching — `true` for every request (the Worker then
-serves static files itself via the `ASSETS` binding), or a glob array
-to intercept only specific paths:
+A path that matches no asset already falls through to the Worker. Set
+`runWorkerFirst` when a path the Worker must own could be answered by
+the asset layer instead, such as an asset file shadowing a route or a
+single-page-application fallback that would serve the app shell to an
+API call:
 
 ```typescript
-export default Cloudflare.Worker(
-  "Worker",
-  {
-    main: import.meta.url,
-    assets: {
-      directory: "./public",
-      // only these paths reach the Worker ahead of assets
-      runWorkerFirst: ["/api/*", "/admin/*"],
-    },
-  },
-  // ...
-);
+assets: {
+  directory: "./public",
+  // only these paths reach the Worker ahead of assets
+  runWorkerFirst: ["/api/*", "/admin/*"],
+},
 ```
 
-You rarely need this for SSR pages or API routes alone — a path that
-matches no asset already falls through to the Worker. Reach for it
-when a path the Worker must own could be answered by the asset layer
-instead: an asset file shadowing a route, a
-`single-page-application` fallback that would serve the app shell to
-navigations, or a handler that intercepts asset requests outright
-(`true`, serving files itself via the `ASSETS` binding).
+`runWorkerFirst: true` routes every request through the Worker, which
+then serves files itself via the `ASSETS` binding. The same routing
+applies under `alchemy dev`.
 
-The same routing applies under `alchemy dev`, so a path that hits
-your handler locally hits it deployed too.
-
-Omit `main` entirely to deploy an **assets-only Worker** — a static
-site with no Worker code of your own:
+Omit `main` entirely for an assets-only Worker. No script is uploaded,
+and the asset layer applies `htmlHandling` and `notFoundHandling`
+itself. Static asset requests are free and never invoke a Worker:
 
 ```typescript
 const site = yield* Cloudflare.Worker("Site", {
@@ -342,47 +224,77 @@ const site = yield* Cloudflare.Worker("Site", {
 });
 ```
 
-Cloudflare's asset layer serves every request and applies
-`htmlHandling` / `notFoundHandling` (including
-single-page-application fallback) itself — the same deployment shape
-as an assets-only `wrangler deploy`. Static asset requests are free
-and never invoke a Worker.
+A `_headers` or `_redirects` file in the directory is applied
+automatically, and a `.assetsignore` file excludes files from the
+upload. If the directory comes from a build command, use
+[StaticSite](/cloudflare/frontend/static-site). For Vite projects, use
+the [Vite resource](/cloudflare/frontend/vite).
 
-The class form works too — declare it in its own file and yield the
-class in your Stack:
+## URLs and domains
+
+`worker.urls` is every URL that serves the Worker, most significant
+first, and `worker.url` is always `urls[0]`. Attach custom domains
+with `domain`:
 
 ```typescript
-export class Site extends Cloudflare.Worker<Site>()("Site", {
-  assets: {
-    directory: "./public",
-    htmlHandling: "drop-trailing-slash",
+const worker = yield* Cloudflare.Worker("Api", {
+  main: "./src/api.ts",
+  domain: {
+    name: "example.com",
+    aliases: ["www.example.com"],
+    redirects: ["old.example.com"], // 301 → https://example.com
   },
-  domain: "static.example.com",
-}) {}
+});
+// worker.url  === "https://example.com"
+// worker.urls === ["https://example.com", "https://www.example.com",
+//                  "https://<name>.<account>.workers.dev"]
 ```
 
-A `_headers` or `_redirects` file in the assets directory is applied
-automatically, and a `.assetsignore` file excludes files from the
-upload.
+Every hostname becomes a Cloudflare custom domain. DNS records and
+edge certificates are managed for you, and the zone must already exist
+in the account. A bare string is shorthand for `{ name }`. Redirect
+hostnames answer with a permanent redirect before the Worker runs, so
+they never appear in `urls`.
 
-If the directory comes from a build command, use
-[StaticSite](/cloudflare/frontend/static-site); for Vite projects,
-use the [Vite resource](/cloudflare/frontend/vite).
+Zone routes attach the Worker to a path pattern instead of a whole
+hostname:
+
+```typescript
+routes: [
+  { pattern: "example.com/api/*", zoneName: "example.com" },
+],
+```
+
+`workersDev` controls the `workers.dev` surface:
+
+```typescript
+workersDev: false, // no workers.dev URLs, url is the custom domain
+workersDev: { enabled: false, previewsEnabled: true }, // preview URLs only
+```
+
+Under `alchemy dev`, `urls` is the dev server's actual surface, the
+`localhost` address first and then the LAN addresses. Pass `urls`
+wholesale wherever a list of origins is needed:
+
+```typescript
+const api = yield* Cloudflare.Worker("Api", {
+  main: "./src/api.ts",
+  env: { ALLOWED_ORIGINS: site.urls }, // CORS allow-list
+});
+```
+
+For zone setup, DNS records, and route patterns, see
+[custom domains](/cloudflare/networking/custom-domains).
 
 ## The Worker's own URL
 
-A Worker often needs to know the URL it is served at — to build
-absolute links, register webhooks, or hand a frontend its API
-origin. That URL only exists at deploy time, and a Worker can't
-reference its own `url` Output, so `Worker.URL` injects it as a
-binding on the Worker itself. Yield it in the Construction phase; the
-accessor it returns is yielded again inside a handler:
+A Worker often needs the URL it is served at, to build absolute links
+or register a webhook. That URL only exists at deploy time, and a
+Worker can't reference its own `url` Output, so `Worker.URL` injects
+it as a binding on the Worker itself. Yield it in the Construction
+phase, then yield the accessor it returns inside a handler:
 
 ```typescript
-import * as Cloudflare from "alchemy/Cloudflare";
-import * as Effect from "effect/Effect";
-import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
-
 export default Cloudflare.Worker(
   "Api",
   { main: import.meta.url },
@@ -399,13 +311,13 @@ export default Cloudflare.Worker(
 );
 ```
 
-The value is resolved before the upload — the first custom
-`domain` if one is configured, otherwise the Worker's `workers.dev`
-URL — and always equals the resource's `url` attribute. Under
-`alchemy dev` it resolves to the local dev server's URL instead.
+The value is the first custom `domain` if one is configured, otherwise
+the `workers.dev` URL, and always equals the resource's `url`
+attribute. Under `alchemy dev` it is the local dev server's URL.
 
-Async Workers declare it on `env`, where `InferEnv` types the
-entry as `string`:
+Async Workers declare it on `env`, where `InferEnv` types the entry as
+`string`. A `VITE_`-prefixed entry is also inlined into a Vite site's
+client bundle, see [the site's own URL](/cloudflare/frontend/vite#the-sites-own-url):
 
 ```typescript
 export const Worker = Cloudflare.Worker("Worker", {
@@ -414,41 +326,27 @@ export const Worker = Cloudflare.Worker("Worker", {
 });
 ```
 
-Because the URL exists before the build, a `VITE_`-prefixed entry
-(`VITE_PUBLIC_URL: Cloudflare.Worker.URL`) is also inlined into a
-Vite site's client bundle — see
-[the site's own URL](/cloudflare/frontend/vite#the-sites-own-url).
+## Async Workers
 
-## Typed env for async Workers
-
-A Worker doesn't have to be an Effect program. When `main` points at
-a plain module — a classic async `fetch` handler, or a prebuilt
-bundle from another tool — declare bindings with the `env` prop and
-derive the runtime type with `InferEnv`:
+A Worker doesn't have to be an Effect program. Point `main` at a plain
+module, a classic `async fetch` handler or a prebuilt bundle from
+another tool, and declare bindings with the `env` prop. `InferEnv`
+derives the handler's env type from them:
 
 ```typescript
 // alchemy.run.ts
 import * as Cloudflare from "alchemy/Cloudflare";
 
-export const Bucket = Cloudflare.R2.Bucket("Bucket");
+export const Uploads = Cloudflare.R2.Bucket("Uploads");
 export const DB = Cloudflare.D1.Database("DB");
 
 export const Worker = Cloudflare.Worker("Worker", {
   main: "./src/worker.ts",
-  env: { Bucket, DB },
+  env: { Uploads, DB },
 });
 
 export type WorkerEnv = Cloudflare.InferEnv<typeof Worker>;
 ```
-
-`InferEnv` maps each `env` entry to its native `workers-types`
-client — an R2 bucket becomes `R2Bucket`, a D1 database becomes
-`D1Database`, a Durable Object (or a
-[Container](/cloudflare/compute/containers#bind-on-an-async-worker),
-which declares a container-backed DO class) becomes a typed
-`DurableObjectNamespace`, and `Config`/`Redacted` values become
-`string`. The handler stays plain JavaScript but the env can never
-drift from the infrastructure that produced it:
 
 ```typescript
 // src/worker.ts
@@ -456,36 +354,37 @@ import type { WorkerEnv } from "../alchemy.run.ts";
 
 export default {
   async fetch(request: Request, env: WorkerEnv) {
-    const object = await env.Bucket.get("hello.txt");
-    return new Response(object ? await object.text() : "Not found");
+    const obj = await env.Uploads.get("hello.txt");
+    return obj
+      ? new Response(await obj.text())
+      : new Response("Not found", { status: 404 });
   },
 };
 ```
 
-## Named entrypoints
+`InferEnv` maps each entry to its native `workers-types` client. An R2
+bucket becomes `R2Bucket`, a D1 database `D1Database`, a Durable
+Object or [Container](/cloudflare/compute/containers#bind-on-an-async-worker)
+a typed `DurableObjectNamespace`, and `Config` or `Redacted` values
+`string`. The handler stays plain JavaScript, but the env can never
+drift from the infrastructure that produced it.
+[Python Workers](/cloudflare/compute/python-workers) are async Workers
+whose `main` is a `.py` file.
 
-Binding another Worker directly (`env: { TARGET: worker }`) targets its
-*default* entrypoint. A Worker can export additional
-[`WorkerEntrypoint` classes](https://developers.cloudflare.com/workers/runtime-apis/bindings/service-bindings/rpc/) —
-workerd treats every named class export of an entry module as an
-entrypoint. Bind one by name with `Cloudflare.WorkerEntrypoint`:
+Binding another Worker on `env` targets its default entrypoint. A
+Worker can export additional
+[`WorkerEntrypoint` classes](https://developers.cloudflare.com/workers/runtime-apis/bindings/service-bindings/rpc/),
+and `Cloudflare.WorkerEntrypoint` binds one by name. `InferEnv` types
+it as a `Fetcher` stub whose RPC methods are called directly:
 
 ```typescript
-const caller = yield* Cloudflare.Worker("Caller", {
-  main: "./src/caller.ts",
-  env: {
-    API: Cloudflare.WorkerEntrypoint(target, "Api"),
-  },
-});
+env: {
+  API: Cloudflare.WorkerEntrypoint(target, "Api"), // env.API.greet("alice")
+},
 ```
 
-`InferEnv` types the entry as a `Fetcher` service stub; RPC methods on
-the target class are called on it directly (`env.API.greet("alice")`).
-
-## Entrypoint props
-
-The options form attaches properties the target entrypoint reads from
-`this.ctx.props` — workerd's per-binding configuration channel. `Output`
+The options form attaches properties the target reads from
+`this.ctx.props`, workerd's per-binding configuration channel. `Output`
 values resolve at deploy time:
 
 ```typescript
@@ -494,81 +393,138 @@ env: {
     entrypoint: "Vendor",
     props: { baseUrl: site.url },
   }),
-}
+},
 ```
 
 :::caution
 `alchemy dev` delivers `props` to the local workerd today. On deployed
 Workers the Cloudflare API's binding schema does not carry the field
-yet, so `props` are dropped at upload until the distilled `workers`
-service adds it — the binding itself (service + entrypoint) deploys
+yet, so `props` are dropped at upload. The binding itself deploys
 correctly either way.
 :::
 
-## Versions & gradual deployments
+## Configure the Worker
 
-Every deploy of a Worker uploads an immutable
-[version](https://developers.cloudflare.com/workers/configuration/versions-and-deployments/),
-and a deployment routes traffic across up to two versions. By default
-alchemy deploys each new version at 100%. The `version` prop unlocks the
-other shapes: preview versions of another Worker, canaries, and gradual
-rollouts of a Worker's own deploys. The
-[Gradual deployments](/cloudflare/compute/gradual-deployments) guide
-covers the full rollout workflow — ramping, rollback, smoke testing
-with version overrides, and pinning users to a version with version
-affinity.
-
-### Preview versions
-
-Set `version.parent` to upload this Worker's code as a version of
-another Worker's script instead of creating a script of its own. The
-parent is usually a Worker deployed in another stage, referenced with
-`Worker.ref`:
+Compatibility flags and the compatibility date go on `compatibility`.
+`nodejs_compat` is the one you reach for most:
 
 ```typescript
-const parent = yield* Cloudflare.Worker.ref("Api", { stage: "staging" });
+{
+  main: import.meta.url,
+  compatibility: { flags: ["nodejs_compat"], date: "2026-08-31" },
+}
+```
 
-const preview = yield* Cloudflare.Worker("Api", {
+Workers Observability is on by default, with logs and invocation logs
+enabled. Pass `observability` to tune sampling, persist logs, or turn
+on traces. Effect-native Workers should provide
+[`Cloudflare.Telemetry()`](/infrastructure-as-effects/telemetry)
+instead of setting `traces` by hand, since the Layer enables traces on
+the Worker and mirrors `Effect.withSpan` into the Cloudflare waterfall:
+
+```typescript
+observability: {
+  logs: { enabled: true, invocationLogs: true, persist: true },
+  traces: { enabled: true, headSamplingRate: 1 },
+},
+```
+
+A [Tail Worker](https://developers.cloudflare.com/workers/observability/logs/tail-workers/)
+receives another Worker's execution traces after each invocation. List
+it in `tailConsumers`, or in `streamingTailConsumers` to receive
+events live while the producer is still running:
+
+```typescript
+const tail = yield* Cloudflare.Worker("Tail", { main: "./src/tail.ts" });
+
+const api = yield* Cloudflare.Worker("Api", {
   main: "./src/api.ts",
-  version: { parent, message: `PR #${process.env.PR_NUMBER}` },
+  tailConsumers: [tail],
 });
 ```
 
-The version receives no traffic. `preview.url` is its *aliased* preview
-URL (`<alias>-<name>.<subdomain>.workers.dev`) — alchemy derives a stable
-alias from the stack, stage, and logical id (override it with
-`version.alias`), so the link stays the same across re-deploys and always
-serves the latest uploaded version, while the parent's live traffic is
-untouched — the PR-preview workflow. The per-version URL
-(`<version-prefix>-...`) is also returned in `urls`. The version
-carries its own bindings, so a preview stage binds its own KV namespaces,
-D1 databases, and secrets for a fully isolated environment — and because
-the aliased URL is known before upload, [`Worker.URL`](#the-workers-own-url)
-works on version workers and resolves to it. `parent` also accepts a
-literal script name as an escape hatch for scripts alchemy doesn't manage.
-
-### Canary traffic
-
-Give the version `traffic` to route a percentage of the parent's
-traffic to it, with the live version keeping the remainder:
+Put Cloudflare Access in front of the Worker with `access`.
+Unauthenticated requests are redirected to your team's login page, and
+handlers read the identity from `Cloudflare.Access.Context`:
 
 ```typescript
-yield* Cloudflare.Worker("Api", {
-  main: "./src/api.ts",
-  version: { parent, traffic: 10 },
+{
+  main: import.meta.url,
+  access: {
+    policies: [{ decision: "allow", include: [{ emailDomain: "example.com" }] }],
+  },
+}
+```
+
+Pass an existing `Cloudflare.Access.Application` instead to share one
+policy set across several Workers. See
+[Protect a Worker with Access](/cloudflare/security/access).
+
+`main` is bundled with rolldown at deploy time. Effect, Alchemy, and
+the cloud SDKs are marked pure so unused code prunes aggressively.
+Mark your own side-effect-free packages the same way with
+`build.pure`, or set `bundle: false` to upload a bundle another tool
+already produced, such as OpenNext, byte for byte:
+
+```typescript
+{
+  main: "./.open-next/worker.js",
+  bundle: false,
+  assets: "./.open-next/assets",
+}
+```
+
+Every prop, including `limits`, `placement`, `logpush`, `crons`, and
+`tags`, is documented on the
+[Worker reference](/providers/cloudflare/workers/worker).
+
+## Background work and scopes
+
+The Worker's constructor runs once per isolate. The first event builds
+your Layers, and every later event reuses them. Each event then runs
+with a fresh `Scope` that closes after the response via
+`ctx.waitUntil`, so a finalizer added in a handler runs after the
+response is sent without blocking it:
+
+```typescript
+fetch: Effect.gen(function* () {
+  yield* Effect.addFinalizer(() => flushMetrics().pipe(Effect.ignore));
+  return HttpServerResponse.text("ok");
+}),
+```
+
+For ad-hoc background work, `WorkerExecutionContext.waitUntil` forks
+an Effect with the caller's full context and keeps the invocation
+alive until it settles:
+
+```typescript
+Effect.gen(function* () {
+  const exec = yield* Cloudflare.WorkerExecutionContext;
+
+  return {
+    fetch: Effect.gen(function* () {
+      yield* exec.waitUntil(writeAuditLog(event));
+      return HttpServerResponse.text("accepted", { status: 202 });
+    }),
+  };
 });
 ```
 
-Destroying the canary restores 100% of traffic to the live version.
-Cloudflare deployments split between at most two versions, so one
-canary can be active per script at a time.
+Streaming responses and WebSocket upgrades transfer the request scope
+to the stream, so its finalizers run when the stream completes. workerd
+has no isolate-teardown hook, so a finalizer added in the constructor
+never runs. Acquire anything that needs cleanup, connections and
+pools, inside handlers. `Drizzle.Postgres` follows this pattern, one
+pool per event, and the
+[SQL connection lifecycle](/sql/effect-sql/lifecycle) spells out the
+contract. [Instance scope vs request scope](/infrastructure-as-effects/runtime#instance-scope-vs-request-scope)
+covers the model across all runtimes.
 
-### Gradual rollouts
+## Versions
 
-On a Worker that deploys as its own script (no `version.parent`),
-`version.traffic` below 100 turns a deploy into a gradual rollout —
-the new version takes that share and the previously-live version
-keeps the rest:
+Every deploy uploads an immutable version, and by default it takes
+100% of traffic. The `version` prop unlocks the other shapes. Split
+traffic to roll a deploy out gradually:
 
 ```typescript
 yield* Cloudflare.Worker("Api", {
@@ -577,44 +533,18 @@ yield* Cloudflare.Worker("Api", {
 });
 ```
 
-Raise the number and re-deploy to ramp; remove the prop (or set 100) to
-promote fully. `traffic: 0` uploads the version without deploying it.
-The very first deploy of a script always goes to 100% since there is no
-previous version to split with.
+Set `version.parent` to upload the code as a preview version or
+canary of another stage's Worker instead. Ramping, rollback, smoke
+testing with version overrides, and pinning users to a version are
+covered in [Gradual deployments](/cloudflare/compute/gradual-deployments).
 
-### What a version carries
-
-A version snapshots code, bindings, compatibility settings, and cache
-configuration. Script-level settings — routes, custom domains, crons,
-tags, observability, logpush, placement, limits, and the workers.dev
-subdomain — apply immediately to all versions, so they belong to the
-parent and are rejected on a version worker. During a gradual rollout
-of a Worker's own deploy, script-level settings keep their live values
-until the next full deploy.
-
-Two Cloudflare platform limits to know: preview URLs require the
-script's workers.dev subdomain (enabled by default, and Workers that
-implement Durable Objects don't get preview URLs), and a version worker
-cannot host Durable Object or Workflow classes — their migrations would
-apply to the parent's script. Host the classes on the parent and
-reference them cross-script instead.
-
-## Version metadata
-
-The `version_metadata` binding exposes the deployed Worker version —
-`id`, `tag`, and `timestamp` — at runtime, so responses, logs, and
-error reports can say exactly which deploy produced them. Yield
-`VersionMetadata()` in the Construction phase and provide its layer; the
-accessor it returns is yielded again inside a handler, where the
-binding actually exists:
+The `version_metadata` binding tells a running Worker which version
+it is, so responses and logs can say exactly which deploy produced
+them:
 
 ```typescript
-import * as Cloudflare from "alchemy/Cloudflare";
-import * as Effect from "effect/Effect";
-import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
-
 export default Cloudflare.Worker(
-  "VersionWorker",
+  "Api",
   { main: import.meta.url },
   Effect.gen(function* () {
     const versionMetadata = yield* Cloudflare.Workers.VersionMetadata();
@@ -629,41 +559,30 @@ export default Cloudflare.Worker(
 );
 ```
 
-Async Workers declare it on `env` instead —
-`env: { CF_VERSION_METADATA: Cloudflare.Workers.VersionMetadata() }` —
-and `InferEnv` types the entry as the native
-`{ id, tag, timestamp }` object.
+Async Workers declare it on `env` as
+`CF_VERSION_METADATA: Cloudflare.Workers.VersionMetadata()`, and
+`InferEnv` types the entry as the native `{ id, tag, timestamp }`
+object.
 
 ## Where next
 
 Guides that build on Workers:
 
-- [Gradual deployments](/cloudflare/compute/gradual-deployments) —
-  canary and ramp deploys across versions instead of cutting over.
-- [Custom domains](/cloudflare/networking/custom-domains) — serve
-  Workers from your own hostnames and routes.
-- [Effect HTTP API](/cloudflare/apis/effect-http-api) — a
-  schema-validated HTTP API with `HttpApi`.
-- [Effect RPC](/cloudflare/apis/effect-rpc) — schema-typed
-  procedures served from a Worker.
-- [Add a React SPA](/cloudflare/frontend/vite-spa) — ship a frontend
-  from the same Stack.
-- [Frontend frameworks](/cloudflare/frontend/frontends) — TanStack
-  Start, React Router, SolidStart, Vue, and static sites.
+- [Gradual deployments](/cloudflare/compute/gradual-deployments) — previews, canaries, and ramped rollouts across versions.
+- [Python Workers](/cloudflare/compute/python-workers) — point `main` at a `.py` file.
+- [Workers Cache](/cloudflare/compute/cache) — serve responses from the edge before the Worker runs.
+- [Rate limiting](/cloudflare/compute/rate-limiting) — throttle requests with a binding.
+- [Browser rendering](/cloudflare/compute/browser-rendering) — a headless browser as a binding.
+- [Worker Loader](/cloudflare/compute/worker-loader) — run untrusted Workers at runtime.
+- [Workers for Platforms](/cloudflare/compute/workers-for-platforms) — run customers' Workers in your account.
+- [Custom domains](/cloudflare/networking/custom-domains) — serve Workers from your own hostnames and routes.
+- [Effect HTTP API](/cloudflare/apis/effect-http-api) and [Effect RPC](/cloudflare/apis/effect-rpc) — schema-validated surfaces.
+- [Frontend frameworks](/cloudflare/frontend/frontends) — ship a frontend from the same Stack.
 
 Related:
 
-- [Durable Objects](/cloudflare/compute/durable-objects) — stateful instances
-  behind your Worker.
-- [KV](/cloudflare/data/kv) — low-latency key-value reads at the edge.
-- [Queues](/cloudflare/messaging/queues) — background work with at-least-once
-  delivery.
-- [Workflows](/cloudflare/compute/workflows) — durable multi-step jobs that
-  outlive a request.
-- [Secrets & env](/cloudflare/security/secrets-env) — bind `.env` values and
-  secrets into the Worker.
-- [Domains](/cloudflare/networking/domains) — zones, DNS records, and
-  certificates.
+- [Durable Objects](/cloudflare/compute/durable-objects), [Workflows](/cloudflare/compute/workflows), and [Containers](/cloudflare/compute/containers) — the other compute Runtimes, all reached through a Worker.
+- [Secrets & env](/cloudflare/security/secrets-env) — bind `.env` values and secrets into the Worker.
 
 Reference:
 

--- a/website/src/content/docs/cloudflare/index.mdx
+++ b/website/src/content/docs/cloudflare/index.mdx
@@ -71,7 +71,7 @@ New here? [Set up your account](/cloudflare/setup), then start the
 | App shape | Stack |
 | --- | --- |
 | HTTP API | [Worker](/cloudflare/compute/workers) + [D1](/cloudflare/data/d1) — see [Effect HTTP API](/cloudflare/apis/effect-http-api) |
-| Call one Worker from another (internal RPC) | [Worker](/cloudflare/compute/workers) — see [Schemaless RPC](/cloudflare/compute/workers#schemaless-rpc) and the [concept](/apis/schemaless) |
+| Call one Worker from another (internal RPC) | [Worker](/cloudflare/compute/workers) — see [Schemaless RPC](/cloudflare/compute/workers#call-another-worker) and the [concept](/apis/schemaless) |
 | Typed API for external clients | [Effect RPC](/cloudflare/apis/effect-rpc) for Effect clients, [Effect HTTP API](/cloudflare/apis/effect-http-api) for plain HTTP |
 | Real-time / WebSockets | [Durable Objects](/cloudflare/compute/durable-objects) — see [Accept WebSockets](/cloudflare/compute/hibernatable-websockets) |
 | Full-stack app | [Worker](/cloudflare/compute/workers) + a React SPA — see [Add a React SPA](/cloudflare/frontend/vite-spa) or [Frontend frameworks](/cloudflare/frontend/frontends) |

--- a/website/src/content/docs/cloudflare/tutorial/part-1.mdx
+++ b/website/src/content/docs/cloudflare/tutorial/part-1.mdx
@@ -13,8 +13,12 @@ import { effectVersion } from "../../../../versions";
 export const pkgs = `"alchemy@latest" "effect@${effectVersion}" "@effect/platform-bun@${effectVersion}" "@effect/platform-node@${effectVersion}"`;
 
 In this first part you'll install Alchemy and Effect, create a Stack
-with a Cloudflare R2 Bucket, and deploy it — all in under five
-minutes.
+with a Cloudflare R2 Bucket, and deploy it, all in under five minutes.
+
+:::tip
+Already deployed the Bucket from [Getting started](/getting-started)?
+That was this part. Skip to [Part 2](/cloudflare/tutorial/part-2).
+:::
 
 ## Prerequisites
 

--- a/website/src/content/docs/cloudflare/tutorial/part-6.mdx
+++ b/website/src/content/docs/cloudflare/tutorial/part-6.mdx
@@ -263,6 +263,9 @@ You've completed the tutorial. You now know how to:
 
 ## What's next
 
+- [Infrastructure as Effects](/infrastructure-as-effects) — the model
+  behind everything you just built: Runtimes, Bindings, Layers, and
+  the two phases
 - [Telemetry](/infrastructure-as-effects/telemetry) — how the
   built-in telemetry works across every runtime (Workers, Durable
   Objects, Workflows, Lambda, containers)

--- a/website/src/content/docs/getting-started.mdx
+++ b/website/src/content/docs/getting-started.mdx
@@ -138,9 +138,9 @@ See [Profiles](/environments/profiles) for the full picture.
 ## Where next
 
 You have a live Stack. [What is Alchemy?](/what-is-alchemy) explains
-what just happened and the model the rest of the docs build on. Then
-[Part 2](/cloudflare/tutorial/part-2) of the tutorial picks up from
-this exact Stack and adds a Worker.
+what just happened and the model the rest of the docs build on. The
+[tutorial](/cloudflare/tutorial/part-1) then builds a full app on
+Cloudflare, starting from this exact Stack.
 
 <div class="next-steps">
 
@@ -149,9 +149,9 @@ this exact Stack and adds a Worker.
   <span>Infrastructure as Code built in Effect, with Infrastructure as Effects on top.</span>
 </a>
 
-<a href="/cloudflare/tutorial/part-2" class="next-card">
-  <strong>Tutorial Part 2: Add a Worker</strong>
-  <span>Bind the Bucket to a Worker and serve it over HTTP.</span>
+<a href="/cloudflare/tutorial/part-1" class="next-card">
+  <strong>Tutorial</strong>
+  <span>Build a full app on Cloudflare, starting from this Stack.</span>
 </a>
 
 <a href="/infrastructure-as-effects" class="next-card">

--- a/website/src/content/docs/getting-started.mdx
+++ b/website/src/content/docs/getting-started.mdx
@@ -1,12 +1,9 @@
 ---
 title: Getting started
 description: Install Alchemy and create your first Stack in under two minutes.
-prev:
+next:
   link: /what-is-alchemy
   label: What is Alchemy?
-next:
-  link: /cloudflare/tutorial/part-2
-  label: "Tutorial Part 2: Add a Worker"
 ---
 
 import Terminal from "../../components/Terminal.astro";
@@ -14,6 +11,12 @@ import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
 import { effectVersion } from "../../versions";
 
 export const pkgs = `"alchemy@latest" "effect@${effectVersion}" "@effect/platform-bun@${effectVersion}" "@effect/platform-node@${effectVersion}"`;
+
+:::tip
+Want the idea before the install? [What is Alchemy?](/what-is-alchemy)
+explains the model in a few minutes. Otherwise, read on and it's the
+next page.
+:::
 
 ## Prerequisites
 
@@ -134,20 +137,26 @@ See [Profiles](/environments/profiles) for the full picture.
 
 ## Where next
 
-You just completed [Part 1](/cloudflare/tutorial/part-1) of the
-tutorial. The next part adds a Worker that reads and writes the
-bucket, and introduces the ideas the rest of the docs build on.
+You have a live Stack. [What is Alchemy?](/what-is-alchemy) explains
+what just happened and the model the rest of the docs build on. Then
+[Part 2](/cloudflare/tutorial/part-2) of the tutorial picks up from
+this exact Stack and adds a Worker.
 
 <div class="next-steps">
 
+<a href="/what-is-alchemy" class="next-card">
+  <strong>What is Alchemy? — recommended</strong>
+  <span>Infrastructure as Code built in Effect, with Infrastructure as Effects on top.</span>
+</a>
+
 <a href="/cloudflare/tutorial/part-2" class="next-card">
-  <strong>Tutorial Part 2: Add a Worker — recommended</strong>
+  <strong>Tutorial Part 2: Add a Worker</strong>
   <span>Bind the Bucket to a Worker and serve it over HTTP.</span>
 </a>
 
 <a href="/infrastructure-as-effects" class="next-card">
   <strong>Infrastructure as Effects</strong>
-  <span>The model behind it: Runtimes, Bindings, and Layers.</span>
+  <span>The full model: Runtimes, Bindings, and Layers.</span>
 </a>
 
 <a href="/cloudflare" class="next-card">

--- a/website/src/content/docs/getting-started.mdx
+++ b/website/src/content/docs/getting-started.mdx
@@ -151,7 +151,7 @@ Cloudflare, starting from this exact Stack.
 
 <a href="/cloudflare/tutorial/part-1" class="next-card">
   <strong>Tutorial</strong>
-  <span>Build a full app on Cloudflare, starting from this Stack.</span>
+  <span>Build a full app on Cloudflare starting from this Stack: a Worker, bindings, tests, local dev, CI, and telemetry.</span>
 </a>
 
 <a href="/infrastructure-as-effects" class="next-card">
@@ -161,17 +161,17 @@ Cloudflare, starting from this exact Stack.
 
 <a href="/cloudflare" class="next-card">
   <strong>Cloudflare</strong>
-  <span>Workers, R2, KV, D1, Durable Objects, and more.</span>
+  <span>Workers, Durable Objects, R2, KV, D1, Queues, Workflows, and Containers, with a tutorial and a guide for each.</span>
 </a>
 
 <a href="/aws" class="next-card">
   <strong>AWS</strong>
-  <span>Lambda, S3, SQS, DynamoDB, and more.</span>
+  <span>Lambda, S3, SQS, DynamoDB, EC2, ECS, and EKS, with a tutorial and a guide for each.</span>
 </a>
 
 <a href="/cli" class="next-card">
   <strong>CLI</strong>
-  <span>Every command — deploy, destroy, dev, tail, state.</span>
+  <span>Every command and its flags: deploy, plan, destroy, dev, tail, logs, and state.</span>
 </a>
 
 </div>

--- a/website/src/content/docs/getting-started.mdx
+++ b/website/src/content/docs/getting-started.mdx
@@ -156,7 +156,7 @@ Cloudflare, starting from this exact Stack.
 
 <a href="/infrastructure-as-effects" class="next-card">
   <strong>Infrastructure as Effects</strong>
-  <span>The full model: Runtimes, Bindings, and Layers.</span>
+  <span>The model the rest of the docs build on: Runtimes, Bindings, Layers, and the Construction and Runtime phases.</span>
 </a>
 
 <a href="/cloudflare" class="next-card">

--- a/website/src/content/docs/getting-started.mdx
+++ b/website/src/content/docs/getting-started.mdx
@@ -144,8 +144,8 @@ Cloudflare, starting from this exact Stack.
 
 <div class="next-steps">
 
-<a href="/what-is-alchemy" class="next-card">
-  <strong>What is Alchemy? — recommended</strong>
+<a href="/what-is-alchemy" class="next-card next-card--recommended">
+  <strong>What is Alchemy?</strong>
   <span>Infrastructure as Code built in Effect, with Infrastructure as Effects on top.</span>
 </a>
 

--- a/website/src/content/docs/getting-started.mdx
+++ b/website/src/content/docs/getting-started.mdx
@@ -1,6 +1,12 @@
 ---
 title: Getting started
 description: Install Alchemy and create your first Stack in under two minutes.
+prev:
+  link: /what-is-alchemy
+  label: What is Alchemy?
+next:
+  link: /cloudflare/tutorial/part-2
+  label: "Tutorial Part 2: Add a Worker"
 ---
 
 import Terminal from "../../components/Terminal.astro";
@@ -128,26 +134,30 @@ See [Profiles](/environments/profiles) for the full picture.
 
 ## Where next
 
+You just completed [Part 1](/cloudflare/tutorial/part-1) of the
+tutorial. The next part adds a Worker that reads and writes the
+bucket, and introduces the ideas the rest of the docs build on.
+
 <div class="next-steps">
 
-<a href="/cloudflare/tutorial/part-1" class="next-card">
-  <strong>Tutorial — recommended</strong>
-  <span>Adds a Worker to this Stack and covers the core concepts.</span>
+<a href="/cloudflare/tutorial/part-2" class="next-card">
+  <strong>Tutorial Part 2: Add a Worker — recommended</strong>
+  <span>Bind the Bucket to a Worker and serve it over HTTP.</span>
+</a>
+
+<a href="/infrastructure-as-effects" class="next-card">
+  <strong>Infrastructure as Effects</strong>
+  <span>The model behind it: Runtimes, Bindings, and Layers.</span>
 </a>
 
 <a href="/cloudflare" class="next-card">
   <strong>Cloudflare</strong>
-  <span>Pick your provider — Workers, R2, KV, D1, and more.</span>
+  <span>Workers, R2, KV, D1, Durable Objects, and more.</span>
 </a>
 
 <a href="/aws" class="next-card">
   <strong>AWS</strong>
-  <span>Pick your provider — Lambda, S3, SQS, DynamoDB, and more.</span>
-</a>
-
-<a href="/migrating-from-v1" class="next-card">
-  <strong>Migrating from v1</strong>
-  <span>Upgrading from async/await Alchemy? Start here.</span>
+  <span>Lambda, S3, SQS, DynamoDB, and more.</span>
 </a>
 
 <a href="/cli" class="next-card">

--- a/website/src/content/docs/infrastructure-as-effects/binding.mdx
+++ b/website/src/content/docs/infrastructure-as-effects/binding.mdx
@@ -4,7 +4,7 @@ description: A Binding connects a Resource to a Worker or Lambda. One line decla
 ---
 
 A **Binding** connects a [Resource](/infrastructure-as-code/resource)
-to a Worker, Lambda Function, or Container. You yield the resource and
+to a Worker, Lambda Function, Container, or Server. You yield the resource and
 get back a typed client:
 
 ```typescript

--- a/website/src/content/docs/infrastructure-as-effects/runtime.mdx
+++ b/website/src/content/docs/infrastructure-as-effects/runtime.mdx
@@ -1,11 +1,11 @@
 ---
 title: Runtime
-description: A Runtime is a Resource that carries the code it runs — a Worker, Lambda Function, or Container declared with the Effectful Constructor pattern. Bind what you need, return what you expose.
+description: A Runtime is a Resource that carries the code it runs — a Worker, Lambda Function, Container, or Server declared with the Effectful Constructor pattern. Bind what you need, return what you expose.
 ---
 
 In Alchemy, a **Runtime** is a [Resource](/infrastructure-as-code/resource)
 that carries the code it runs: a Cloudflare Worker, Lambda Function,
-ECS Task, or Container. The props are the cloud configuration. The
+ECS Task, Container, or Server. The props are the cloud configuration. The
 Effect is the code:
 
 ```typescript

--- a/website/src/content/docs/infrastructure-as-effects/runtime.mdx
+++ b/website/src/content/docs/infrastructure-as-effects/runtime.mdx
@@ -218,8 +218,12 @@ Providing the Layer is what brings the infrastructure in. On the next
 deploy the `Jobs` namespace is created and bound to this Worker, and
 the handler only ever sees `JobService`. Swap `JobServiceKV` for a Layer
 backed by DynamoDB and the handler doesn't change. This is the
-fundamental building block of Infrastructure as Effects, and
-[Layers](/infrastructure-as-effects/layers) builds one from scratch.
+fundamental building block of Infrastructure as Effects.
+
+:::note
+[Layers](/infrastructure-as-effects/layers) builds one from scratch and
+shows the swap across clouds.
+:::
 
 ## Three ways to declare one
 

--- a/website/src/content/docs/sql/effect-sql/lifecycle.mdx
+++ b/website/src/content/docs/sql/effect-sql/lifecycle.mdx
@@ -97,7 +97,7 @@ finalizers run, and the Lambda SIGTERM window.
 - [Postgres](/sql/effect-sql/postgres) /
   [MySQL](/sql/effect-sql/mysql) / [D1](/sql/effect-sql/d1) — the
   clients this contract governs.
-- [Workers: isolate scope vs request scope](/cloudflare/compute/workers#isolate-scope-vs-request-scope)
+- [Workers: isolate scope vs request scope](/cloudflare/compute/workers#background-work-and-scopes)
   — the same rules from the Worker's point of view.
 - [Runtime](/infrastructure-as-effects/runtime)
   — the cross-cloud runtime model.

--- a/website/src/content/docs/what-is-alchemy.mdx
+++ b/website/src/content/docs/what-is-alchemy.mdx
@@ -6,6 +6,8 @@ next:
   label: Getting started
 ---
 
+import DeployTerminal from "../../components/marketing-islands/DeployTerminal.tsx";
+
 Alchemy is an **Infrastructure as Code** engine built in pure
 [Effect](https://effect.website), with **Infrastructure as Effects**
 on top. The engine declares, diffs, and deploys cloud resources the
@@ -82,8 +84,13 @@ alchemy deploy --stage prod
 ```
 
 Alchemy reads the current state, diffs it against your program, shows
-the plan, and applies it in dependency order. `state` is where the
-result persists between runs. [Stacks](/infrastructure-as-code/stack)
+the plan, and applies it in dependency order. Here is that loop for a
+Stack with a bucket, a KV namespace, and a Worker bound to both:
+
+<DeployTerminal client:visible />
+
+`state` is where the result persists between runs, so the next deploy
+only touches what changed. [Stacks](/infrastructure-as-code/stack)
 covers stages, outputs, and state.
 
 A **Resource** is any cloud entity Alchemy manages: a bucket, a

--- a/website/src/content/docs/what-is-alchemy.mdx
+++ b/website/src/content/docs/what-is-alchemy.mdx
@@ -5,8 +5,8 @@ prev:
   link: /getting-started
   label: Getting started
 next:
-  link: /cloudflare/tutorial/part-2
-  label: "Tutorial Part 2: Add a Worker"
+  link: /cloudflare/tutorial/part-1
+  label: Tutorial
 ---
 
 import DeployTerminal from "../../components/marketing-islands/DeployTerminal.tsx";
@@ -276,9 +276,9 @@ overview puts the three ideas together.
 
 <div class="next-steps">
 
-<a href="/cloudflare/tutorial/part-2" class="next-card">
-  <strong>Tutorial Part 2: Add a Worker — recommended</strong>
-  <span>Pick up the Stack from Getting started and bind the Bucket to a Worker.</span>
+<a href="/cloudflare/tutorial/part-1" class="next-card">
+  <strong>Tutorial — recommended</strong>
+  <span>Build a full app on Cloudflare: a Worker, bindings, tests, local dev, CI, and telemetry.</span>
 </a>
 
 <a href="/infrastructure-as-effects" class="next-card">

--- a/website/src/content/docs/what-is-alchemy.mdx
+++ b/website/src/content/docs/what-is-alchemy.mdx
@@ -10,6 +10,7 @@ next:
 ---
 
 import DeployTerminal from "../../components/marketing-islands/DeployTerminal.tsx";
+import ProviderIcons from "../../components/ProviderIcons.astro";
 
 Alchemy is **Infrastructure as Code** built in pure
 [Effect](https://effect.website), with **Infrastructure as Effects**
@@ -293,7 +294,7 @@ overview puts the three ideas together.
 
 <a href="/providers" class="next-card">
   <strong>More providers</strong>
-  <span>Hetzner, Fly, Railway, Kubernetes, Neon, PlanetScale, GitHub, Axiom, and every other provider Alchemy manages.</span>
+  <ProviderIcons />
 </a>
 
 </div>

--- a/website/src/content/docs/what-is-alchemy.mdx
+++ b/website/src/content/docs/what-is-alchemy.mdx
@@ -278,22 +278,22 @@ overview puts the three ideas together.
 
 <a href="/cloudflare/tutorial/part-1" class="next-card next-card--recommended">
   <strong>Tutorial</strong>
-  <span>Build a full app on Cloudflare: a Worker, bindings, tests, local dev, CI, and telemetry.</span>
+  <span>Build a full app on Cloudflare starting from the Stack you just deployed: a Worker, bindings, tests, local dev, CI, and telemetry.</span>
 </a>
 
 <a href="/infrastructure-as-effects" class="next-card">
   <strong>Infrastructure as Effects</strong>
-  <span>The full model: Runtimes, Bindings, Layers, and the two phases.</span>
+  <span>The model the rest of the docs build on: Runtimes, Bindings, Layers, and the Construction and Runtime phases.</span>
 </a>
 
 <a href="/cloudflare" class="next-card">
   <strong>Cloudflare</strong>
-  <span>Workers, R2, KV, D1, Durable Objects, and more.</span>
+  <span>Workers, Durable Objects, R2, KV, D1, Queues, Workflows, and Containers, with a tutorial and a guide for each.</span>
 </a>
 
 <a href="/aws" class="next-card">
   <strong>AWS</strong>
-  <span>Lambda, S3, SQS, DynamoDB, and more.</span>
+  <span>Lambda, S3, SQS, DynamoDB, EC2, ECS, and EKS, with a tutorial and a guide for each.</span>
 </a>
 
 </div>

--- a/website/src/content/docs/what-is-alchemy.mdx
+++ b/website/src/content/docs/what-is-alchemy.mdx
@@ -126,7 +126,8 @@ to write your own.
 
 ## A superset of Infrastructure as Code
 
-With only the engine, Alchemy looks like any IaC tool. One file
+With only the engine, Alchemy looks like and functions like any other
+IaC tool. One file
 declares the bucket and the Worker, passing the bucket on the Worker's
 `env`. Another file is the handler, reaching for the bucket through
 that env:

--- a/website/src/content/docs/what-is-alchemy.mdx
+++ b/website/src/content/docs/what-is-alchemy.mdx
@@ -44,13 +44,10 @@ export default Cloudflare.Worker(
 );
 ```
 
-```sh
-bun alchemy deploy
-```
-
-Alchemy creates the Bucket, bundles the Worker, wires the binding
-between them, and prints the URL. Let's start with the engine
-underneath, then look at what the layer on top adds.
+That one file is a complete application. The Bucket is declared next
+to the Worker that uses it, and `bucket` is a typed client the handler
+closes over. Let's start with the engine underneath, then look at what
+the layer on top adds.
 
 ## Infrastructure as Code
 
@@ -75,7 +72,14 @@ export default Alchemy.Stack(
 );
 ```
 
-Every deploy targets a stage, an isolated environment with its own
+Deploy it:
+
+```sh
+bun alchemy deploy
+```
+
+Alchemy creates the Bucket, bundles the Worker, wires the binding
+between them, and prints the URL. Every deploy targets a stage, an isolated environment with its own
 copy of every resource, so `dev` and `prod` never touch each other:
 
 ```sh

--- a/website/src/content/docs/what-is-alchemy.mdx
+++ b/website/src/content/docs/what-is-alchemy.mdx
@@ -1,56 +1,32 @@
 ---
 title: What is Alchemy?
-description: Alchemy is an Infrastructure-as-Effects framework that combines cloud infrastructure and application logic into a single type-safe program powered by Effect.
+description: Alchemy is an Infrastructure-as-Effects framework. Declare your cloud resources and write the code that runs on them in one type-safe TypeScript program, then deploy it with one command.
+next:
+  link: /getting-started
+  label: Getting started
 ---
 
-Alchemy is an **[Infrastructure-as-Effects](/infrastructure-as-effects)** framework. It extends
-Infrastructure-as-Code by combining your cloud resources and the
-application logic that uses them into a single, type-safe program
-powered by [Effect](https://effect.website).
+Alchemy is an **Infrastructure-as-Effects** framework. You declare
+your cloud resources and write the code that runs on them in one
+TypeScript program, built on [Effect](https://effect.website), and
+deploy it with one command.
 
-## Infrastructure-as-Code vs Infrastructure-as-Effects
-
-Traditional IaC tools like Terraform, Pulumi, and CDK separate
-infrastructure definitions from application code. You write your
-infrastructure in one place and your business logic in another, then
-wire them together with environment variables, ARNs, and config
-files.
-
-Alchemy takes a different approach: infrastructure and logic are
-**Effects** in the same program.
+Here is a complete application. An R2 bucket, and a Worker that
+serves files from it:
 
 ```typescript
-// alchemy.run.ts — infrastructure and logic in one program
-import * as Alchemy from "alchemy";
-import * as Cloudflare from "alchemy/Cloudflare";
-import * as Effect from "effect/Effect";
-import Worker from "./src/worker.ts";
-
-const Bucket = Cloudflare.R2.Bucket("Bucket");
-
-export default Alchemy.Stack(
-  "MyApp",
-  { providers: Cloudflare.providers(), state: Cloudflare.state() },
-  Effect.gen(function* () {
-    const bucket = yield* Bucket;
-    const worker = yield* Worker;
-    return { url: worker.url };
-  }),
-);
-```
-
-```typescript
-// src/worker.ts — the Worker binds the Bucket directly
+// src/worker.ts
 import * as Cloudflare from "alchemy/Cloudflare";
 import * as Effect from "effect/Effect";
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
-import { Bucket } from "./bucket.ts";
+
+export const Uploads = Cloudflare.R2.Bucket("Uploads");
 
 export default Cloudflare.Worker(
-  "Worker",
+  "Api",
   { main: import.meta.url },
   Effect.gen(function* () {
-    const bucket = yield* Cloudflare.R2.ReadWriteBucket(Bucket);
+    const bucket = yield* Cloudflare.R2.ReadWriteBucket(Uploads);
 
     return {
       fetch: Effect.gen(function* () {
@@ -60,206 +36,128 @@ export default Cloudflare.Worker(
           : HttpServerResponse.text("Not found", { status: 404 });
       }),
     };
-  }),
+  }).pipe(Effect.provide(Cloudflare.R2.ReadWriteBucketBinding)),
 );
 ```
-
-There's no separate "infra" project — it's one program.
-
-## Type safety
-
-Alchemy uses TypeScript and Effect's type system to catch mistakes at
-compile time. If you forget to provide the right providers for your
-resources, the compiler tells you:
-
-```typescript
-import * as Alchemy from "alchemy";
-import * as Cloudflare from "alchemy/Cloudflare";
-import * as Effect from "effect/Effect";
-import * as Layer from "effect/Layer";
-
-export default Alchemy.Stack(
-  "MyApp",
-  {
-    providers: Layer.empty,
-    // @error: ts(2322) Type 'Layer<never, never, never>' is not assignable to type 'Layer<NoInfer<Providers>, never, StackServices>'.
-    // @error:   Type 'Providers' is not assignable to type 'never'.
-  },
-  Effect.gen(function* () {
-    const bucket = yield* Cloudflare.R2.Bucket("Bucket");
-  }),
-);
-```
-
-This error goes away when you provide `Cloudflare.providers()`. The
-type system ensures every resource has its provider wired up before
-you can deploy.
-
-## Resources
-
-A **Resource** is any cloud entity managed by Alchemy — buckets,
-databases, queues, workers, IAM roles, DNS records, and more. Each
-resource is declared as an Effect and `yield*`-ed inside a Stack:
-
-```typescript
-const bucket = yield* Cloudflare.R2.Bucket("Bucket");
-const db = yield* Cloudflare.D1.Database("DB");
-const queue = yield* AWS.SQS.Queue("Jobs");
-```
-
-Resources are just descriptions until they're yielded. You can
-declare them in separate files and import them from anywhere:
-
-```typescript
-// src/bucket.ts
-export const Bucket = Cloudflare.R2.Bucket("Bucket");
-```
-
-```typescript
-// src/worker.ts
-import { Bucket } from "./bucket.ts";
-const bucket = yield* Cloudflare.R2.ReadWriteBucket(Bucket);
-```
-
-## Bindings
-
-A **Binding** connects a resource to a Worker or Lambda. A single
-binding call hands your handler a typed client and — at deploy time
-— wires up the permissions, environment variables, and platform
-bindings that client needs:
-
-```typescript
-const bucket = yield* Cloudflare.R2.ReadWriteBucket(Bucket);
-
-// later, inside fetch:
-yield* bucket.put("hello.txt", "world");
-```
-
-`bucket` is the resource presented as a typed SDK. There's no
-`env.BUCKET`, no `BUCKET_NAME` lookup, and no hand-written IAM policy
-— the binding **is** the client.
-
-On AWS, the binding emits least-privilege IAM scoped to the exact
-resource ARN. On Cloudflare, it attaches the native Worker binding
-(R2, KV, D1, Durable Object). The runtime API is identical, so code
-written against one consumes the other.
-
-Bindings also enable **circular references** between resources —
-Worker A can hold a typed client to Worker B and vice versa — which
-plain props, a directed acyclic graph, can't express.
-
-See [Bindings](/infrastructure-as-effects/binding) for event sources, sinks, and the
-deploy-time mechanics.
-
-## Stacks and stages
-
-A **Stack** is a collection of resources deployed together. Every
-deploy targets a **stage** — an isolated environment like `dev`,
-`prod`, or `pr-42`:
 
 ```sh
-alchemy deploy              # deploys to dev_$USER by default
-alchemy deploy --stage prod # deploys to prod
+bun alchemy deploy
 ```
 
-Each stage has its own resources with distinct physical names, so
-environments never interfere with each other.
+Alchemy creates the bucket, bundles the Worker, wires the binding
+between them, and prints the URL. There is no separate infrastructure
+project. The Worker is a resource that carries its own code, and the
+bucket is a typed value inside it.
 
-## Providers
+Traditional infrastructure as code keeps these apart. One project
+declares the bucket, the Worker, and the permission between them.
+Another holds the handler, which reaches for the bucket through an
+environment variable, and the two agree only by convention. Alchemy
+supports that shape too, but its model is the one above. Three ideas
+make it work.
 
-A **Provider** teaches Alchemy how to manage a resource type. Behind
-every resource is a provider implementing four lifecycle operations:
+## Runtime
 
-- **`read`** — look up the resource's live state in the cloud.
-- **`diff`** — decide whether a change is a no-op, an update, or a replacement.
-- **`reconcile`** — make the cloud match the desired state.
-- **`delete`** — remove the resource; idempotent.
-
-The engine drives these in a **plan → apply** loop: `read` and
-`diff` build the plan, then `reconcile` and `delete` apply it in
-dependency order. See [Providers](/infrastructure-as-code/provider) and
-[Resource lifecycle](/infrastructure-as-code/resource-lifecycle).
-
-Providers are Effect Layers, wired into a Stack with
-`Cloudflare.providers()` or `AWS.providers()`:
+A Worker, Lambda Function, or Container is a **Runtime**: a resource
+that carries the code it runs. Its Effect always has the same shape.
+Bind what you need, then return what you expose:
 
 ```typescript
-Alchemy.Stack(
-  "App",
-  { providers: Cloudflare.providers(), state: Cloudflare.state() },
-);
-```
+Effect.gen(function* () {
+  const bucket = yield* Cloudflare.R2.ReadWriteBucket(Uploads);
 
-The type system checks the wiring — using a Cloudflare resource
-without `Cloudflare.providers()`, or providing the wrong cloud's
-providers, is a compile-time error.
-
-A stack can use any number of providers at once — merge their
-layers with `Layer.mergeAll`:
-
-```typescript
-providers: Layer.mergeAll(Cloudflare.providers(), AWS.providers()),
-```
-
-See [Providers › Multiple
-providers](/infrastructure-as-code/provider#multiple-providers). To
-support a new cloud or third-party API, see [Writing a Custom
-Resource Provider](/infrastructure-as-code/custom-provider).
-
-## Two styles: Effect and async
-
-Alchemy supports two styles for writing Workers:
-
-**Effect style** — your runtime code is an Effect, with typed errors,
-composable retries, and bindings resolved through the Effect system:
-
-```typescript
-export default Cloudflare.Worker(
-  "Worker",
-  { main: import.meta.url },
-  Effect.gen(function* () {
-    const bucket = yield* Cloudflare.R2.ReadWriteBucket(Bucket);
-    return {
-      fetch: Effect.gen(function* () {
-        // Effect-native runtime code
-      }),
-    };
-  }),
-);
-```
-
-**Async style** — your runtime code is a standard `async fetch`
-handler. Bindings are passed as props and you get a typed `env`
-object via `InferEnv`:
-
-```typescript
-// alchemy.run.ts
-export type WorkerEnv = Cloudflare.InferEnv<typeof Worker>;
-
-export const Worker = Cloudflare.Worker("Worker", {
-  main: "./src/worker.ts",
-  env: { Bucket },
+  return { fetch: /* ... */ };
 });
 ```
 
-```typescript
-// src/worker.ts
-import type { WorkerEnv } from "../alchemy.run.ts";
+The outer Effect runs at deploy time and again at cold start. The
+handlers it returns run per request. [Runtime](/infrastructure-as-effects/runtime)
+covers the shape, the `fetch` and RPC interface, and the ways to
+declare one.
 
-export default {
-  async fetch(request: Request, env: WorkerEnv) {
-    const object = await env.Bucket.get("key");
-    return new Response(object?.body ?? null);
-  },
-};
+## Binding
+
+`yield* Cloudflare.R2.ReadWriteBucket(Uploads)` is a **Binding**. It
+hands back a typed client and generates whatever that client needs to
+work. On Cloudflare that is a native Worker binding. On AWS it is an
+IAM statement scoped to one resource, plus the resource's name in the
+Function's environment:
+
+```typescript
+const getItem = yield* AWS.DynamoDB.GetItem(Jobs);
+// → { Action: ["dynamodb:GetItem"], Resource: [Jobs.tableArn] }
+// → Jobs_tableName=Jobs-a1b2c3
 ```
 
-Both styles use the same infrastructure declarations, the same CLI,
-and the same deployment pipeline. Choose whichever fits your team.
+There is no `env.BUCKET` and no hand-written policy. The binding is
+the SDK. [Bindings](/infrastructure-as-effects/binding) follows one
+through everything it generates.
+
+## Layer
+
+A Binding is a contract plus a Layer that implements it, which is why
+`ReadWriteBucketBinding` above can be swapped for `ReadWriteBucketHttp`
+without touching the handler. The same split works for services of
+your own. Put resources and bindings behind a service, and the handler
+depends on the service alone:
+
+```typescript
+Effect.gen(function* () {
+  const jobs = yield* JobService;
+
+  return {
+    fetch: Effect.gen(function* () {
+      return HttpServerResponse.json(yield* jobs.getJob("job-1"));
+    }),
+  };
+}).pipe(Effect.provide(JobServiceKV))
+```
+
+Provide `JobServiceKV` and a KV namespace is created and bound.
+Provide a DynamoDB-backed Layer and a table is instead. The handler
+doesn't change. [Layers](/infrastructure-as-effects/layers) builds one
+from scratch.
+
+## Infrastructure as Code underneath
+
+All of this rests on an infrastructure-as-code engine. A
+[Stack](/infrastructure-as-code/stack) groups the resources that
+deploy together, and every deploy targets a stage, an isolated
+environment with its own copy of every resource:
+
+```sh
+alchemy deploy              # dev_$USER by default
+alchemy deploy --stage prod
+```
+
+Alchemy reads the current state, diffs it against your program, shows
+the plan, and applies it in dependency order. Each cloud ships as a
+set of [Providers](/infrastructure-as-code/provider), and the type
+system checks that every resource in a Stack has its provider wired
+in before you can deploy.
 
 ## Where next
 
-- [Getting started](/getting-started) — install and deploy in two minutes
-- Pick your provider: [Cloudflare](/cloudflare) or [AWS](/aws)
-- [Migrating from v1](/migrating-from-v1) — upgrade from
-  Alchemy v1
+<div class="next-steps">
+
+<a href="/getting-started" class="next-card">
+  <strong>Getting started — recommended</strong>
+  <span>Install Alchemy and deploy your first Stack in two minutes.</span>
+</a>
+
+<a href="/infrastructure-as-effects" class="next-card">
+  <strong>Infrastructure as Effects</strong>
+  <span>The full model: Runtimes, Bindings, Layers, and the two phases.</span>
+</a>
+
+<a href="/cloudflare" class="next-card">
+  <strong>Cloudflare</strong>
+  <span>Workers, R2, KV, D1, Durable Objects, and more.</span>
+</a>
+
+<a href="/aws" class="next-card">
+  <strong>AWS</strong>
+  <span>Lambda, S3, SQS, DynamoDB, and more.</span>
+</a>
+
+</div>

--- a/website/src/content/docs/what-is-alchemy.mdx
+++ b/website/src/content/docs/what-is-alchemy.mdx
@@ -183,9 +183,12 @@ Effect.gen(function* () {
 ```
 
 The outer Effect runs at deploy time and again at cold start. The
-handlers it returns run per request. [Runtime](/infrastructure-as-effects/runtime)
-covers the shape, the `fetch` and RPC interface, and the ways to
-declare one.
+handlers it returns run per request.
+
+:::note
+[Runtime](/infrastructure-as-effects/runtime) covers the shape, the
+`fetch` and RPC interface, and the three ways to declare one.
+:::
 
 `yield* Cloudflare.R2.ReadWriteBucket(Uploads)` is a **Binding**. It
 hands back a typed client and generates whatever that client needs to
@@ -200,8 +203,12 @@ const getItem = yield* AWS.DynamoDB.GetItem(Jobs);
 ```
 
 There is no `env.Uploads` to reach for and no hand-written policy. The
-binding is the SDK. [Bindings](/infrastructure-as-effects/binding)
-follows one through everything it generates.
+binding is the SDK.
+
+:::note
+[Bindings](/infrastructure-as-effects/binding) follows one binding
+through the permissions, configuration, and client it generates.
+:::
 
 A Binding is a contract plus a **Layer** that implements it, which is
 why `ReadWriteBucketBinding` can be swapped for `ReadWriteBucketHttp`
@@ -223,10 +230,13 @@ Effect.gen(function* () {
 
 Provide `JobServiceKV` and a KV Namespace is created and bound.
 Provide a DynamoDB-backed Layer and a Table is instead. The handler
-doesn't change. [Layers](/infrastructure-as-effects/layers) builds one
-from scratch, and the
-[Infrastructure as Effects](/infrastructure-as-effects) overview puts
-the three ideas together.
+doesn't change.
+
+:::note
+[Layers](/infrastructure-as-effects/layers) builds one from scratch,
+and the [Infrastructure as Effects](/infrastructure-as-effects)
+overview puts the three ideas together.
+:::
 
 ## Where next
 

--- a/website/src/content/docs/what-is-alchemy.mdx
+++ b/website/src/content/docs/what-is-alchemy.mdx
@@ -1,21 +1,22 @@
 ---
 title: What is Alchemy?
-description: Alchemy is an Infrastructure-as-Effects framework. Declare your cloud resources and write the code that runs on them in one type-safe TypeScript program, then deploy it with one command.
+description: Alchemy is an Infrastructure as Code engine built in pure Effect, with Infrastructure as Effects on top. Declare your cloud resources and the code that runs on them in one type-safe TypeScript program, and deploy it with one command.
 next:
   link: /getting-started
   label: Getting started
 ---
 
-Alchemy is an **Infrastructure-as-Effects** framework. You declare
-your cloud resources and write the code that runs on them in one
-TypeScript program, built on [Effect](https://effect.website), and
-deploy it with one command.
+Alchemy is an **Infrastructure as Code** engine built in pure
+[Effect](https://effect.website), with **Infrastructure as Effects**
+on top. The engine declares, diffs, and deploys cloud resources the
+way Terraform or Pulumi does. The layer on top lets the code that runs
+on those resources live in the same program, as typed values.
 
-Here is a complete application. An R2 bucket, and a Worker that
+Here is the whole thing in one file. An R2 bucket, and a Worker that
 serves files from it:
 
 ```typescript
-// src/worker.ts
+// src/api.ts
 import * as Cloudflare from "alchemy/Cloudflare";
 import * as Effect from "effect/Effect";
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
@@ -45,93 +46,21 @@ bun alchemy deploy
 ```
 
 Alchemy creates the bucket, bundles the Worker, wires the binding
-between them, and prints the URL. There is no separate infrastructure
-project. The Worker is a resource that carries its own code, and the
-bucket is a typed value inside it.
+between them, and prints the URL. Let's start with the engine
+underneath, then look at what the layer on top adds.
 
-Traditional infrastructure as code keeps these apart. One project
-declares the bucket, the Worker, and the permission between them.
-Another holds the handler, which reaches for the bucket through an
-environment variable, and the two agree only by convention. Alchemy
-supports that shape too, but its model is the one above. Three ideas
-make it work, Runtime, Binding, and Layer, and three more underneath
-them, Stack, Resource, and Provider, are the infrastructure-as-code
-engine they run on.
+## Infrastructure as Code
 
-## Runtime
-
-A Worker, Lambda Function, or Container is a **Runtime**: a resource
-that carries the code it runs. Its Effect always has the same shape.
-Bind what you need, then return what you expose:
-
-```typescript
-Effect.gen(function* () {
-  const bucket = yield* Cloudflare.R2.ReadWriteBucket(Uploads);
-
-  return { fetch: /* ... */ };
-});
-```
-
-The outer Effect runs at deploy time and again at cold start. The
-handlers it returns run per request. [Runtime](/infrastructure-as-effects/runtime)
-covers the shape, the `fetch` and RPC interface, and the ways to
-declare one.
-
-## Binding
-
-`yield* Cloudflare.R2.ReadWriteBucket(Uploads)` is a **Binding**. It
-hands back a typed client and generates whatever that client needs to
-work. On Cloudflare that is a native Worker binding. On AWS it is an
-IAM statement scoped to one resource, plus the resource's name in the
-Function's environment:
-
-```typescript
-const getItem = yield* AWS.DynamoDB.GetItem(Jobs);
-// → { Action: ["dynamodb:GetItem"], Resource: [Jobs.tableArn] }
-// → Jobs_tableName=Jobs-a1b2c3
-```
-
-There is no `env.BUCKET` and no hand-written policy. The binding is
-the SDK. [Bindings](/infrastructure-as-effects/binding) follows one
-through everything it generates.
-
-## Layer
-
-A Binding is a contract plus a Layer that implements it, which is why
-`ReadWriteBucketBinding` above can be swapped for `ReadWriteBucketHttp`
-without touching the handler. The same split works for services of
-your own. Put resources and bindings behind a service, and the handler
-depends on the service alone:
-
-```typescript
-Effect.gen(function* () {
-  const jobs = yield* JobService;
-
-  return {
-    fetch: Effect.gen(function* () {
-      return HttpServerResponse.json(yield* jobs.getJob("job-1"));
-    }),
-  };
-}).pipe(Effect.provide(JobServiceKV))
-```
-
-Provide `JobServiceKV` and a KV namespace is created and bound.
-Provide a DynamoDB-backed Layer and a table is instead. The handler
-doesn't change. [Layers](/infrastructure-as-effects/layers) builds one
-from scratch.
-
-## Stack
-
-All of this rests on an infrastructure-as-code engine. A **Stack** is
-the unit you deploy: an Effect that yields resources and returns the
-outputs you want printed:
+The engine has three ideas. A **Stack** is the unit you deploy, an
+Effect that yields resources and returns the outputs you want
+printed:
 
 ```typescript
 // alchemy.run.ts
 import * as Alchemy from "alchemy";
 import * as Cloudflare from "alchemy/Cloudflare";
 import * as Effect from "effect/Effect";
-import Api from "./src/worker.ts";
+import Api from "./src/api.ts";
 
 export default Alchemy.Stack(
   "MyApp",
@@ -156,12 +85,9 @@ the plan, and applies it in dependency order. `state` is where the
 result persists between runs. [Stacks](/infrastructure-as-code/stack)
 covers stages, outputs, and state.
 
-## Resource
-
 A **Resource** is any cloud entity Alchemy manages: a bucket, a
 database, a queue, a Worker, a DNS record. Declaring one is inert. It
-becomes real when it is yielded, inside a Stack or inside a Runtime's
-constructor:
+becomes real when it is yielded:
 
 ```typescript
 export const Uploads = Cloudflare.R2.Bucket("Uploads"); // a declaration
@@ -170,12 +96,10 @@ const bucket = yield* Uploads; // created on deploy; bucket.bucketName is its Ou
 ```
 
 Each declaration has a stable logical id, `"Uploads"` here, that
-Alchemy uses to track it across deploys. Its outputs, like the
-physical name Alchemy generates, are typed values you can pass into
-other resources. [Resources](/infrastructure-as-code/resource) covers
-props, outputs, and how one resource references another.
-
-## Provider
+Alchemy tracks across deploys. Its outputs, like the physical name
+Alchemy generates, are typed values you can pass into other
+resources. [Resources](/infrastructure-as-code/resource) covers props,
+outputs, and references between resources.
 
 A **Provider** teaches Alchemy how to read, diff, create, update, and
 delete one resource type. Each cloud ships its providers as an Effect
@@ -190,7 +114,110 @@ that only provides `Cloudflare.providers()` and the program does not
 compile. [Providers](/infrastructure-as-code/provider) covers the
 built-in ones, and
 [Custom Provider](/infrastructure-as-code/custom-provider) shows how
-to write your own for a cloud or API Alchemy doesn't ship.
+to write your own.
+
+## A superset of Infrastructure as Code
+
+With only the engine, Alchemy looks like any IaC tool. One file
+declares the bucket and the Worker, passing the bucket on the Worker's
+`env`. Another file is the handler, reaching for the bucket through
+that env:
+
+```typescript
+// alchemy.run.ts
+import * as Cloudflare from "alchemy/Cloudflare";
+
+export const Uploads = Cloudflare.R2.Bucket("Uploads");
+
+export const Api = Cloudflare.Worker("Api", {
+  main: "./src/api.ts",
+  env: { Uploads },
+});
+
+export type ApiEnv = Cloudflare.InferEnv<typeof Api>;
+```
+
+```typescript
+// src/api.ts
+import type { ApiEnv } from "../alchemy.run.ts";
+
+export default {
+  async fetch(request: Request, env: ApiEnv) {
+    const obj = await env.Uploads.get("hello.txt");
+    return obj
+      ? new Response(await obj.text())
+      : new Response("Not found", { status: 404 });
+  },
+};
+```
+
+This works, and it is fully supported. `InferEnv` even types the env
+from the declaration, which is more than most IaC tools give you. But
+the two files are still held together by the name `Uploads`, and the
+handler knows nothing about how the bucket got there. Infrastructure
+as Effects is what turns those two files into the one at the top of
+this page.
+
+## Infrastructure as Effects
+
+The layer on top adds three ideas. A **Runtime** is a Resource that
+carries the code it runs: a Worker, Lambda Function, or Container.
+Its Effect always has the same shape. Bind what you need, then return
+what you expose:
+
+```typescript
+Effect.gen(function* () {
+  const bucket = yield* Cloudflare.R2.ReadWriteBucket(Uploads);
+
+  return { fetch: /* ... */ };
+});
+```
+
+The outer Effect runs at deploy time and again at cold start. The
+handlers it returns run per request. [Runtime](/infrastructure-as-effects/runtime)
+covers the shape, the `fetch` and RPC interface, and the ways to
+declare one.
+
+`yield* Cloudflare.R2.ReadWriteBucket(Uploads)` is a **Binding**. It
+hands back a typed client and generates whatever that client needs to
+work. On Cloudflare that is a native Worker binding. On AWS it is an
+IAM statement scoped to one resource, plus the resource's name in the
+Function's environment:
+
+```typescript
+const getItem = yield* AWS.DynamoDB.GetItem(Jobs);
+// → { Action: ["dynamodb:GetItem"], Resource: [Jobs.tableArn] }
+// → Jobs_tableName=Jobs-a1b2c3
+```
+
+There is no `env.Uploads` to reach for and no hand-written policy. The
+binding is the SDK. [Bindings](/infrastructure-as-effects/binding)
+follows one through everything it generates.
+
+A Binding is a contract plus a **Layer** that implements it, which is
+why `ReadWriteBucketBinding` can be swapped for `ReadWriteBucketHttp`
+without touching the handler. The same split works for services of
+your own. Put resources and bindings behind a service, and the handler
+depends on the service alone:
+
+```typescript
+Effect.gen(function* () {
+  const jobs = yield* JobService;
+
+  return {
+    fetch: Effect.gen(function* () {
+      return HttpServerResponse.json(yield* jobs.getJob("job-1"));
+    }),
+  };
+}).pipe(Effect.provide(JobServiceKV))
+```
+
+Provide `JobServiceKV` and a KV namespace is created and bound.
+Provide a DynamoDB-backed Layer and a table is instead. The handler
+doesn't change. [Layers](/infrastructure-as-effects/layers) builds one
+from scratch, and the
+[Infrastructure as Effects](/infrastructure-as-effects) overview puts
+the three ideas together.
 
 ## Where next
 

--- a/website/src/content/docs/what-is-alchemy.mdx
+++ b/website/src/content/docs/what-is-alchemy.mdx
@@ -5,8 +5,8 @@ prev:
   link: /getting-started
   label: Getting started
 next:
-  link: /cloudflare/tutorial/part-1
-  label: Tutorial
+  link: /infrastructure-as-effects
+  label: Infrastructure as Effects
 ---
 
 import DeployTerminal from "../../components/marketing-islands/DeployTerminal.tsx";
@@ -276,12 +276,7 @@ overview puts the three ideas together.
 
 <div class="next-steps">
 
-<a href="/cloudflare/tutorial/part-1" class="next-card next-card--recommended">
-  <strong>Tutorial</strong>
-  <span>Build a full app on Cloudflare from the Stack you just deployed: a Worker, bindings, tests, local dev, CI, and telemetry.</span>
-</a>
-
-<a href="/infrastructure-as-effects" class="next-card">
+<a href="/infrastructure-as-effects" class="next-card next-card--recommended">
   <strong>Infrastructure as Effects</strong>
   <span>The model the rest of the docs build on: Runtimes, Bindings, Layers, and the Construction and Runtime phases.</span>
 </a>
@@ -294,6 +289,11 @@ overview puts the three ideas together.
 <a href="/aws" class="next-card">
   <strong>AWS</strong>
   <span>Lambda, S3, SQS, DynamoDB, EC2, ECS, and EKS, with a tutorial and a guide for each.</span>
+</a>
+
+<a href="/providers" class="next-card">
+  <strong>More providers</strong>
+  <span>Hetzner, Fly, Railway, Neon, PlanetScale, Stripe, GitHub, Axiom, and every other provider Alchemy manages.</span>
 </a>
 
 </div>

--- a/website/src/content/docs/what-is-alchemy.mdx
+++ b/website/src/content/docs/what-is-alchemy.mdx
@@ -54,7 +54,9 @@ declares the bucket, the Worker, and the permission between them.
 Another holds the handler, which reaches for the bucket through an
 environment variable, and the two agree only by convention. Alchemy
 supports that shape too, but its model is the one above. Three ideas
-make it work.
+make it work, Runtime, Binding, and Layer, and three more underneath
+them, Stack, Resource, and Provider, are the infrastructure-as-code
+engine they run on.
 
 ## Runtime
 
@@ -118,12 +120,31 @@ Provide a DynamoDB-backed Layer and a table is instead. The handler
 doesn't change. [Layers](/infrastructure-as-effects/layers) builds one
 from scratch.
 
-## Infrastructure as Code underneath
+## Stack
 
-All of this rests on an infrastructure-as-code engine. A
-[Stack](/infrastructure-as-code/stack) groups the resources that
-deploy together, and every deploy targets a stage, an isolated
-environment with its own copy of every resource:
+All of this rests on an infrastructure-as-code engine. A **Stack** is
+the unit you deploy: an Effect that yields resources and returns the
+outputs you want printed:
+
+```typescript
+// alchemy.run.ts
+import * as Alchemy from "alchemy";
+import * as Cloudflare from "alchemy/Cloudflare";
+import * as Effect from "effect/Effect";
+import Api from "./src/worker.ts";
+
+export default Alchemy.Stack(
+  "MyApp",
+  { providers: Cloudflare.providers(), state: Cloudflare.state() },
+  Effect.gen(function* () {
+    const api = yield* Api;
+    return { url: api.url };
+  }),
+);
+```
+
+Every deploy targets a stage, an isolated environment with its own
+copy of every resource, so `dev` and `prod` never touch each other:
 
 ```sh
 alchemy deploy              # dev_$USER by default
@@ -131,10 +152,45 @@ alchemy deploy --stage prod
 ```
 
 Alchemy reads the current state, diffs it against your program, shows
-the plan, and applies it in dependency order. Each cloud ships as a
-set of [Providers](/infrastructure-as-code/provider), and the type
-system checks that every resource in a Stack has its provider wired
-in before you can deploy.
+the plan, and applies it in dependency order. `state` is where the
+result persists between runs. [Stacks](/infrastructure-as-code/stack)
+covers stages, outputs, and state.
+
+## Resource
+
+A **Resource** is any cloud entity Alchemy manages: a bucket, a
+database, a queue, a Worker, a DNS record. Declaring one is inert. It
+becomes real when it is yielded, inside a Stack or inside a Runtime's
+constructor:
+
+```typescript
+export const Uploads = Cloudflare.R2.Bucket("Uploads"); // a declaration
+
+const bucket = yield* Uploads; // created on deploy; bucket.bucketName is its Output
+```
+
+Each declaration has a stable logical id, `"Uploads"` here, that
+Alchemy uses to track it across deploys. Its outputs, like the
+physical name Alchemy generates, are typed values you can pass into
+other resources. [Resources](/infrastructure-as-code/resource) covers
+props, outputs, and how one resource references another.
+
+## Provider
+
+A **Provider** teaches Alchemy how to read, diff, create, update, and
+delete one resource type. Each cloud ships its providers as an Effect
+Layer, and a Stack takes as many as it needs:
+
+```typescript
+providers: Layer.mergeAll(Cloudflare.providers(), AWS.providers()),
+```
+
+The type system checks the wiring. Yield an AWS resource in a Stack
+that only provides `Cloudflare.providers()` and the program does not
+compile. [Providers](/infrastructure-as-code/provider) covers the
+built-in ones, and
+[Custom Provider](/infrastructure-as-code/custom-provider) shows how
+to write your own for a cloud or API Alchemy doesn't ship.
 
 ## Where next
 

--- a/website/src/content/docs/what-is-alchemy.mdx
+++ b/website/src/content/docs/what-is-alchemy.mdx
@@ -171,19 +171,25 @@ this page.
 
 The layer on top adds three ideas. A **Runtime** is a Resource that
 carries the code it runs: a Worker, Lambda Function, Container, or Server.
-Its Effect always has the same shape. Bind what you need, then return
-what you expose:
+That code is always written the same way, as an **Effectful
+Constructor**. Bind what you need, then return what you expose:
 
 ```typescript
 Effect.gen(function* () {
+  // bind what you need
   const bucket = yield* Cloudflare.R2.ReadWriteBucket(Uploads);
 
+  // return what you expose
   return { fetch: /* ... */ };
 });
 ```
 
-The outer Effect runs at deploy time and again at cold start. The
-handlers it returns run per request.
+The outer Effect is the Construction phase. It runs at deploy time,
+where the bindings are recorded, and again at cold start, where they
+become live clients. What it returns is the Runtime phase, the handlers
+that run per request. A Worker returns `fetch`, a Durable Object
+returns its RPC methods, a Workflow returns its run function, and
+every Runtime in Alchemy is a variation on that one shape.
 
 :::note
 [Runtime](/infrastructure-as-effects/runtime) covers the shape, the

--- a/website/src/content/docs/what-is-alchemy.mdx
+++ b/website/src/content/docs/what-is-alchemy.mdx
@@ -293,7 +293,7 @@ overview puts the three ideas together.
 
 <a href="/providers" class="next-card">
   <strong>More providers</strong>
-  <span>Hetzner, Fly, Railway, Neon, PlanetScale, Stripe, GitHub, Axiom, and every other provider Alchemy manages.</span>
+  <span>Hetzner, Fly, Railway, Kubernetes, Neon, PlanetScale, GitHub, Axiom, and every other provider Alchemy manages.</span>
 </a>
 
 </div>

--- a/website/src/content/docs/what-is-alchemy.mdx
+++ b/website/src/content/docs/what-is-alchemy.mdx
@@ -179,13 +179,17 @@ export default {
 ```
 
 This works, and it is fully supported. `InferEnv` even types the env
-from the declaration, which is more than most IaC tools give you, and
-two Workers can bind each other, a cycle most IaC engines reject
-([Circular Bindings](/infrastructure-as-effects/circular-bindings)).
-But the two files are still held together by the name `Uploads`, and
-the handler knows nothing about how the Bucket got there.
-Infrastructure as Effects is what turns those two files into the one
-at the top of this page.
+from the declaration, which is more than most IaC tools give you. But
+the two files are still held together by the name `Uploads`, and the
+handler knows nothing about how the Bucket got there. Infrastructure
+as Effects is what turns those two files into the one at the top of
+this page.
+
+:::tip
+The engine already goes one step past most IaC tools: two Workers can
+bind each other, a cycle a dependency graph can't express. See
+[Circular Bindings](/infrastructure-as-effects/circular-bindings).
+:::
 
 ## Infrastructure as Effects
 

--- a/website/src/content/docs/what-is-alchemy.mdx
+++ b/website/src/content/docs/what-is-alchemy.mdx
@@ -186,8 +186,8 @@ as Effects is what turns those two files into the one at the top of
 this page.
 
 :::tip
-The engine already goes one step past most IaC tools: two Workers can
-bind each other, a cycle a dependency graph can't express. See
+Alchemy's IaC engine also supports circular references in the
+dependency graph, which most IaC tools reject. See
 [Circular Bindings](/infrastructure-as-effects/circular-bindings).
 :::
 

--- a/website/src/content/docs/what-is-alchemy.mdx
+++ b/website/src/content/docs/what-is-alchemy.mdx
@@ -1,6 +1,6 @@
 ---
 title: What is Alchemy?
-description: Alchemy is an Infrastructure as Code engine built in pure Effect, with Infrastructure as Effects on top. Declare your cloud resources and the code that runs on them in one type-safe TypeScript program, and deploy it with one command.
+description: Alchemy is Infrastructure as Code built in pure Effect, with Infrastructure as Effects on top. Declare your cloud resources and the code that runs on them in one type-safe TypeScript program, and deploy it with one command.
 next:
   link: /getting-started
   label: Getting started
@@ -8,12 +8,12 @@ next:
 
 import DeployTerminal from "../../components/marketing-islands/DeployTerminal.tsx";
 
-Alchemy is an **Infrastructure as Code** engine built in pure
+Alchemy is **Infrastructure as Code** built in pure
 [Effect](https://effect.website), with **Infrastructure as Effects**
-on top. The engine declares, diffs, and deploys cloud resources the
-way Terraform or Pulumi does. The layer on top lets the code that runs
-on those resources live in the same program, as typed Effects and
-Layers.
+on top. Infrastructure as Code declares, diffs, and deploys cloud
+resources the way Terraform or Pulumi does. Infrastructure as Effects
+lets the code that runs on those resources live in the same program,
+as typed Effects and Layers.
 
 Here is the whole thing in one file. An R2 Bucket, and a Worker that
 serves files from it:
@@ -46,8 +46,8 @@ export default Cloudflare.Worker(
 
 That one file is a complete application. The Bucket is declared next
 to the Worker that uses it, and `bucket` is a typed client the handler
-closes over. Let's start with the engine underneath, then look at what
-the layer on top adds.
+closes over. Let's start with Infrastructure as Code, then look at what
+Infrastructure as Effects adds on top.
 
 ## Infrastructure as Code
 
@@ -144,7 +144,7 @@ to write your own.
 
 ## A superset of Infrastructure as Code
 
-With only the engine, Alchemy looks like and functions like any other
+With only Infrastructure as Code, Alchemy looks like and functions like any other
 IaC tool. One file
 declares the Bucket and the Worker, passing the Bucket on the Worker's
 `env`. Another file is the handler, reaching for the Bucket through
@@ -186,14 +186,15 @@ as Effects is what turns those two files into the one at the top of
 this page.
 
 :::tip
-Alchemy's IaC engine also supports circular references in the
+Alchemy also supports circular references in the
 dependency graph, which most IaC tools reject. See
 [Circular Bindings](/infrastructure-as-effects/circular-bindings).
 :::
 
 ## Infrastructure as Effects
 
-Infrastructure as Effects is what Alchemy adds on top of that engine.
+Infrastructure as Effects is what Alchemy adds on top of
+Infrastructure as Code.
 A **Runtime** is a Resource that carries the code it runs: a Worker, Lambda Function, Container, or Server.
 That code is always written the same way, as an **Effectful
 Constructor**. Bind what you need, then return what you expose:

--- a/website/src/content/docs/what-is-alchemy.mdx
+++ b/website/src/content/docs/what-is-alchemy.mdx
@@ -278,7 +278,7 @@ overview puts the three ideas together.
 
 <a href="/cloudflare/tutorial/part-1" class="next-card next-card--recommended">
   <strong>Tutorial</strong>
-  <span>Build a full app on Cloudflare starting from the Stack you just deployed: a Worker, bindings, tests, local dev, CI, and telemetry.</span>
+  <span>Build a full app on Cloudflare from the Stack you just deployed: a Worker, bindings, tests, local dev, CI, and telemetry.</span>
 </a>
 
 <a href="/infrastructure-as-effects" class="next-card">

--- a/website/src/content/docs/what-is-alchemy.mdx
+++ b/website/src/content/docs/what-is-alchemy.mdx
@@ -15,7 +15,7 @@ way Terraform or Pulumi does. The layer on top lets the code that runs
 on those resources live in the same program, as typed Effects and
 Layers.
 
-Here is the whole thing in one file. An R2 bucket, and a Worker that
+Here is the whole thing in one file. An R2 Bucket, and a Worker that
 serves files from it:
 
 ```typescript
@@ -48,7 +48,7 @@ export default Cloudflare.Worker(
 bun alchemy deploy
 ```
 
-Alchemy creates the bucket, bundles the Worker, wires the binding
+Alchemy creates the Bucket, bundles the Worker, wires the binding
 between them, and prints the URL. Let's start with the engine
 underneath, then look at what the layer on top adds.
 
@@ -85,7 +85,7 @@ alchemy deploy --stage prod
 
 Alchemy reads the current state, diffs it against your program, shows
 the plan, and applies it in dependency order. Here is that loop for a
-Stack with a bucket, a KV namespace, and a Worker bound to both:
+Stack with a Bucket, a KV Namespace, and a Worker bound to both:
 
 <DeployTerminal client:visible />
 
@@ -128,8 +128,8 @@ to write your own.
 
 With only the engine, Alchemy looks like and functions like any other
 IaC tool. One file
-declares the bucket and the Worker, passing the bucket on the Worker's
-`env`. Another file is the handler, reaching for the bucket through
+declares the Bucket and the Worker, passing the Bucket on the Worker's
+`env`. Another file is the handler, reaching for the Bucket through
 that env:
 
 ```typescript
@@ -163,7 +163,7 @@ export default {
 This works, and it is fully supported. `InferEnv` even types the env
 from the declaration, which is more than most IaC tools give you. But
 the two files are still held together by the name `Uploads`, and the
-handler knows nothing about how the bucket got there. Infrastructure
+handler knows nothing about how the Bucket got there. Infrastructure
 as Effects is what turns those two files into the one at the top of
 this page.
 
@@ -221,8 +221,8 @@ Effect.gen(function* () {
 }).pipe(Effect.provide(JobServiceKV))
 ```
 
-Provide `JobServiceKV` and a KV namespace is created and bound.
-Provide a DynamoDB-backed Layer and a table is instead. The handler
+Provide `JobServiceKV` and a KV Namespace is created and bound.
+Provide a DynamoDB-backed Layer and a Table is instead. The handler
 doesn't change. [Layers](/infrastructure-as-effects/layers) builds one
 from scratch, and the
 [Infrastructure as Effects](/infrastructure-as-effects) overview puts

--- a/website/src/content/docs/what-is-alchemy.mdx
+++ b/website/src/content/docs/what-is-alchemy.mdx
@@ -179,11 +179,13 @@ export default {
 ```
 
 This works, and it is fully supported. `InferEnv` even types the env
-from the declaration, which is more than most IaC tools give you. But
-the two files are still held together by the name `Uploads`, and the
-handler knows nothing about how the Bucket got there. Infrastructure
-as Effects is what turns those two files into the one at the top of
-this page.
+from the declaration, which is more than most IaC tools give you, and
+two Workers can bind each other, a cycle most IaC engines reject
+([Circular Bindings](/infrastructure-as-effects/circular-bindings)).
+But the two files are still held together by the name `Uploads`, and
+the handler knows nothing about how the Bucket got there.
+Infrastructure as Effects is what turns those two files into the one
+at the top of this page.
 
 ## Infrastructure as Effects
 

--- a/website/src/content/docs/what-is-alchemy.mdx
+++ b/website/src/content/docs/what-is-alchemy.mdx
@@ -10,7 +10,8 @@ Alchemy is an **Infrastructure as Code** engine built in pure
 [Effect](https://effect.website), with **Infrastructure as Effects**
 on top. The engine declares, diffs, and deploys cloud resources the
 way Terraform or Pulumi does. The layer on top lets the code that runs
-on those resources live in the same program, as typed values.
+on those resources live in the same program, as typed Effects and
+Layers.
 
 Here is the whole thing in one file. An R2 bucket, and a Worker that
 serves files from it:

--- a/website/src/content/docs/what-is-alchemy.mdx
+++ b/website/src/content/docs/what-is-alchemy.mdx
@@ -109,9 +109,23 @@ const bucket = yield* Uploads; // bucket.bucketName is an Output
 ```
 
 Each Resource has a logical id, `"Uploads"` here, that Alchemy uses to
-track it across deploys. Its outputs, like the physical name Alchemy
-generates, are typed values you can pass into other Resources. [Resources](/infrastructure-as-code/resource) covers props,
-outputs, and references between resources.
+track it across deploys. Its outputs are typed values you can pass
+into other Resources. Here the physical bucket name Alchemy generated
+becomes an environment variable on a Worker:
+
+```typescript
+const bucket = yield* Uploads;
+
+yield* Cloudflare.Worker("Api", {
+  main: "./src/api.ts",
+  env: { BUCKET_NAME: bucket.bucketName },
+});
+```
+
+:::note
+[Resources](/infrastructure-as-code/resource) covers props, outputs,
+and references between Resources.
+:::
 
 A **Provider** teaches Alchemy how to read, diff, create, update, and
 delete one resource type. Each cloud ships its providers as an Effect

--- a/website/src/content/docs/what-is-alchemy.mdx
+++ b/website/src/content/docs/what-is-alchemy.mdx
@@ -276,8 +276,8 @@ overview puts the three ideas together.
 
 <div class="next-steps">
 
-<a href="/cloudflare/tutorial/part-1" class="next-card">
-  <strong>Tutorial — recommended</strong>
+<a href="/cloudflare/tutorial/part-1" class="next-card next-card--recommended">
+  <strong>Tutorial</strong>
   <span>Build a full app on Cloudflare: a Worker, bindings, tests, local dev, CI, and telemetry.</span>
 </a>
 

--- a/website/src/content/docs/what-is-alchemy.mdx
+++ b/website/src/content/docs/what-is-alchemy.mdx
@@ -51,9 +51,10 @@ the layer on top adds.
 
 ## Infrastructure as Code
 
-The engine has three ideas. A **Stack** is the unit you deploy, an
-Effect that yields resources and returns the outputs you want
-printed:
+The core of Alchemy is Infrastructure as Code, in the same family as
+Terraform, Pulumi, CloudFormation, and the CDK. A **Stack** is the
+unit you deploy, an Effect that yields resources and returns the
+outputs you want printed:
 
 ```typescript
 // alchemy.run.ts
@@ -173,8 +174,8 @@ this page.
 
 ## Infrastructure as Effects
 
-The layer on top adds three ideas. A **Runtime** is a Resource that
-carries the code it runs: a Worker, Lambda Function, Container, or Server.
+Infrastructure as Effects is what Alchemy adds on top of that engine.
+A **Runtime** is a Resource that carries the code it runs: a Worker, Lambda Function, Container, or Server.
 That code is always written the same way, as an **Effectful
 Constructor**. Bind what you need, then return what you expose:
 

--- a/website/src/content/docs/what-is-alchemy.mdx
+++ b/website/src/content/docs/what-is-alchemy.mdx
@@ -170,7 +170,7 @@ this page.
 ## Infrastructure as Effects
 
 The layer on top adds three ideas. A **Runtime** is a Resource that
-carries the code it runs: a Worker, Lambda Function, or Container.
+carries the code it runs: a Worker, Lambda Function, Container, or Server.
 Its Effect always has the same shape. Bind what you need, then return
 what you expose:
 

--- a/website/src/content/docs/what-is-alchemy.mdx
+++ b/website/src/content/docs/what-is-alchemy.mdx
@@ -1,9 +1,12 @@
 ---
 title: What is Alchemy?
 description: Alchemy is Infrastructure as Code built in pure Effect, with Infrastructure as Effects on top. Declare your cloud resources and the code that runs on them in one type-safe TypeScript program, and deploy it with one command.
-next:
+prev:
   link: /getting-started
   label: Getting started
+next:
+  link: /cloudflare/tutorial/part-2
+  label: "Tutorial Part 2: Add a Worker"
 ---
 
 import DeployTerminal from "../../components/marketing-islands/DeployTerminal.tsx";
@@ -273,9 +276,9 @@ overview puts the three ideas together.
 
 <div class="next-steps">
 
-<a href="/getting-started" class="next-card">
-  <strong>Getting started — recommended</strong>
-  <span>Install Alchemy and deploy your first Stack in two minutes.</span>
+<a href="/cloudflare/tutorial/part-2" class="next-card">
+  <strong>Tutorial Part 2: Add a Worker — recommended</strong>
+  <span>Pick up the Stack from Getting started and bind the Bucket to a Worker.</span>
 </a>
 
 <a href="/infrastructure-as-effects" class="next-card">

--- a/website/src/content/docs/what-is-alchemy.mdx
+++ b/website/src/content/docs/what-is-alchemy.mdx
@@ -98,20 +98,19 @@ Stack with a Bucket, a KV Namespace, and a Worker bound to both:
 only touches what changed. [Stacks](/infrastructure-as-code/stack)
 covers stages, outputs, and state.
 
-A **Resource** is any cloud entity Alchemy manages: a bucket, a
-database, a queue, a Worker, a DNS record. Declaring one is inert. It
-becomes real when it is yielded:
+A **Resource** is a cloud entity in a Stack managed by Alchemy: a
+bucket, a database, a queue, a Worker, a DNS record. Declare it, then
+yield it in the Stack to add it to the plan:
 
 ```typescript
-export const Uploads = Cloudflare.R2.Bucket("Uploads"); // a declaration
+export const Uploads = Cloudflare.R2.Bucket("Uploads");
 
-const bucket = yield* Uploads; // created on deploy; bucket.bucketName is its Output
+const bucket = yield* Uploads; // bucket.bucketName is an Output
 ```
 
-Each declaration has a stable logical id, `"Uploads"` here, that
-Alchemy tracks across deploys. Its outputs, like the physical name
-Alchemy generates, are typed values you can pass into other
-resources. [Resources](/infrastructure-as-code/resource) covers props,
+Each Resource has a logical id, `"Uploads"` here, that Alchemy uses to
+track it across deploys. Its outputs, like the physical name Alchemy
+generates, are typed values you can pass into other Resources. [Resources](/infrastructure-as-code/resource) covers props,
 outputs, and references between resources.
 
 A **Provider** teaches Alchemy how to read, diff, create, update, and

--- a/website/src/docs-tabs-sidebar.ts
+++ b/website/src/docs-tabs-sidebar.ts
@@ -34,11 +34,39 @@ export const onRequest = defineRouteMiddleware(async (context, next) => {
 
   const links = flattenLinks(group.entries);
   const index = links.findIndex((link) => link.isCurrent);
+  const { prev, next: nextLink } = starlightRoute.entry.data;
   starlightRoute.pagination = {
-    prev: index > 0 ? links[index - 1] : undefined,
-    next: index !== -1 ? links[index + 1] : undefined,
+    prev: override(prev, index > 0 ? links[index - 1] : undefined),
+    next: override(nextLink, index !== -1 ? links[index + 1] : undefined),
   };
 });
+
+/**
+ * Apply a page's `prev` / `next` frontmatter to the sidebar-derived link, the
+ * same way Starlight's own pagination does: `false` removes the link, a
+ * string relabels it, and `{ link, label }` replaces it outright.
+ */
+function override(
+  config: StarlightRouteData["entry"]["data"]["prev"],
+  link: SidebarLink | undefined,
+): SidebarLink | undefined {
+  if (config === undefined || config === true) return link;
+  if (config === false) return undefined;
+  if (typeof config === "string") {
+    return link ? { ...link, label: config } : undefined;
+  }
+  const href = config.link ?? link?.href;
+  const label = config.label ?? link?.label;
+  if (!href || !label) return link;
+  return {
+    type: "link",
+    label,
+    href,
+    isCurrent: false,
+    badge: undefined,
+    attrs: {},
+  };
+}
 
 function flattenLinks(items: SidebarItem[]): SidebarLink[] {
   const links: SidebarLink[] = [];

--- a/website/src/styles/custom.css
+++ b/website/src/styles/custom.css
@@ -737,24 +737,27 @@ p:has(> .alc-btn) {
   );
 }
 .next-card--recommended::after {
+  /* A 12rem band rotated 45deg, centered 3rem in from the top-right
+     corner on both axes, so the segment visible inside the card is
+     ~6rem long: enough for the word at this size. */
   content: "Recommended";
   position: absolute;
-  top: 1.1rem;
-  right: -2.6rem;
-  width: 9rem;
+  top: 2.3rem;
+  right: -3rem;
+  width: 12rem;
+  line-height: 1.3rem;
   transform: rotate(45deg);
   text-align: center;
-  padding: 0.2rem 0;
   background: var(--alc-accent);
   color: var(--alc-fg-on-accent);
-  font-size: 0.68rem;
+  font-size: 0.6rem;
   font-weight: 600;
-  letter-spacing: 0.04em;
+  letter-spacing: 0.03em;
   text-transform: uppercase;
   pointer-events: none;
 }
 .next-card--recommended strong {
-  padding-right: 3.5rem;
+  padding-right: 4.5rem;
 }
 @media (max-width: 600px) {
   .next-steps {

--- a/website/src/styles/custom.css
+++ b/website/src/styles/custom.css
@@ -726,6 +726,36 @@ p:has(> .alc-btn) {
   font-size: 0.9rem;
   line-height: 1.5;
 }
+/* A corner ribbon marks the recommended card; the title stays one line. */
+.next-card--recommended {
+  position: relative;
+  overflow: hidden;
+  border-color: color-mix(
+    in srgb,
+    var(--alc-accent) 45%,
+    var(--alc-hairline-2)
+  );
+}
+.next-card--recommended::after {
+  content: "Recommended";
+  position: absolute;
+  top: 1.1rem;
+  right: -2.6rem;
+  width: 9rem;
+  transform: rotate(45deg);
+  text-align: center;
+  padding: 0.2rem 0;
+  background: var(--alc-accent);
+  color: var(--alc-fg-invert);
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  pointer-events: none;
+}
+.next-card--recommended strong {
+  padding-right: 3.5rem;
+}
 @media (max-width: 600px) {
   .next-steps {
     grid-template-columns: 1fr;

--- a/website/src/styles/custom.css
+++ b/website/src/styles/custom.css
@@ -753,6 +753,21 @@ p:has(> .alc-btn) {
   line-height: 1.4;
   pointer-events: none;
 }
+/* Provider brand marks in place of a description on the directory card. */
+.next-card .provider-icons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem 0.9rem;
+  margin-top: 0.6rem;
+  color: var(--alc-fg-2);
+}
+.next-card .provider-icons svg {
+  flex: none;
+  transition: color var(--alc-dur) var(--alc-ease);
+}
+.next-card:hover .provider-icons {
+  color: var(--alc-fg-1);
+}
 @media (max-width: 600px) {
   .next-steps {
     grid-template-columns: 1fr;

--- a/website/src/styles/custom.css
+++ b/website/src/styles/custom.css
@@ -726,38 +726,32 @@ p:has(> .alc-btn) {
   font-size: 0.9rem;
   line-height: 1.5;
 }
-/* A corner ribbon marks the recommended card; the title stays one line. */
+/* A small tab sits on the top edge of the recommended card, outside the
+   content, so it never collides with the title or description. */
 .next-card--recommended {
   position: relative;
-  overflow: hidden;
   border-color: color-mix(
     in srgb,
     var(--alc-accent) 45%,
     var(--alc-hairline-2)
   );
 }
-.next-card--recommended::after {
-  /* A 12rem band rotated 45deg, centered 3rem in from the top-right
-     corner on both axes, so the segment visible inside the card is
-     ~6rem long: enough for the word at this size. */
+.next-card--recommended::before {
   content: "Recommended";
   position: absolute;
-  top: 2.3rem;
-  right: -3rem;
-  width: 12rem;
-  line-height: 1.3rem;
-  transform: rotate(45deg);
-  text-align: center;
+  top: 0;
+  right: 1.25rem;
+  transform: translateY(-50%);
+  padding: 0.15rem 0.6rem;
+  border-radius: 999px;
   background: var(--alc-accent);
   color: var(--alc-fg-on-accent);
-  font-size: 0.6rem;
+  font-size: 0.66rem;
   font-weight: 600;
-  letter-spacing: 0.03em;
+  letter-spacing: 0.04em;
   text-transform: uppercase;
+  line-height: 1.4;
   pointer-events: none;
-}
-.next-card--recommended strong {
-  padding-right: 4.5rem;
 }
 @media (max-width: 600px) {
   .next-steps {

--- a/website/src/styles/custom.css
+++ b/website/src/styles/custom.css
@@ -746,7 +746,7 @@ p:has(> .alc-btn) {
   text-align: center;
   padding: 0.2rem 0;
   background: var(--alc-accent);
-  color: var(--alc-fg-invert);
+  color: var(--alc-fg-on-accent);
   font-size: 0.68rem;
   font-weight: 600;
   letter-spacing: 0.04em;

--- a/website/src/worker.ts
+++ b/website/src/worker.ts
@@ -60,7 +60,7 @@ const REDIRECTS: Record<string, string> = {
   "/tutorial/cloudflare/rpc-durable-object":
     "/cloudflare/compute/durable-objects#schemaless-rpc",
   "/tutorial/cloudflare/rpc-worker":
-    "/cloudflare/compute/workers#schemaless-rpc",
+    "/cloudflare/compute/workers#call-another-worker",
   "/tutorial/cloudflare/ai-gateway": "/cloudflare/ai/ai-gateway",
   "/tutorial/cloudflare/ai-search": "/cloudflare/ai/ai-search",
   "/tutorial/cloudflare/artifacts": "/cloudflare/data/artifacts",


### PR DESCRIPTION
Carry the narrative style of the Infrastructure as Effects section (#1470) forward into the onboarding funnel and the Cloudflare compute docs, and make the hand-written Workers page and the generated Worker reference complete against each other.

### Onboarding funnel

```
Getting started  →  What is Alchemy?  →  Tutorial Part 2 … Part 6  →  Infrastructure as Effects
```

- **Getting started** comes first. A tip at the top offers What is Alchemy for readers who want the idea before the install; the pager and first card go there after the deploy. Tutorial Part 2 picks up from the exact Stack Getting started deployed.
- **What is Alchemy?** is rewritten as a short narrative: Infrastructure as Code built in Effect (Stack, Resource, Provider, with the animated plan/deploy/destroy loop), the two-file async form as the superset, then Infrastructure as Effects on top (Runtime with the Effectful Constructor, Binding, Layer). Go-deeper links sit in `:::note` callouts.
- **Tutorial Part 1** tells Getting started graduates to skip ahead; **Part 6** sends finishers to the Infrastructure as Effects overview.
- **Migrating from v1** moves to the end of Core so the pager no longer lands on it.
- The docs-tabs route middleware now honors `prev` / `next` frontmatter overrides, which it previously discarded when recomputing the pager per tab.

### Workers hub

[workers.mdx](https://alchemy.run/cloudflare/compute/workers/) is rewritten as one progression: the Worker as a Runtime, one binding, calling another Worker, static assets, URLs, the Worker's own URL, async Workers, configuration, scopes, versions. Content that only existed in the reference is now covered here in brief with a link out:

- Access (`access`), Observability and Tail Workers, compatibility flags
- Bundling (`build.pure`), prebuilt bundles (`bundle: false`), zone routes
- `WorkerExecutionContext.waitUntil` for background work

The long Versions subsections are folded into a short section that points at Gradual deployments instead of repeating it.

### Worker reference (JSDoc on `Worker.ts`)

- Adds the content that only existed on the hand-written page: named entrypoints and entrypoint `props`, `runWorkerFirst`, `_headers` / `_redirects` / `.assetsignore`
- Fixes the `Worker.URL` example, which provided a `Cloudflare.Workers.URLBinding` Layer that does not exist
- Adopts the Construction / Runtime phase terminology in prose and comments

### Worker guides

Gradual deployments, Python Workers, Workers Cache, Rate limiting, Browser rendering, Worker Loader, and Workers for Platforms keep their structure but lose the em-dash-heavy sentences in favor of short, direct ones.

### Sidebar

Compute is regrouped so the Worker guides sit together after Workers, followed by Durable Objects, cross-worker DOs, WebSockets, Containers, and Workflows. Links into old Workers anchors are repointed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
