### PR TITLE
Refactor auth profiles into provider files

### DIFF
--- a/packages/alchemy/src/AWS/AuthProvider.ts
+++ b/packages/alchemy/src/AWS/AuthProvider.ts
@@ -36,7 +36,7 @@ import {
   type ProviderDetailLine,
   type ProviderDetails,
 } from "../Auth/AuthProvider.ts";
-import { CredentialsStore, displayRedacted } from "../Auth/Credentials.ts";
+import { displayRedacted } from "../Auth/Credentials.ts";
 import {
   getEnv,
   getEnvRedacted,
@@ -94,7 +94,7 @@ export const silentConsole: EffectConsole.Console = {
   warn: noop,
 };
 
-/** Manifest-entry schema for {@link AwsAuthConfig}. */
+/** Typed values stored in an AWS provider profile document. */
 export const AwsAuthConfigSchema = Schema.Union([
   Schema.Struct({
     method: Schema.Literal("sso"),
@@ -103,7 +103,14 @@ export const AwsAuthConfigSchema = Schema.Union([
       Schema.Union([Schema.Literal("oauth"), Schema.Literal("device")]),
     ),
   }),
-  Schema.Struct({ method: Schema.Literal("stored") }),
+  Schema.Struct({
+    method: Schema.Literal("stored"),
+    accountId: Schema.optional(Schema.String),
+    accessKeyId: Schema.String,
+    secretAccessKey: Schema.String,
+    sessionToken: Schema.optional(Schema.String),
+    region: Schema.String,
+  }),
   Schema.Struct({
     method: Schema.Literal("local"),
     endpoint: Schema.optional(Schema.String),
@@ -135,17 +142,6 @@ const options: Array<{
     description: "floci / LocalStack — no AWS account required",
   },
 ];
-
-export const AwsStoredCredentials = Schema.Struct({
-  accountId: Schema.String,
-  accessKeyId: Schema.RedactedFromValue(Schema.String),
-  secretAccessKey: Schema.RedactedFromValue(Schema.String),
-  sessionToken: Schema.optional(Schema.RedactedFromValue(Schema.String)),
-  region: Schema.String,
-});
-export type AwsStoredCredentials = typeof AwsStoredCredentials.Type;
-
-const STORAGE_KEY = "aws-stored";
 
 /** `--set` fields for `--method keys` (static access keys, persisted). */
 const keysFields: ReadonlyArray<ConfigureField> = [
@@ -225,8 +221,6 @@ export const AwsAuth = AuthProviderLayer<
   AWS_AUTH_PROVIDER_NAME,
   Effect.gen(function* () {
     const interaction = Interaction.accessors;
-    const store = yield* CredentialsStore;
-
     const getAccountId = ({
       accessKeyId,
       secretAccessKey,
@@ -309,16 +303,16 @@ export const AwsAuth = AuthProviderLayer<
         region,
       });
 
-      yield* store.write(profileName, STORAGE_KEY, AwsStoredCredentials, {
-        accountId,
-        accessKeyId: Redacted.make(accessKeyId),
-        secretAccessKey: Redacted.make(secretAccessKey),
-        sessionToken: sessionToken ? Redacted.make(sessionToken) : undefined,
-        region,
-      });
       yield* interaction.output.success("AWS credentials saved.");
 
-      return { method: "stored" as const };
+      return {
+        method: "stored" as const,
+        accountId,
+        accessKeyId,
+        secretAccessKey,
+        sessionToken: sessionToken || undefined,
+        region,
+      };
     });
 
     const configureInteractive = (profileName: string) =>
@@ -456,14 +450,17 @@ export const AwsAuth = AuthProviderLayer<
                   }),
               ),
             );
-            yield* store.write(profileName, STORAGE_KEY, AwsStoredCredentials, {
+            return {
+              method: "stored" as const,
               accountId,
-              accessKeyId,
-              secretAccessKey,
-              sessionToken,
+              accessKeyId: Redacted.value(accessKeyId),
+              secretAccessKey: Redacted.value(secretAccessKey),
+              sessionToken:
+                sessionToken === undefined
+                  ? undefined
+                  : Redacted.value(sessionToken),
               region,
-            });
-            return { method: "stored" as const };
+            };
           }),
         ),
         Match.when("sso", () =>
@@ -514,7 +511,11 @@ export const AwsAuth = AuthProviderLayer<
         ),
       );
 
-    const resolveCredentials = (profileName: string, config: AwsAuthConfig) =>
+    const resolveCredentials = (
+      profileName: string,
+      config: AwsAuthConfig,
+      updateConfig?: (config: AwsAuthConfig) => Effect.Effect<void, AuthError>,
+    ) =>
       Effect.gen(function* () {
         const reauth = refreshHint(AWS_AUTH_PROVIDER_NAME, profileName);
         return yield* Match.value(config)
@@ -563,76 +564,32 @@ export const AwsAuth = AuthProviderLayer<
                 } satisfies AwsResolvedCredentials;
               }),
             ),
-            Match.when({ method: "stored" }, () =>
-              store.read(profileName, STORAGE_KEY, AwsStoredCredentials).pipe(
-                Effect.flatMap((creds) =>
-                  creds == null
-                    ? Effect.fail(
-                        new NeedsReauth({
-                          provider: AWS_AUTH_PROVIDER_NAME,
-                          profile: profileName,
-                          message: `AWS stored credentials not found. ${reauth}`,
-                        }),
-                      )
-                    : Effect.succeed({
-                        accountId: creds.accountId,
-                        credentials: Effect.succeed<AwsCredentials>({
-                          accessKeyId: creds.accessKeyId,
-                          secretAccessKey: creds.secretAccessKey,
-                          sessionToken: creds.sessionToken,
-                          region: creds.region,
-                        }),
-                        region: creds.region,
-                        source: { type: "stored" as const },
-                      } satisfies AwsResolvedCredentials),
-                ),
-                // an older verson of the stored credentials didn't include the account ID, so we patch it hre
-                Effect.flatMap((creds) =>
-                  creds.accountId
-                    ? Effect.succeed(creds)
-                    : creds.credentials.pipe(
-                        Effect.flatMap((resolved) =>
-                          getAccountId({
-                            accessKeyId: resolved.accessKeyId,
-                            secretAccessKey: resolved.secretAccessKey,
-                            sessionToken: resolved.sessionToken,
-                            region: creds.region,
-                          }),
-                        ),
-                        Effect.map(
-                          (accountId) =>
-                            ({
-                              ...creds,
-                              accountId,
-                            }) satisfies AwsResolvedCredentials,
-                        ),
-                        // re-write the stored credentials
-                        Effect.tap((creds) =>
-                          creds.credentials.pipe(
-                            Effect.tap(
-                              ({
-                                accessKeyId,
-                                secretAccessKey,
-                                sessionToken,
-                              }) =>
-                                store.write(
-                                  profileName,
-                                  STORAGE_KEY,
-                                  AwsStoredCredentials,
-                                  {
-                                    accessKeyId,
-                                    secretAccessKey,
-                                    sessionToken,
-                                    region: creds.region,
-                                    accountId: creds.accountId,
-                                  },
-                                ),
-                            ),
-                          ),
-                        ),
-                      ),
-                ),
-              ),
+            Match.when({ method: "stored" }, (config) =>
+              Effect.gen(function* () {
+                const credentials: AwsCredentials = {
+                  accessKeyId: Redacted.make(config.accessKeyId),
+                  secretAccessKey: Redacted.make(config.secretAccessKey),
+                  sessionToken:
+                    config.sessionToken === undefined
+                      ? undefined
+                      : Redacted.make(config.sessionToken),
+                  region: config.region,
+                };
+                const accountId =
+                  config.accountId ?? (yield* getAccountId(credentials));
+                if (
+                  config.accountId === undefined &&
+                  updateConfig !== undefined
+                ) {
+                  yield* updateConfig({ ...config, accountId });
+                }
+                return {
+                  accountId,
+                  credentials: Effect.succeed(credentials),
+                  region: config.region,
+                  source: { type: "stored" as const },
+                } satisfies AwsResolvedCredentials;
+              }),
             ),
             Match.when({ method: "sso" }, (config) =>
               Effect.gen(function* () {
@@ -710,7 +667,7 @@ export const AwsAuth = AuthProviderLayer<
             // diagnosis. Only genuinely unexpected failures (store I/O, the
             // STS accountId backfill) get wrapped.
             Effect.mapError((e) =>
-              e._tag === "NeedsReauth" || e._tag === "AuthError"
+              e._tag === "AuthError"
                 ? e
                 : new AuthError({
                     message: "failed to resolve AWS credentials",
@@ -730,7 +687,11 @@ export const AwsAuth = AuthProviderLayer<
           );
       });
 
-    const details = (profileName: string, config: AwsAuthConfig) =>
+    const details = (
+      profileName: string,
+      config: AwsAuthConfig,
+      updateConfig?: (config: AwsAuthConfig) => Effect.Effect<void, AuthError>,
+    ) =>
       Effect.gen(function* () {
         // Profile display is observational. Resolving local credentials calls
         // ensureFloci(), which may inspect/start Docker and wait for health;
@@ -748,7 +709,11 @@ export const AwsAuth = AuthProviderLayer<
             ],
           } satisfies ProviderDetails;
         }
-        const creds = yield* resolveCredentials(profileName, config);
+        const creds = yield* resolveCredentials(
+          profileName,
+          config,
+          updateConfig,
+        );
         const reauth = refreshHint(AWS_AUTH_PROVIDER_NAME, profileName);
         // Resolve the live credentials. An expired/invalid SSO token only
         // surfaces here (the inner effect is lazy), so convert those tags
@@ -794,7 +759,7 @@ export const AwsAuth = AuthProviderLayer<
         return { lines };
       });
 
-    const logout = (profileName: string, config: AwsAuthConfig) =>
+    const logout = (_profileName: string, config: AwsAuthConfig) =>
       Match.value(config).pipe(
         Match.when({ method: "local" }, () => Effect.void),
         Match.when({ method: "sso" }, (config) =>
@@ -815,34 +780,18 @@ export const AwsAuth = AuthProviderLayer<
               }),
             ),
         ),
-        Match.when({ method: "stored" }, () =>
-          store
-            .delete(profileName, STORAGE_KEY)
-            .pipe(
-              Effect.andThen(
-                interaction.output.success("AWS: stored credentials removed"),
-              ),
-            ),
-        ),
+        Match.when({ method: "stored" }, () => Effect.void),
         Match.exhaustive,
       );
 
     const login = (profileName: string, config: AwsAuthConfig) =>
       Match.value(config)
         .pipe(
-          Match.when({ method: "local" }, () => Effect.void),
+          Match.when({ method: "local" }, (config) => Effect.succeed(config)),
           Match.when({ method: "sso" }, (config) =>
             loginSSO(config, config.authorizationMethod ?? "oauth"),
           ),
-          Match.when({ method: "stored" }, () =>
-            store
-              .read(profileName, STORAGE_KEY, AwsStoredCredentials)
-              .pipe(
-                Effect.flatMap((creds) =>
-                  creds == null ? loginStored(profileName) : Effect.void,
-                ),
-              ),
-          ),
+          Match.when({ method: "stored" }, (config) => Effect.succeed(config)),
           Match.exhaustive,
         )
         .pipe(

--- a/packages/alchemy/src/Alchemist/routes/profile.ts
+++ b/packages/alchemy/src/Alchemist/routes/profile.ts
@@ -2,6 +2,7 @@ import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 import * as Redacted from "effect/Redacted";
 import type { Interaction } from "../../Interaction.ts";
+import { AuthError } from "../../Auth/AuthProvider.ts";
 import { CredentialsStore } from "../../Auth/Credentials.ts";
 import {
   inspectProvider,
@@ -101,7 +102,10 @@ export const list = Effect.fn("Alchemist.profile.list")(function* () {
       active: name === selected.name,
       providers: Object.entries(profile.providers)
         .sort(([a], [b]) => a.localeCompare(b))
-        .map(([name, config]) => ({ name, method: config.method })),
+        .map(([name, config]) => ({
+          name,
+          method: config.method ?? "unknown",
+        })),
     }));
 });
 
