### PR TITLE
chroe(cli): resolve dev mode alchemy to typescript src files

### DIFF
--- a/packages/alchemy/bin/register-dev-mode.js
+++ b/packages/alchemy/bin/register-dev-mode.js
@@ -45,4 +45,4 @@ const { registerOxc } = await import("@alchemy.run/node-utils/register-oxc");
 // Oxc discovers the nearest tsconfig for each transformed file. Alchemy's
 // TSX therefore uses Alchemy's React settings while the user's config and its
 // dependencies retain their own compiler settings.
-registerOxc();
+registerOxc({ conditions: ["bun"] });

--- a/packages/alchemy/test/Cli/fixtures/register-dev-mode-probe.ts
+++ b/packages/alchemy/test/Cli/fixtures/register-dev-mode-probe.ts
@@ -1,0 +1,2 @@
+export const alchemyUrl = import.meta.resolve("alchemy");
+export const subpathUrl = import.meta.resolve("alchemy/Cloudflare");

--- a/packages/alchemy/test/Cli/registerDevMode.test.ts
+++ b/packages/alchemy/test/Cli/registerDevMode.test.ts
@@ -28,12 +28,16 @@ it.live.skipIf(!nodeSupportsDevMode)(
       const runtimeTsx = fileURLToPath(
         new URL("../../src/Cli/components/view/Runtime.tsx", import.meta.url),
       );
+      const resolutionProbe = fileURLToPath(
+        new URL("./fixtures/register-dev-mode-probe.ts", import.meta.url),
+      );
       // No explicit sigil probe: two-arg import.meta.resolve is flagged in
       // node, and Runtime.tsx importing sigil transitively already proves
       // the published package (no `bun` condition) loads from its dist.
       const script = `
-        console.log("alchemy=" + import.meta.resolve("alchemy"));
-        console.log("sub=" + import.meta.resolve("alchemy/Cloudflare"));
+        const probe = await import(${JSON.stringify(resolutionProbe)});
+        console.log("alchemy=" + probe.alchemyUrl);
+        console.log("sub=" + probe.subpathUrl);
         await import(${JSON.stringify(runtimeTsx)});
         console.log("tsx=ok");
       `;
@@ -77,6 +81,38 @@ it.live.skipIf(!nodeSupportsDevMode)(
       expect(stdout).toMatch(/alchemy=file:.*\/src\/index\.ts/);
       expect(stdout).toMatch(/sub=file:.*\/src\/Cloudflare\/index\.ts/);
       expect(stdout).toContain("tsx=ok");
+
+      const repoDir = fileURLToPath(new URL("../../../..", import.meta.url));
+      const pnpm = Bun.which("pnpm");
+      expect(pnpm).not.toBeNull();
+      const cli = yield* ChildProcess.make(pnpm!, ["alchemy", "--version"], {
+        cwd: repoDir,
+        env: { NO_COLOR: "1" },
+        extendEnv: true,
+        stdin: "ignore",
+        stdout: "pipe",
+        stderr: "pipe",
+        killSignal: "SIGKILL",
+      });
+      const [cliStdout, cliStderr, cliExitCode] = yield* Effect.all(
+        [
+          cli.stdout.pipe(
+            Stream.decodeText,
+            Stream.runCollect,
+            Effect.map((chunks) => chunks.join("")),
+          ),
+          cli.stderr.pipe(
+            Stream.decodeText,
+            Stream.runCollect,
+            Effect.map((chunks) => chunks.join("")),
+          ),
+          cli.exitCode,
+        ],
+        { concurrency: 3 },
+      );
+      expect(cliStderr).toBe("");
+      expect(cliExitCode).toBe(0);
+      expect(cliStdout).toMatch(/alchemy v.*\(node [^,]+, src\)/);
     }).pipe(Effect.scoped, Effect.provide(PlatformServices)),
   { timeout: 60_000 },
 );

--- a/packages/node-utils/src/import-loader.ts
+++ b/packages/node-utils/src/import-loader.ts
@@ -18,6 +18,12 @@ export type SourceTransform = (
 
 export interface ImportLoaderOptions {
   /**
+   * Additional package export conditions used during module resolution.
+   * They are made available alongside Node's ambient conditions to both the
+   * TypeScript-aware resolver and Node's package exports resolver.
+   */
+  readonly conditions?: ReadonlyArray<string> | undefined;
+  /**
    * Oxc transform configuration, layered over the nearest `tsconfig.json`
    * of each transformed file (`jsx`, decorators, …).
    */

--- a/packages/node-utils/src/register-oxc.ts
+++ b/packages/node-utils/src/register-oxc.ts
@@ -239,14 +239,23 @@ export const registerOxc = (
         return nextResolve(specifier, context);
       }
 
+      const resolutionContext =
+        options.conditions === undefined || options.conditions.length === 0
+          ? context
+          : {
+              ...context,
+              conditions: [
+                ...new Set([...options.conditions, ...context.conditions]),
+              ],
+            };
       const resolved = request
         ? resolveSpecifier(
             resolver,
             request.specifier,
-            { ...context, parentURL: request.parentURL },
+            { ...resolutionContext, parentURL: request.parentURL },
             nextResolve,
           )
-        : resolveSpecifier(resolver, specifier, context, nextResolve);
+        : resolveSpecifier(resolver, specifier, resolutionContext, nextResolve);
       if (
         namespace !== undefined &&
         resolved.url.startsWith("file:") &&

--- a/packages/node-utils/test/register-oxc.test.ts
+++ b/packages/node-utils/test/register-oxc.test.ts
@@ -66,6 +66,18 @@ const makeProject = () => {
     'export const fromWorkspaceDep: string = "ws";\n',
   );
   write(
+    at("node_modules/conditional/package.json"),
+    '{"name":"conditional","type":"module","exports":{".":{"bun":"./src/index.ts","import":"./lib/index.js"}}}',
+  );
+  write(
+    at("node_modules/conditional/src/index.ts"),
+    'export const selected: string = "src";\n',
+  );
+  write(
+    at("node_modules/conditional/lib/index.js"),
+    'export const selected = "lib";\n',
+  );
+  write(
     at("src/lib/helper.ts"),
     'export const helper = (): string => "helper";\n',
   );
@@ -155,6 +167,25 @@ describe("registerOxc", () => {
     });
     // Inline source maps are applied to stack traces.
     expect(frame).toMatch(/entry\.ts:16:/);
+  });
+
+  it("adds configured package export conditions to project resolution", () => {
+    const root = makeProject();
+    write(
+      path.join(root, "src/conditional.ts"),
+      'export { selected } from "conditional";\n',
+    );
+    const result = runNode(
+      root,
+      `
+      const { registerOxc } = await import(${JSON.stringify(registerUrl)});
+      registerOxc({ conditions: ["bun"] });
+      const conditional = await import("./src/conditional.ts");
+      console.log(conditional.selected);
+      `,
+    );
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout.trim()).toBe("src");
   });
 
   it("isolates namespaced imports and leaves node_modules to Node with a filter", () => {


### PR DESCRIPTION
## Summary

- Add configurable package export conditions to the Oxc import loader.
- Enable the `bun` condition for Alchemy dev mode.
- Add resolution and CLI regression coverage.

## Testing

- Added `registerOxc` coverage for conditional package exports.
- Extended dev-mode coverage to verify source package resolution and CLI startup.
- Not run