@@ -146,10 +150,25 @@ export const get = Effect.fn("Alchemist.profile.get")(function* (input: {
         Interaction
       > =>
         includeProviderStatus
-          ? inspectProvider(input.name, provider, config, registered)
+          ? inspectProvider(
+              input.name,
+              provider,
+              config,
+              registered,
+              (updated) =>
+                profiles.setProviderConfig(input.name, provider, updated).pipe(
+                  Effect.mapError(
+                    (cause) =>
+                      new AuthError({
+                        message: `Could not persist repaired ${provider} credentials for profile '${input.name}'.`,
+                        cause,
+                      }),
+                  ),
+                ),
+            )
           : Effect.succeed({
               name: provider,
-              method: config.method,
+              method: config.method ?? "unknown",
               status: "connected",
               details: [],
             }),
@@ -306,10 +325,7 @@ export const configure = Effect.fn("Alchemist.profile.configure")(function* (
                 .pipe(Effect.orElseSucceed(() => undefined))
             : undefined,
         );
-  yield* profiles.setProfile(input.profile, {
-    ...stored,
-    providers: { ...stored.providers, [input.provider]: config },
-  });
+  yield* profiles.setProviderConfig(input.profile, input.provider, config);
   yield* report({
     _tag: "provider.configure.completed",
     provider: input.provider,
@@ -350,11 +366,7 @@ export const removeProvider = Effect.fn("Alchemist.profile.removeProvider")(
         logout = "completed";
       } else logout = "skipped-invalid-config";
     }
-    const { [input.provider]: _removed, ...remaining } = stored.providers;
-    yield* profiles.setProfile(input.profile, {
-      ...stored,
-      providers: remaining,
-    });
+    yield* profiles.deleteProviderConfig(input.profile, input.provider);
     return { profile: input.profile, provider: input.provider, logout };
   },
 );
@@ -388,10 +400,23 @@ export const refresh = Effect.fn("Alchemist.profile.refresh")(function* (
       );
     }
     yield* report({ _tag: "provider.refresh.started", provider: name });
-    yield* provider.login(
+    const refreshed = yield* provider.login(
       input.profile,
       yield* provider.decodeConfig(input.profile, config),
+      (updated) =>
+        profiles.setProviderConfig(input.profile, name, updated).pipe(
+          Effect.mapError(
+            (cause) =>
+              new AuthError({
+                message: `Could not persist refreshed ${name} credentials for profile '${input.profile}'.`,
+                cause,
+              }),
+          ),
+        ),
     );
+    if (refreshed !== undefined) {
+      yield* profiles.setProviderConfig(input.profile, name, refreshed);
+    }
     yield* report({ _tag: "provider.refresh.completed", provider: name });
   }
   return yield* get({

--- a/packages/alchemy/src/Auth/AuthProvider.ts
+++ b/packages/alchemy/src/Auth/AuthProvider.ts
@@ -43,7 +43,7 @@ export class AuthError extends Schema.TaggedError<AuthError>()("AuthError", {
 
 /**
  * Stored credentials exist (or are expected) but cannot be used until the
- * user re-authenticates: a missing credential file, an expired/rotated
+ * user re-authenticates: missing values, an expired/rotated
  * token, or a session the provider can no longer refresh silently. The
  * profile UI renders this as "needs re-login" instead of a generic error,
  * and callers match it with `Effect.catchTag("NeedsReauth", ...)` — never
@@ -210,7 +210,7 @@ export interface AuthProviderImpl<
   R = never,
 > {
   /**
-   * Schema for the provider's manifest entry ({@link Config}). Stored
+   * Schema for the provider-owned `values` object ({@link Config}). Stored
    * entries are user-editable JSON that may also come from a newer or
    * older alchemy, so every load decodes against this schema — an invalid
    * entry fails with a reconfigure hint instead of reaching provider code
@@ -246,7 +246,8 @@ export interface AuthProviderImpl<
   login(
     profileName: string,
     config: Config,
-  ): Effect.Effect<void, AuthError, R | Interaction>;
+    updateConfig?: (config: Config) => Effect.Effect<void, AuthError>,
+  ): Effect.Effect<Config | void, AuthError, R | Interaction>;
 
   logout(
     profileName: string,
@@ -262,10 +263,11 @@ export interface AuthProviderImpl<
   details(
     profileName: string,
     config: Config,
+    updateConfig?: (config: Config) => Effect.Effect<void, AuthError>,
   ): Effect.Effect<ProviderDetails, AuthError | NeedsReauth, R | Interaction>;
 
   /**
-   * Resolve credentials from the store/config, silently refreshing when the
+   * Resolve credentials from the profile values, silently refreshing when the
    * provider supports it. MUST be non-interactive — this is the only method
    * (with {@link readEnvironment}) that child processes exercise, and their
    * graphs carry no interaction services. When re-authentication is needed,
@@ -274,6 +276,7 @@ export interface AuthProviderImpl<
   read(
     profileName: string,
     config: Config,
+    updateConfig?: (config: Config) => Effect.Effect<void, AuthError>,
   ): Effect.Effect<Credentials, AuthError | NeedsReauth, R>;
 
   /**
@@ -303,13 +306,13 @@ export interface AuthProvider<
    */
   readonly environment: ReadonlyArray<EnvironmentVariable>;
   /**
-   * Decode a raw manifest entry against {@link AuthProviderImpl.configSchema}.
+   * Decode raw provider values against {@link AuthProviderImpl.configSchema}.
    * Fails with an {@link AuthError} carrying the reconfigure hint, so every
    * consumer of stored configuration reports invalid entries the same way.
    */
   decodeConfig(
     profileName: string,
-    config: { readonly method: string },
+    config: unknown,
   ): Effect.Effect<Config, AuthError>;
 }
 
@@ -394,20 +397,25 @@ export const AuthProvider =
               .configure(profileName, currentConfig)
               .pipe(Effect.provideContext(ctx)),
           ),
-        login: (profileName, config) =>
+        login: (profileName, config, updateConfig) =>
           Semaphore.withPermits(
             interactiveMutex,
             1,
           )(
-            service.login(profileName, config).pipe(Effect.provideContext(ctx)),
+            service
+              .login(profileName, config, updateConfig)
+              .pipe(Effect.provideContext(ctx)),
           ),
         logout: (profileName, config) =>
           withProfileCredentialsLock(
             profileName,
             service.logout(profileName, config),
           ).pipe(Effect.provideContext(ctx)),
-        details: (profileName, config) =>
-          service.details(profileName, config).pipe(Effect.provideContext(ctx)),
+        details: (profileName, config, updateConfig) =>
+          withProfileCredentialsLock(
+            profileName,
+            service.details(profileName, config, updateConfig),
+          ).pipe(Effect.provideContext(ctx)),
         ...(service.configureWith === undefined
           ? {}
           : {
@@ -423,10 +431,10 @@ export const AuthProvider =
                 ),
               configureMethods: service.configureMethods,
             }),
-        read: (profileName, config) =>
+        read: (profileName, config, updateConfig) =>
           withProfileCredentialsLock(
             profileName,
-            service.read(profileName, config),
+            service.read(profileName, config, updateConfig),
           ).pipe(Effect.provideContext(ctx)),
         readEnvironment: service.readEnvironment?.pipe(
           Effect.provideContext(ctx),
@@ -443,7 +451,7 @@ export const AuthProvider =
                   new AuthError({
                     message:
                       `Stored ${name} configuration in profile '${profileName}' is not valid ` +
-                      `for this version of alchemy (method '${config.method}'). ` +
+                      `for this version of alchemy. ` +
                       `${reconfigureHint(name, profileName)}`,
                     cause,
                   }),

--- a/packages/alchemy/src/Auth/Inspect.ts
+++ b/packages/alchemy/src/Auth/Inspect.ts
@@ -1,7 +1,12 @@
 import * as Effect from "effect/Effect";
 import * as Predicate from "effect/Predicate";
 import * as Result from "effect/Result";
-import type { AuthProviders, ProviderDetailLine } from "./AuthProvider.ts";
+import {
+  type AuthError,
+  reconfigureHint,
+  type AuthProviders,
+  type ProviderDetailLine,
+} from "./AuthProvider.ts";
 import type { ProviderConfig } from "./Profile.ts";
 
 /**
@@ -14,7 +19,12 @@ export interface ProviderConnection {
   readonly name: string;
   /** How credentials were supplied (`oauth`, `api-token`, …). */
   readonly method: string;
-  readonly status: "connected" | "needs-reauth" | "invalid" | "unavailable";
+  readonly status:
+    | "connected"
+    | "needs-reauth"
+    | "needs-reconfigure"
+    | "invalid"
+    | "unavailable";
   readonly details: ReadonlyArray<ProviderDetailLine>;
   /** Present whenever `status` is anything but `connected`. */
   readonly diagnostic?: {
@@ -48,12 +58,14 @@ export const inspectProvider = Effect.fn("inspectProvider")(function* (
   name: string,
   config: ProviderConfig,
   registered: AuthProviders["Service"],
+  updateConfig?: (config: ProviderConfig) => Effect.Effect<void, AuthError>,
 ) {
+  const method = config.method ?? "unknown";
   const provider = registered[name];
   if (provider === undefined) {
     return {
       name,
-      method: config.method,
+      method,
       status: "unavailable",
       details: [],
       diagnostic: {
@@ -64,11 +76,28 @@ export const inspectProvider = Effect.fn("inspectProvider")(function* (
     } satisfies ProviderConnection;
   }
 
+  // A deliberately empty migrated document records that the provider was
+  // connected in v0 while making no claim that its obsolete credentials are
+  // usable. Keep that distinct from malformed provider-owned values.
+  if (config.method === undefined) {
+    return {
+      name,
+      method,
+      status: "needs-reconfigure",
+      details: [],
+      diagnostic: {
+        severity: "warning",
+        code: "provider.needs-reconfigure",
+        message: `Provider '${name}' needs to be reconfigured. ${reconfigureHint(name, profile)}`,
+      },
+    } satisfies ProviderConnection;
+  }
+
   const decoded = yield* Effect.result(provider.decodeConfig(profile, config));
   if (Result.isFailure(decoded)) {
     return broken(
       name,
-      config.method,
+      method,
       "error",
       "provider.invalid-config",
       decoded.failure.message,
@@ -76,12 +105,12 @@ export const inspectProvider = Effect.fn("inspectProvider")(function* (
   }
 
   const details = yield* Effect.result(
-    provider.details(profile, decoded.success),
+    provider.details(profile, decoded.success, updateConfig),
   );
   if (Result.isSuccess(details)) {
     return {
       name,
-      method: config.method,
+      method,
       status: "connected",
       details: details.success.lines,
     } satisfies ProviderConnection;
@@ -92,7 +121,7 @@ export const inspectProvider = Effect.fn("inspectProvider")(function* (
   const needsReauth = Predicate.isTagged("NeedsReauth")(details.failure);
   return broken(
     name,
-    config.method,
+    method,
     needsReauth ? "warning" : "error",
     needsReauth ? "provider.needs-reauth" : "provider.details-failed",
     details.failure.message,

--- a/packages/alchemy/src/Auth/Paths.ts
+++ b/packages/alchemy/src/Auth/Paths.ts
@@ -3,7 +3,7 @@ import path from "pathe";
 
 /**
  * Root of alchemy's user-level auth state (`~/.alchemy`). Overridable with
- * `ALCHEMY_HOME`, which relocates the profile manifest, credential files,
+ * `ALCHEMY_HOME`, which relocates profiles, credential files,
  * and cross-process locks together — used by tests to isolate a temp home
  * and available to users who keep dotfiles elsewhere. Resolved lazily so an
  * override set after module load (e.g. in a test) still takes effect.
@@ -12,6 +12,17 @@ export const rootDir = () =>
   process.env.ALCHEMY_HOME ?? path.join(os.homedir(), ".alchemy");
 
 export const configFilePath = () => path.join(rootDir(), "profiles.json");
+
+/** Directory containing one directory per named profile. */
+export const profilesDirPath = () => path.join(rootDir(), "profiles");
+
+/** Directory containing all provider documents for a named profile. */
+export const profileDirPath = (profile: string) =>
+  path.join(profilesDirPath(), profile);
+
+/** The single persisted document for one provider in one profile. */
+export const profileProviderFilePath = (profile: string, provider: string) =>
+  path.join(profileDirPath(profile), `${provider.toLowerCase()}.json`);
 
 export const credentialsDirPath = () => path.join(rootDir(), "credentials");
 

--- a/packages/alchemy/src/Auth/Profile.ts
+++ b/packages/alchemy/src/Auth/Profile.ts
@@ -1,25 +1,26 @@
 import * as Config from "effect/Config";
-import * as DateTime from "effect/DateTime";
 import * as Context from "effect/Context";
+import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
-import * as Schema from "effect/Schema";
-import type { PlatformError } from "effect/PlatformError";
-import { UserFacingError } from "../UserFacingError.ts";
 import * as Path from "effect/Path";
-import crypto from "node:crypto";
-import path from "pathe";
+import type { PlatformError } from "effect/PlatformError";
+import * as Result from "effect/Result";
+import * as Schema from "effect/Schema";
+import { UserFacingError } from "../UserFacingError.ts";
 import { writeFileAtomic } from "../Util/AtomicFile.ts";
 import { profileCommandHint } from "../Util/interactive.ts";
-import { AuthError } from "./AuthProvider.ts";
-import type { AuthProvider } from "./AuthProvider.ts";
-import { withLock, withProfileCredentialsLock } from "./Lock.ts";
+import { AuthError, type AuthProvider } from "./AuthProvider.ts";
+import { withLock } from "./Lock.ts";
 import {
   configFilePath,
   credentialsDirPath,
   profileCredentialsDirPath,
+  profileDirPath,
+  profileProviderFilePath,
+  profilesDirPath,
   rootDir,
 } from "./Paths.ts";
 
@@ -27,58 +28,87 @@ export {
   configFilePath,
   credentialsDirPath,
   profileCredentialsDirPath,
+  profileDirPath,
+  profileProviderFilePath,
+  profilesDirPath,
   rootDir,
 } from "./Paths.ts";
 
-/**
- * Config key consulted by the various `fromAuthProvider` /
- * `fromEnvironment` layers to pick which named profile in
- * `~/.alchemy/profiles.json` to use.
- */
+/** Config key selecting a directory under `~/.alchemy/profiles`. */
 export const ALCHEMY_PROFILE = Config.string("ALCHEMY_PROFILE");
 
-export const PROFILE_MANIFEST_VERSION = 2;
+/** Version of the synthesized in-memory manifest returned by readManifest. */
+export const PROFILE_MANIFEST_VERSION = 3;
 
-/**
- * The built-in profile every command uses when `--profile` /
- * `$ALCHEMY_PROFILE` is absent — the same model as the AWS CLI's `default`
- * profile. It always exists, cannot be renamed or deleted, and there is no
- * stored "default selection" to change: any other profile must be named
- * explicitly.
- */
+/** Stable format identifier for an individual provider profile document. */
+export const PROFILE_FORMAT = "alchemy.profile/v1" as const;
+
 export const DEFAULT_PROFILE_NAME = "default";
-
-/**
- * The id assigned to the built-in default profile. Deterministic (not
- * random) so a manifest that has never been written still presents the
- * same id on every read.
- */
 export const DEFAULT_PROFILE_ID = "default";
 
 /**
- * Configuration stored per provider inside a profile. `method` selects the
- * provider's auth flow (e.g. `oauth`, `stored`); the rest is provider-defined
- * and never contains secrets — those live in `~/.alchemy/credentials`.
+ * The minimum contract shared by provider-owned values. Providers refine this
+ * with their own Effect Schema codec. The method is deliberately an open
+ * string: adding an auth method never changes Alchemy's storage schema.
  */
+export const ProviderConfigSchema = Schema.Record(
+  Schema.String,
+  Schema.Unknown,
+);
+
 export interface ProviderConfig {
-  method: string;
+  readonly method?: string;
+  readonly [key: string]: unknown;
 }
 
+/** User-facing, non-secret annotations. Provider schemas may refine it. */
+export const ProfileMetadataSchema = Schema.Record(
+  Schema.String,
+  Schema.Unknown,
+);
+export type ProfileMetadata = typeof ProfileMetadataSchema.Type;
+
+/**
+ * Base on-disk schema. Only this envelope is owned by Alchemy core; the
+ * selected AuthProvider decodes `metadata` and `values` with its own schemas.
+ */
+export const ProviderProfileFileSchema = Schema.StructWithRest(
+  Schema.Struct({
+    format: Schema.Literal(PROFILE_FORMAT),
+    provider: Schema.String,
+    metadata: ProfileMetadataSchema,
+    values: ProviderConfigSchema,
+  }),
+  [Schema.Record(Schema.String, Schema.Unknown)],
+);
+
+export type ProviderProfileFile = typeof ProviderProfileFileSchema.Type;
+
+/** Compose the base envelope with a custom provider's typed schemas. */
+export const makeProviderProfileSchema = <Metadata, Values>(
+  provider: string,
+  metadata: Schema.Codec<Metadata>,
+  values: Schema.Codec<Values>,
+) =>
+  Schema.Struct({
+    format: Schema.Literal(PROFILE_FORMAT),
+    provider: Schema.Literal(provider),
+    metadata,
+    values,
+  });
+
+/**
+ * Aggregate view used by the profile UI. It is synthesized from provider
+ * files and is never persisted as a central manifest.
+ */
 export interface Profile {
-  /**
-   * Stable identifier assigned when the profile is created (or migrated
-   * from a pre-id manifest). Survives renames — reference a profile by id
-   * when the reference must not break as the user reorganizes names.
-   */
-  id: string;
-  providers: {
-    [providerName: string]: ProviderConfig;
-  };
+  readonly id: string;
+  readonly providers: Record<string, ProviderConfig>;
 }
 
 export interface ProfileManifest {
-  version: typeof PROFILE_MANIFEST_VERSION;
-  profiles: Record<string, Profile>;
+  readonly version: typeof PROFILE_MANIFEST_VERSION;
+  readonly profiles: Record<string, Profile>;
 }
 
 export interface ProfileSelection {
@@ -86,34 +116,34 @@ export interface ProfileSelection {
   readonly source: "configuration" | "default";
 }
 
-const ProviderConfigSchema = Schema.StructWithRest(
-  Schema.Struct({ method: Schema.String }),
-  [Schema.Record(Schema.String, Schema.Unknown)],
-);
-
-const ProfileSchema = Schema.Struct({
-  id: Schema.String,
-  providers: Schema.Record(Schema.String, ProviderConfigSchema),
-});
-
-/** Pre-v2 profile shape: a bare provider-name → config record, no id. */
-const LegacyProfileSchema = Schema.Record(Schema.String, ProviderConfigSchema);
-
-// StructWithRest so unknown top-level keys written by a newer alchemy
-// survive a read-modify-write cycle instead of being silently dropped.
-// `defaultProfile` is decoded only so manifests written by the short-lived
-// stored-default-selection scheme can be recognized and dropped on read.
-const StoredManifestSchema = Schema.StructWithRest(
+/** Only the released v0 centralized layout is migrated. */
+const V0ManifestSchema = Schema.StructWithRest(
   Schema.Struct({
-    version: Schema.Number,
-    defaultProfile: Schema.optional(Schema.String),
-    profiles: Schema.Record(
-      Schema.String,
-      Schema.Union([ProfileSchema, LegacyProfileSchema]),
-    ),
+    version: Schema.Literal(0),
+    profiles: Schema.Record(Schema.String, Schema.Unknown),
   }),
   [Schema.Record(Schema.String, Schema.Unknown)],
 );
+
+const LEGACY_CREDENTIAL_KEYS: Record<string, string | Record<string, string>> =
+  {
+    AWS: "aws-stored",
+    Axiom: "axiom-stored",
+    Cloudflare: "cloudflare-stored",
+    Fly: "fly-stored",
+    GitHub: "github-stored",
+    Hetzner: "hetzner-stored",
+    Neon: "neon-stored",
+    Planetscale: {
+      stored: "planetscale-stored",
+      oauth: "planetscale-oauth",
+    },
+    Prisma: "prisma-stored",
+    Railway: {
+      stored: "railway-stored",
+      oauth: "railway-oauth",
+    },
+  };
 
 export class ProfileError extends Schema.TaggedError<ProfileError>()(
   "ProfileError",
@@ -125,7 +155,6 @@ export class ProfileError extends Schema.TaggedError<ProfileError>()(
   readonly [UserFacingError] = true;
 }
 
-/** A registry-only layer reached a provider with no stored configuration. */
 export class MissingProviderConfig extends Schema.TaggedError<MissingProviderConfig>()(
   "MissingProviderConfig",
   {
@@ -135,11 +164,6 @@ export class MissingProviderConfig extends Schema.TaggedError<MissingProviderCon
   },
 ) {}
 
-/**
- * Registry-only consumers use this to ignore provider layers whose account
- * has not been connected yet. Normal commands surface an actionable
- * {@link AuthError}. Neither path starts configuration implicitly.
- */
 export const SuppressMissingProviderConfig = Context.Reference<boolean>(
   "Auth/SuppressMissingProviderConfig",
   { defaultValue: () => false },
@@ -147,25 +171,10 @@ export const SuppressMissingProviderConfig = Context.Reference<boolean>(
 
 const emptyManifest = (): ProfileManifest => ({
   version: PROFILE_MANIFEST_VERSION,
-  profiles: {},
+  profiles: {
+    [DEFAULT_PROFILE_NAME]: { id: DEFAULT_PROFILE_ID, providers: {} },
+  },
 });
-
-/**
- * Guarantee the built-in `default` profile exists in a manifest. The
- * synthesized entry uses the deterministic {@link DEFAULT_PROFILE_ID} so it
- * is stable before the manifest is ever written; applying this on every
- * write persists it to disk.
- */
-const withDefaultProfile = (manifest: ProfileManifest): ProfileManifest =>
-  manifest.profiles[DEFAULT_PROFILE_NAME] !== undefined
-    ? manifest
-    : {
-        ...manifest,
-        profiles: {
-          ...manifest.profiles,
-          [DEFAULT_PROFILE_NAME]: { id: DEFAULT_PROFILE_ID, providers: {} },
-        },
-      };
 
 export const createProfileHint = (name?: string) =>
   Effect.map(
@@ -179,16 +188,11 @@ const profileNotFound = Effect.fn(function* (name: string) {
   });
 });
 
-/**
- * Shared by the store's locked `deleteProfile` check and the CLI's
- * friendlier pre-confirmation check, so the user-facing copy can't drift.
- */
 export const cannotDeleteDefaultProfile = () =>
   new ProfileError({
     message: `Cannot delete the built-in '${DEFAULT_PROFILE_NAME}' profile.`,
   });
 
-/** Same sharing rationale as {@link cannotDeleteDefaultProfile}. */
 export const cannotRenameDefaultProfile = () =>
   new ProfileError({
     message: `Cannot rename the built-in '${DEFAULT_PROFILE_NAME}' profile.`,
@@ -209,12 +213,17 @@ export const validateProfileName = (
         }),
       );
 
-/**
- * Service exposing on-disk profile helpers. All methods have `R = never` —
- * the {@link FileSystem.FileSystem} requirement is captured by
- * {@link ProfileStoreLive} when the layer is built, freeing call sites from
- * having to thread `FileSystem` through their own Effects.
- */
+const validateProviderName = (
+  name: string,
+): Effect.Effect<string, ProfileError> =>
+  PROFILE_NAME_PATTERN.test(name)
+    ? Effect.succeed(name)
+    : Effect.fail(
+        new ProfileError({
+          message: `Invalid provider id '${name}'. Provider ids must be safe as filenames.`,
+        }),
+      );
+
 export interface ProfileStoreService {
   readonly readManifest: Effect.Effect<
     ProfileManifest,
@@ -223,18 +232,12 @@ export interface ProfileStoreService {
   readonly getProfile: (
     name: string,
   ) => Effect.Effect<Profile | undefined, ProfileError | PlatformError>;
-  /**
-   * Like {@link getProfile}, but fails with an actionable creation hint when
-   * the named profile does not exist. The built-in `default` profile always
-   * exists.
-   */
   readonly ensureProfile: (
     name: string,
   ) => Effect.Effect<Profile, ProfileError | PlatformError>;
   readonly createProfile: (
     name: string,
   ) => Effect.Effect<void, ProfileError | PlatformError>;
-  /** Rename a profile. The built-in `default` profile cannot be renamed. */
   readonly renameProfile: (
     name: string,
     newName: string,
@@ -243,15 +246,15 @@ export interface ProfileStoreService {
     ProfileSelection,
     ProfileError | PlatformError
   >;
-  readonly setProfile: (
-    name: string,
-    profile: Profile,
+  readonly setProviderConfig: (
+    profile: string,
+    provider: string,
+    values: ProviderConfig,
   ) => Effect.Effect<void, ProfileError | PlatformError>;
-  /**
-   * Delete `name` from the manifest. Returns `false` when the profile
-   * doesn't exist. Fails when `name` is the built-in `default` profile,
-   * which cannot be deleted.
-   */
+  readonly deleteProviderConfig: (
+    profile: string,
+    provider: string,
+  ) => Effect.Effect<boolean, ProfileError | PlatformError>;
   readonly deleteProfile: (
     name: string,
   ) => Effect.Effect<boolean, ProfileError | PlatformError>;
@@ -269,24 +272,17 @@ export class ProfileStore extends Context.Service<
   ProfileStoreService
 >()("Alchemy::ProfileStore") {}
 
-/**
- * Layer that builds the {@link ProfileStore} service. Captures the
- * {@link FileSystem.FileSystem} dependency at layer-build time, so any
- * Effect that yields {@link ProfileStore} ends up with `R = ProfileStore` (no
- * `FileSystem` leak). Provide this once at the top of your runtime
- * (alongside `PlatformServices` / `NodeContext`).
- */
 export const ProfileStoreLive = Layer.effect(
   ProfileStore,
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
     const pathService = yield* Path.Path;
 
-    /**
-     * The cross-process lock resolves FileSystem/Path from context; the
-     * store's method signatures stay dependency-free, so satisfy the lock
-     * from the services captured at layer build.
-     */
+    yield* fs.makeDirectory(profileDirPath(DEFAULT_PROFILE_NAME), {
+      recursive: true,
+    });
+    yield* fs.chmod(profileDirPath(DEFAULT_PROFILE_NAME), 0o700);
+
     const provideLockServices = <A, E>(
       effect: Effect.Effect<A, E, FileSystem.FileSystem | Path.Path>,
     ): Effect.Effect<A, E> =>
@@ -295,291 +291,349 @@ export const ProfileStoreLive = Layer.effect(
         Effect.provideService(Path.Path, pathService),
       );
 
-    /**
-     * Legacy manifests recorded `method: "env"` entries for providers whose
-     * credentials came from environment variables. Profiles no longer track
-     * env-backed credentials (env vars resolve without any profile entry),
-     * so those entries are dropped on read — the removal is persisted by the
-     * next manifest write.
-     */
-    const dropLegacyEnvEntries = (
-      providers: Profile["providers"],
-    ): Profile["providers"] =>
-      Object.fromEntries(
-        Object.entries(providers).filter(([, cfg]) => cfg.method !== "env"),
+    const decodeJson = (file: string) =>
+      fs.readFileString(file).pipe(
+        Effect.flatMap(
+          Schema.decodeUnknownEffect(Schema.fromJsonString(Schema.Unknown)),
+        ),
+        Effect.mapError(
+          (cause) =>
+            new ProfileError({
+              message: `Could not parse '${file}'.`,
+              cause,
+            }),
+        ),
       );
 
-    /**
-     * Normalize a decoded profile entry to the v2 shape. Pre-v2 entries are
-     * bare provider maps without ids; they get the profile's name as its id,
-     * which is deterministic across reads (a random id would drift until the
-     * first write persisted it).
-     */
-    const normalizeProfile = (
-      name: string,
-      value: typeof ProfileSchema.Type | typeof LegacyProfileSchema.Type,
-    ): Profile => {
-      const current = Schema.decodeUnknownOption(ProfileSchema)(value);
-      if (Option.isSome(current)) {
-        return {
-          id: current.value.id,
-          providers: dropLegacyEnvEntries(current.value.providers),
+    const backupInvalidProfileFile = (file: string, reason: unknown) =>
+      provideLockServices(
+        withLock(
+          "profiles-invalid",
+          Effect.gen(function* () {
+            if (!(yield* fs.exists(file))) return undefined;
+            const stamp = DateTime.formatIso(yield* DateTime.now)
+              .replaceAll(":", "-")
+              .replaceAll(".", "-");
+            const backup = `${file}.invalid-${stamp}.bak`;
+            yield* fs.rename(file, backup);
+            yield* Effect.logWarning(
+              `Invalid profile file '${file}' was backed up to '${backup}' and skipped.`,
+              reason,
+            );
+            return backup;
+          }),
+        ),
+      );
+
+    const writeProviderFile = (
+      profile: string,
+      provider: string,
+      values: ProviderConfig,
+      previous?: ProviderProfileFile,
+    ) =>
+      Effect.gen(function* () {
+        yield* validateProfileName(profile);
+        yield* validateProviderName(provider);
+        const dir = profileDirPath(profile);
+        yield* fs.makeDirectory(dir, { recursive: true });
+        yield* fs.chmod(dir, 0o700);
+        const document: ProviderProfileFile = {
+          format: PROFILE_FORMAT,
+          provider,
+          metadata: previous?.metadata ?? {},
+          values,
         };
-      }
-      const providers = Schema.decodeUnknownSync(LegacyProfileSchema)(value);
-      return {
-        id: name,
-        providers: dropLegacyEnvEntries(providers),
-      };
-    };
-
-    /**
-     * Read + decode the raw manifest file. `undefined` when the file does
-     * not exist; decode failures are typed `ProfileError`s that leave the
-     * file untouched.
-     */
-    const decodeStoredManifest = Effect.suspend(() => {
-      const manifestPath = configFilePath();
-      return fs.readFileString(manifestPath).pipe(
-        Effect.flatMap((data) =>
-          Schema.decodeUnknownEffect(Schema.fromJsonString(Schema.Unknown))(
-            data,
-          ).pipe(
-            Effect.mapError(
-              (cause) =>
-                new ProfileError({
-                  message: `Could not parse '${manifestPath}'. The file was left untouched.`,
-                  cause,
-                }),
-            ),
-          ),
-        ),
-        Effect.flatMap((json) =>
-          Schema.decodeUnknownEffect(StoredManifestSchema)(json).pipe(
-            Effect.mapError(
-              (cause) =>
-                new ProfileError({
-                  message: `Invalid profile manifest at '${manifestPath}'. The file was left untouched.`,
-                  cause,
-                }),
-            ),
-          ),
-        ),
-        Effect.catchReason("PlatformError", "NotFound", () =>
-          Effect.succeed(undefined),
-        ),
-      );
-    });
-
-    /**
-     * Normalize a decoded manifest to the current shape: stamp the version,
-     * drop the short-lived stored-default-selection `defaultProfile` key,
-     * and normalize each profile entry (pre-id entries get their name as id,
-     * legacy `method: "env"` provider entries are dropped).
-     */
-    const toCurrentManifest = (
-      stored: typeof StoredManifestSchema.Type,
-    ): ProfileManifest => {
-      const { defaultProfile: _dropped, ...rest } = stored;
-      return {
-        ...rest,
-        version: PROFILE_MANIFEST_VERSION,
-        profiles: Object.fromEntries(
-          Object.entries(stored.profiles).map(([name, value]) => [
-            name,
-            normalizeProfile(name, value),
-          ]),
-        ),
-      } satisfies ProfileManifest;
-    };
-
-    const writeManifest = (config: ProfileManifest) =>
-      Effect.suspend(() => {
-        const manifestPath = configFilePath();
-        return fs
-          .makeDirectory(path.dirname(manifestPath), { recursive: true })
-          .pipe(
-            Effect.flatMap(() =>
-              writeFileAtomic(
-                fs,
-                manifestPath,
-                JSON.stringify(withDefaultProfile(config), null, 2),
-                0o600,
-              ),
-            ),
-          );
+        yield* writeFileAtomic(
+          fs,
+          profileProviderFilePath(profile, provider),
+          JSON.stringify(document, null, 2),
+          0o600,
+        );
       });
 
-    /**
-     * One-shot on-disk upgrade of a pre-v2 store. The credential storage
-     * layout changed with the manifest (renamed file keys, schema-validated
-     * contents), so stored secrets from a v0/v1 store cannot be trusted to
-     * load — instead of migrating values, the whole legacy state is moved
-     * into `~/.alchemy/.v0-profiles-<timestamp>/` and the manifest is
-     * rewritten in the current format with every profile/provider entry
-     * kept. Providers then report
-     * a clean "credentials not found — reconfigure" instead of a schema
-     * error, and the backup allows manual recovery.
-     *
-     * Runs under its own cross-process lock (distinct from
-     * `profiles-manifest`, which may already be held by `modifyManifest`
-     * when this is reached) and re-checks the stored version after
-     * acquisition, so concurrent processes migrate exactly once.
-     */
-    const migrateLegacyStore = provideLockServices(
+    const readLegacyProviderValues = (
+      profile: string,
+      provider: string,
+      values: ProviderConfig,
+    ) =>
+      Effect.gen(function* () {
+        // Cloudflare's released OAuth grant is obsolete, but its stored API
+        // token and global API key formats still map exactly to the new
+        // provider-owned values schema.
+        if (provider === "Cloudflare" && values.method !== "stored") {
+          return { method: "oauth" };
+        }
+        const configuredKey = LEGACY_CREDENTIAL_KEYS[provider];
+        const key =
+          typeof configuredKey === "string"
+            ? configuredKey
+            : values.method === undefined
+              ? undefined
+              : configuredKey?.[values.method];
+        if (key === undefined) return values;
+
+        const candidates = [key];
+        // The earliest GitHub sidecar used this shorter filename.
+        if (provider === "GitHub") candidates.push("gh-stored");
+        // The earliest Cloudflare sidecar used this shorter filename.
+        if (provider === "Cloudflare") candidates.push("cf-stored");
+        let credentialFile: string | undefined;
+        for (const candidate of candidates) {
+          const file = pathService.join(
+            profileCredentialsDirPath(profile),
+            `${candidate}.json`,
+          );
+          if (yield* fs.exists(file)) {
+            credentialFile = file;
+            break;
+          }
+        }
+        if (credentialFile === undefined) {
+          return provider === "Cloudflare" ? {} : values;
+        }
+
+        const decoded = yield* Effect.result(
+          decodeJson(credentialFile).pipe(
+            Effect.flatMap(Schema.decodeUnknownEffect(ProviderConfigSchema)),
+          ),
+        );
+        if (Result.isFailure(decoded)) {
+          yield* Effect.logWarning(
+            `Could not decode legacy credentials from '${credentialFile}'; migrating the manifest values and preserving the sidecar in the v0 backup.`,
+            decoded.failure,
+          );
+          return provider === "Cloudflare" ? {} : values;
+        }
+        const credential = decoded.success;
+        const { type: _type, ...inline } = credential;
+        const normalizedInline =
+          provider === "Axiom" && inline.apiToken !== undefined
+            ? (({ apiToken, ...rest }) => ({ ...rest, token: apiToken }))(
+                inline,
+              )
+            : inline;
+        const { storageKey: _storageKey, ...manifestValues } = values;
+        const migrated: ProviderConfig = {
+          ...manifestValues,
+          ...normalizedInline,
+        };
+        if (provider !== "Cloudflare") return migrated;
+        return migrated.credentialType === "apiKey" &&
+          typeof migrated.apiKey === "string" &&
+          typeof migrated.email === "string" &&
+          typeof migrated.accountId === "string"
+          ? migrated
+          : migrated.credentialType === "apiToken" &&
+              typeof migrated.apiToken === "string" &&
+              typeof migrated.accountId === "string"
+            ? migrated
+            : {};
+      });
+
+    /** Expand the released v0 store and preserve every original file. */
+    const migrateCentralManifest = provideLockServices(
       withLock(
         "profiles-migrate",
         Effect.gen(function* () {
-          const stored = yield* decodeStoredManifest;
-          if (
-            stored === undefined ||
-            stored.version >= PROFILE_MANIFEST_VERSION
-          ) {
+          const legacy = configFilePath();
+          if (!(yield* fs.exists(legacy))) return;
+          const jsonResult = yield* Effect.result(decodeJson(legacy));
+          if (Result.isFailure(jsonResult)) {
+            yield* backupInvalidProfileFile(legacy, jsonResult.failure);
             return;
           }
-          // Second precision, `:` swapped out for a filename-safe stamp.
-          const stamp = DateTime.formatIso(yield* DateTime.now)
-            .slice(0, 19)
-            .replaceAll(":", "-");
-          const backupDir = pathService.join(
-            rootDir(),
-            `.v0-profiles-${stamp}`,
+          const header = Schema.decodeUnknownOption(
+            Schema.Struct({ version: Schema.Number }),
+          )(jsonResult.success);
+          // The short-lived centralized versions were never released and do
+          // not need a compatibility path. Leave them untouched.
+          if (Option.isSome(header) && header.value.version !== 0) return;
+          const storedResult = yield* Effect.result(
+            Schema.decodeUnknownEffect(V0ManifestSchema)(jsonResult.success),
           );
-          const credentialsBackupDir = pathService.join(
-            backupDir,
-            "credentials",
-          );
-          yield* fs.makeDirectory(backupDir, { recursive: true });
-          // The backup holds credential secrets — keep it owner-only.
-          yield* fs.chmod(backupDir, 0o700);
-          yield* fs.copyFile(
-            configFilePath(),
-            pathService.join(backupDir, "profiles.json"),
-          );
-          // The manifest predates the current storage layout, so every file
-          // under credentials/ does too — move them all into the backup.
-          const credentialsRoot = credentialsDirPath();
-          const entries = yield* fs
-            .readDirectory(credentialsRoot)
-            .pipe(
-              Effect.catchReason("PlatformError", "NotFound", () =>
-                Effect.succeed<string[]>([]),
-              ),
-            );
-          for (const entry of entries) {
-            const profileDir = pathService.join(credentialsRoot, entry);
-            const info = yield* fs.stat(profileDir);
-            if (info.type !== "Directory") continue;
-            const files = yield* fs.readDirectory(profileDir);
-            const target = pathService.join(credentialsBackupDir, entry);
-            yield* fs.makeDirectory(target, { recursive: true });
-            for (const file of files) {
-              yield* fs.rename(
-                pathService.join(profileDir, file),
-                pathService.join(target, file),
-              );
-            }
-            // Now empty (every entry was renamed away); the next credential
-            // write recreates it with 0o700.
-            yield* fs
-              .remove(profileDir, { recursive: true })
-              .pipe(Effect.ignore);
+          if (Result.isFailure(storedResult)) {
+            yield* backupInvalidProfileFile(legacy, storedResult.failure);
+            return;
           }
-          yield* writeManifest(toCurrentManifest(stored));
-          yield* Effect.logWarning(
-            "Alchemy's profile storage layout changed: your profiles were kept, but some connected " +
-              "accounts must be configured again — run `alchemy profile`. The previous profiles.json " +
-              `and credential files were backed up to '${backupDir}'.`,
-          );
+          const stored = storedResult.success;
+          for (const [name, entry] of Object.entries(stored.profiles)) {
+            const validName = yield* Effect.result(validateProfileName(name));
+            if (Result.isFailure(validName)) {
+              yield* Effect.logWarning(
+                `Skipping invalid v0 profile name '${name}'. It remains available in the v0 backup.`,
+              );
+              continue;
+            }
+            const providersResult = yield* Effect.result(
+              Schema.decodeUnknownEffect(
+                Schema.Record(Schema.String, Schema.Unknown),
+              )(entry),
+            );
+            if (Result.isFailure(providersResult)) {
+              yield* Effect.logWarning(
+                `Skipping invalid v0 profile '${name}'. It remains available in the v0 backup.`,
+                providersResult.failure,
+              );
+              continue;
+            }
+            yield* fs.makeDirectory(profileDirPath(name), { recursive: true });
+            yield* fs.chmod(profileDirPath(name), 0o700);
+            for (const [provider, rawValues] of Object.entries(
+              providersResult.success,
+            )) {
+              const validProvider = yield* Effect.result(
+                validateProviderName(provider),
+              );
+              if (Result.isFailure(validProvider)) {
+                yield* Effect.logWarning(
+                  `Skipping invalid v0 provider name '${provider}' in profile '${name}'. It remains available in the v0 backup.`,
+                );
+                continue;
+              }
+              const valuesResult = yield* Effect.result(
+                Schema.decodeUnknownEffect(ProviderConfigSchema)(rawValues),
+              );
+              if (Result.isFailure(valuesResult)) {
+                if (provider === "Cloudflare") {
+                  const target = profileProviderFilePath(name, provider);
+                  if (!(yield* fs.exists(target))) {
+                    yield* writeProviderFile(name, provider, {});
+                  }
+                  continue;
+                }
+                yield* Effect.logWarning(
+                  `Skipping invalid v0 provider '${provider}' in profile '${name}'. It remains available in the v0 backup.`,
+                  valuesResult.failure,
+                );
+                continue;
+              }
+              const values = valuesResult.success;
+              if (values.method === "env") continue;
+              // Known legacy sidecars become inline provider values.
+              const migratedValues = yield* readLegacyProviderValues(
+                name,
+                provider,
+                values,
+              );
+              const target = profileProviderFilePath(name, provider);
+              if (!(yield* fs.exists(target))) {
+                yield* writeProviderFile(name, provider, migratedValues);
+              }
+            }
+          }
+          const stamp = DateTime.formatIso(yield* DateTime.now)
+            .replaceAll(":", "-")
+            .replaceAll(".", "-");
+          const backup = pathService.join(rootDir(), `.profiles-v0-${stamp}`);
+          yield* fs.makeDirectory(backup, { recursive: true });
+          yield* fs.chmod(backup, 0o700);
+          yield* fs.rename(legacy, pathService.join(backup, "profiles.json"));
+          const credentials = credentialsDirPath();
+          if (yield* fs.exists(credentials)) {
+            yield* fs.rename(
+              credentials,
+              pathService.join(backup, "credentials"),
+            );
+          }
         }),
       ),
     );
 
-    const readManifest = decodeStoredManifest.pipe(
-      Effect.flatMap((stored) =>
-        stored !== undefined && stored.version < PROFILE_MANIFEST_VERSION
-          ? // Pre-v2 store: upgrade it on disk (backing up the legacy
-            // manifest + credential files), then re-read the result.
-            migrateLegacyStore.pipe(Effect.andThen(decodeStoredManifest))
-          : Effect.succeed(stored),
-      ),
-      Effect.flatMap((stored) =>
-        stored === undefined
-          ? Effect.succeed(emptyManifest())
-          : stored.version <= PROFILE_MANIFEST_VERSION
-            ? Effect.succeed(toCurrentManifest(stored))
-            : Effect.fail(
-                new ProfileError({
-                  message:
-                    `Profile manifest version ${stored.version} is not supported by this Alchemy version. ` +
-                    "The file was left untouched.",
-                }),
-              ),
-      ),
-      // The built-in `default` profile always exists from the reader's
-      // perspective; the synthesized entry is persisted by the next
-      // manifest write.
-      Effect.map(withDefaultProfile),
-    );
+    const readProviderFile = (profile: string, file: string) =>
+      Effect.gen(function* () {
+        const fullPath = pathService.join(profileDirPath(profile), file);
+        const json = yield* decodeJson(fullPath);
+        const document = yield* Schema.decodeUnknownEffect(
+          ProviderProfileFileSchema,
+        )(json).pipe(
+          Effect.mapError(
+            (cause) =>
+              new ProfileError({
+                message: `Invalid provider profile at '${fullPath}'.`,
+                cause,
+              }),
+          ),
+        );
+        const filenameProvider = file.slice(0, -".json".length);
+        if (document.provider.toLowerCase() !== filenameProvider) {
+          return yield* Effect.fail(
+            new ProfileError({
+              message: `Provider '${document.provider}' in '${fullPath}' does not match lowercase filename '${filenameProvider}'.`,
+            }),
+          );
+        }
+        return document;
+      });
 
-    /**
-     * Run `f` against the freshly-read manifest under the cross-process
-     * manifest lock — the scaffold shared by every mutating store method.
-     */
-    const modifyManifest = <A>(
-      f: (
-        manifest: ProfileManifest,
-      ) => Effect.Effect<A, ProfileError | PlatformError>,
-    ): Effect.Effect<A, ProfileError | PlatformError> =>
-      provideLockServices(
-        withLock("profiles-manifest", Effect.flatMap(readManifest, f)),
-      );
+    const readManifest = Effect.gen(function* () {
+      yield* migrateCentralManifest;
+      const manifest = emptyManifest();
+      const names = yield* fs
+        .readDirectory(profilesDirPath())
+        .pipe(
+          Effect.catchReason("PlatformError", "NotFound", () =>
+            Effect.succeed<string[]>([]),
+          ),
+        );
+      for (const name of names) {
+        if (!PROFILE_NAME_PATTERN.test(name)) continue;
+        const info = yield* fs.stat(profileDirPath(name));
+        if (info.type !== "Directory") continue;
+        const providers: Record<string, ProviderConfig> = {};
+        const files = yield* fs.readDirectory(profileDirPath(name));
+        for (const file of files.sort()) {
+          if (!file.endsWith(".json")) continue;
+          const read = yield* Effect.result(readProviderFile(name, file));
+          if (Result.isFailure(read)) {
+            yield* backupInvalidProfileFile(
+              pathService.join(profileDirPath(name), file),
+              read.failure,
+            );
+            continue;
+          }
+          providers[read.success.provider] = read.success.values;
+        }
+        manifest.profiles[name] = { id: name, providers };
+      }
+      return manifest;
+    });
 
     const getProfile = (name: string) =>
       validateProfileName(name).pipe(
         Effect.flatMap(() => readManifest),
-        Effect.map((config) => config.profiles[name]),
+        Effect.map((manifest) => manifest.profiles[name]),
       );
 
-    const ensureProfile = (
-      name: string,
-    ): Effect.Effect<Profile, ProfileError | PlatformError> =>
-      validateProfileName(name).pipe(
-        Effect.flatMap(() => readManifest),
-        Effect.flatMap(
-          (manifest): Effect.Effect<Profile, ProfileError | PlatformError> => {
-            const existing = manifest.profiles[name];
-            return existing !== undefined
-              ? Effect.succeed(existing)
-              : Effect.flatMap(profileNotFound(name), Effect.fail);
-          },
+    const ensureProfile = (name: string) =>
+      getProfile(name).pipe(
+        Effect.flatMap((profile) =>
+          profile === undefined
+            ? Effect.flatMap(profileNotFound(name), Effect.fail)
+            : Effect.succeed(profile),
         ),
       );
 
-    const createProfile = (
-      name: string,
-    ): Effect.Effect<void, ProfileError | PlatformError> =>
+    const createProfile = (name: string) =>
       validateProfileName(name).pipe(
         Effect.flatMap(() =>
-          modifyManifest(
-            (manifest): Effect.Effect<void, ProfileError | PlatformError> =>
-              name in manifest.profiles
-                ? Effect.fail(
+          provideLockServices(
+            withLock(
+              "profiles",
+              Effect.gen(function* () {
+                const existing = (yield* readManifest).profiles[name];
+                if (existing !== undefined) {
+                  return yield* Effect.fail(
                     new ProfileError({
                       message: `Profile '${name}' already exists.`,
                     }),
-                  )
-                : Effect.sync(() => crypto.randomUUID()).pipe(
-                    Effect.flatMap((id) =>
-                      writeManifest({
-                        ...manifest,
-                        profiles: {
-                          ...manifest.profiles,
-                          [name]: { id, providers: {} },
-                        },
-                      }),
-                    ),
-                  ),
+                  );
+                }
+                yield* fs.makeDirectory(profileDirPath(name), {
+                  recursive: true,
+                });
+                yield* fs.chmod(profileDirPath(name), 0o700);
+              }),
+            ),
           ),
         ),
       );
@@ -591,106 +645,37 @@ export const ProfileStoreLive = Layer.effect(
         }
         yield* validateProfileName(name);
         yield* validateProfileName(newName);
-        return yield* Effect.gen(function* () {
-          const locked = modifyManifest((manifest) => {
-            if (!(name in manifest.profiles)) {
-              return Effect.fail(
-                new ProfileError({
-                  message: `Profile '${name}' does not exist.`,
-                }),
-              );
-            }
-            if (newName in manifest.profiles) {
-              return Effect.fail(
-                new ProfileError({
-                  message: `Profile '${newName}' already exists.`,
-                }),
-              );
-            }
-
-            const sourceCredentials = profileCredentialsDirPath(name);
-            const targetCredentials = profileCredentialsDirPath(newName);
-            return Effect.all([
-              fs.exists(sourceCredentials),
-              fs.exists(targetCredentials),
-            ]).pipe(
-              Effect.flatMap(
-                ([sourceExists, targetExists]): Effect.Effect<
-                  void,
-                  ProfileError | PlatformError
-                > => {
-                  if (targetExists) {
-                    return Effect.fail(
-                      new ProfileError({
-                        message:
-                          `Cannot rename profile '${name}' to '${newName}' because ` +
-                          `credentials already exist at '${targetCredentials}'.`,
-                      }),
-                    );
-                  }
-
-                  const { [name]: renamed, ...remaining } = manifest.profiles;
-                  const updated: ProfileManifest = {
-                    ...manifest,
-                    profiles: { ...remaining, [newName]: renamed! },
-                  };
-                  const moveCredentials = sourceExists
-                    ? fs.rename(sourceCredentials, targetCredentials)
-                    : Effect.void;
-                  const rollbackCredentials = sourceExists
-                    ? fs
-                        .rename(targetCredentials, sourceCredentials)
-                        .pipe(Effect.ignore)
-                    : Effect.void;
-
-                  return moveCredentials.pipe(
-                    Effect.flatMap(() => writeManifest(updated)),
-                    Effect.onError(() => rollbackCredentials),
-                    Effect.uninterruptible,
-                  );
-                },
-              ),
-            );
-          });
-          return yield* provideLockServices(
-            [...new Set([name, newName])]
-              .sort()
-              .reduceRight(
-                (
-                  effect: Effect.Effect<
-                    void,
-                    ProfileError | PlatformError,
-                    FileSystem.FileSystem | Path.Path
-                  >,
-                  profileName,
-                ) => withProfileCredentialsLock(profileName, effect),
-                locked,
-              ),
-          );
-        });
-      });
-
-    /** Locked read-modify-write of a profile that must already exist. */
-    const updateManifestForProfile = (
-      name: string,
-      update: (manifest: ProfileManifest) => ProfileManifest,
-    ): Effect.Effect<void, ProfileError | PlatformError> =>
-      validateProfileName(name).pipe(
-        Effect.flatMap(() =>
-          modifyManifest(
-            (manifest): Effect.Effect<void, ProfileError | PlatformError> =>
-              name in manifest.profiles
-                ? writeManifest(update(manifest))
-                : Effect.flatMap(profileNotFound(name), Effect.fail),
+        yield* provideLockServices(
+          withLock(
+            "profiles",
+            Effect.gen(function* () {
+              const manifest = yield* readManifest;
+              if (manifest.profiles[name] === undefined) {
+                return yield* Effect.fail(
+                  new ProfileError({
+                    message: `Profile '${name}' does not exist.`,
+                  }),
+                );
+              }
+              if (manifest.profiles[newName] !== undefined) {
+                return yield* Effect.fail(
+                  new ProfileError({
+                    message: `Profile '${newName}' already exists.`,
+                  }),
+                );
+              }
+              yield* fs.rename(profileDirPath(name), profileDirPath(newName));
+              const oldCredentials = profileCredentialsDirPath(name);
+              if (yield* fs.exists(oldCredentials)) {
+                yield* fs.rename(
+                  oldCredentials,
+                  profileCredentialsDirPath(newName),
+                );
+              }
+            }),
           ),
-        ),
-      );
-
-    const setProfile = (name: string, profile: Profile) =>
-      updateManifestForProfile(name, (manifest) => ({
-        ...manifest,
-        profiles: { ...manifest.profiles, [name]: profile },
-      }));
+        );
+      });
 
     const current: Effect.Effect<
       ProfileSelection,
@@ -706,52 +691,100 @@ export const ProfileStoreLive = Layer.effect(
         ),
       );
       if (Option.isSome(configured)) {
-        const name = yield* validateProfileName(configured.value);
-        return { name, source: "configuration" as const };
+        return {
+          name: yield* validateProfileName(configured.value),
+          source: "configuration" as const,
+        };
       }
-      // No explicit selection — the built-in `default` profile, which
-      // always exists. There is no stored default selection to consult.
       return { name: DEFAULT_PROFILE_NAME, source: "default" as const };
     });
 
-    const deleteProfile = (name: string) =>
-      validateProfileName(name).pipe(
-        Effect.flatMap(() =>
-          modifyManifest(
-            (
-              manifest,
-            ): Effect.Effect<boolean, ProfileError | PlatformError> => {
-              if (name === DEFAULT_PROFILE_NAME) {
-                return Effect.fail(cannotDeleteDefaultProfile());
+    const setProviderConfig = (
+      profile: string,
+      provider: string,
+      values: ProviderConfig,
+    ) =>
+      Effect.gen(function* () {
+        yield* validateProfileName(profile);
+        yield* validateProviderName(provider);
+        yield* provideLockServices(
+          withLock(
+            "profiles",
+            Effect.gen(function* () {
+              if ((yield* readManifest).profiles[profile] === undefined) {
+                return yield* Effect.flatMap(
+                  profileNotFound(profile),
+                  Effect.fail,
+                );
               }
-              if (!(name in manifest.profiles)) {
-                return Effect.succeed(false);
+              const file = profileProviderFilePath(profile, provider);
+              let previous: ProviderProfileFile | undefined;
+              if (yield* fs.exists(file)) {
+                const read = yield* Effect.result(
+                  readProviderFile(profile, `${provider.toLowerCase()}.json`),
+                );
+                if (Result.isFailure(read)) {
+                  yield* backupInvalidProfileFile(file, read.failure);
+                } else {
+                  previous = read.success;
+                }
               }
-              const { [name]: _removed, ...profiles } = manifest.profiles;
-              return writeManifest({ ...manifest, profiles }).pipe(
-                Effect.as(true),
-              );
-            },
+              yield* writeProviderFile(profile, provider, values, previous);
+            }),
           ),
-        ),
-      );
+        );
+      });
+
+    const deleteProviderConfig = (profile: string, provider: string) =>
+      Effect.gen(function* () {
+        yield* validateProfileName(profile);
+        yield* validateProviderName(provider);
+        return yield* provideLockServices(
+          withLock(
+            "profiles",
+            Effect.gen(function* () {
+              const file = profileProviderFilePath(profile, provider);
+              if (!(yield* fs.exists(file))) return false;
+              yield* fs.remove(file);
+              return true;
+            }),
+          ),
+        );
+      });
+
+    const deleteProfile = (
+      name: string,
+    ): Effect.Effect<boolean, ProfileError | PlatformError> =>
+      Effect.gen(function* () {
+        yield* validateProfileName(name);
+        if (name === DEFAULT_PROFILE_NAME) {
+          return yield* Effect.fail(cannotDeleteDefaultProfile());
+        }
+        return yield* provideLockServices(
+          withLock(
+            "profiles",
+            Effect.gen(function* () {
+              const dir = profileDirPath(name);
+              if (!(yield* fs.exists(dir))) return false;
+              yield* fs.remove(dir, { recursive: true });
+              const credentials = profileCredentialsDirPath(name);
+              if (yield* fs.exists(credentials)) {
+                yield* fs.remove(credentials, { recursive: true });
+              }
+              return true;
+            }),
+          ),
+        );
+      });
 
     const loadProviderConfig = <Config extends { method: string }>(
       auth: AuthProvider<Config>,
       profileName: string,
-    ): Effect.Effect<
-      Config,
-      AuthError | MissingProviderConfig | ProfileError | PlatformError
-    > =>
+    ) =>
       Effect.gen(function* () {
         const existing = yield* ensureProfile(profileName);
-        // Legacy `method: "env"` entries never reach this point — the
-        // manifest reader drops them, so they resolve as "not configured".
         const stored = existing.providers[auth.name];
-        if (stored) {
-          // Manifest entries are user-editable JSON that may come from
-          // another alchemy version; decode against the provider's schema
-          // instead of trusting the shape.
+        if (stored !== undefined) {
           return yield* auth.decodeConfig(profileName, stored);
         }
         if (yield* SuppressMissingProviderConfig) {
@@ -759,15 +792,16 @@ export const ProfileStoreLive = Layer.effect(
             new MissingProviderConfig({
               provider: auth.name,
               profileName,
-              message: `No credentials configured for '${auth.name}' in profile '${profileName}'.`,
+              message: `Provider '${auth.name}' is not configured in profile '${profileName}'.`,
             }),
           );
         }
+        const command = yield* profileCommandHint(
+          `alchemy profile edit --profile ${profileName} --add ${auth.name}`,
+        );
         return yield* Effect.fail(
           new AuthError({
-            message:
-              `No credentials configured for '${auth.name}' in profile '${profileName}'. ` +
-              `Run \`${yield* profileCommandHint(`alchemy profile edit --profile ${profileName} --add ${auth.name}`)}\` to connect it.`,
+            message: `Provider '${auth.name}' is not configured in profile '${profileName}'. Run \`${command}\`.`,
           }),
         );
       });
@@ -779,7 +813,8 @@ export const ProfileStoreLive = Layer.effect(
       createProfile,
       renameProfile,
       current,
-      setProfile,
+      setProviderConfig,
+      deleteProviderConfig,
       deleteProfile,
       loadProviderConfig,
     } satisfies ProfileStoreService;

--- a/packages/alchemy/src/Auth/Resolve.ts
+++ b/packages/alchemy/src/Auth/Resolve.ts
@@ -113,7 +113,17 @@ export const resolveProviderConfig = <
       auth,
       profileName,
       config,
-      resolve: auth.read(profileName, config),
+      resolve: auth.read(profileName, config, (updated) =>
+        profile.setProviderConfig(profileName, providerName, updated).pipe(
+          Effect.mapError(
+            (cause) =>
+              new AuthError({
+                message: `${providerName}: could not persist refreshed credentials for profile '${profileName}'.`,
+                cause,
+              }),
+          ),
+        ),
+      ),
       source: "profile" as const,
     };
   });

--- a/packages/alchemy/src/Auth/StoredAuthProvider.ts
+++ b/packages/alchemy/src/Auth/StoredAuthProvider.ts
@@ -5,13 +5,11 @@ import * as Interaction from "../Interaction.ts";
 import {
   AuthError,
   AuthProviderLayer,
-  NeedsReauth,
-  refreshHint,
   type ConfigureField,
   type ConfigureMethod,
   type EnvironmentVariable,
 } from "./AuthProvider.ts";
-import { CredentialsStore, displayRedacted } from "./Credentials.ts";
+import { displayRedacted } from "./Credentials.ts";
 import { mapPromptCancellation } from "./Env.ts";
 
 /**
@@ -41,8 +39,8 @@ export const storedSecret = (value: StoredValue | undefined) =>
  * Everything needed to generate a complete single-method ("stored")
  * {@link AuthProviderImpl} for a provider whose credential is a token (or a
  * small set of fields) the user pastes once: prompts, flag-driven
- * configuration, schema-validated persistence, login/logout, structured
- * details, and typed {@link NeedsReauth} failures.
+ * configuration, schema-validated inline values, login/logout, and
+ * structured details.
  *
  * Providers with several auth methods (browser OAuth, SSO) don't fit this
  * factory — they hand-roll the impl and may still reuse
@@ -51,8 +49,6 @@ export const storedSecret = (value: StoredValue | undefined) =>
 export interface StoredAuthProviderConfig<Resolved> {
   /** Registry name, e.g. `"Neon"`. */
   readonly provider: string;
-  /** Credential file key, e.g. `"neon-stored"`. */
-  readonly storageKey: string;
   /** The fields collected interactively or via `--set`. */
   readonly fields: ReadonlyArray<ConfigureField>;
   /**
@@ -73,13 +69,11 @@ export interface StoredAuthProviderConfig<Resolved> {
   readonly environment?: ReadonlyArray<EnvironmentVariable>;
 }
 
-/** Manifest-entry schema for factory-made stored credential providers. */
-export const StoredAuthConfigSchema = Schema.Struct({
-  method: Schema.Literal("stored"),
-});
-
-/** The config shape every factory-made provider persists in the manifest. */
-export type StoredAuthConfig = typeof StoredAuthConfigSchema.Type;
+/** Inline-values type for factory-made static-token providers. */
+export type StoredAuthConfig = {
+  readonly method: "stored";
+  readonly [key: string]: StoredValue | undefined;
+};
 
 /**
  * Validate flag-provided values against the field specs: unknown keys,
@@ -173,14 +167,13 @@ export const collectFieldValues = (
   });
 
 /**
- * Build a registration Layer (plus the derived stored-credentials schema)
+ * Build a registration Layer (plus the derived inline-values schema)
  * for a single-method stored-credential provider.
  *
  * ```ts
  * export const { layer: NeonAuth, storedSchema: NeonStoredCredentials } =
  *   makeStoredAuthProvider({
  *     provider: "Neon",
- *     storageKey: "neon-stored",
  *     fields: [{ name: "apiKey", label: "Neon API Key", secret: true }],
  *     toResolved: (values, source) => ({ ... }),
  *     readEnvironment: ...,
@@ -191,40 +184,44 @@ export const collectFieldValues = (
 export const makeStoredAuthProvider = <Resolved>(
   config: StoredAuthProviderConfig<Resolved>,
 ) => {
-  const { provider, storageKey, fields } = config;
+  const { provider, fields } = config;
+
+  const fieldSchemas = Object.fromEntries(
+    fields.map((field) => [
+      field.name,
+      field.optional ? Schema.optional(Schema.String) : Schema.String,
+    ]),
+  );
 
   const storedSchema = Schema.Struct(
-    Object.fromEntries(
-      fields.map((field) => [
-        field.name,
-        field.optional
-          ? Schema.optional(
-              field.secret
-                ? Schema.RedactedFromValue(Schema.String)
-                : Schema.String,
-            )
-          : field.secret
-            ? Schema.RedactedFromValue(Schema.String)
-            : Schema.String,
-      ]),
-    ),
+    fieldSchemas,
     // SAFETY: each generated property schema corresponds exactly to the
     // ConfigureField entry used to construct StoredValues above.
-  ) as Schema.Codec<StoredValues, Record<string, string | undefined>>;
+  ) as Schema.Codec<StoredValues>;
+
+  const configSchema = Schema.Struct({
+    method: Schema.Literal("stored"),
+    ...fieldSchemas,
+  }) as Schema.Codec<StoredAuthConfig>;
 
   const layer = AuthProviderLayer<StoredAuthConfig, Resolved>()(
     provider,
     Effect.gen(function* () {
       const interaction = Interaction.accessors;
-      const store = yield* CredentialsStore;
-
-      const persist = (profileName: string, values: StoredValues) =>
+      const persist = (_profileName: string, values: StoredValues) =>
         Effect.gen(function* () {
           const complete = config.complete?.(values) ?? Effect.succeed(values);
           const completed = yield* complete;
-          yield* store.write(profileName, storageKey, storedSchema, completed);
           yield* interaction.output.success(`${provider}: credentials saved.`);
-          return { method: "stored" as const };
+          return {
+            method: "stored" as const,
+            ...Object.fromEntries(
+              Object.entries(completed).map(([key, value]) => [
+                key,
+                storedValueText(value),
+              ]),
+            ),
+          };
         });
 
       const configure = (profileName: string) =>
@@ -246,73 +243,37 @@ export const makeStoredAuthProvider = <Resolved>(
               }),
             );
 
-      const readStored = (profileName: string) =>
-        store.read(profileName, storageKey, storedSchema).pipe(
-          Effect.flatMap(
-            Effect.fn(function* (values) {
-              if (values != null) return values;
-              return yield* Effect.fail(
-                new NeedsReauth({
-                  provider,
-                  profile: profileName,
-                  message: `${provider} stored credentials not found. ${refreshHint(provider, profileName)}`,
-                }),
-              );
-            }),
-          ),
-        );
+      const read = (_profileName: string, values: StoredAuthConfig) =>
+        Effect.succeed(config.toResolved(values, "stored"));
 
-      const read = (profileName: string, _config: StoredAuthConfig) =>
-        readStored(profileName).pipe(
-          Effect.map((values) => config.toResolved(values, "stored")),
-        );
+      const login = (_profileName: string, values: StoredAuthConfig) =>
+        Effect.succeed(values);
 
-      const login = (profileName: string, _config: StoredAuthConfig) =>
-        store
-          .read(profileName, storageKey, storedSchema)
-          .pipe(
-            Effect.flatMap((values) =>
-              values == null
-                ? configure(profileName).pipe(Effect.asVoid)
-                : Effect.void,
-            ),
-          );
+      const logout = (_profileName: string, _config: StoredAuthConfig) =>
+        Effect.void;
 
-      const logout = (profileName: string, _config: StoredAuthConfig) =>
-        store
-          .delete(profileName, storageKey)
-          .pipe(
-            Effect.andThen(
-              interaction.output.success(
-                `${provider}: stored credentials removed`,
-              ),
-            ),
-          );
-
-      const details = (profileName: string, _config: StoredAuthConfig) =>
-        readStored(profileName).pipe(
-          Effect.map((values) => ({
-            lines: fields.flatMap((field) => {
-              const value = values[field.name];
-              if (value === undefined) return [];
-              return [
-                {
-                  key: field.name,
-                  value: field.secret
-                    ? displayRedacted(storedSecret(value) ?? Redacted.make(""))
-                    : (storedValueText(value) ?? ""),
-                },
-              ];
-            }),
-          })),
-        );
+      const details = (_profileName: string, values: StoredAuthConfig) =>
+        Effect.succeed({
+          lines: fields.flatMap((field) => {
+            const value = values[field.name];
+            if (value === undefined) return [];
+            return [
+              {
+                key: field.name,
+                value: field.secret
+                  ? displayRedacted(storedSecret(value) ?? Redacted.make(""))
+                  : (storedValueText(value) ?? ""),
+              },
+            ];
+          }),
+        });
 
       const configureMethods: ReadonlyArray<ConfigureMethod> = [
         { method: "stored", fields },
       ];
 
       return {
-        configSchema: StoredAuthConfigSchema,
+        configSchema,
         configure,
         configureWith,
         configureMethods,

--- a/packages/alchemy/src/Axiom/AuthProvider.ts
+++ b/packages/alchemy/src/Axiom/AuthProvider.ts
@@ -15,7 +15,7 @@ export const AXIOM_AUTH_PROVIDER_NAME = "Axiom";
 export type AxiomAuthConfig = StoredAuthConfig;
 
 /**
- * Resolved Axiom credentials. The stored credential file is a flat record
+ * Resolved Axiom credentials. The provider values are a flat record
  * (token + optional orgId/apiBaseUrl); the `apiToken`/`pat` distinction is
  * derived at resolution time from orgId presence — an org id means the token
  * is treated as a personal access token, mirroring how the CI environment
@@ -67,7 +67,6 @@ const readEnvironment = Effect.gen(function* () {
 
 const axiomAuth = makeStoredAuthProvider<AxiomResolvedCredentials>({
   provider: AXIOM_AUTH_PROVIDER_NAME,
-  storageKey: "axiom-stored",
   fields: [
     {
       name: "token",
@@ -135,6 +134,6 @@ const axiomAuth = makeStoredAuthProvider<AxiomResolvedCredentials>({
  */
 export const AxiomAuth = axiomAuth.layer;
 
-/** Schema of the stored Axiom credential file (flat field record). */
+/** Schema of Axiom's inline static-token values. */
 export const AxiomStoredCredentials = axiomAuth.storedSchema;
 export type AxiomStoredCredentials = typeof AxiomStoredCredentials.Type;

--- a/packages/alchemy/src/Cli/commands/profile/hub.ts
+++ b/packages/alchemy/src/Cli/commands/profile/hub.ts
@@ -76,7 +76,9 @@ export const profileHub = Effect.fn(function* (options: {
                 ? ("configured" as const)
                 : provider.status === "needs-reauth"
                   ? ("reauth" as const)
-                  : ("error" as const),
+                  : provider.status === "needs-reconfigure"
+                    ? ("reconfigure" as const)
+                    : ("error" as const),
             lines: [
               ...provider.details.map(({ key, value }) => `${key}: ${value}`),
               ...(provider.diagnostic ? [provider.diagnostic.message] : []),

--- a/packages/alchemy/src/Cli/commands/profile/hub.ts
+++ b/packages/alchemy/src/Cli/commands/profile/hub.ts
@@ -124,6 +124,7 @@ export const profileHub = Effect.fn(function* (options: {
         if (action.kind === "refresh") {
           yield* Profiles.refresh({
             profile: action.name,
+            providers: [action.provider],
             entrypoint: options.main,
             envFile,
           }).pipe(
@@ -133,7 +134,10 @@ export const profileHub = Effect.fn(function* (options: {
                 : Effect.void,
             ),
           );
-          return { ok: true, message: "Credentials refreshed." };
+          return {
+            ok: true,
+            message: `${action.provider} credentials refreshed.`,
+          };
         }
 
         const outcomes: string[] = [];

--- a/packages/alchemy/src/Cli/commands/profile/hub.ts
+++ b/packages/alchemy/src/Cli/commands/profile/hub.ts
@@ -124,7 +124,8 @@ export const profileHub = Effect.fn(function* (options: {
         if (action.kind === "refresh") {
           yield* Profiles.refresh({
             profile: action.name,
-            providers: [action.provider],
+            providers:
+              action.provider === undefined ? undefined : [action.provider],
             entrypoint: options.main,
             envFile,
           }).pipe(
@@ -136,7 +137,10 @@ export const profileHub = Effect.fn(function* (options: {
           );
           return {
             ok: true,
-            message: `${action.provider} credentials refreshed.`,
+            message:
+              action.provider === undefined
+                ? "Credentials refreshed."
+                : `${action.provider} credentials refreshed.`,
           };
         }
 

--- a/packages/alchemy/src/Cli/components/view/Profile.tsx
+++ b/packages/alchemy/src/Cli/components/view/Profile.tsx
@@ -172,12 +172,15 @@ export function ProfileDetailsBody({
   providers,
   reauthHint,
   refreshingProvider,
+  focusedProvider,
 }: {
   readonly providers: ReadonlyArray<ProfileProviderDisplay>;
   /** Muted hint appended to rows with `status: "reauth"`. */
   readonly reauthHint?: string;
   /** Provider whose detail rows are temporarily replaced by refresh status. */
   readonly refreshingProvider?: string;
+  /** Provider currently focused by an interactive parent view. */
+  readonly focusedProvider?: string;
 }): JSX.Element {
   const glyphs = useGlyphs();
   const borderStyle = useBorderStyle();
@@ -207,6 +210,13 @@ export function ProfileDetailsBody({
             >
               <Gutter>
                 <Box flexDirection="row">
+                  {focusedProvider === undefined ? null : (
+                    <Text tone="brand">
+                      {provider.name === focusedProvider
+                        ? glyphs.selected
+                        : " "}{" "}
+                    </Text>
+                  )}
                   <Box width={nameWidth} flexShrink={0}>
                     <Text bold color={theme.color.accent}>
                       {provider.name}
@@ -218,7 +228,10 @@ export function ProfileDetailsBody({
                   <Text color={status.color}>
                     {glyphs[status.glyph]} {status.label}
                   </Text>
-                  {reauthHint !== undefined && provider.status === "reauth" ? (
+                  {reauthHint !== undefined &&
+                  provider.status === "reauth" &&
+                  (focusedProvider === undefined ||
+                    provider.name === focusedProvider) ? (
                     <Text tone="muted"> — {reauthHint}</Text>
                   ) : null}
                 </Box>

--- a/packages/alchemy/src/Cli/components/view/Profile.tsx
+++ b/packages/alchemy/src/Cli/components/view/Profile.tsx
@@ -173,6 +173,7 @@ export function ProfileDetailsBody({
   reauthHint,
   refreshingProvider,
   focusedProvider,
+  showFocusRail = false,
 }: {
   readonly providers: ReadonlyArray<ProfileProviderDisplay>;
   /** Muted hint appended to rows with `status: "reauth"`. */
@@ -181,6 +182,8 @@ export function ProfileDetailsBody({
   readonly refreshingProvider?: string;
   /** Provider currently focused by an interactive parent view. */
   readonly focusedProvider?: string;
+  /** Reserve a stable focus rail column for an interactive parent view. */
+  readonly showFocusRail?: boolean;
 }): JSX.Element {
   const glyphs = useGlyphs();
   const borderStyle = useBorderStyle();
@@ -195,28 +198,24 @@ export function ProfileDetailsBody({
       ) : (
         providers.map((provider, providerIndex) => {
           const status = providerStatusStyle[provider.status];
+          const focused = showFocusRail && provider.name === focusedProvider;
           return (
             <Box
               key={provider.name}
               flexDirection="column"
               paddingTop={providerIndex === 0 ? 0 : 1}
+              paddingLeft={showFocusRail ? (focused ? 0 : 1) : 0}
               borderStyle={borderStyle}
               borderTop={providerIndex > 0}
               borderBottom={false}
-              borderLeft={false}
+              borderLeft={focused}
               borderRight={false}
               borderColor={theme.color.muted}
+              borderLeftColor={theme.color.brand}
               borderDimColor
             >
               <Gutter>
                 <Box flexDirection="row">
-                  {focusedProvider === undefined ? null : (
-                    <Text tone="brand">
-                      {provider.name === focusedProvider
-                        ? glyphs.selected
-                        : " "}{" "}
-                    </Text>
-                  )}
                   <Box width={nameWidth} flexShrink={0}>
                     <Text bold color={theme.color.accent}>
                       {provider.name}

--- a/packages/alchemy/src/Cli/components/view/Profile.tsx
+++ b/packages/alchemy/src/Cli/components/view/Profile.tsx
@@ -14,7 +14,7 @@ import { theme } from "../../CliKit/index.ts";
 export interface ProfileProviderDisplay {
   readonly name: string;
   readonly method: string;
-  readonly status: "ready" | "configured" | "reauth" | "error";
+  readonly status: "ready" | "configured" | "reauth" | "reconfigure" | "error";
   readonly lines: ReadonlyArray<string>;
 }
 
@@ -43,6 +43,11 @@ export const providerStatusStyle = {
     color: theme.color.warning,
     glyph: "refresh",
     label: "needs re-login",
+  },
+  reconfigure: {
+    color: theme.color.warning,
+    glyph: "edit",
+    label: "needs setup",
   },
   error: {
     color: theme.color.danger,

--- a/packages/alchemy/src/Cli/components/view/ProfileDashboard.tsx
+++ b/packages/alchemy/src/Cli/components/view/ProfileDashboard.tsx
@@ -421,9 +421,21 @@ function Dashboard({ store, initialSelected }: DashboardProps): JSX.Element {
       setMode("create");
     } else if (entry === undefined) {
       return;
-    } else if (key.left || input === "h" || (key.shift && key.tab)) {
+    } else if (
+      key.up ||
+      key.left ||
+      input === "k" ||
+      input === "h" ||
+      (key.shift && key.tab)
+    ) {
       setSelected((s) => (s + entries.length - 1) % entries.length);
-    } else if (key.right || input === "l" || key.tab) {
+    } else if (
+      key.down ||
+      key.right ||
+      input === "j" ||
+      input === "l" ||
+      key.tab
+    ) {
       setSelected((s) => (s + 1) % entries.length);
     } else if (input === "R" && !entry.isDefault) {
       setMode("rename");
@@ -506,8 +518,10 @@ function Dashboard({ store, initialSelected }: DashboardProps): JSX.Element {
           ["q", "quit"],
         ]
       : [
-          [keyGlyphs.leftRight, "switch"],
-          ...(details?.state === "ready" ? ([["e", "edit"]] as const) : []),
+          [keyGlyphs.upDown, "select profile"],
+          ...(details?.state === "ready"
+            ? ([["e", "configure"]] as const)
+            : []),
           ...(flow?.kind === "refresh" ? [] : ([["r", "refresh"]] as const)),
           ["n", "new"],
           ...(entry.isDefault

--- a/packages/alchemy/src/Cli/components/view/ProfileDashboard.tsx
+++ b/packages/alchemy/src/Cli/components/view/ProfileDashboard.tsx
@@ -419,8 +419,11 @@ type DashboardProps = {
 function Dashboard({ store, initialSelected }: DashboardProps): JSX.Element {
   const state = useLiveStore(store);
   const keyGlyphs = useKeyGlyphs();
+  const glyphs = useGlyphs();
   const [selected, setSelected] = useState(initialSelected);
-  const [focusedProvider, setFocusedProvider] = useState(0);
+  // -1 is the profile-level slot: no provider is focused and profile actions
+  // are shown. Up/down cycles through this slot and every connected provider.
+  const [focusedProvider, setFocusedProvider] = useState(-1);
   const [mode, setMode] = useState<Mode>("normal");
   const [screen, setScreen] = useState<"overview" | "edit">("overview");
   const { entries, focus: requestedFocus, flow, busy, notice } = state;
@@ -430,19 +433,23 @@ function Dashboard({ store, initialSelected }: DashboardProps): JSX.Element {
       (entry) => entry.name === requestedFocus,
     );
     store.clearFocus();
-    if (focusIndex >= 0) setSelected(focusIndex);
+    if (focusIndex >= 0) {
+      setSelected(focusIndex);
+    }
   }, [entries, requestedFocus, store]);
   const index = Math.min(Math.max(selected, 0), entries.length - 1);
   const entry = entries[index];
   const details =
     entry === undefined ? undefined : store.detailsFor(entry.name);
   const providers = details?.state === "ready" ? details.providers : [];
-  const providerIndex = Math.min(
-    Math.max(focusedProvider, 0),
-    providers.length - 1,
-  );
-  const provider = providers[providerIndex];
-  useEffect(() => setFocusedProvider(0), [entry?.name]);
+  const provider = providers[focusedProvider];
+  const moveProviderFocus = (delta: -1 | 1) =>
+    setFocusedProvider((current) => {
+      const slotCount = providers.length + 1;
+      const position = current + 1;
+      return ((position + delta + slotCount) % slotCount) - 1;
+    });
+  useEffect(() => setFocusedProvider(-1), [entry?.name]);
 
   useTerminalInput((input, key) => {
     // flow prompts, the edit screen, and the inline TextField/InlineConfirm
@@ -453,26 +460,30 @@ function Dashboard({ store, initialSelected }: DashboardProps): JSX.Element {
       store.dispatch({ kind: "exit" });
     } else if (key.ctrl || key.meta) {
       return;
-    } else if (input === "n") {
-      setMode("create");
     } else if (entry === undefined) {
-      return;
-    } else if (key.shift && key.tab) {
+      if (input === "n") setMode("create");
+    } else if (key.left) {
       setSelected((s) => (s + entries.length - 1) % entries.length);
-    } else if (key.tab) {
+      setFocusedProvider(-1);
+    } else if (key.right) {
       setSelected((s) => (s + 1) % entries.length);
+      setFocusedProvider(-1);
     } else if (key.up && providers.length > 0) {
-      setFocusedProvider(
-        (current) => (current + providers.length - 1) % providers.length,
-      );
+      moveProviderFocus(-1);
     } else if (key.down && providers.length > 0) {
-      setFocusedProvider((current) => (current + 1) % providers.length);
-    } else if (input === "R" && !entry.isDefault) {
+      moveProviderFocus(1);
+    } else if (provider === undefined && input === "R" && !entry.isDefault) {
       setMode("rename");
-    } else if (input === "D" && !entry.isDefault) {
+    } else if (provider === undefined && input === "D" && !entry.isDefault) {
       setMode("delete");
-    } else if (input === "a" && details?.state === "ready") {
+    } else if (
+      provider === undefined &&
+      input === "a" &&
+      details?.state === "ready"
+    ) {
       setScreen("edit");
+    } else if (provider === undefined && input === "n") {
+      setMode("create");
     } else if (input === "e" && provider !== undefined) {
       store.dispatch({
         kind: "edit-apply",
@@ -562,25 +573,28 @@ function Dashboard({ store, initialSelected }: DashboardProps): JSX.Element {
           ["q", "quit"],
         ]
       : [
-          [keyGlyphs.tab, "switch profile"],
-          ...(provider === undefined
+          [keyGlyphs.leftRight, "switch profile"],
+          ...(providers.length === 0
             ? []
-            : ([
-                [keyGlyphs.upDown, "focus provider"],
+            : ([[keyGlyphs.upDown, "focus provider"]] as const)),
+          ...(provider !== undefined
+            ? ([
                 ["e", "reconfigure"],
                 ["r", "refresh"],
                 ["d", "remove"],
-              ] as const)),
-          ...(details?.state === "ready"
-            ? ([["a", "manage providers"]] as const)
-            : []),
-          ["n", "new"],
-          ...(entry.isDefault
-            ? []
+              ] as const)
             : ([
-                ["R", "rename"],
-                ["D", "delete profile"],
-              ] as const)),
+                ...(details?.state === "ready"
+                  ? ([["a", "manage providers"]] as const)
+                  : []),
+                ["n", "new"],
+                ...(entry.isDefault
+                  ? []
+                  : ([
+                      ["R", "rename"],
+                      ["D", "delete profile"],
+                    ] as const)),
+              ] as ReadonlyArray<readonly [string, string]>)),
           ["q", "quit"],
         ];
 
@@ -600,6 +614,9 @@ function Dashboard({ store, initialSelected }: DashboardProps): JSX.Element {
         ) : (
           <>
             <Text>
+              <Text tone="brand">
+                {provider === undefined ? glyphs.selected : " "}{" "}
+              </Text>
               <Text bold color={theme.color.accent}>
                 {entry.name}
               </Text>

--- a/packages/alchemy/src/Cli/components/view/ProfileDashboard.tsx
+++ b/packages/alchemy/src/Cli/components/view/ProfileDashboard.tsx
@@ -4,7 +4,8 @@
  * mounted for the whole session and screens replace each other in place:
  *
  *   overview — chip tabs (default profile first), selected profile's
- *              provider details, keybind bar, inline rename/new/delete
+ *              provider details with an up/down focus cursor, keybind bar,
+ *              inline rename/new/delete/remove
  *   edit     — replaces the overview: per-provider cycle rows
  *              (keep / reconfigure / remove, add for unconnected)
  *
@@ -78,7 +79,7 @@ export type FlowAction =
       reconfigure: string[];
       remove: string[];
     }
-  | { kind: "refresh"; name: string };
+  | { kind: "refresh"; name: string; provider: string };
 
 export type ExternalAction = FlowAction | { kind: "exit" };
 
@@ -191,11 +192,13 @@ class DashStore extends LiveStore<DashState> {
 type DetailsPaneProps = {
   details: Details;
   refreshingProvider?: string;
+  focusedProvider?: string;
 };
 
 function DetailsPane({
   details,
   refreshingProvider,
+  focusedProvider,
 }: DetailsPaneProps): JSX.Element {
   if (details.state === "loading") {
     return <Spinner label="resolving credentials…" />;
@@ -215,6 +218,7 @@ function DetailsPane({
       providers={details.providers}
       reauthHint="press r to re-login"
       refreshingProvider={refreshingProvider}
+      focusedProvider={focusedProvider}
     />
   );
 }
@@ -314,13 +318,14 @@ function EditScreen({
 
 // --- main component ---------------------------------------------------------
 
-type Mode = "normal" | "rename" | "create" | "delete";
+type Mode = "normal" | "rename" | "create" | "delete" | "remove";
 
 type DashboardControlsProps = {
   readonly mode: Mode;
   readonly busy: boolean;
   readonly flow: Flow | undefined;
   readonly entry: DashboardEntry | undefined;
+  readonly provider: ProfileProviderDisplay | undefined;
   readonly keybinds: ReadonlyArray<readonly [string, string]>;
   readonly keyGlyphs: ReturnType<typeof useKeyGlyphs>;
   readonly store: DashStore;
@@ -332,6 +337,7 @@ function DashboardControls({
   busy,
   flow,
   entry,
+  provider,
   keybinds,
   keyGlyphs,
   store,
@@ -348,6 +354,28 @@ function DashboardControls({
         onSubmit={(confirmed) => {
           setMode("normal");
           if (confirmed) store.dispatch({ kind: "delete", name: entry.name });
+        }}
+        onCancel={() => setMode("normal")}
+      />
+    );
+  }
+  if (mode === "remove" && entry !== undefined && provider !== undefined) {
+    return (
+      <InlineConfirm
+        message={`Remove '${provider.name}' from profile '${entry.name}'?`}
+        confirmLabel="Remove"
+        cancelLabel="Cancel"
+        onSubmit={(confirmed) => {
+          setMode("normal");
+          if (confirmed) {
+            store.dispatch({
+              kind: "edit-apply",
+              name: entry.name,
+              add: [],
+              reconfigure: [],
+              remove: [provider.name],
+            });
+          }
         }}
         onCancel={() => setMode("normal")}
       />
@@ -392,6 +420,7 @@ function Dashboard({ store, initialSelected }: DashboardProps): JSX.Element {
   const state = useLiveStore(store);
   const keyGlyphs = useKeyGlyphs();
   const [selected, setSelected] = useState(initialSelected);
+  const [focusedProvider, setFocusedProvider] = useState(0);
   const [mode, setMode] = useState<Mode>("normal");
   const [screen, setScreen] = useState<"overview" | "edit">("overview");
   const { entries, focus: requestedFocus, flow, busy, notice } = state;
@@ -407,6 +436,13 @@ function Dashboard({ store, initialSelected }: DashboardProps): JSX.Element {
   const entry = entries[index];
   const details =
     entry === undefined ? undefined : store.detailsFor(entry.name);
+  const providers = details?.state === "ready" ? details.providers : [];
+  const providerIndex = Math.min(
+    Math.max(focusedProvider, 0),
+    providers.length - 1,
+  );
+  const provider = providers[providerIndex];
+  useEffect(() => setFocusedProvider(0), [entry?.name]);
 
   useTerminalInput((input, key) => {
     // flow prompts, the edit screen, and the inline TextField/InlineConfirm
@@ -421,18 +457,38 @@ function Dashboard({ store, initialSelected }: DashboardProps): JSX.Element {
       setMode("create");
     } else if (entry === undefined) {
       return;
-    } else if (key.up || key.left || (key.shift && key.tab)) {
+    } else if (key.shift && key.tab) {
       setSelected((s) => (s + entries.length - 1) % entries.length);
-    } else if (key.down || key.right || key.tab) {
+    } else if (key.tab) {
       setSelected((s) => (s + 1) % entries.length);
+    } else if (key.up && providers.length > 0) {
+      setFocusedProvider(
+        (current) => (current + providers.length - 1) % providers.length,
+      );
+    } else if (key.down && providers.length > 0) {
+      setFocusedProvider((current) => (current + 1) % providers.length);
     } else if (input === "R" && !entry.isDefault) {
       setMode("rename");
-    } else if (input === "d" && !entry.isDefault) {
+    } else if (input === "D" && !entry.isDefault) {
       setMode("delete");
-    } else if (input === "e" && details?.state === "ready") {
+    } else if (input === "a" && details?.state === "ready") {
       setScreen("edit");
-    } else if (input === "r") {
-      store.dispatch({ kind: "refresh", name: entry.name });
+    } else if (input === "e" && provider !== undefined) {
+      store.dispatch({
+        kind: "edit-apply",
+        name: entry.name,
+        add: [],
+        reconfigure: [provider.name],
+        remove: [],
+      });
+    } else if (input === "r" && provider !== undefined) {
+      store.dispatch({
+        kind: "refresh",
+        name: entry.name,
+        provider: provider.name,
+      });
+    } else if (input === "d" && provider !== undefined) {
+      setMode("remove");
     }
   });
 
@@ -506,17 +562,24 @@ function Dashboard({ store, initialSelected }: DashboardProps): JSX.Element {
           ["q", "quit"],
         ]
       : [
-          [keyGlyphs.upDown, "select profile"],
+          [keyGlyphs.tab, "switch profile"],
+          ...(provider === undefined
+            ? []
+            : ([
+                [keyGlyphs.upDown, "focus provider"],
+                ["e", "reconfigure"],
+                ["r", "refresh"],
+                ["d", "remove"],
+              ] as const)),
           ...(details?.state === "ready"
-            ? ([["e", "configure"]] as const)
+            ? ([["a", "manage providers"]] as const)
             : []),
-          ...(flow?.kind === "refresh" ? [] : ([["r", "refresh"]] as const)),
           ["n", "new"],
           ...(entry.isDefault
             ? []
             : ([
                 ["R", "rename"],
-                ["d", "delete"],
+                ["D", "delete profile"],
               ] as const)),
           ["q", "quit"],
         ];
@@ -547,6 +610,7 @@ function Dashboard({ store, initialSelected }: DashboardProps): JSX.Element {
             <Box>
               <DetailsPane
                 details={details ?? { state: "loading" }}
+                focusedProvider={provider?.name}
                 refreshingProvider={
                   flow?.kind === "refresh" ? flow.provider : undefined
                 }
@@ -569,6 +633,7 @@ function Dashboard({ store, initialSelected }: DashboardProps): JSX.Element {
           busy={busy}
           flow={flow}
           entry={entry}
+          provider={provider}
           keybinds={keybinds}
           keyGlyphs={keyGlyphs}
           store={store}
@@ -708,6 +773,8 @@ export const runProfileDashboardSession = <R,>(
                   store.setFlow({
                     kind: action.kind,
                     name: action.name,
+                    provider:
+                      action.kind === "refresh" ? action.provider : undefined,
                     // refresh keeps the overview on screen with a spinner; only
                     // account editing takes over the whole view
                     inline: action.kind === "refresh",

--- a/packages/alchemy/src/Cli/components/view/ProfileDashboard.tsx
+++ b/packages/alchemy/src/Cli/components/view/ProfileDashboard.tsx
@@ -421,21 +421,9 @@ function Dashboard({ store, initialSelected }: DashboardProps): JSX.Element {
       setMode("create");
     } else if (entry === undefined) {
       return;
-    } else if (
-      key.up ||
-      key.left ||
-      input === "k" ||
-      input === "h" ||
-      (key.shift && key.tab)
-    ) {
+    } else if (key.up || key.left || (key.shift && key.tab)) {
       setSelected((s) => (s + entries.length - 1) % entries.length);
-    } else if (
-      key.down ||
-      key.right ||
-      input === "j" ||
-      input === "l" ||
-      key.tab
-    ) {
+    } else if (key.down || key.right || key.tab) {
       setSelected((s) => (s + 1) % entries.length);
     } else if (input === "R" && !entry.isDefault) {
       setMode("rename");

--- a/packages/alchemy/src/Cli/components/view/ProfileDashboard.tsx
+++ b/packages/alchemy/src/Cli/components/view/ProfileDashboard.tsx
@@ -34,6 +34,7 @@ import {
   Text,
   TextField,
   Toast,
+  useBorderStyle,
   useCycleNavigation,
   useGlyphs,
   useKeyGlyphs,
@@ -79,7 +80,7 @@ export type FlowAction =
       reconfigure: string[];
       remove: string[];
     }
-  | { kind: "refresh"; name: string; provider: string };
+  | { kind: "refresh"; name: string; provider?: string };
 
 export type ExternalAction = FlowAction | { kind: "exit" };
 
@@ -219,6 +220,7 @@ function DetailsPane({
       reauthHint="press r to re-login"
       refreshingProvider={refreshingProvider}
       focusedProvider={focusedProvider}
+      showFocusRail
     />
   );
 }
@@ -419,7 +421,7 @@ type DashboardProps = {
 function Dashboard({ store, initialSelected }: DashboardProps): JSX.Element {
   const state = useLiveStore(store);
   const keyGlyphs = useKeyGlyphs();
-  const glyphs = useGlyphs();
+  const borderStyle = useBorderStyle();
   const [selected, setSelected] = useState(initialSelected);
   // -1 is the profile-level slot: no provider is focused and profile actions
   // are shown. Up/down cycles through this slot and every connected provider.
@@ -474,14 +476,16 @@ function Dashboard({ store, initialSelected }: DashboardProps): JSX.Element {
       moveProviderFocus(1);
     } else if (provider === undefined && input === "R" && !entry.isDefault) {
       setMode("rename");
-    } else if (provider === undefined && input === "D" && !entry.isDefault) {
+    } else if (provider === undefined && input === "d" && !entry.isDefault) {
       setMode("delete");
     } else if (
       provider === undefined &&
-      input === "a" &&
+      input === "e" &&
       details?.state === "ready"
     ) {
       setScreen("edit");
+    } else if (provider === undefined && input === "r") {
+      store.dispatch({ kind: "refresh", name: entry.name });
     } else if (provider === undefined && input === "n") {
       setMode("create");
     } else if (input === "e" && provider !== undefined) {
@@ -585,14 +589,17 @@ function Dashboard({ store, initialSelected }: DashboardProps): JSX.Element {
               ] as const)
             : ([
                 ...(details?.state === "ready"
-                  ? ([["a", "manage providers"]] as const)
+                  ? ([
+                      ["e", "edit"],
+                      ["r", "refresh"],
+                    ] as const)
                   : []),
                 ["n", "new"],
                 ...(entry.isDefault
                   ? []
                   : ([
                       ["R", "rename"],
-                      ["D", "delete profile"],
+                      ["d", "delete"],
                     ] as const)),
               ] as ReadonlyArray<readonly [string, string]>)),
           ["q", "quit"],
@@ -613,17 +620,23 @@ function Dashboard({ store, initialSelected }: DashboardProps): JSX.Element {
           <Text tone="muted">No profiles yet — press n to create one.</Text>
         ) : (
           <>
-            <Text>
-              <Text tone="brand">
-                {provider === undefined ? glyphs.selected : " "}{" "}
-              </Text>
+            <Box
+              flexDirection="row"
+              paddingLeft={provider === undefined ? 0 : 1}
+              borderStyle={borderStyle}
+              borderLeft={provider === undefined}
+              borderRight={false}
+              borderTop={false}
+              borderBottom={false}
+              borderColor={theme.color.brand}
+            >
               <Text bold color={theme.color.accent}>
                 {entry.name}
               </Text>
               {annotation === "" ? null : (
                 <Text tone="muted"> · {annotation}</Text>
               )}
-            </Text>
+            </Box>
             <Box>
               <DetailsPane
                 details={details ?? { state: "loading" }}

--- a/packages/alchemy/src/Cloudflare/Auth/AuthConfig.ts
+++ b/packages/alchemy/src/Cloudflare/Auth/AuthConfig.ts
@@ -4,43 +4,37 @@ import * as Schema from "effect/Schema";
 import { AuthError } from "../../Auth/AuthProvider.ts";
 import { profileCommandHint } from "../../Util/interactive.ts";
 
-/** Manifest-entry schema for Cloudflare authentication. */
+/** Typed values stored in a Cloudflare provider profile document. */
 export const CloudflareAuthConfigSchema = Schema.Union([
   Schema.Struct({
     method: Schema.Literal("stored"),
-    credentialType: Schema.Literals(["apiToken", "apiKey"]),
+    credentialType: Schema.Literal("apiToken"),
+    apiToken: Schema.String,
+    accountId: Schema.String,
+  }),
+  Schema.Struct({
+    method: Schema.Literal("stored"),
+    credentialType: Schema.Literal("apiKey"),
+    apiKey: Schema.String,
+    email: Schema.String,
+    accountId: Schema.String,
   }),
   Schema.Struct({
     method: Schema.Literal("oauth"),
     scopes: Schema.mutable(Schema.Array(Schema.String)),
     accountId: Schema.String,
+    clientId: Schema.optional(Schema.String),
+    access: Schema.String,
+    refresh: Schema.String,
+    expires: Schema.Number,
+  }),
+  // Released v0 OAuth grants cannot be reused, but retaining the method lets
+  // `profile refresh` restart OAuth at scope selection.
+  Schema.Struct({
+    method: Schema.Literal("oauth"),
   }),
 ]);
 export type CloudflareAuthConfig = typeof CloudflareAuthConfigSchema.Type;
-
-/**
- * On-disk shape of the `method: "stored"` credentials persisted under
- * `~/.alchemy/credentials/{profile}/cloudflare-stored.json`.
- */
-export const CloudflareStoredCredentials = Schema.Union([
-  Schema.Struct({
-    type: Schema.Literal("apiToken"),
-    apiToken: Schema.RedactedFromValue(Schema.String),
-    accountId: Schema.String,
-  }),
-  Schema.Struct({
-    type: Schema.Literal("apiKey"),
-    apiKey: Schema.RedactedFromValue(Schema.String),
-    email: Schema.RedactedFromValue(Schema.String),
-    accountId: Schema.String,
-  }),
-]);
-export type CloudflareStoredCredentials =
-  typeof CloudflareStoredCredentials.Type;
-
-/** Credential-store file keys (`~/.alchemy/credentials/{profile}/{key}.json`). */
-export const STORED_STORAGE_KEY = "cloudflare-stored";
-export const OAUTH_STORAGE_KEY = "cloudflare-oauth";
 
 export type CloudflareResolvedCredentials =
   | {

--- a/packages/alchemy/src/Cloudflare/Auth/AuthProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Auth/AuthProvider.ts
@@ -39,9 +39,6 @@ import * as OAuthClient from "./OAuthClient.ts";
 import {
   CLOUDFLARE_AUTH_PROVIDER_NAME,
   CloudflareAuthConfigSchema,
-  CloudflareStoredCredentials,
-  OAUTH_STORAGE_KEY,
-  STORED_STORAGE_KEY,
   validateAccountId,
   validateAccountIdField,
   type CloudflareAuthConfig,
@@ -261,7 +258,7 @@ export const CloudflareAuth = AuthProviderLayer<
     const interaction = Interaction.accessors;
     const store = yield* CredentialsStore;
 
-    const oauthLogin = (profileName: string, scopes: string[]) =>
+    const oauthLogin = (_profileName: string, scopes: string[]) =>
       Effect.gen(function* () {
         const authorization = yield* OAuthClient.authorize([
           ...scopes,
@@ -275,12 +272,6 @@ export const CloudflareAuth = AuthProviderLayer<
           exchange: (input) =>
             OAuthClient.exchangeCallbackInput(input, authorization),
         });
-        yield* store.write(
-          profileName,
-          OAUTH_STORAGE_KEY,
-          OAuthClient.OAuthCredentials,
-          credentials,
-        );
         yield* interaction.output.success(
           "Connected to Cloudflare with OAuth.",
         );
@@ -313,16 +304,12 @@ export const CloudflareAuth = AuthProviderLayer<
               .pipe(mapPromptCancellation, Effect.map(Redacted.make));
             const accountId = yield* promptAccountId();
 
-            yield* store.write(
-              profileName,
-              STORED_STORAGE_KEY,
-              CloudflareStoredCredentials,
-              { type: "apiToken", apiToken, accountId },
-            );
             yield* interaction.output.success("Cloudflare: credentials saved.");
             return {
               method: "stored" as const,
               credentialType: "apiToken" as const,
+              apiToken: Redacted.value(apiToken),
+              accountId,
             };
           }),
         ),
@@ -343,16 +330,13 @@ export const CloudflareAuth = AuthProviderLayer<
               .pipe(mapPromptCancellation, Effect.map(Redacted.make));
             const accountId = yield* promptAccountId();
 
-            yield* store.write(
-              profileName,
-              STORED_STORAGE_KEY,
-              CloudflareStoredCredentials,
-              { type: "apiKey", apiKey, email, accountId },
-            );
             yield* interaction.output.success("Cloudflare: credentials saved.");
             return {
               method: "stored" as const,
               credentialType: "apiKey" as const,
+              apiKey: Redacted.value(apiKey),
+              email: Redacted.value(email),
+              accountId,
             };
           }),
         ),
@@ -387,6 +371,10 @@ export const CloudflareAuth = AuthProviderLayer<
         method: "oauth" as const,
         scopes: [...scopes],
         accountId,
+        clientId: oauthCreds.clientId,
+        access: Redacted.value(oauthCreds.access),
+        refresh: Redacted.value(oauthCreds.refresh),
+        expires: oauthCreds.expires,
       };
     });
 
@@ -443,75 +431,64 @@ export const CloudflareAuth = AuthProviderLayer<
     const resolveCredentials = (
       profileName: string,
       config: CloudflareAuthConfig,
+      updateConfig?: (
+        config: CloudflareAuthConfig,
+      ) => Effect.Effect<void, AuthError>,
     ) =>
       Effect.gen(function* () {
         const reauth = refreshHint(CLOUDFLARE_AUTH_PROVIDER_NAME, profileName);
         return yield* Match.value(config).pipe(
-          Match.when({ method: "stored" }, () =>
-            store
-              .read(
-                profileName,
-                STORED_STORAGE_KEY,
-                CloudflareStoredCredentials,
-              )
-              .pipe(
-                Effect.flatMap(
-                  Effect.fn(function* (creds) {
-                    if (creds == null) {
-                      return yield* Effect.fail(
-                        new NeedsReauth({
-                          provider: CLOUDFLARE_AUTH_PROVIDER_NAME,
-                          profile: profileName,
-                          message: `Cloudflare stored credentials not found. ${reauth}`,
-                        }),
-                      );
-                    }
-                    const accountId = yield* validateAccountId(
-                      creds.accountId,
-                      `stored for profile '${profileName}'`,
-                    );
-                    return Match.value(creds).pipe(
-                      Match.when({ type: "apiToken" }, (c) => ({
-                        type: "apiToken" as const,
-                        apiToken: c.apiToken,
-                        accountId,
-                        source: { type: "stored" as const },
-                      })),
-                      Match.when({ type: "apiKey" }, (c) => ({
-                        type: "apiKey" as const,
-                        apiKey: c.apiKey,
-                        email: c.email,
-                        accountId,
-                        source: { type: "stored" as const },
-                      })),
-                      Match.exhaustive,
-                    );
-                  }),
-                ),
-              ),
+          Match.when({ method: "stored", credentialType: "apiToken" }, (c) =>
+            validateAccountId(
+              c.accountId,
+              `stored for profile '${profileName}'`,
+            ).pipe(
+              Effect.map((accountId) => ({
+                type: "apiToken" as const,
+                apiToken: Redacted.make(c.apiToken),
+                accountId,
+                source: { type: "stored" as const },
+              })),
+            ),
+          ),
+          Match.when({ method: "stored", credentialType: "apiKey" }, (c) =>
+            validateAccountId(
+              c.accountId,
+              `stored for profile '${profileName}'`,
+            ).pipe(
+              Effect.map((accountId) => ({
+                type: "apiKey" as const,
+                apiKey: Redacted.make(c.apiKey),
+                email: Redacted.make(c.email),
+                accountId,
+                source: { type: "stored" as const },
+              })),
+            ),
           ),
           Match.when({ method: "oauth" }, (cfg) =>
             Effect.gen(function* () {
-              const accountId = yield* validateAccountId(
-                cfg.accountId,
-                `configured for profile '${profileName}'`,
-              );
-              const creds = yield* store.read(
-                profileName,
-                OAUTH_STORAGE_KEY,
-                OAuthClient.OAuthCredentials,
-              );
-              if (creds == null || creds.type !== "oauth") {
+              if (!("scopes" in cfg)) {
                 return yield* Effect.fail(
                   new NeedsReauth({
                     provider: CLOUDFLARE_AUTH_PROVIDER_NAME,
                     profile: profileName,
-                    message: `Cloudflare OAuth credentials not found. ${reauth}`,
+                    message: `Cloudflare OAuth scopes need to be selected. ${reauth}`,
                   }),
                 );
               }
+              const accountId = yield* validateAccountId(
+                cfg.accountId,
+                `configured for profile '${profileName}'`,
+              );
+              const creds: OAuthClient.OAuthCredentials = {
+                type: "oauth",
+                clientId: cfg.clientId,
+                access: Redacted.make(cfg.access),
+                refresh: Redacted.make(cfg.refresh),
+                expires: cfg.expires,
+                scopes: cfg.scopes,
+              };
               if (!OAuthClient.usesCurrentClient(creds)) {
-                yield* store.delete(profileName, OAUTH_STORAGE_KEY);
                 return yield* Effect.fail(
                   new NeedsReauth({
                     provider: CLOUDFLARE_AUTH_PROVIDER_NAME,
@@ -528,14 +505,6 @@ export const CloudflareAuth = AuthProviderLayer<
                 creds.expires > now + 10_000
                   ? creds
                   : yield* OAuthClient.refresh(creds).pipe(
-                      Effect.tap((refreshed) =>
-                        store.write(
-                          profileName,
-                          OAUTH_STORAGE_KEY,
-                          OAuthClient.OAuthCredentials,
-                          refreshed,
-                        ),
-                      ),
                       Effect.mapError(
                         (e) =>
                           new NeedsReauth({
@@ -546,6 +515,19 @@ export const CloudflareAuth = AuthProviderLayer<
                           }),
                       ),
                     );
+              if (fresh !== creds) {
+                yield* (
+                  updateConfig?.({
+                    method: "oauth",
+                    accountId,
+                    clientId: fresh.clientId,
+                    access: Redacted.value(fresh.access),
+                    refresh: Redacted.value(fresh.refresh),
+                    expires: fresh.expires,
+                    scopes: fresh.scopes,
+                  }) ?? Effect.void
+                );
+              }
               return {
                 type: "oauth" as const,
                 accessToken: fresh.access,
@@ -596,45 +578,27 @@ export const CloudflareAuth = AuthProviderLayer<
     const logout = (profileName: string, config: CloudflareAuthConfig) =>
       Match.value(config)
         .pipe(
-          Match.when({ method: "stored" }, () =>
-            store
-              .delete(profileName, STORED_STORAGE_KEY)
-              .pipe(
-                Effect.andThen(
-                  interaction.output.success(
-                    "Cloudflare: stored credentials removed",
+          Match.when({ method: "stored" }, () => Effect.void),
+          Match.when({ method: "oauth" }, (config) => {
+            if (!("scopes" in config)) return Effect.void;
+            const credentials: OAuthClient.OAuthCredentials = {
+              type: "oauth",
+              clientId: config.clientId,
+              access: Redacted.make(config.access),
+              refresh: Redacted.make(config.refresh),
+              expires: config.expires,
+              scopes: config.scopes,
+            };
+            return OAuthClient.usesCurrentClient(credentials)
+              ? OAuthClient.revoke(credentials).pipe(
+                  Effect.catchTag("OAuthError", (err) =>
+                    interaction.output.warning(
+                      `Cloudflare: could not revoke OAuth token: ${err.errorDescription}`,
+                    ),
                   ),
-                ),
-              ),
-          ),
-          Match.when({ method: "oauth" }, () =>
-            store
-              .read(
-                profileName,
-                OAUTH_STORAGE_KEY,
-                OAuthClient.OAuthCredentials,
-              )
-              .pipe(
-                Effect.tap((creds) =>
-                  creds?.type === "oauth" &&
-                  OAuthClient.usesCurrentClient(creds)
-                    ? OAuthClient.revoke(creds).pipe(
-                        Effect.catchTag("OAuthError", (err) =>
-                          interaction.output.warning(
-                            `Cloudflare: could not revoke OAuth token: ${err.errorDescription}`,
-                          ),
-                        ),
-                      )
-                    : Effect.void,
-                ),
-                Effect.andThen(store.delete(profileName, OAUTH_STORAGE_KEY)),
-                Effect.andThen(
-                  interaction.output.success(
-                    "Cloudflare: OAuth credentials removed.",
-                  ),
-                ),
-              ),
-          ),
+                )
+              : Effect.void;
+          }),
           Match.exhaustive,
         )
         // The cached state-store credentials are derived from the account we
@@ -647,107 +611,121 @@ export const CloudflareAuth = AuthProviderLayer<
           ),
         );
 
-    const login = (profileName: string, config: CloudflareAuthConfig) =>
+    const login = (
+      profileName: string,
+      config: CloudflareAuthConfig,
+      updateConfig?: (
+        config: CloudflareAuthConfig,
+      ) => Effect.Effect<void, AuthError>,
+    ) =>
       Match.value(config)
         .pipe(
-          Match.when({ method: "stored" }, () =>
-            store
-              .read(
-                profileName,
-                STORED_STORAGE_KEY,
-                CloudflareStoredCredentials,
-              )
-              .pipe(
-                Effect.flatMap((creds) =>
-                  creds == null ? loginStored(profileName) : Effect.void,
-                ),
-              ),
-          ),
+          Match.when({ method: "stored" }, (config) => Effect.succeed(config)),
           Match.when({ method: "oauth" }, (c) =>
-            Effect.gen(function* () {
-              const creds = yield* store.read(
-                profileName,
-                OAUTH_STORAGE_KEY,
-                OAuthClient.OAuthCredentials,
-              );
-              const reconfigure = reconfigureHint(
-                CLOUDFLARE_AUTH_PROVIDER_NAME,
-                profileName,
-              );
-              // Any path that falls back to a full browser login rebuilds the
-              // authorize URL from the profile's stored scopes. Those scopes
-              // may predate the current OAuth client (or a catalog change), and
-              // one unknown scope makes the whole authorize URL invalid — so
-              // sanitize before generating a URL, never after it fails.
-              const fullLogin = Effect.suspend(() => {
-                const { valid, dropped } = partitionOAuthScopes(c.scopes);
-                if (valid.length === 0) {
-                  return Effect.fail(
-                    new AuthError({
-                      message:
-                        `The OAuth scopes stored for profile '${profileName}' are no longer offered by Alchemy's Cloudflare OAuth client. ` +
-                        `Scopes must be picked again. ${reconfigure}`,
-                    }),
+            "scopes" in c
+              ? Effect.gen(function* () {
+                  const creds: OAuthClient.OAuthCredentials = {
+                    type: "oauth",
+                    clientId: c.clientId,
+                    access: Redacted.make(c.access),
+                    refresh: Redacted.make(c.refresh),
+                    expires: c.expires,
+                    scopes: c.scopes,
+                  };
+                  const reconfigure = reconfigureHint(
+                    CLOUDFLARE_AUTH_PROVIDER_NAME,
+                    profileName,
                   );
-                }
-                return (
-                  dropped.length === 0
-                    ? Effect.void
-                    : interaction.output.warning(
-                        `Cloudflare: dropping ${dropped.length} stored scope${dropped.length === 1 ? "" : "s"} no longer offered by the current OAuth client (${dropped.join(", ")}). ` +
-                          `Scopes must be picked again. ${reconfigure}`,
-                      )
-                ).pipe(Effect.andThen(oauthLogin(profileName, valid)));
-              });
+                  // Any path that falls back to a full browser login rebuilds the
+                  // authorize URL from the profile's stored scopes. Those scopes
+                  // may predate the current OAuth client (or a catalog change), and
+                  // one unknown scope makes the whole authorize URL invalid — so
+                  // sanitize before generating a URL, never after it fails.
+                  const fullLogin = Effect.gen(function* () {
+                    const { valid, dropped } = partitionOAuthScopes(c.scopes);
+                    if (valid.length === 0) {
+                      return yield* Effect.fail(
+                        new AuthError({
+                          message:
+                            `The OAuth scopes stored for profile '${profileName}' are no longer offered by Alchemy's Cloudflare OAuth client. ` +
+                            `Scopes must be picked again. ${reconfigure}`,
+                        }),
+                      );
+                    }
+                    const refreshed = yield* (
+                      dropped.length === 0
+                        ? Effect.void
+                        : interaction.output.warning(
+                            `Cloudflare: dropping ${dropped.length} stored scope${dropped.length === 1 ? "" : "s"} no longer offered by the current OAuth client (${dropped.join(", ")}). ` +
+                              `Scopes must be picked again. ${reconfigure}`,
+                          )
+                    ).pipe(Effect.andThen(oauthLogin(profileName, valid)));
+                    return {
+                      ...c,
+                      scopes: valid,
+                      clientId: refreshed.clientId,
+                      access: Redacted.value(refreshed.access),
+                      refresh: Redacted.value(refreshed.refresh),
+                      expires: refreshed.expires,
+                    };
+                  });
 
-              // The silent refresh rotates a single-use refresh token, so
-              // its read-refresh-persist section runs under the profile
-              // lock — a concurrent `read` refreshing the same token would
-              // double-spend it. The lock is held only for this API
-              // round-trip, never across the browser wait below.
-              const outcome =
-                creds?.type === "oauth" && OAuthClient.usesCurrentClient(creds)
-                  ? yield* withProfileCredentialsLock(
-                      profileName,
-                      interaction.output
-                        .info("Cloudflare: refreshing OAuth credentials...")
-                        .pipe(
-                          Effect.andThen(OAuthClient.refresh(creds)),
-                          Effect.flatMap((refreshed) =>
-                            store
-                              .write(
-                                profileName,
-                                OAUTH_STORAGE_KEY,
-                                OAuthClient.OAuthCredentials,
-                                refreshed,
-                              )
-                              .pipe(
-                                Effect.andThen(
-                                  interaction.output.success(
-                                    "Cloudflare: OAuth credentials refreshed.",
-                                  ),
+                  // The silent refresh rotates a single-use refresh token, so
+                  // its read-refresh-persist section runs under the profile
+                  // lock — a concurrent `read` refreshing the same token would
+                  // double-spend it. The lock is held only for this API
+                  // round-trip, never across the browser wait below.
+                  const outcome =
+                    creds.type === "oauth" &&
+                    OAuthClient.usesCurrentClient(creds)
+                      ? yield* withProfileCredentialsLock(
+                          profileName,
+                          interaction.output
+                            .info("Cloudflare: refreshing OAuth credentials...")
+                            .pipe(
+                              Effect.andThen(OAuthClient.refresh(creds)),
+                              Effect.flatMap((credentials) => {
+                                const config = {
+                                  ...c,
+                                  clientId: credentials.clientId,
+                                  access: Redacted.value(credentials.access),
+                                  refresh: Redacted.value(credentials.refresh),
+                                  expires: credentials.expires,
+                                  scopes: credentials.scopes,
+                                };
+                                return (
+                                  updateConfig?.(config) ?? Effect.void
+                                ).pipe(
+                                  Effect.as({
+                                    type: "refreshed" as const,
+                                    config,
+                                  }),
+                                );
+                              }),
+                              Effect.tap(() =>
+                                interaction.output.success(
+                                  "Cloudflare: OAuth credentials refreshed.",
                                 ),
                               ),
-                          ),
-                          Effect.as("refreshed" as const),
-                          Effect.catchTag("OAuthError", () =>
-                            Effect.succeed("browser" as const),
-                          ),
-                        ),
-                    )
-                  : yield* Effect.gen(function* () {
-                      if (creds?.type === "oauth") {
-                        yield* store.delete(profileName, OAUTH_STORAGE_KEY);
-                        yield* interaction.output.warning(
-                          "Cloudflare: removed OAuth credentials issued to the previous client.",
-                        );
-                      }
-                      return "browser" as const;
-                    });
-              if (outcome === "browser") {
-                yield* fullLogin;
-              }
-            }),
+                              Effect.catchTag("OAuthError", () =>
+                                Effect.succeed({ type: "browser" as const }),
+                              ),
+                            ),
+                        )
+                      : yield* Effect.gen(function* () {
+                          if (creds.type === "oauth") {
+                            yield* interaction.output.warning(
+                              "Cloudflare: removed OAuth credentials issued to the previous client.",
+                            );
+                          }
+                          return { type: "browser" as const };
+                        });
+                  if (outcome.type === "browser") {
+                    return yield* fullLogin;
+                  }
+                  return outcome.config;
+                })
+              : configureOAuth(profileName, c),
           ),
           Match.exhaustive,
         )
@@ -761,9 +739,15 @@ export const CloudflareAuth = AuthProviderLayer<
           ),
         );
 
-    const details = (profileName: string, config: CloudflareAuthConfig) =>
+    const details = (
+      profileName: string,
+      config: CloudflareAuthConfig,
+      updateConfig?: (
+        config: CloudflareAuthConfig,
+      ) => Effect.Effect<void, AuthError>,
+    ) =>
       Effect.all([
-        resolveCredentials(profileName, config),
+        resolveCredentials(profileName, config, updateConfig),
         Clock.currentTimeMillis,
       ]).pipe(
         Effect.map(([creds, now]) => {
@@ -820,28 +804,10 @@ export const CloudflareAuth = AuthProviderLayer<
         readonly values: Record<string, string>;
       },
     ): Effect.Effect<CloudflareAuthConfig, AuthError> => {
-      const persist = (
-        credentials: CloudflareStoredCredentials,
-        config: CloudflareAuthConfig,
-      ) =>
+      const persist = (config: CloudflareAuthConfig) =>
         store
-          .write(
-            profileName,
-            STORED_STORAGE_KEY,
-            CloudflareStoredCredentials,
-            credentials,
-          )
-          .pipe(
-            // Re-configuring may point this profile at a different
-            // Cloudflare account; the cached state-store credentials are
-            // minted per-account, so drop them (same as `configure`).
-            Effect.andThen(
-              store
-                .delete(profileName, STATE_STORE_CREDENTIALS_FILE)
-                .pipe(Effect.ignore),
-            ),
-            Effect.as(config),
-          );
+          .delete(profileName, STATE_STORE_CREDENTIALS_FILE)
+          .pipe(Effect.ignore, Effect.as(config));
       return Match.value(input.method).pipe(
         Match.when("api-token", () =>
           validateFieldValues(
@@ -850,16 +816,16 @@ export const CloudflareAuth = AuthProviderLayer<
             input.values,
           ).pipe(
             Effect.flatMap((values) =>
-              persist(
-                {
-                  type: "apiToken",
-                  apiToken: storedSecret(values.apiToken) ?? Redacted.make(""),
-                  accountId: (storedValueText(values.accountId) ?? "")
-                    .trim()
-                    .toLowerCase(),
-                },
-                { method: "stored", credentialType: "apiToken" },
-              ),
+              persist({
+                method: "stored",
+                credentialType: "apiToken",
+                apiToken: Redacted.value(
+                  storedSecret(values.apiToken) ?? Redacted.make(""),
+                ),
+                accountId: (storedValueText(values.accountId) ?? "")
+                  .trim()
+                  .toLowerCase(),
+              }),
             ),
           ),
         ),
@@ -870,17 +836,19 @@ export const CloudflareAuth = AuthProviderLayer<
             input.values,
           ).pipe(
             Effect.flatMap((values) =>
-              persist(
-                {
-                  type: "apiKey",
-                  apiKey: storedSecret(values.apiKey) ?? Redacted.make(""),
-                  email: storedSecret(values.email) ?? Redacted.make(""),
-                  accountId: (storedValueText(values.accountId) ?? "")
-                    .trim()
-                    .toLowerCase(),
-                },
-                { method: "stored", credentialType: "apiKey" },
-              ),
+              persist({
+                method: "stored",
+                credentialType: "apiKey",
+                apiKey: Redacted.value(
+                  storedSecret(values.apiKey) ?? Redacted.make(""),
+                ),
+                email: Redacted.value(
+                  storedSecret(values.email) ?? Redacted.make(""),
+                ),
+                accountId: (storedValueText(values.accountId) ?? "")
+                  .trim()
+                  .toLowerCase(),
+              }),
             ),
           ),
         ),

--- a/packages/alchemy/src/Cloudflare/Auth/AuthProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Auth/AuthProvider.ts
@@ -204,16 +204,17 @@ const promptOAuthScopes = (currentConfig?: CloudflareAuthConfig) =>
     const mode = yield* interaction.prompt
       .select({
         message: "Cloudflare OAuth scopes",
+        initialValue: "all" as const,
         options: [
-          {
-            value: "basic" as const,
-            label: "Basic Scopes",
-            description: "recommended — covers typical Alchemy use cases",
-          },
           {
             value: "all" as const,
             label: "All Scopes",
             description: "authorize every available Cloudflare permission",
+          },
+          {
+            value: "basic" as const,
+            label: "Basic Scopes",
+            description: "covers typical Alchemy use cases",
           },
           {
             value: "custom" as const,

--- a/packages/alchemy/src/Cloudflare/Auth/OAuthScopes.ts
+++ b/packages/alchemy/src/Cloudflare/Auth/OAuthScopes.ts
@@ -870,7 +870,7 @@ export const partitionOAuthScopes = (
 /**
  * Initial selections for the custom-scope prompt. Reconfiguration restores
  * the existing OAuth grant while dropping scopes no longer offered by the
- * current client; first-time and stored-credential setup use the basic set.
+ * current client; first-time and stored-credential setup select every scope.
  */
 export const customOAuthScopeDefaults = (currentConfig?: {
   readonly method: string;
@@ -879,7 +879,7 @@ export const customOAuthScopeDefaults = (currentConfig?: {
 }): string[] =>
   currentConfig?.method === "oauth" && currentConfig.scopes !== undefined
     ? partitionOAuthScopes(currentConfig.scopes).valid
-    : [...BASIC_SCOPES];
+    : [...ALL_SCOPE_IDS];
 
 /** Reusable scope bundles for common OAuth authorization flows. */
 export const OAUTH_SCOPE_TEMPLATES = {

--- a/packages/alchemy/src/Cloudflare/Auth/OAuthScopes.ts
+++ b/packages/alchemy/src/Cloudflare/Auth/OAuthScopes.ts
@@ -877,7 +877,7 @@ export const partitionOAuthScopes = (
 export const customOAuthScopeDefaults = (
   currentConfig?: CloudflareAuthConfig,
 ): string[] =>
-  currentConfig?.method === "oauth"
+  currentConfig?.method === "oauth" && "scopes" in currentConfig
     ? partitionOAuthScopes(currentConfig.scopes).valid
     : [...BASIC_SCOPES];
 

--- a/packages/alchemy/src/Cloudflare/Auth/OAuthScopes.ts
+++ b/packages/alchemy/src/Cloudflare/Auth/OAuthScopes.ts
@@ -1,5 +1,3 @@
-import type { CloudflareAuthConfig } from "./AuthConfig.ts";
-
 /** Scopes enabled on Alchemy's public Cloudflare OAuth client. */
 export const OAUTH_SCOPE_GROUPS = [
   {
@@ -874,10 +872,12 @@ export const partitionOAuthScopes = (
  * the existing OAuth grant while dropping scopes no longer offered by the
  * current client; first-time and stored-credential setup use the basic set.
  */
-export const customOAuthScopeDefaults = (
-  currentConfig?: CloudflareAuthConfig,
-): string[] =>
-  currentConfig?.method === "oauth" && "scopes" in currentConfig
+export const customOAuthScopeDefaults = (currentConfig?: {
+  readonly method: string;
+  readonly scopes?: ReadonlyArray<string>;
+  readonly [key: string]: unknown;
+}): string[] =>
+  currentConfig?.method === "oauth" && currentConfig.scopes !== undefined
     ? partitionOAuthScopes(currentConfig.scopes).valid
     : [...BASIC_SCOPES];
 

--- a/packages/alchemy/src/Fly/AuthProvider.ts
+++ b/packages/alchemy/src/Fly/AuthProvider.ts
@@ -32,7 +32,6 @@ const resolveApiBaseUrl = (explicit?: string) =>
 
 const flyAuth = makeStoredAuthProvider<FlyResolvedCredentials>({
   provider: FLY_AUTH_PROVIDER_NAME,
-  storageKey: "fly-stored",
   fields: [
     { name: "apiKey", label: "Fly.io API Token", secret: true },
     {

--- a/packages/alchemy/src/GitHub/AuthProvider.ts
+++ b/packages/alchemy/src/GitHub/AuthProvider.ts
@@ -14,7 +14,7 @@ import {
   type ConfigureMethod,
   type ProviderDetails,
 } from "../Auth/AuthProvider.ts";
-import { CredentialsStore, displayRedacted } from "../Auth/Credentials.ts";
+import { displayRedacted } from "../Auth/Credentials.ts";
 import { getEnvRedacted, mapPromptCancellation } from "../Auth/Env.ts";
 import {
   storedSecret,
@@ -41,30 +41,27 @@ const options: Array<{
   {
     value: "stored",
     label: "Personal Access Token",
-    description: "enter PAT interactively, stored in ~/.alchemy/credentials",
+    description: "enter PAT interactively and store it in the profile",
   },
 ];
 
-/** Manifest-entry schema for GitHub authentication. */
+/** Typed values stored in a GitHub provider profile document. */
 export const GitHubAuthConfigSchema = Schema.Union([
   Schema.Struct({
     method: Schema.Literal("stored"),
+    token: Schema.String,
     baseUrl: Schema.optionalKey(Schema.String),
   }),
   Schema.Struct({
     method: Schema.Literal("gh-cli"),
+    // v0 delegated to `gh auth token` and therefore had no inline token.
+    // Keep that migration state readable; the first credential resolution
+    // captures the token inline through updateConfig.
+    token: Schema.optionalKey(Schema.String),
     baseUrl: Schema.optionalKey(Schema.String),
   }),
 ]);
 export type GitHubAuthConfig = typeof GitHubAuthConfigSchema.Type;
-
-export const GitHubStoredCredentials = Schema.Struct({
-  type: Schema.Literal("pat"),
-  token: Schema.RedactedFromValue(Schema.String),
-});
-export type GitHubStoredCredentials = typeof GitHubStoredCredentials.Type;
-
-const STORAGE_KEY = "github-stored";
 
 export interface GitHubResolvedCredentials {
   type: "token";
@@ -129,7 +126,7 @@ export const readEnvCredentials = (
  *
  * Supported methods:
  * - `gh-cli`: shells out to `gh auth token` (recommended).
- * - `stored`: prompts for a PAT and writes it to `~/.alchemy/credentials`.
+ * - `stored`: prompts for a PAT and stores it inline in the provider file.
  *
  * GitHub Enterprise (Server or Cloud with data residency) is supported by
  * every method: `alchemy profile edit --reconfigure GitHub` prompts for the host, or set
@@ -163,7 +160,6 @@ export const makeGitHubAuth = (authOptions?: GitHubAuthOptions) =>
       // requirements, and child processes (which only ever call `read`) build
       // this layer with no interaction services at all.
       const interaction = Interaction.accessors;
-      const store = yield* CredentialsStore;
       const cp = yield* ChildProcessSpawner;
 
       // Hard-coded host from `providers({ baseUrl })`, resolved once at layer
@@ -240,10 +236,7 @@ export const makeGitHubAuth = (authOptions?: GitHubAuthOptions) =>
           ),
         );
 
-      const loginStored = Effect.fn(function* (
-        profileName: string,
-        baseUrl?: string,
-      ) {
+      const loginStored = Effect.fn(function* (baseUrl?: string) {
         const token = yield* interaction.prompt
           .password({
             message: "GitHub Personal Access Token",
@@ -251,14 +244,9 @@ export const makeGitHubAuth = (authOptions?: GitHubAuthOptions) =>
               "Requires `repo` scope and `workflow` for GitHub Actions.",
             validate: (v) => (v.length === 0 ? "Required" : undefined),
           })
-          .pipe(mapPromptCancellation, Effect.map(Redacted.make));
-
-        yield* store.write(profileName, STORAGE_KEY, GitHubStoredCredentials, {
-          type: "pat",
-          token,
-        });
+          .pipe(mapPromptCancellation);
         yield* interaction.output.success("GitHub: credentials saved.");
-        return { method: "stored" as const, baseUrl };
+        return { method: "stored" as const, token, baseUrl };
       });
 
       // Optional GitHub Enterprise host. Blank means github.com; anything else
@@ -282,7 +270,7 @@ export const makeGitHubAuth = (authOptions?: GitHubAuthOptions) =>
           }),
         );
 
-      const configureInteractive = (profileName: string) =>
+      const configureInteractive = (_profileName: string) =>
         Effect.gen(function* () {
           const method = yield* interaction.prompt.select({
             message: "GitHub authentication method",
@@ -301,7 +289,11 @@ export const makeGitHubAuth = (authOptions?: GitHubAuthOptions) =>
                   ? githubHostname(verifyHost)
                   : undefined,
               ).pipe(
-                Effect.as({ method: "gh-cli" as const, baseUrl }),
+                Effect.map((token) => ({
+                  method: "gh-cli" as const,
+                  token,
+                  baseUrl,
+                })),
                 Effect.mapError(
                   (e) =>
                     new AuthError({
@@ -311,7 +303,7 @@ export const makeGitHubAuth = (authOptions?: GitHubAuthOptions) =>
                 ),
               ),
             ),
-            Match.when("stored", () => loginStored(profileName, baseUrl)),
+            Match.when("stored", () => loginStored(baseUrl)),
             Match.exhaustive,
           );
         });
@@ -330,27 +322,18 @@ export const makeGitHubAuth = (authOptions?: GitHubAuthOptions) =>
       const resolveCredentials = (
         profileName: string,
         config: GitHubAuthConfig,
+        updateConfig?: (
+          config: GitHubAuthConfig,
+        ) => Effect.Effect<void, AuthError>,
       ): Effect.Effect<GitHubResolvedCredentials, AuthError | NeedsReauth> =>
         Match.value(config).pipe(
           Match.when(
             { method: "stored" },
             Effect.fn(function* (c) {
               const baseUrl = yield* effectiveBaseUrl(c);
-              const creds = yield* store.read(
-                profileName,
-                STORAGE_KEY,
-                GitHubStoredCredentials,
-              );
-              if (creds == null) {
-                return yield* new NeedsReauth({
-                  provider: GITHUB_AUTH_PROVIDER_NAME,
-                  profile: profileName,
-                  message: `GitHub stored credentials not found. ${refreshHint(GITHUB_AUTH_PROVIDER_NAME, profileName)}`,
-                });
-              }
               return {
                 type: "token" as const,
-                token: creds.token,
+                token: Redacted.make(c.token),
                 baseUrl,
                 source: { type: "stored" as const },
               };
@@ -360,9 +343,24 @@ export const makeGitHubAuth = (authOptions?: GitHubAuthOptions) =>
             { method: "gh-cli" },
             Effect.fn(function* (c) {
               const baseUrl = yield* effectiveBaseUrl(c);
-              const token = yield* ghCliToken(
-                baseUrl !== undefined ? githubHostname(baseUrl) : undefined,
-              );
+              const token =
+                c.token ??
+                (yield* ghCliToken(
+                  baseUrl !== undefined ? githubHostname(baseUrl) : undefined,
+                ).pipe(
+                  Effect.mapError(
+                    (cause) =>
+                      new NeedsReauth({
+                        provider: GITHUB_AUTH_PROVIDER_NAME,
+                        profile: profileName,
+                        message: `GitHub CLI credentials need to be refreshed. ${refreshHint(GITHUB_AUTH_PROVIDER_NAME, profileName)}`,
+                        cause,
+                      }),
+                  ),
+                ));
+              if (c.token === undefined && updateConfig !== undefined) {
+                yield* updateConfig({ ...c, token });
+              }
               return {
                 type: "token" as const,
                 token: Redacted.make(token),
@@ -374,24 +372,14 @@ export const makeGitHubAuth = (authOptions?: GitHubAuthOptions) =>
           Match.exhaustive,
         );
 
-      const logout = (profileName: string, config: GitHubAuthConfig) =>
+      const logout = (_profileName: string, config: GitHubAuthConfig) =>
         Match.value(config).pipe(
           Match.when({ method: "gh-cli" }, () => Effect.void),
-          Match.when({ method: "stored" }, () =>
-            store
-              .delete(profileName, STORAGE_KEY)
-              .pipe(
-                Effect.andThen(
-                  interaction.output.success(
-                    "GitHub: stored credentials removed",
-                  ),
-                ),
-              ),
-          ),
+          Match.when({ method: "stored" }, () => Effect.void),
           Match.exhaustive,
         );
 
-      const login = (profileName: string, config: GitHubAuthConfig) =>
+      const login = (_profileName: string, config: GitHubAuthConfig) =>
         Match.value(config)
           .pipe(
             Match.when({ method: "gh-cli" }, (c) =>
@@ -406,20 +394,10 @@ export const makeGitHubAuth = (authOptions?: GitHubAuthOptions) =>
                     "GitHub: gh CLI authentication available.",
                   ),
                 ),
-                Effect.asVoid,
+                Effect.map((token) => ({ ...c, token })),
               ),
             ),
-            Match.when({ method: "stored" }, (c) =>
-              store
-                .read(profileName, STORAGE_KEY, GitHubStoredCredentials)
-                .pipe(
-                  Effect.flatMap((creds) =>
-                    creds == null
-                      ? loginStored(profileName, c.baseUrl)
-                      : Effect.void,
-                  ),
-                ),
-            ),
+            Match.when({ method: "stored" }, (c) => Effect.succeed(c)),
             Match.exhaustive,
           )
           .pipe(
@@ -431,8 +409,11 @@ export const makeGitHubAuth = (authOptions?: GitHubAuthOptions) =>
       const details = (
         profileName: string,
         config: GitHubAuthConfig,
+        updateConfig?: (
+          config: GitHubAuthConfig,
+        ) => Effect.Effect<void, AuthError>,
       ): Effect.Effect<ProviderDetails, AuthError | NeedsReauth> =>
-        resolveCredentials(profileName, config).pipe(
+        resolveCredentials(profileName, config, updateConfig).pipe(
           Effect.map((creds) => {
             const sourceStr = creds.source.details
               ? `${creds.source.type} - ${creds.source.details}`
@@ -474,7 +455,7 @@ export const makeGitHubAuth = (authOptions?: GitHubAuthOptions) =>
       ];
 
       const configureWith = (
-        profileName: string,
+        _profileName: string,
         input: {
           readonly method: string;
           readonly values: Record<string, string>;
@@ -499,19 +480,13 @@ export const makeGitHubAuth = (authOptions?: GitHubAuthOptions) =>
                             storedValueText(values.baseUrl) ?? "",
                           )
                         : undefined;
-                  yield* store.write(
-                    profileName,
-                    STORAGE_KEY,
-                    GitHubStoredCredentials,
-                    {
-                      type: "pat",
-                      token: storedSecret(values.token) ?? Redacted.make(""),
-                    },
+                  const token = Redacted.value(
+                    storedSecret(values.token) ?? Redacted.make(""),
                   );
                   yield* interaction.output.success(
                     "GitHub: credentials saved.",
                   );
-                  return { method: "stored" as const, baseUrl };
+                  return { method: "stored" as const, token, baseUrl };
                 }),
               ),
             )

--- a/packages/alchemy/src/Hetzner/AuthProvider.ts
+++ b/packages/alchemy/src/Hetzner/AuthProvider.ts
@@ -24,7 +24,6 @@ export type HetznerResolvedCredentials = {
 
 const hetznerAuth = makeStoredAuthProvider<HetznerResolvedCredentials>({
   provider: HETZNER_AUTH_PROVIDER_NAME,
-  storageKey: "hetzner-stored",
   fields: [
     { name: "token", label: "Hetzner Cloud API Token", secret: true },
     {

--- a/packages/alchemy/src/Neon/AuthProvider.ts
+++ b/packages/alchemy/src/Neon/AuthProvider.ts
@@ -19,7 +19,6 @@ export type NeonResolvedCredentials = {
 
 const neonAuth = makeStoredAuthProvider<NeonResolvedCredentials>({
   provider: NEON_AUTH_PROVIDER_NAME,
-  storageKey: "neon-stored",
   fields: [{ name: "apiKey", label: "Neon API Key", secret: true }],
   toResolved: (values) => ({
     type: "apiKey",

--- a/packages/alchemy/src/Planetscale/AuthProvider.ts
+++ b/packages/alchemy/src/Planetscale/AuthProvider.ts
@@ -23,7 +23,7 @@ import {
   storedValueText,
   validateFieldValues,
 } from "../Auth/StoredAuthProvider.ts";
-import { CredentialsStore, displayRedacted } from "../Auth/Credentials.ts";
+import { displayRedacted } from "../Auth/Credentials.ts";
 import { withProfileCredentialsLock } from "../Auth/Lock.ts";
 import {
   getEnvRedactedRequired,
@@ -123,47 +123,34 @@ const options: Array<{
     value: "stored",
     label: "Service Token",
     description:
-      "enter service token interactively, stored in ~/.alchemy/credentials",
+      "enter a service token and store it inline in the provider file",
   },
 ];
 
 /**
- * Auth configuration persisted in `~/.alchemy/profiles.json` for the
- * PlanetScale provider.
- *
- * - `stored`: read service-token credentials from
- *   `~/.alchemy/credentials/<profile>/planetscale-stored.json`.
- * - `oauth`: browser-based login; the access/refresh tokens are stored at
- *   `~/.alchemy/credentials/<profile>/planetscale-oauth.json` and refreshed
- *   on demand. PlanetScale has no PKCE flow, so the OAuth application's
+ * Typed values stored in a PlanetScale provider profile document. Both
+ * service-token and OAuth values are inline. PlanetScale has no PKCE flow,
+ * so the OAuth application's
  *   `client_secret` ships in the CLI — see {@link OAuthClient}.
  */
-/** Manifest-entry schema for PlanetScale authentication. */
 export const PlanetscaleAuthConfigSchema = Schema.Union([
-  Schema.Struct({ method: Schema.Literal("stored") }),
+  Schema.Struct({
+    method: Schema.Literal("stored"),
+    tokenId: Schema.String,
+    token: Schema.String,
+    organization: Schema.String,
+  }),
   Schema.Struct({
     method: Schema.Literal("oauth"),
     organization: Schema.String,
+    clientId: Schema.optional(Schema.String),
+    access: Schema.String,
+    refresh: Schema.String,
+    expires: Schema.Number,
+    scopes: Schema.mutable(Schema.Array(Schema.String)),
   }),
 ]);
 export type PlanetscaleAuthConfig = typeof PlanetscaleAuthConfigSchema.Type;
-
-/**
- * apiToken credentials persisted to disk for `method: "stored"`.
- * Stored under the file key `"planetscale-stored"`.
- */
-export const PlanetscaleStoredCredentials = Schema.Struct({
-  type: Schema.Literal("apiToken"),
-  tokenId: Schema.RedactedFromValue(Schema.String),
-  token: Schema.RedactedFromValue(Schema.String),
-  organization: Schema.String,
-});
-export type PlanetscaleStoredCredentials =
-  typeof PlanetscaleStoredCredentials.Type;
-
-/** Credential-store file keys (`~/.alchemy/credentials/{profile}/{key}.json`). */
-const STORED_STORAGE_KEY = "planetscale-stored";
-const OAUTH_STORAGE_KEY = "planetscale-oauth";
 
 /**
  * Resolved in-memory PlanetScale credentials returned by
@@ -198,10 +185,8 @@ export type PlanetscaleResolvedCredentials =
  * PlanetScale `providers()` layer so the alchemy CLI can discover it.
  *
  * Supported methods:
- * - `stored`: prompts for a service token interactively and writes it to
- *   `~/.alchemy/credentials/<profile>/planetscale-stored.json`.
- * - `oauth`: browser-based login storing access/refresh tokens at
- *   `~/.alchemy/credentials/<profile>/planetscale-oauth.json`.
+ * - `stored`: prompts for a service token and stores it inline.
+ * - `oauth`: browser-based login storing access/refresh values inline.
  */
 export const PlanetscaleAuth = AuthProviderLayer<
   PlanetscaleAuthConfig,
@@ -210,9 +195,7 @@ export const PlanetscaleAuth = AuthProviderLayer<
   PLANETSCALE_AUTH_PROVIDER_NAME,
   Effect.gen(function* () {
     const interaction = Interaction.accessors;
-    const store = yield* CredentialsStore;
-
-    const oauthLogin = (profileName: string) =>
+    const oauthLogin = (_profileName: string) =>
       Effect.gen(function* () {
         const authorization = yield* OAuthClient.authorize();
 
@@ -223,12 +206,6 @@ export const PlanetscaleAuth = AuthProviderLayer<
           exchange: (input) =>
             OAuthClient.exchangeCallbackInput(input, authorization),
         });
-        yield* store.write(
-          profileName,
-          OAUTH_STORAGE_KEY,
-          OAuthClient.OAuthCredentials,
-          credentials,
-        );
         yield* interaction.output.success(
           "Planetscale: OAuth credentials saved.",
         );
@@ -261,23 +238,31 @@ export const PlanetscaleAuth = AuthProviderLayer<
         ),
       );
 
-      return { method: "oauth" as const, organization };
+      return {
+        method: "oauth" as const,
+        organization,
+        clientId: oauthCreds.clientId,
+        access: Redacted.value(oauthCreds.access),
+        refresh: Redacted.value(oauthCreds.refresh),
+        expires: oauthCreds.expires,
+        scopes: oauthCreds.scopes,
+      };
     });
 
-    const loginStored = Effect.fn(function* (profileName: string) {
+    const loginStored = Effect.fn(function* (_profileName: string) {
       const tokenId = yield* interaction.prompt
         .text({
           message: "Planetscale Service Token ID",
           validate: (v) => (v.length === 0 ? "Required" : undefined),
         })
-        .pipe(mapPromptCancellation, Effect.map(Redacted.make));
+        .pipe(mapPromptCancellation);
 
       const token = yield* interaction.prompt
         .password({
           message: "Planetscale Service Token",
           validate: (v) => (v.length === 0 ? "Required" : undefined),
         })
-        .pipe(mapPromptCancellation, Effect.map(Redacted.make));
+        .pipe(mapPromptCancellation);
 
       const organization = yield* interaction.prompt
         .text({
@@ -286,19 +271,8 @@ export const PlanetscaleAuth = AuthProviderLayer<
         })
         .pipe(mapPromptCancellation);
 
-      yield* store.write(
-        profileName,
-        STORED_STORAGE_KEY,
-        PlanetscaleStoredCredentials,
-        {
-          type: "apiToken",
-          tokenId,
-          token,
-          organization,
-        },
-      );
       yield* interaction.output.success("Planetscale: credentials saved.");
-      return { method: "stored" as const };
+      return { method: "stored" as const, tokenId, token, organization };
     });
 
     const configureInteractive = (profileName: string) =>
@@ -345,7 +319,7 @@ export const PlanetscaleAuth = AuthProviderLayer<
     ];
 
     const configureWith = (
-      profileName: string,
+      _profileName: string,
       input: {
         readonly method: string;
         readonly values: Record<string, string>;
@@ -361,23 +335,19 @@ export const PlanetscaleAuth = AuthProviderLayer<
             serviceTokenFields,
             input.values,
           ).pipe(
-            Effect.flatMap((values) =>
-              store.write(
-                profileName,
-                STORED_STORAGE_KEY,
-                PlanetscaleStoredCredentials,
-                {
-                  type: "apiToken",
-                  tokenId: storedSecret(values.tokenId) ?? Redacted.make(""),
-                  token: storedSecret(values.token) ?? Redacted.make(""),
-                  organization: storedValueText(values.organization) ?? "",
-                },
+            Effect.map((values) => ({
+              method: "stored" as const,
+              tokenId: Redacted.value(
+                storedSecret(values.tokenId) ?? Redacted.make(""),
               ),
-            ),
-            Effect.andThen(
+              token: Redacted.value(
+                storedSecret(values.token) ?? Redacted.make(""),
+              ),
+              organization: storedValueText(values.organization) ?? "",
+            })),
+            Effect.tap(() =>
               interaction.output.success("Planetscale: credentials saved."),
             ),
-            Effect.as({ method: "stored" as const }),
           )
         : Effect.fail(
             new AuthError({
@@ -388,58 +358,33 @@ export const PlanetscaleAuth = AuthProviderLayer<
     const resolveCredentials = (
       profileName: string,
       config: PlanetscaleAuthConfig,
+      updateConfig?: (
+        config: PlanetscaleAuthConfig,
+      ) => Effect.Effect<void, AuthError>,
     ) =>
       Effect.gen(function* () {
         const reauth = refreshHint(PLANETSCALE_AUTH_PROVIDER_NAME, profileName);
         return yield* Match.value(config).pipe(
-          Match.when({ method: "stored" }, () =>
-            store
-              .read(
-                profileName,
-                STORED_STORAGE_KEY,
-                PlanetscaleStoredCredentials,
-              )
-              .pipe(
-                Effect.flatMap((creds) =>
-                  creds == null
-                    ? Effect.fail(
-                        new NeedsReauth({
-                          provider: PLANETSCALE_AUTH_PROVIDER_NAME,
-                          profile: profileName,
-                          message: `Planetscale stored credentials not found. ${reauth}`,
-                        }),
-                      )
-                    : Effect.succeed({
-                        type: "apiToken" as const,
-                        tokenId: creds.tokenId,
-                        token: creds.token,
-                        organization: creds.organization,
-                        source: {
-                          type: "stored" as const,
-                          details: undefined,
-                        },
-                      } satisfies PlanetscaleResolvedCredentials),
-                ),
-              ),
+          Match.when({ method: "stored" }, (stored) =>
+            Effect.succeed({
+              type: "apiToken" as const,
+              tokenId: Redacted.make(stored.tokenId),
+              token: Redacted.make(stored.token),
+              organization: stored.organization,
+              source: { type: "stored" as const, details: undefined },
+            } satisfies PlanetscaleResolvedCredentials),
           ),
           Match.when({ method: "oauth" }, (cfg) =>
             Effect.gen(function* () {
-              const creds = yield* store.read(
-                profileName,
-                OAUTH_STORAGE_KEY,
-                OAuthClient.OAuthCredentials,
-              );
-              if (creds == null || creds.type !== "oauth") {
-                return yield* Effect.fail(
-                  new NeedsReauth({
-                    provider: PLANETSCALE_AUTH_PROVIDER_NAME,
-                    profile: profileName,
-                    message: `Planetscale OAuth credentials not found. ${reauth}`,
-                  }),
-                );
-              }
+              const creds: OAuthClient.OAuthCredentials = {
+                type: "oauth",
+                clientId: cfg.clientId,
+                access: Redacted.make(cfg.access),
+                refresh: Redacted.make(cfg.refresh),
+                expires: cfg.expires,
+                scopes: cfg.scopes,
+              };
               if (!OAuthClient.usesCurrentClient(creds)) {
-                yield* store.delete(profileName, OAUTH_STORAGE_KEY);
                 return yield* Effect.fail(
                   new NeedsReauth({
                     provider: PLANETSCALE_AUTH_PROVIDER_NAME,
@@ -468,15 +413,20 @@ export const PlanetscaleAuth = AuthProviderLayer<
                             cause: e,
                           }),
                       ),
-                      Effect.tap((refreshed) =>
-                        store.write(
-                          profileName,
-                          OAUTH_STORAGE_KEY,
-                          OAuthClient.OAuthCredentials,
-                          refreshed,
-                        ),
-                      ),
                     );
+              if (fresh !== creds) {
+                yield* (
+                  updateConfig?.({
+                    method: "oauth",
+                    organization: cfg.organization,
+                    clientId: fresh.clientId,
+                    access: Redacted.value(fresh.access),
+                    refresh: Redacted.value(fresh.refresh),
+                    expires: fresh.expires,
+                    scopes: fresh.scopes,
+                  }) ?? Effect.void
+                );
+              }
               return {
                 type: "oauth" as const,
                 accessToken: fresh.access,
@@ -490,106 +440,67 @@ export const PlanetscaleAuth = AuthProviderLayer<
         );
       });
 
-    const logout = (profileName: string, config: PlanetscaleAuthConfig) =>
+    const logout = (_profileName: string, config: PlanetscaleAuthConfig) =>
       Match.value(config).pipe(
-        Match.when({ method: "stored" }, () =>
-          store
-            .delete(profileName, STORED_STORAGE_KEY)
-            .pipe(
-              Effect.andThen(
-                interaction.output.success(
-                  "Planetscale: stored credentials removed",
-                ),
-              ),
-            ),
-        ),
-        // PlanetScale publishes no token-revocation endpoint, so logout just
-        // drops the locally stored tokens.
-        Match.when({ method: "oauth" }, () =>
-          store
-            .delete(profileName, OAUTH_STORAGE_KEY)
-            .pipe(
-              Effect.andThen(
-                interaction.output.success(
-                  "Planetscale: OAuth credentials removed.",
-                ),
-              ),
-            ),
-        ),
+        Match.when({ method: "stored" }, () => Effect.void),
+        Match.when({ method: "oauth" }, () => Effect.void),
         Match.exhaustive,
       );
 
-    const login = (profileName: string, config: PlanetscaleAuthConfig) =>
+    const login = (
+      profileName: string,
+      config: PlanetscaleAuthConfig,
+      updateConfig?: (
+        config: PlanetscaleAuthConfig,
+      ) => Effect.Effect<void, AuthError>,
+    ) =>
       Match.value(config)
         .pipe(
-          Match.when({ method: "stored" }, () =>
-            store
-              .read(
-                profileName,
-                STORED_STORAGE_KEY,
-                PlanetscaleStoredCredentials,
-              )
-              .pipe(
-                Effect.flatMap((creds) =>
-                  creds == null ? loginStored(profileName) : Effect.void,
-                ),
-              ),
-          ),
-          Match.when({ method: "oauth" }, () =>
+          Match.when({ method: "stored" }, (stored) => Effect.succeed(stored)),
+          Match.when({ method: "oauth" }, (oauth) =>
             Effect.gen(function* () {
-              const creds = yield* store.read(
-                profileName,
-                OAUTH_STORAGE_KEY,
-                OAuthClient.OAuthCredentials,
-              );
-
-              // The silent refresh rotates a single-use refresh token, so
-              // its read-refresh-persist section runs under the profile
-              // lock — a concurrent `read` refreshing the same token would
-              // double-spend it. The lock is held only for this API
-              // round-trip, never across the browser wait below.
-              const outcome =
-                creds?.type === "oauth" && OAuthClient.usesCurrentClient(creds)
-                  ? yield* withProfileCredentialsLock(
-                      profileName,
-                      interaction.output
-                        .info("Planetscale: refreshing OAuth credentials...")
-                        .pipe(
-                          Effect.andThen(OAuthClient.refresh(creds)),
-                          Effect.flatMap((refreshed) =>
-                            store
-                              .write(
-                                profileName,
-                                OAUTH_STORAGE_KEY,
-                                OAuthClient.OAuthCredentials,
-                                refreshed,
-                              )
-                              .pipe(
-                                Effect.andThen(
-                                  interaction.output.success(
-                                    "Planetscale: OAuth credentials refreshed.",
-                                  ),
-                                ),
-                              ),
-                          ),
-                          Effect.as("refreshed" as const),
-                          Effect.catchTag("OAuthError", () =>
-                            Effect.succeed("browser" as const),
-                          ),
-                        ),
-                    )
-                  : yield* Effect.gen(function* () {
-                      if (creds?.type === "oauth") {
-                        yield* store.delete(profileName, OAUTH_STORAGE_KEY);
-                        yield* interaction.output.warning(
-                          "Planetscale: removed OAuth credentials issued to the previous client.",
-                        );
-                      }
-                      return "browser" as const;
-                    });
-              if (outcome === "browser") {
-                yield* oauthLogin(profileName);
+              const credentials: OAuthClient.OAuthCredentials = {
+                type: "oauth",
+                clientId: oauth.clientId,
+                access: Redacted.make(oauth.access),
+                refresh: Redacted.make(oauth.refresh),
+                expires: oauth.expires,
+                scopes: oauth.scopes,
+              };
+              if (!OAuthClient.usesCurrentClient(credentials)) {
+                return yield* configureOAuth(profileName);
               }
+              const refreshed = yield* withProfileCredentialsLock(
+                profileName,
+                interaction.output
+                  .info("Planetscale: refreshing OAuth credentials...")
+                  .pipe(
+                    Effect.andThen(OAuthClient.refresh(credentials)),
+                    Effect.flatMap((credentials) => {
+                      const config = {
+                        ...oauth,
+                        clientId: credentials.clientId,
+                        access: Redacted.value(credentials.access),
+                        refresh: Redacted.value(credentials.refresh),
+                        expires: credentials.expires,
+                        scopes: credentials.scopes,
+                      };
+                      return (updateConfig?.(config) ?? Effect.void).pipe(
+                        Effect.as(config),
+                      );
+                    }),
+                    Effect.tap(() =>
+                      interaction.output.success(
+                        "Planetscale: OAuth credentials refreshed.",
+                      ),
+                    ),
+                  ),
+              ).pipe(
+                Effect.catchTag("OAuthError", () =>
+                  configureOAuth(profileName),
+                ),
+              );
+              return refreshed;
             }),
           ),
           Match.exhaustive,
@@ -600,9 +511,15 @@ export const PlanetscaleAuth = AuthProviderLayer<
           ),
         );
 
-    const details = (profileName: string, config: PlanetscaleAuthConfig) =>
+    const details = (
+      profileName: string,
+      config: PlanetscaleAuthConfig,
+      updateConfig?: (
+        config: PlanetscaleAuthConfig,
+      ) => Effect.Effect<void, AuthError>,
+    ) =>
       Effect.all([
-        resolveCredentials(profileName, config),
+        resolveCredentials(profileName, config, updateConfig),
         Clock.currentTimeMillis,
       ]).pipe(
         Effect.map(([creds, now]): ProviderDetails => {

--- a/packages/alchemy/src/Prisma/AuthProvider.ts
+++ b/packages/alchemy/src/Prisma/AuthProvider.ts
@@ -20,7 +20,6 @@ export interface PrismaResolvedCredentials {
 
 const prismaAuth = makeStoredAuthProvider<PrismaResolvedCredentials>({
   provider: PRISMA_AUTH_PROVIDER_NAME,
-  storageKey: "prisma-stored",
   fields: [
     {
       name: "serviceToken",
@@ -78,6 +77,6 @@ const prismaAuth = makeStoredAuthProvider<PrismaResolvedCredentials>({
  */
 export const PrismaAuth = prismaAuth.layer;
 
-/** Schema of the stored Prisma credential file (flat field record). */
+/** Schema of Prisma's inline static-token values. */
 export const PrismaStoredCredentials = prismaAuth.storedSchema;
 export type PrismaStoredCredentials = typeof PrismaStoredCredentials.Type;

--- a/packages/alchemy/src/Railway/AuthProvider.ts
+++ b/packages/alchemy/src/Railway/AuthProvider.ts
@@ -10,12 +10,11 @@ import {
   AuthError,
   AuthProviderLayer,
   NeedsReauth,
-  refreshHint,
   type ConfigureField,
   type ConfigureMethod,
   type ProviderDetails,
 } from "../Auth/AuthProvider.ts";
-import { CredentialsStore, displayRedacted } from "../Auth/Credentials.ts";
+import { displayRedacted } from "../Auth/Credentials.ts";
 import {
   getEnv,
   getEnvRedacted,
@@ -38,28 +37,21 @@ export const RAILWAY_AUTH_PROVIDER_NAME = "Railway";
 export const RAILWAY_API_TOKEN_ENV = "RAILWAY_API_TOKEN";
 export const RAILWAY_API_URL_ENV = "RAILWAY_API_URL";
 
-const STORAGE_KEY = "railway-stored";
-const OAUTH_STORAGE_KEY = "railway-oauth";
-
-/** Manifest-entry schema for Railway authentication. */
+/** Typed values stored in a Railway provider profile document. */
 export const RailwayAuthConfigSchema = Schema.Union([
   Schema.Struct({ method: Schema.Literal("env") }),
-  Schema.Struct({ method: Schema.Literal("stored") }),
-  Schema.Struct({ method: Schema.Literal("oauth") }),
+  Schema.Struct({
+    method: Schema.Literal("stored"),
+    token: Schema.String,
+    apiBaseUrl: Schema.optional(Schema.String),
+  }),
+  Schema.Struct({
+    method: Schema.Literal("oauth"),
+    token: Schema.String,
+    apiBaseUrl: Schema.optional(Schema.String),
+  }),
 ]);
 export type RailwayAuthConfig = typeof RailwayAuthConfigSchema.Type;
-
-/**
- * Token credentials persisted to disk for `method: "stored"` and
- * `method: "oauth"`. The JSON shape (`token` as a plain string) is
- * unchanged from the pre-schema store, so existing credential files decode.
- */
-export const RailwayStoredCredentials = Schema.Struct({
-  type: Schema.Literal("token"),
-  token: Schema.RedactedFromValue(Schema.String),
-  apiBaseUrl: Schema.optional(Schema.String),
-});
-export type RailwayStoredCredentials = typeof RailwayStoredCredentials.Type;
 
 export type RailwayResolvedCredentials = {
   type: "token";
@@ -88,7 +80,7 @@ const options: Array<{
   {
     value: "stored",
     label: "API Token",
-    description: "enter interactively, stored in ~/.alchemy/credentials",
+    description: "enter interactively and store inline in the provider file",
   },
 ];
 
@@ -110,8 +102,7 @@ const resolveApiBaseUrl = (explicit?: string) =>
  * Supported methods:
  * - `env`: reads `RAILWAY_API_TOKEN` (account Bearer). Project tokens are
  *   not used — they cannot reach workspace-wide operations.
- * - `stored`: prompts for an API token and writes it to
- *   `~/.alchemy/credentials/<profile>/railway-stored.json`.
+ * - `stored`: prompts for an API token and stores it in the provider file.
  * - `oauth`: CLI login session (`loginSessionCreate` → open the pairing URL →
  *   poll `loginSessionVerify` / `loginSessionConsume` → store the token).
  *   Does not require a pre-existing token. An optional `RAILWAY_API_URL`
@@ -124,15 +115,13 @@ export const RailwayAuth = AuthProviderLayer<
   RAILWAY_AUTH_PROVIDER_NAME,
   Effect.gen(function* () {
     const interaction = Interaction.accessors;
-    const store = yield* CredentialsStore;
-
-    const loginStored = Effect.fn(function* (profileName: string) {
+    const loginStored = Effect.fn(function* (_profileName: string) {
       const token = yield* interaction.prompt
         .password({
           message: "Railway API Token",
           validate: (v) => (v.length === 0 ? "Required" : undefined),
         })
-        .pipe(mapPromptCancellation, Effect.map(Redacted.make));
+        .pipe(mapPromptCancellation);
 
       const envUrl = yield* getEnv(RAILWAY_API_URL_ENV);
       const urlPrompt = yield* interaction.prompt
@@ -148,16 +137,11 @@ export const RailwayAuth = AuthProviderLayer<
           ? trimmed
           : undefined;
 
-      yield* store.write(profileName, STORAGE_KEY, RailwayStoredCredentials, {
-        type: "token",
-        token,
-        apiBaseUrl,
-      });
       yield* interaction.output.success("Railway: credentials saved.");
-      return { method: "stored" as const };
+      return { method: "stored" as const, token, apiBaseUrl };
     });
 
-    const loginOAuth = Effect.fn(function* (profileName: string) {
+    const loginOAuth = Effect.fn(function* (_profileName: string) {
       const apiBaseUrl = yield* resolveApiBaseUrl();
       const hostname = yield* Effect.sync(() => {
         try {
@@ -235,19 +219,13 @@ export const RailwayAuth = AuthProviderLayer<
         });
       }
 
-      yield* store.write(
-        profileName,
-        OAUTH_STORAGE_KEY,
-        RailwayStoredCredentials,
-        {
-          type: "token",
-          token: Redacted.make(token),
-          apiBaseUrl:
-            apiBaseUrl === DEFAULT_API_BASE_URL ? undefined : apiBaseUrl,
-        },
-      );
       yield* interaction.output.success("Railway: OAuth credentials saved.");
-      return { method: "oauth" as const };
+      return {
+        method: "oauth" as const,
+        token,
+        apiBaseUrl:
+          apiBaseUrl === DEFAULT_API_BASE_URL ? undefined : apiBaseUrl,
+      };
     });
 
     const configureInteractive = (profileName: string) =>
@@ -309,7 +287,7 @@ export const RailwayAuth = AuthProviderLayer<
     ];
 
     const configureWith = (
-      profileName: string,
+      _profileName: string,
       input: {
         readonly method: string;
         readonly values: Record<string, string>;
@@ -321,17 +299,16 @@ export const RailwayAuth = AuthProviderLayer<
             tokenFields,
             input.values,
           ).pipe(
-            Effect.flatMap((values) =>
-              store.write(profileName, STORAGE_KEY, RailwayStoredCredentials, {
-                type: "token",
-                token: storedSecret(values.token) ?? Redacted.make(""),
-                apiBaseUrl: storedValueText(values.apiBaseUrl),
-              }),
-            ),
-            Effect.andThen(
+            Effect.map((values) => ({
+              method: "stored" as const,
+              token: Redacted.value(
+                storedSecret(values.token) ?? Redacted.make(""),
+              ),
+              apiBaseUrl: storedValueText(values.apiBaseUrl),
+            })),
+            Effect.tap(() =>
               interaction.output.success("Railway: credentials saved."),
             ),
-            Effect.as({ method: "stored" as const }),
           )
         : input.method === "env"
           ? Effect.succeed({ method: "env" as const })
@@ -342,31 +319,16 @@ export const RailwayAuth = AuthProviderLayer<
             );
 
     const readStoredToken = (
-      profileName: string,
-      key: string,
-      sourceType: "stored" | "oauth",
-      missingMessage: string,
-    ): Effect.Effect<RailwayResolvedCredentials, AuthError | NeedsReauth> =>
+      config: Extract<RailwayAuthConfig, { method: "stored" | "oauth" }>,
+    ): Effect.Effect<RailwayResolvedCredentials, AuthError> =>
       Effect.gen(function* () {
-        const creds = yield* store.read(
-          profileName,
-          key,
-          RailwayStoredCredentials,
-        );
-        if (creds == null) {
-          return yield* new NeedsReauth({
-            provider: RAILWAY_AUTH_PROVIDER_NAME,
-            profile: profileName,
-            message: missingMessage,
-          });
-        }
-        const apiBaseUrl = yield* resolveApiBaseUrl(creds.apiBaseUrl);
+        const apiBaseUrl = yield* resolveApiBaseUrl(config.apiBaseUrl);
         return {
           type: "token" as const,
-          token: creds.token,
+          token: Redacted.make(config.token),
           tokenKind: "account" as const,
           apiBaseUrl,
-          source: { type: sourceType },
+          source: { type: config.method },
         };
       });
 
@@ -375,7 +337,6 @@ export const RailwayAuth = AuthProviderLayer<
       config: RailwayAuthConfig,
     ): Effect.Effect<RailwayResolvedCredentials, AuthError | NeedsReauth> =>
       Effect.gen(function* () {
-        const reauth = refreshHint(RAILWAY_AUTH_PROVIDER_NAME, profileName);
         return yield* Match.value(config).pipe(
           Match.when(
             { method: "env" },
@@ -399,53 +360,19 @@ export const RailwayAuth = AuthProviderLayer<
               } satisfies RailwayResolvedCredentials;
             }),
           ),
-          Match.when({ method: "stored" }, () =>
-            readStoredToken(
-              profileName,
-              STORAGE_KEY,
-              "stored",
-              `Railway stored credentials not found. ${reauth}`,
-            ),
-          ),
-          Match.when({ method: "oauth" }, () =>
-            readStoredToken(
-              profileName,
-              OAUTH_STORAGE_KEY,
-              "oauth",
-              `Railway OAuth credentials not found. ${reauth}`,
-            ),
-          ),
+          Match.when({ method: "stored" }, readStoredToken),
+          Match.when({ method: "oauth" }, readStoredToken),
           Match.exhaustive,
         );
       });
 
-    const logout = (profileName: string, config: RailwayAuthConfig) =>
+    const logout = (_profileName: string, config: RailwayAuthConfig) =>
       Match.value(config).pipe(
         Match.when({ method: "env" }, () => Effect.void),
-        Match.when({ method: "stored" }, () =>
-          store
-            .delete(profileName, STORAGE_KEY)
-            .pipe(
-              Effect.andThen(
-                interaction.output.success(
-                  "Railway: stored credentials removed",
-                ),
-              ),
-            ),
-        ),
+        Match.when({ method: "stored" }, () => Effect.void),
         // Railway account tokens have no revocation endpoint for CLI-session
         // tokens, so logout just drops the locally stored token.
-        Match.when({ method: "oauth" }, () =>
-          store
-            .delete(profileName, OAUTH_STORAGE_KEY)
-            .pipe(
-              Effect.andThen(
-                interaction.output.success(
-                  "Railway: OAuth credentials removed",
-                ),
-              ),
-            ),
-        ),
+        Match.when({ method: "oauth" }, () => Effect.void),
         Match.exhaustive,
       );
 
@@ -469,28 +396,8 @@ export const RailwayAuth = AuthProviderLayer<
           ),
           // Railway account tokens neither expire nor refresh, so login only
           // (re-)prompts when no credential is stored yet.
-          Match.when({ method: "stored" }, () =>
-            store
-              .read(profileName, STORAGE_KEY, RailwayStoredCredentials)
-              .pipe(
-                Effect.flatMap((creds) =>
-                  creds == null
-                    ? loginStored(profileName).pipe(Effect.asVoid)
-                    : Effect.void,
-                ),
-              ),
-          ),
-          Match.when({ method: "oauth" }, () =>
-            store
-              .read(profileName, OAUTH_STORAGE_KEY, RailwayStoredCredentials)
-              .pipe(
-                Effect.flatMap((creds) =>
-                  creds == null
-                    ? loginOAuth(profileName).pipe(Effect.asVoid)
-                    : Effect.void,
-                ),
-              ),
-          ),
+          Match.when({ method: "stored" }, (config) => Effect.succeed(config)),
+          Match.when({ method: "oauth" }, (config) => Effect.succeed(config)),
           Match.exhaustive,
         )
         .pipe(

--- a/packages/alchemy/test/AWS/Local/CredentialFreeDev.local.test.ts
+++ b/packages/alchemy/test/AWS/Local/CredentialFreeDev.local.test.ts
@@ -238,7 +238,8 @@ const noCredsProfile: ProfileStoreService = {
   createProfile: () => unexpectedProfileMutation,
   renameProfile: () => unexpectedProfileMutation,
   current: Effect.succeed({ name: NO_CREDS_PROFILE, source: "configuration" }),
-  setProfile: () => unexpectedProfileMutation,
+  setProviderConfig: () => unexpectedProfileMutation,
+  deleteProviderConfig: () => unexpectedProfileMutation,
   deleteProfile: () => Effect.succeed(false),
   loadProviderConfig: () => unexpectedProfileMutation,
 };

--- a/packages/alchemy/test/Auth/Demand.test.ts
+++ b/packages/alchemy/test/Auth/Demand.test.ts
@@ -111,15 +111,12 @@ const withTempHome = <A, E, R>(
           else process.env.ALCHEMY_HOME = previous;
         }),
     );
-    return yield* effect;
-  }).pipe(Effect.scoped, Effect.provide(makeTestLayer(config)));
+    return yield* effect.pipe(Effect.provide(makeTestLayer(config)));
+  }).pipe(Effect.scoped, Effect.provide(NodeServices.layer));
 
 const configureProbe = Effect.gen(function* () {
   const profile = yield* ProfileStore;
-  yield* profile.setProfile("default", {
-    id: "default",
-    providers: { [PROBE]: { method: "stored" } },
-  });
+  yield* profile.setProviderConfig("default", PROBE, { method: "stored" });
 });
 
 const demand: CredentialDemand = {

--- a/packages/alchemy/test/Auth/Migration.test.ts
+++ b/packages/alchemy/test/Auth/Migration.test.ts
@@ -1,15 +1,18 @@
 import { AuthProviders } from "@/Auth/AuthProvider.ts";
 import {
-  PROFILE_MANIFEST_VERSION,
+  PROFILE_FORMAT,
+  profileProviderFilePath,
   ProfileStore,
   ProfileStoreLive,
 } from "@/Auth/Profile.ts";
+import { GitHubAuthConfigSchema } from "@/GitHub/AuthProvider.ts";
 import * as NodeServices from "@effect/platform-node/NodeServices";
 import { expect, it } from "alchemy-test";
 import * as ConfigProvider from "effect/ConfigProvider";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
+import * as Schema from "effect/Schema";
 import path from "pathe";
 
 const FIXTURE_HOME = path.join(import.meta.dirname, "fixtures/v0-home");
@@ -60,8 +63,8 @@ const withFixtureHome = <A, E, R>(
           else process.env.ALCHEMY_HOME = previous;
         }),
     );
-    return yield* effect(dir);
-  }).pipe(Effect.scoped, Effect.provide(testLayer()));
+    return yield* effect(dir).pipe(Effect.provide(testLayer()));
+  }).pipe(Effect.scoped, Effect.provide(NodeServices.layer));
 
 it.live(
   "migrates a full v0 store: entries kept, credentials dropped into a backup",
@@ -82,35 +85,75 @@ it.live(
         ]);
         expect(manifest.profiles.default?.id).toBe("default");
         expect(manifest.profiles.work?.id).toBe("work");
-        expect(manifest.profiles.default?.providers.Cloudflare?.method).toBe(
-          "oauth",
-        );
+        expect(manifest.profiles.default?.providers.Cloudflare).toEqual({
+          method: "oauth",
+        });
         expect(manifest.profiles.default?.providers.AWS?.method).toBe("sso");
+        expect(manifest.profiles.default?.providers.GitHub).toEqual({
+          method: "gh-cli",
+        });
+        expect(
+          Schema.decodeUnknownSync(GitHubAuthConfigSchema)(
+            manifest.profiles.default?.providers.GitHub,
+          ),
+        ).toEqual({ method: "gh-cli" });
         expect(manifest.profiles.default?.providers.Neon).toBeUndefined();
         expect(manifest.profiles.work?.providers.GitHub?.method).toBe("stored");
         expect(manifest.profiles.work?.providers.Axiom?.method).toBe("stored");
-        expect(manifest.profiles.work?.providers.Cloudflare?.method).toBe(
-          "stored",
+        expect(manifest.profiles.work?.providers.Cloudflare).toEqual({
+          method: "stored",
+          credentialType: "apiKey",
+          apiKey: "v0-cf-global-api-key",
+          email: "worker@example.com",
+          accountId: "0123456789abcdef0123456789abcdef",
+        });
+        expect(manifest.profiles.work?.providers.GitHub?.token).toBe(
+          "ghp_v0token",
         );
+        expect(manifest.profiles.work?.providers.Axiom).toEqual({
+          method: "stored",
+          token: "xaat-v0-token",
+          apiBaseUrl: "https://api.axiom.co",
+        });
 
-        // The manifest on disk is upgraded in place, keeping provider
-        // details like the SSO profile and OAuth scopes.
-        const onDisk = JSON.parse(
-          yield* fs.readFileString(path.join(home, "profiles.json")),
+        // Each provider is now its own document. Compatible provider values
+        // survive. Cloudflare OAuth is deliberately emptied because its old
+        // grant is obsolete; stored API key credentials remain compatible.
+        const aws = JSON.parse(
+          yield* fs.readFileString(profileProviderFilePath("default", "AWS")),
         );
-        expect(onDisk.version).toBe(PROFILE_MANIFEST_VERSION);
-        expect(onDisk.profiles.work.id).toBe("work");
-        expect(onDisk.profiles.default.providers.AWS.ssoProfile).toBe("dev");
-        expect(onDisk.profiles.default.providers.Cloudflare.scopes).toEqual([
-          "account:read",
-          "workers:write",
-        ]);
-        expect(onDisk.profiles.default.providers.Neon).toBeUndefined();
+        expect(aws).toEqual({
+          format: PROFILE_FORMAT,
+          provider: "AWS",
+          metadata: {},
+          values: { method: "sso", ssoProfile: "dev" },
+        });
+        const oauthCloudflare = JSON.parse(
+          yield* fs.readFileString(
+            profileProviderFilePath("default", "Cloudflare"),
+          ),
+        );
+        expect(oauthCloudflare.values).toEqual({ method: "oauth" });
+        const storedCloudflare = JSON.parse(
+          yield* fs.readFileString(
+            profileProviderFilePath("work", "Cloudflare"),
+          ),
+        );
+        expect(storedCloudflare.values).toEqual(
+          manifest.profiles.work?.providers.Cloudflare,
+        );
+        expect(
+          (yield* fs.readDirectory(path.join(home, "profiles/default"))).sort(),
+        ).toEqual(["aws.json", "cloudflare.json", "github.json"]);
+        expect(
+          yield* fs.exists(profileProviderFilePath("default", "Neon")),
+        ).toBe(false);
+        expect(yield* fs.exists(path.join(home, "profiles.json"))).toBe(false);
 
         // The original manifest and every credential file are preserved in
         // a timestamped backup for manual recovery.
         const backups = (yield* fs.readDirectory(home)).filter((entry) =>
-          entry.startsWith(".v0-profiles-"),
+          entry.startsWith(".profiles-v0-"),
         );
         expect(backups).toHaveLength(1);
         const backupDir = path.join(home, backups[0]!);
@@ -135,22 +178,20 @@ it.live(
           expect(yield* fs.exists(path.join(backupDir, file))).toBe(true);
         }
 
-        // The live credential store is empty — providers report a clean
-        // "not configured" instead of loading stale v0 secrets.
-        expect(yield* fs.exists(path.join(home, "credentials/default"))).toBe(
-          false,
-        );
-        expect(yield* fs.exists(path.join(home, "credentials/work"))).toBe(
-          false,
-        );
+        // The live credential store is gone; all obsolete sidecars live only
+        // in the recoverable v0 backup.
+        expect(yield* fs.exists(path.join(home, "credentials"))).toBe(false);
 
         // Idempotent: a second read is a plain current-version read — no new
         // backup dir, and the existing one is untouched.
         const again = yield* store.readManifest;
         expect(again.profiles.work?.providers.GitHub?.method).toBe("stored");
+        expect(again.profiles.work?.providers.Cloudflare).toEqual(
+          manifest.profiles.work?.providers.Cloudflare,
+        );
         expect(
           (yield* fs.readDirectory(home)).filter((entry) =>
-            entry.startsWith(".v0-profiles-"),
+            entry.startsWith(".profiles-v0-"),
           ),
         ).toHaveLength(1);
         expect(
@@ -164,46 +205,204 @@ it.live(
 );
 
 it.live(
-  "leaves a current-version store untouched (no backup, credentials kept)",
+  "leaves the directory-backed store untouched",
   () =>
     withFixtureHome(undefined, (home) =>
       Effect.gen(function* () {
         const fs = yield* FileSystem.FileSystem;
-        yield* fs.writeFileString(
-          path.join(home, "profiles.json"),
-          JSON.stringify({
-            version: PROFILE_MANIFEST_VERSION,
-            profiles: {
-              default: { id: "default", providers: {} },
-              work: {
-                id: "work-id",
-                providers: { Neon: { method: "stored" } },
-              },
-            },
-          }),
-        );
-        yield* fs.makeDirectory(path.join(home, "credentials/work"), {
+        const providerFile = profileProviderFilePath("work", "Neon");
+        yield* fs.makeDirectory(path.dirname(providerFile), {
           recursive: true,
         });
         yield* fs.writeFileString(
-          path.join(home, "credentials/work/neon-stored.json"),
-          JSON.stringify({ apiKey: "current-key" }),
+          providerFile,
+          JSON.stringify({
+            format: PROFILE_FORMAT,
+            provider: "Neon",
+            metadata: { label: "production" },
+            values: { method: "stored", apiKey: "current-key" },
+          }),
         );
 
         const store = yield* ProfileStore;
         const manifest = yield* store.readManifest;
 
-        expect(manifest.profiles.work?.id).toBe("work-id");
+        expect(manifest.profiles.work?.id).toBe("work");
+        expect(manifest.profiles.work?.providers.Neon).toEqual({
+          method: "stored",
+          apiKey: "current-key",
+        });
         expect(
           (yield* fs.readDirectory(home)).filter((entry) =>
-            entry.startsWith(".v0-profiles-"),
+            entry.startsWith(".profiles-v0-"),
           ),
         ).toHaveLength(0);
         expect(
-          yield* fs.exists(
-            path.join(home, "credentials/work/neon-stored.json"),
+          JSON.parse(yield* fs.readFileString(providerFile)).metadata,
+        ).toEqual({ label: "production" });
+      }),
+    ),
+  { exclusive: true },
+);
+
+it.live(
+  "salvages valid v0 providers when another entry or sidecar is invalid",
+  () =>
+    withFixtureHome(FIXTURE_HOME, (home) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const legacyFile = path.join(home, "profiles.json");
+        const legacy = JSON.parse(yield* fs.readFileString(legacyFile));
+        legacy.profiles.work.Broken = "not-an-object";
+        yield* fs.writeFileString(legacyFile, JSON.stringify(legacy));
+        yield* fs.writeFileString(
+          path.join(home, "credentials/work/axiom-stored.json"),
+          "{not-json",
+        );
+
+        const manifest = yield* (yield* ProfileStore).readManifest;
+        expect(manifest.profiles.default?.providers.AWS).toEqual({
+          method: "sso",
+          ssoProfile: "dev",
+        });
+        expect(manifest.profiles.work?.providers.GitHub?.token).toBe(
+          "ghp_v0token",
+        );
+        expect(manifest.profiles.work?.providers.Axiom).toEqual({
+          method: "stored",
+        });
+        expect(manifest.profiles.work?.providers.Broken).toBeUndefined();
+
+        const backup = (yield* fs.readDirectory(home)).find((entry) =>
+          entry.startsWith(".profiles-v0-"),
+        );
+        expect(backup).toBeDefined();
+        expect(
+          yield* fs.readFileString(
+            path.join(home, backup!, "credentials/work/axiom-stored.json"),
           ),
-        ).toBe(true);
+        ).toBe("{not-json");
+      }),
+    ),
+  { exclusive: true },
+);
+
+it.live(
+  "inlines every recognized v0 credential sidecar",
+  () =>
+    withFixtureHome(undefined, (home) =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const staticCredentials = {
+          "aws-stored": {
+            accessKeyId: "AKIAFIXTURE",
+            secretAccessKey: "aws-secret",
+            region: "us-east-1",
+          },
+          "axiom-stored": {
+            type: "apiToken",
+            apiToken: "axiom-token",
+            orgId: "axiom-org",
+          },
+          "fly-stored": { apiKey: "fly-token" },
+          "github-stored": { type: "pat", token: "github-token" },
+          "hetzner-stored": { token: "hetzner-token" },
+          "neon-stored": { apiKey: "neon-key" },
+          "planetscale-stored": {
+            type: "apiToken",
+            tokenId: "ps-token-id",
+            token: "ps-token",
+            organization: "ps-org",
+          },
+          "prisma-stored": { serviceToken: "prisma-token" },
+          "railway-stored": { type: "token", token: "railway-token" },
+        };
+        const oauthCredentials = {
+          "planetscale-oauth": {
+            type: "oauth",
+            clientId: "ps-client",
+            access: "ps-access",
+            refresh: "ps-refresh",
+            expires: 4_102_444_800_000,
+            scopes: ["read_organizations"],
+          },
+          "railway-oauth": { type: "token", token: "railway-oauth-token" },
+        };
+        yield* fs.writeFileString(
+          path.join(home, "profiles.json"),
+          JSON.stringify({
+            version: 0,
+            profiles: {
+              static: {
+                AWS: { method: "stored" },
+                Axiom: { method: "stored" },
+                Fly: { method: "stored" },
+                GitHub: { method: "stored" },
+                Hetzner: { method: "stored" },
+                Neon: { method: "stored" },
+                Planetscale: { method: "stored" },
+                Prisma: { method: "stored" },
+                Railway: { method: "stored" },
+              },
+              oauth: {
+                Planetscale: { method: "oauth", organization: "ps-org" },
+                Railway: { method: "oauth" },
+              },
+            },
+          }),
+        );
+        for (const [profile, credentials] of Object.entries({
+          static: staticCredentials,
+          oauth: oauthCredentials,
+        })) {
+          const dir = path.join(home, "credentials", profile);
+          yield* fs.makeDirectory(dir, { recursive: true });
+          for (const [key, values] of Object.entries(credentials)) {
+            yield* fs.writeFileString(
+              path.join(dir, `${key}.json`),
+              JSON.stringify(values),
+            );
+          }
+        }
+
+        const manifest = yield* (yield* ProfileStore).readManifest;
+        expect(manifest.profiles.static?.providers).toEqual({
+          AWS: {
+            method: "stored",
+            accessKeyId: "AKIAFIXTURE",
+            secretAccessKey: "aws-secret",
+            region: "us-east-1",
+          },
+          Axiom: {
+            method: "stored",
+            token: "axiom-token",
+            orgId: "axiom-org",
+          },
+          Fly: { method: "stored", apiKey: "fly-token" },
+          GitHub: { method: "stored", token: "github-token" },
+          Hetzner: { method: "stored", token: "hetzner-token" },
+          Neon: { method: "stored", apiKey: "neon-key" },
+          Planetscale: {
+            method: "stored",
+            tokenId: "ps-token-id",
+            token: "ps-token",
+            organization: "ps-org",
+          },
+          Prisma: { method: "stored", serviceToken: "prisma-token" },
+          Railway: { method: "stored", token: "railway-token" },
+        });
+        expect(manifest.profiles.oauth?.providers).toEqual({
+          Planetscale: {
+            method: "oauth",
+            organization: "ps-org",
+            clientId: "ps-client",
+            access: "ps-access",
+            refresh: "ps-refresh",
+            expires: 4_102_444_800_000,
+            scopes: ["read_organizations"],
+          },
+          Railway: { method: "oauth", token: "railway-oauth-token" },
+        });
       }),
     ),
   { exclusive: true },

--- a/packages/alchemy/test/Auth/Profile.test.ts
+++ b/packages/alchemy/test/Auth/Profile.test.ts
@@ -6,7 +6,10 @@ import {
 } from "@/Auth/AuthProvider.ts";
 import {
   configFilePath,
-  PROFILE_MANIFEST_VERSION,
+  makeProviderProfileSchema,
+  PROFILE_FORMAT,
+  profileDirPath,
+  profileProviderFilePath,
   ProfileError,
   ProfileStore,
   ProfileStoreLive,
@@ -117,8 +120,8 @@ const withTempHome = <A, E, R>(
           else process.env.ALCHEMY_HOME = previous;
         }),
     );
-    return yield* effect;
-  }).pipe(Effect.scoped, Effect.provide(makeTestLayer(config)));
+    return yield* effect.pipe(Effect.provide(makeTestLayer(config)));
+  }).pipe(Effect.scoped, Effect.provide(NodeServices.layer));
 
 /** Set a process env var for the duration of the surrounding scope. */
 const withProcessEnv = (name: string, value: string) =>
@@ -191,11 +194,13 @@ it.live(
     withTempHome(
       Effect.gen(function* () {
         const profile = yield* ProfileStore;
+        const fs = yield* FileSystem.FileSystem;
         // Never written to disk, yet the reader still presents `default`
         // with its deterministic id.
         const manifest = yield* profile.readManifest;
         expect(Object.keys(manifest.profiles)).toEqual(["default"]);
         expect(manifest.profiles.default!.id).toBe("default");
+        expect(yield* fs.exists(profileDirPath("default"))).toBe(true);
         expect(yield* profile.ensureProfile("default")).toEqual({
           id: "default",
           providers: {},
@@ -215,7 +220,8 @@ it.live(
       Effect.gen(function* () {
         const fs = yield* FileSystem.FileSystem;
         const profile = yield* ProfileStore;
-        // Any manifest write persists the synthesized `default` entry.
+        // Creating a profile only creates its directory. The built-in
+        // default remains synthesized until it has a provider file.
         yield* profile.createProfile("work");
 
         const renameError = yield* profile
@@ -248,21 +254,15 @@ it.live(
           "already exists",
         );
 
-        const raw = JSON.parse(yield* fs.readFileString(configFilePath())) as {
-          version: number;
-          defaultProfile?: string;
-          profiles: Record<string, { id: string }>;
-        };
-        expect(raw.version).toBe(PROFILE_MANIFEST_VERSION);
-        expect(raw.profiles.default!.id).toBe("default");
-        expect(raw.defaultProfile).toBeUndefined();
+        expect(yield* fs.exists(profileDirPath("work"))).toBe(true);
+        expect(yield* fs.exists(configFilePath())).toBe(false);
       }),
     ),
   { exclusive: true },
 );
 
 it.live(
-  "migrates pre-id manifests and preserves unknown top-level keys",
+  "migrates centralized manifests into provider files",
   () =>
     withTempHome(
       Effect.gen(function* () {
@@ -285,30 +285,36 @@ it.live(
         );
 
         const manifest = yield* profile.readManifest;
-        // Migrated in place: id defaults to the profile name so it is
-        // deterministic before the manifest is rewritten.
         expect(manifest.profiles.legacy!.id).toBe("legacy");
         expect(manifest.profiles.legacy!.providers.Cloudflare).toEqual({
           method: "oauth",
-          scopes: ["d1.write"],
         });
-        // The built-in default is synthesized alongside the migrated entry.
         expect(manifest.profiles.default!.id).toBe("default");
 
-        // A write upgrades the version but keeps unknown top-level keys.
-        yield* profile.setProfile("legacy", manifest.profiles.legacy!);
-        const raw = JSON.parse(
-          yield* fs.readFileString(configFilePath()),
-        ) as Record<string, unknown>;
-        expect(raw.version).toBe(PROFILE_MANIFEST_VERSION);
-        expect(raw.futureField).toEqual({ anything: true });
+        const providerFile = JSON.parse(
+          yield* fs.readFileString(
+            profileProviderFilePath("legacy", "Cloudflare"),
+          ),
+        );
+        expect(providerFile).toEqual({
+          format: PROFILE_FORMAT,
+          provider: "Cloudflare",
+          metadata: {},
+          values: { method: "oauth" },
+        });
+        expect(yield* fs.exists(configFilePath())).toBe(false);
+        expect(
+          (yield* fs.readDirectory(path.dirname(configFilePath()))).filter(
+            (entry) => entry.startsWith(".profiles-v0-"),
+          ),
+        ).toHaveLength(1);
       }),
     ),
   { exclusive: true },
 );
 
 it.live(
-  "drops a legacy stored-default selection from the manifest",
+  "ignores unreleased centralized manifest versions",
   () =>
     withTempHome(
       Effect.gen(function* () {
@@ -326,23 +332,82 @@ it.live(
           }),
         );
 
-        // The stored selection has no authority: without an explicit
-        // --profile/$ALCHEMY_PROFILE the built-in `default` is used.
+        // Only released v0 is migrated. The short-lived centralized v1/v2
+        // formats are left untouched and do not enter the directory store.
         const manifest = yield* profile.readManifest;
-        expect(
-          (manifest as { defaultProfile?: string }).defaultProfile,
-        ).toBeUndefined();
+        expect(manifest.profiles.work).toBeUndefined();
         expect((yield* profile.current).name).toBe("default");
 
-        // The next write persists the removal.
         yield* profile.createProfile("scratch");
-        const raw = JSON.parse(yield* fs.readFileString(configFilePath())) as {
-          defaultProfile?: string;
-          profiles: Record<string, unknown>;
-        };
-        expect(raw.defaultProfile).toBeUndefined();
-        expect(raw.profiles.default).toBeDefined();
-        expect(raw.profiles.work).toBeDefined();
+        expect(yield* fs.exists(profileDirPath("work"))).toBe(false);
+        expect(yield* fs.exists(profileDirPath("scratch"))).toBe(true);
+        expect(yield* fs.exists(configFilePath())).toBe(true);
+      }),
+    ),
+  { exclusive: true },
+);
+
+it.live(
+  "backs up invalid provider files and continues loading the profile",
+  () =>
+    withTempHome(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const profiles = yield* ProfileStore;
+        yield* fs.writeFileString(
+          profileProviderFilePath("default", "Cloudflare"),
+          "{not-json",
+        );
+        yield* fs.writeFileString(
+          profileProviderFilePath("default", "Other"),
+          JSON.stringify({
+            format: PROFILE_FORMAT,
+            provider: "Other",
+            metadata: {},
+            values: { method: "stored" },
+          }),
+        );
+
+        const manifest = yield* profiles.readManifest;
+        expect(manifest.profiles.default!.providers.Cloudflare).toBeUndefined();
+        expect(manifest.profiles.default!.providers.Other).toEqual({
+          method: "stored",
+        });
+        const files = yield* fs.readDirectory(profileDirPath("default"));
+        expect(files).toContain("other.json");
+        expect(
+          files.some((file) => file.startsWith("cloudflare.json.invalid-")),
+        ).toBe(true);
+      }),
+    ),
+  { exclusive: true },
+);
+
+it.live(
+  "backs up an invalid provider file before reconfiguration replaces it",
+  () =>
+    withTempHome(
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const profiles = yield* ProfileStore;
+        const file = profileProviderFilePath("default", "Cloudflare");
+        yield* fs.writeFileString(file, "{not-json");
+
+        yield* profiles.setProviderConfig("default", "Cloudflare", {
+          method: "oauth",
+        });
+
+        expect(JSON.parse(yield* fs.readFileString(file))).toEqual({
+          format: PROFILE_FORMAT,
+          provider: "Cloudflare",
+          metadata: {},
+          values: { method: "oauth" },
+        });
+        expect(
+          (yield* fs.readDirectory(profileDirPath("default"))).some((entry) =>
+            entry.startsWith("cloudflare.json.invalid-"),
+          ),
+        ).toBe(true);
       }),
     ),
   { exclusive: true },
@@ -389,13 +454,12 @@ it.live(
         expect(error).toBeInstanceOf(AuthError);
         expect((error as AuthError).message).toContain("--add");
 
-        // A manifest write persists the removal.
-        yield* profile.setProfile("ci", manifest.profiles.ci!);
-        const raw = JSON.parse(yield* fs.readFileString(configFilePath())) as {
-          profiles: Record<string, { providers: Record<string, unknown> }>;
-        };
-        expect(raw.profiles.ci!.providers[FAKE_PROVIDER]).toBeUndefined();
-        expect(raw.profiles.ci!.providers.Other).toBeDefined();
+        expect(
+          yield* fs.exists(profileProviderFilePath("ci", FAKE_PROVIDER)),
+        ).toBe(false);
+        expect(yield* fs.exists(profileProviderFilePath("ci", "Other"))).toBe(
+          true,
+        );
       }),
     ),
   { exclusive: true },
@@ -407,6 +471,40 @@ it.effect("accepts portable profile names", () =>
       "production-admin",
     );
     expect(yield* validateProfileName("team.prod_2")).toBe("team.prod_2");
+  }),
+);
+
+it.effect("lets custom providers refine metadata and values", () =>
+  Effect.gen(function* () {
+    const CustomProfile = makeProviderProfileSchema(
+      "Acme",
+      Schema.Struct({ team: Schema.String }),
+      Schema.Union([
+        Schema.Struct({
+          method: Schema.Literal("token"),
+          token: Schema.String,
+        }),
+        Schema.Struct({
+          method: Schema.Literal("oauth"),
+          access: Schema.String,
+          refresh: Schema.String,
+          scopes: Schema.Array(Schema.String),
+        }),
+      ]),
+    );
+    expect(
+      yield* Schema.decodeUnknownEffect(CustomProfile)({
+        format: PROFILE_FORMAT,
+        provider: "Acme",
+        metadata: { team: "platform" },
+        values: { method: "token", token: "secret" },
+      }),
+    ).toEqual({
+      format: PROFILE_FORMAT,
+      provider: "Acme",
+      metadata: { team: "platform" },
+      values: { method: "token", token: "secret" },
+    });
   }),
 );
 
@@ -512,7 +610,6 @@ it.live(
           .pipe(Effect.flip);
         expect(error).toBeInstanceOf(AuthError);
         expect((error as AuthError).message).toContain("--reconfigure");
-        expect((error as AuthError).message).toContain("bogus");
       }),
     ),
   { exclusive: true },

--- a/packages/alchemy/test/Auth/fixtures/v0-home/credentials/work/cf-stored.json
+++ b/packages/alchemy/test/Auth/fixtures/v0-home/credentials/work/cf-stored.json
@@ -1,5 +1,6 @@
 {
-  "type": "apiToken",
-  "apiToken": "v0-cf-api-token",
+  "type": "apiKey",
+  "apiKey": "v0-cf-global-api-key",
+  "email": "worker@example.com",
   "accountId": "0123456789abcdef0123456789abcdef"
 }

--- a/packages/alchemy/test/Auth/fixtures/v0-home/profiles.json
+++ b/packages/alchemy/test/Auth/fixtures/v0-home/profiles.json
@@ -11,6 +11,9 @@
         "method": "sso",
         "ssoProfile": "dev"
       },
+      "GitHub": {
+        "method": "gh-cli"
+      },
       "Neon": {
         "method": "env"
       }
@@ -24,7 +27,7 @@
       },
       "Cloudflare": {
         "method": "stored",
-        "credentialType": "apiToken"
+        "credentialType": "apiKey"
       }
     }
   }

--- a/packages/alchemy/test/Cloudflare/Auth/OAuthScopes.test.ts
+++ b/packages/alchemy/test/Cloudflare/Auth/OAuthScopes.test.ts
@@ -1,4 +1,5 @@
 import {
+  ALL_SCOPE_IDS,
   ALL_SCOPES,
   BASIC_SCOPES,
   customOAuthScopeDefaults,
@@ -47,7 +48,7 @@ describe("Cloudflare public OAuth client", () => {
     expect(BASIC_SCOPES).toContain("zone.read");
   });
 
-  it("restores valid custom scopes when OAuth is reconfigured", () => {
+  it("defaults to all scopes and restores valid scopes when reconfigured", () => {
     expect(
       customOAuthScopeDefaults({
         method: "oauth",
@@ -61,7 +62,7 @@ describe("Cloudflare public OAuth client", () => {
         method: "stored",
         credentialType: "apiToken",
       }),
-    ).toEqual(BASIC_SCOPES);
+    ).toEqual(ALL_SCOPE_IDS);
   });
 
   it.effect(

--- a/packages/alchemy/test/Prisma/AuthProvider.test.ts
+++ b/packages/alchemy/test/Prisma/AuthProvider.test.ts
@@ -1,5 +1,4 @@
 import { AuthProviders, getAuthProvider } from "@/Auth/AuthProvider";
-import { CredentialsStore } from "@/Auth/Credentials";
 import { ProfileStore } from "@/Auth/Profile";
 import * as Interaction from "@/Interaction.ts";
 import {
@@ -7,7 +6,6 @@ import {
   PrismaAuth,
   type PrismaAuthConfig,
   type PrismaResolvedCredentials,
-  type PrismaStoredCredentials,
 } from "@/Prisma/AuthProvider";
 import { describe, expect, it } from "alchemy-test";
 import * as NodeServices from "@effect/platform-node/NodeServices";
@@ -15,21 +13,17 @@ import * as ConfigProvider from "effect/ConfigProvider";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Redacted from "effect/Redacted";
-import { makeFakeCredentialsStore, makeFakeProfileStore } from "./fakes.ts";
+import { makeFakeProfileStore } from "./fakes.ts";
 
 const fakeProfile = makeFakeProfileStore();
 
-const testLayer = (
-  config: Record<string, string> = {},
-  stored?: PrismaStoredCredentials,
-) => {
+const testLayer = (config: Record<string, string> = {}) => {
   const authProviders: AuthProviders["Service"] = {};
   const authRegistry = Layer.succeed(AuthProviders, authProviders);
   const base = Layer.mergeAll(
     NodeServices.layer,
     authRegistry,
     Layer.succeed(ProfileStore, fakeProfile),
-    Layer.succeed(CredentialsStore, makeFakeCredentialsStore(stored)),
     ConfigProvider.layer(ConfigProvider.fromUnknown(config)),
     Interaction.layerNonInteractive(),
   );
@@ -43,7 +37,10 @@ const prismaAuthProvider = getAuthProvider<
 
 const readStoredCredentials = Effect.gen(function* () {
   const auth = yield* prismaAuthProvider;
-  return yield* auth.read("default", { method: "stored" });
+  return yield* auth.read("default", {
+    method: "stored",
+    serviceToken: "stored-token",
+  });
 });
 
 const readEnvironmentCredentials = Effect.gen(function* () {
@@ -81,50 +78,27 @@ describe("Prisma auth provider", () => {
     }).pipe(Effect.provide(testLayer({ PRISMA_API_TOKEN: "api-token" }))),
   );
 
-  it.effect(
-    "reads stored Prisma service tokens from the credentials store",
-    () =>
-      Effect.gen(function* () {
-        const credentials = yield* readStoredCredentials;
+  it.effect("reads inline stored Prisma service tokens", () =>
+    Effect.gen(function* () {
+      const credentials = yield* readStoredCredentials;
 
-        expect(credentials.type).toBe("serviceToken");
-        expect(credentials.source).toEqual({ type: "stored" });
-        expect(Redacted.value(credentials.serviceToken)).toBe("stored-token");
-      }).pipe(Effect.provide(testLayer({}, { serviceToken: "stored-token" }))),
-  );
-
-  it.effect(
-    "fails with NeedsReauth when stored Prisma credentials are missing",
-    () =>
-      Effect.gen(function* () {
-        const error = yield* readStoredCredentials.pipe(Effect.flip);
-
-        expect(error._tag).toBe("NeedsReauth");
-        expect(error.message).toContain(
-          "alchemy profile refresh --profile default --provider Prisma",
-        );
-      }).pipe(Effect.provide(testLayer())),
+      expect(credentials.type).toBe("serviceToken");
+      expect(credentials.source).toEqual({ type: "stored" });
+      expect(Redacted.value(credentials.serviceToken)).toBe("stored-token");
+    }).pipe(Effect.provide(testLayer())),
   );
 
   it.effect("returns redacted details for stored credentials", () =>
     Effect.gen(function* () {
       const auth = yield* prismaAuthProvider;
-      const details = yield* auth.details("default", { method: "stored" });
+      const details = yield* auth.details("default", {
+        method: "stored",
+        serviceToken: "stored-token",
+      });
 
       expect(details.lines).toEqual([
         { key: "serviceToken", value: "stor****" },
       ]);
-    }).pipe(Effect.provide(testLayer({}, { serviceToken: "stored-token" }))),
-  );
-
-  it.effect("details fails with NeedsReauth when credentials are missing", () =>
-    Effect.gen(function* () {
-      const auth = yield* prismaAuthProvider;
-      const error = yield* auth
-        .details("default", { method: "stored" })
-        .pipe(Effect.flip);
-
-      expect(error._tag).toBe("NeedsReauth");
     }).pipe(Effect.provide(testLayer())),
   );
 

--- a/packages/alchemy/test/Prisma/PrismaEnvironment.test.ts
+++ b/packages/alchemy/test/Prisma/PrismaEnvironment.test.ts
@@ -1,11 +1,7 @@
 import { AuthProviders } from "@/Auth/AuthProvider";
-import { CredentialsStore } from "@/Auth/Credentials";
 import { ProfileStore } from "@/Auth/Profile";
 import * as CliKit from "@/Cli/CliKit";
-import {
-  PrismaAuth,
-  type PrismaStoredCredentials,
-} from "@/Prisma/AuthProvider";
+import { PrismaAuth } from "@/Prisma/AuthProvider";
 import { PrismaEnvironment, fromProfile } from "@/Prisma/PrismaEnvironment";
 import { describe, expect, it } from "alchemy-test";
 import * as NodeServices from "@effect/platform-node/NodeServices";
@@ -13,22 +9,13 @@ import * as ConfigProvider from "effect/ConfigProvider";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Redacted from "effect/Redacted";
-import { makeFakeCredentialsStore, makeFakeProfileStore } from "./fakes.ts";
+import { makeFakeProfileStore } from "./fakes.ts";
 
-const makeProfile = (): ProfileStore["Service"] =>
+const makeProfile = (serviceToken: string): ProfileStore["Service"] =>
   makeFakeProfileStore({
     loadProviderConfig: <Config extends { method: string }>() =>
-      Effect.succeed({ method: "stored" } as Config),
+      Effect.succeed({ method: "stored", serviceToken } as Config),
   });
-
-const makeCredentialsStore = (
-  serviceToken?: string,
-): CredentialsStore["Service"] =>
-  makeFakeCredentialsStore(
-    serviceToken
-      ? ({ serviceToken } satisfies PrismaStoredCredentials)
-      : undefined,
-  );
 
 const testLayer = (
   config: Record<string, string>,
@@ -40,11 +27,10 @@ const testLayer = (
   return fromProfile().pipe(
     Layer.provideMerge(PrismaAuth),
     Layer.provideMerge(Layer.succeed(AuthProviders, authProviders)),
-    Layer.provideMerge(Layer.succeed(ProfileStore, makeProfile())),
     Layer.provideMerge(
       Layer.succeed(
-        CredentialsStore,
-        makeCredentialsStore(options.storedToken),
+        ProfileStore,
+        makeProfile(options.storedToken ?? "test-token"),
       ),
     ),
     Layer.provideMerge(

--- a/packages/alchemy/test/Prisma/PrismaEnvironment.test.ts
+++ b/packages/alchemy/test/Prisma/PrismaEnvironment.test.ts
@@ -14,7 +14,7 @@ import { makeFakeProfileStore } from "./fakes.ts";
 const makeProfile = (serviceToken: string): ProfileStore["Service"] =>
   makeFakeProfileStore({
     loadProviderConfig: <Config extends { method: string }>() =>
-      Effect.succeed({ method: "stored", serviceToken } as Config),
+      Effect.succeed({ method: "stored", serviceToken } as unknown as Config),
   });
 
 const testLayer = (

--- a/packages/alchemy/test/Prisma/fakes.ts
+++ b/packages/alchemy/test/Prisma/fakes.ts
@@ -7,13 +7,14 @@ import * as Schema from "effect/Schema";
 export const makeFakeProfileStore = (
   overrides?: Partial<ProfileStore["Service"]>,
 ): ProfileStore["Service"] => ({
-  readManifest: Effect.succeed({ version: 2, profiles: {} }),
+  readManifest: Effect.succeed({ version: 3, profiles: {} }),
   getProfile: () => Effect.succeed(undefined),
   ensureProfile: () => Effect.succeed({ id: "fake", providers: {} }),
   createProfile: () => Effect.void,
   renameProfile: () => Effect.void,
   current: Effect.succeed({ name: "default", source: "configuration" }),
-  setProfile: () => Effect.void,
+  setProviderConfig: () => Effect.void,
+  deleteProviderConfig: () => Effect.succeed(false),
   deleteProfile: () => Effect.succeed(false),
   loadProviderConfig: <Config extends { method: string }>() =>
     Effect.succeed({ method: "stored" } as Config),


### PR DESCRIPTION
## Summary

- replace the centralized profile manifest and auth sidecars with one typed provider document per profile
- migrate released v0 profiles with recoverable backups, inline compatible credentials, and restart obsolete Cloudflare OAuth at scope selection
- persist rotated OAuth and GitHub CLI tokens safely, preserve the default profile, and back up invalid files before repair
- support custom provider schemas through the shared profile envelope

## Testing

- vp exec tsc -b packages/alchemy/tsconfig.json --pretty false
- timeout 240 vpr test test/Auth test/AWS/AuthProvider.test.ts test/Prisma/AuthProvider.test.ts test/Prisma/PrismaEnvironment.test.ts test/GitHub/BaseUrl.test.ts --profile testing
- 101 tests passed