### PR TITLE
feat(cli): standardize auth provider methods, env precedence, drop AWS local

### DIFF
--- a/packages/alchemy/src/AWS/AuthProvider.ts
+++ b/packages/alchemy/src/AWS/AuthProvider.ts
@@ -34,7 +34,6 @@ import {
   type ConfigureField,
   type ConfigureMethod,
   type ProviderDetailLine,
-  type ProviderDetails,
 } from "../Auth/AuthProvider.ts";
 import { displayRedacted } from "../Auth/Credentials.ts";
 import {
@@ -57,7 +56,7 @@ export const AWS_AUTH_PROVIDER_NAME = "AWS";
 export const DEFAULT_LOCAL_ENDPOINT = `http://localhost:${Floci.DEFAULT_FLOCI_PORT}`;
 
 /**
- * Dummy account stamped on every floci / `{ method: "local" }` environment.
+ * Dummy account stamped on every floci environment.
  * A custom `AWS_ENDPOINT_URL` on env/sso credentials does NOT use this —
  * those keep the real account from STS / `AWS_ACCOUNT_ID`.
  */
@@ -111,13 +110,6 @@ export const AwsAuthConfigSchema = Schema.Union([
     sessionToken: Schema.optional(Schema.String),
     region: Schema.String,
   }),
-  Schema.Struct({
-    method: Schema.Literal("local"),
-    endpoint: Schema.optional(Schema.String),
-    region: Schema.optional(Schema.String),
-    accountId: Schema.optional(Schema.String),
-    autoStart: Schema.optional(Schema.Boolean),
-  }),
 ]);
 export type AwsAuthConfig = typeof AwsAuthConfigSchema.Type;
 
@@ -136,14 +128,9 @@ const options: Array<{
     label: "Access Keys",
     description: "enter an access key and secret directly",
   },
-  {
-    value: "local",
-    label: "Local emulator",
-    description: "floci / LocalStack — no AWS account required",
-  },
 ];
 
-/** `--set` fields for `--method keys` (static access keys, persisted). */
+/** `--set` fields for `--method stored` (static access keys, persisted). */
 const keysFields: ReadonlyArray<ConfigureField> = [
   { name: "accessKeyId", label: "AWS Access Key ID" },
   { name: "secretAccessKey", label: "AWS Secret Access Key", secret: true },
@@ -161,19 +148,9 @@ const ssoFields: ReadonlyArray<ConfigureField> = [
   { name: "ssoProfile", label: "AWS profile name (from ~/.aws/config)" },
 ];
 
-const localFields: ReadonlyArray<ConfigureField> = [
-  {
-    name: "endpoint",
-    label: "Emulator endpoint",
-    defaultValue: DEFAULT_LOCAL_ENDPOINT,
-  },
-  { name: "region", label: "AWS Region", defaultValue: "us-east-1" },
-];
-
 const configureMethods: ReadonlyArray<ConfigureMethod> = [
-  { method: "keys", fields: keysFields },
+  { method: "stored", fields: keysFields },
   { method: "sso", fields: ssoFields },
-  { method: "local", fields: localFields },
 ];
 
 export interface AwsResolvedCredentials {
@@ -254,8 +231,7 @@ export const AwsAuth = AuthProviderLayer<
             // AWSEnvironment — the very service this STS call is
             // constructing — and deadlocks the fiber on its own in-flight
             // cache (no I/O, no timer, no output). Same reason as
-            // `Region.of` above. (The local-emulator method never reaches
-            // this call — it stamps a dummy account instead.)
+            // `Region.of` above.
             Endpoint.none,
           ),
         ),
@@ -360,23 +336,6 @@ export const AwsAuth = AuthProviderLayer<
                 }),
               ),
               Match.when("stored", () => loginStored(profileName)),
-              Match.when("local", () =>
-                Effect.gen(function* () {
-                  const endpoint = yield* interaction.prompt.text({
-                    message: "Emulator endpoint",
-                    defaultValue: DEFAULT_LOCAL_ENDPOINT,
-                  });
-                  const region = yield* interaction.prompt.text({
-                    message: "AWS Region",
-                    defaultValue: "us-east-1",
-                  });
-                  return {
-                    method: "local" as const,
-                    endpoint: endpoint || DEFAULT_LOCAL_ENDPOINT,
-                    region: region || "us-east-1",
-                  };
-                }),
-              ),
               Match.exhaustive,
             ),
           ),
@@ -416,7 +375,7 @@ export const AwsAuth = AuthProviderLayer<
       },
     ) =>
       Match.value(input.method).pipe(
-        Match.when("keys", () =>
+        Match.when("stored", () =>
           Effect.gen(function* () {
             const values = yield* validateFieldValues(
               AWS_AUTH_PROVIDER_NAME,
@@ -488,24 +447,10 @@ export const AwsAuth = AuthProviderLayer<
             return { method: "sso" as const, ssoProfile };
           }),
         ),
-        Match.when("local", () =>
-          validateFieldValues(
-            AWS_AUTH_PROVIDER_NAME,
-            localFields,
-            input.values,
-          ).pipe(
-            Effect.map((values) => ({
-              method: "local" as const,
-              endpoint:
-                storedValueText(values.endpoint) || DEFAULT_LOCAL_ENDPOINT,
-              region: storedValueText(values.region) || "us-east-1",
-            })),
-          ),
-        ),
         Match.orElse(() =>
           Effect.fail(
             new AuthError({
-              message: `AWS: unknown method '${input.method}'. Supported methods: keys, sso, local.`,
+              message: `AWS: unknown method '${input.method}'. Valid methods: stored, sso.`,
             }),
           ),
         ),
@@ -520,50 +465,6 @@ export const AwsAuth = AuthProviderLayer<
         const reauth = refreshHint(AWS_AUTH_PROVIDER_NAME, profileName);
         return yield* Match.value(config)
           .pipe(
-            Match.when(
-              { method: "local" },
-              Effect.fn(function* (config) {
-                const endpoint = config.endpoint ?? DEFAULT_LOCAL_ENDPOINT;
-                const autoStart =
-                  config.autoStart ?? endpoint === DEFAULT_LOCAL_ENDPOINT;
-                if (autoStart) {
-                  const port = yield* Effect.try({
-                    try: () =>
-                      Number.parseInt(new URL(endpoint).port, 10) ||
-                      Floci.DEFAULT_FLOCI_PORT,
-                    catch: () =>
-                      new AuthError({
-                        message: `invalid local emulator endpoint: ${endpoint}`,
-                      }),
-                  });
-                  yield* Floci.ensureFloci({ port }).pipe(
-                    Effect.mapError(
-                      (cause) =>
-                        new AuthError({ message: cause.message, cause }),
-                    ),
-                  );
-                } else if (!(yield* Floci.isServing(endpoint))) {
-                  return yield* new AuthError({
-                    message: `no local AWS emulator is listening at ${endpoint}`,
-                  });
-                }
-                const region = config.region ?? "us-east-1";
-                return {
-                  // Fixed dummy account — emulators accept any non-empty
-                  // credentials, and calling STS here would be pure overhead.
-                  accountId: config.accountId ?? LOCAL_ACCOUNT_ID,
-                  credentials: Effect.succeed<AwsCredentials>({
-                    accessKeyId: Redacted.make("test"),
-                    secretAccessKey: Redacted.make("test"),
-                    sessionToken: undefined,
-                    region,
-                  }),
-                  region,
-                  endpoint,
-                  source: { type: "local" as const, details: endpoint },
-                } satisfies AwsResolvedCredentials;
-              }),
-            ),
             Match.when({ method: "stored" }, (config) =>
               Effect.gen(function* () {
                 const credentials: AwsCredentials = {
@@ -693,22 +594,6 @@ export const AwsAuth = AuthProviderLayer<
       updateConfig?: (config: AwsAuthConfig) => Effect.Effect<void, AuthError>,
     ) =>
       Effect.gen(function* () {
-        // Profile display is observational. Resolving local credentials calls
-        // ensureFloci(), which may inspect/start Docker and wait for health;
-        // doing that just to render the dashboard freezes the spinner and
-        // gives a read-only command surprising side effects.
-        if (config.method === "local") {
-          return {
-            lines: [
-              {
-                key: "endpoint",
-                value: config.endpoint ?? DEFAULT_LOCAL_ENDPOINT,
-              },
-              { key: "region", value: config.region ?? "us-east-1" },
-              { key: "source", value: "local" },
-            ],
-          } satisfies ProviderDetails;
-        }
         const creds = yield* resolveCredentials(
           profileName,
           config,
@@ -761,7 +646,6 @@ export const AwsAuth = AuthProviderLayer<
 
     const logout = (_profileName: string, config: AwsAuthConfig) =>
       Match.value(config).pipe(
-        Match.when({ method: "local" }, () => Effect.void),
         Match.when({ method: "sso" }, (config) =>
           interaction.output
             .info(
@@ -787,7 +671,6 @@ export const AwsAuth = AuthProviderLayer<
     const login = (profileName: string, config: AwsAuthConfig) =>
       Match.value(config)
         .pipe(
-          Match.when({ method: "local" }, (config) => Effect.succeed(config)),
           Match.when({ method: "sso" }, (config) =>
             loginSSO(config, config.authorizationMethod ?? "oauth"),
           ),

--- a/packages/alchemy/src/AWS/Environment.ts
+++ b/packages/alchemy/src/AWS/Environment.ts
@@ -59,7 +59,7 @@ export class AWSEnvironment extends Context.Service<
 >()("AWS::Environment") {
   static current = AWSEnvironment.use((env) => env);
   /**
-   * Whether this environment is the floci / `{ method: "local" }` emulator
+   * Whether this environment is the floci emulator
    * (dummy account {@link LOCAL_ACCOUNT_ID}). A set `endpoint` is not
    * enough: `AWS_ENDPOINT_URL` and explicit endpoint overrides also
    * populate it on real-account credentials.
@@ -77,11 +77,21 @@ export const isLocalEmulator = AWSEnvironment.isLocalEmulator;
 export const Default = Layer.effect(
   AWSEnvironment,
   Effect.gen(function* () {
-    const { resolve } = yield* resolveProviderConfig<
+    // Provider layers are built on every run — before any profile may be
+    // configured — so nothing may resolve at construction. A dev run with
+    // zero AWS credentials builds this layer too (the ambient environment
+    // is the emulator; only `Alchemy.remote()` rows ever need it), so the
+    // profile/CI precedence is captured here and evaluated on first use,
+    // exactly once.
+    const resolve = resolveProviderConfig<
       AwsAuthConfig,
       AwsResolvedCredentials
-    >(AWS_AUTH_PROVIDER_NAME);
-
-    return yield* resolve.pipe(Effect.orDie, Effect.cached);
+    >(AWS_AUTH_PROVIDER_NAME).pipe(Effect.flatMap(({ resolve }) => resolve));
+    const context = yield* Effect.context<Effect.Services<typeof resolve>>();
+    return yield* resolve.pipe(
+      Effect.provideContext(context),
+      Effect.orDie,
+      Effect.cached,
+    );
   }),
 ).pipe(Layer.orDie);

--- a/packages/alchemy/src/Alchemist/Session.ts
+++ b/packages/alchemy/src/Alchemist/Session.ts
@@ -22,11 +22,13 @@ import { withProfileOverride } from "../Auth/Resolve.ts";
 import { AwsAuth } from "../AWS/AuthProvider.ts";
 import { AxiomAuth } from "../Axiom/AuthProvider.ts";
 import { CloudflareAuth } from "../Cloudflare/Auth/AuthProvider.ts";
+import { FlyAuth } from "../Fly/AuthProvider.ts";
 import { GitHubAuth } from "../GitHub/AuthProvider.ts";
 import { HetznerAuth } from "../Hetzner/AuthProvider.ts";
 import { NeonAuth } from "../Neon/AuthProvider.ts";
 import { PlanetscaleAuth } from "../Planetscale/AuthProvider.ts";
 import { PrismaAuth } from "../Prisma/AuthProvider.ts";
+import { RailwayAuth } from "../Railway/AuthProvider.ts";
 import * as Stack from "../Stack.ts";
 import { Stage } from "../Stage.ts";
 import { Progress } from "./Progress.ts";
@@ -367,11 +369,13 @@ const builtinAuth = Layer.mergeAll(
   AwsAuth,
   AxiomAuth,
   CloudflareAuth,
+  FlyAuth,
   GitHubAuth,
   HetznerAuth,
   NeonAuth,
   PlanetscaleAuth,
   PrismaAuth,
+  RailwayAuth,
 );
 
 const buildBuiltinAuthProviders = Effect.fn("buildBuiltinAuthProviders")(

--- a/packages/alchemy/src/Auth/AuthProvider.ts
+++ b/packages/alchemy/src/Auth/AuthProvider.ts
@@ -1,7 +1,9 @@
+import * as Config from "effect/Config";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
 import * as Path from "effect/Path";
 import * as Schema from "effect/Schema";
 
@@ -130,26 +132,33 @@ export const describeEnvironment = (
     .join(", ");
 
 /**
- * The variable names a provider's environment resolution would consume from
- * `env`, or `undefined` when the declared contract is not fully satisfied
- * (some required variable has no non-empty value). Used outside CI to decide
- * whether explicitly exported variables should take precedence over an
- * implicitly selected profile — and to tell the user exactly which keys won.
+ * The variable names a provider's environment resolution would consume, or
+ * `undefined` when the declared contract is not fully satisfied (some
+ * required variable has no non-empty value). Reads through the ambient
+ * `ConfigProvider` — the process environment plus `.env` / `--env-file` —
+ * so it sees exactly what `readEnvironment` will. Environment credentials
+ * take precedence over any profile, CI or not; the returned names tell the
+ * user exactly which keys won.
  */
 export const presentEnvironment = (
   environment: ReadonlyArray<EnvironmentVariable>,
-  env: Record<string, string | undefined>,
-): ReadonlyArray<string> | undefined => {
-  const used: string[] = [];
-  for (const variable of environment) {
-    const found = [variable.name, ...(variable.alternatives ?? [])].find(
-      (name) => (env[name] ?? "") !== "",
-    );
-    if (found !== undefined) used.push(found);
-    else if (variable.required) return undefined;
-  }
-  return used.length > 0 ? used : undefined;
-};
+) =>
+  Effect.gen(function* () {
+    const used: string[] = [];
+    for (const variable of environment) {
+      let found: string | undefined;
+      for (const name of [variable.name, ...(variable.alternatives ?? [])]) {
+        const value = yield* Config.option(Config.string(name));
+        if (Option.isSome(value) && value.value !== "") {
+          found = name;
+          break;
+        }
+      }
+      if (found !== undefined) used.push(found);
+      else if (variable.required) return undefined;
+    }
+    return used.length > 0 ? used : undefined;
+  });
 
 /**
  * One rendered line of a provider's credential details: `key: value`.
@@ -199,7 +208,11 @@ export interface ConfigureField {
  * appear here.
  */
 export interface ConfigureMethod {
-  /** `--method` value, e.g. `"api-token"`. */
+  /**
+   * `--method` value. Always the same literal the provider persists as the
+   * config's `method` (`"stored"`, `"sso"`, `"local"`, `"env"`), so the
+   * flag and the credentials file speak one vocabulary.
+   */
   readonly method: string;
   readonly fields: ReadonlyArray<ConfigureField>;
 }

--- a/packages/alchemy/src/Auth/Demand.ts
+++ b/packages/alchemy/src/Auth/Demand.ts
@@ -22,9 +22,9 @@
  *   read what a parent persisted) start with a warm token.
  * - AWS's `read` returns a credentials RECIPE whose inner effect stays
  *   unevaluated (SSO tokens are loaded lazily by consumers), so an
- *   expired SSO token passes the gate and still surfaces mid-run; an
- *   `{ method: "local" }` profile's read ensures the floci emulator,
- *   which the gate consequently starts before apply.
+ *   expired SSO token passes the gate and still surfaces mid-run. Local-mode
+ *   AWS providers carry a floci-scoped environment of their own (see
+ *   `AWS/Local/FlociServices.ts`) and ensure the emulator there.
  *
  * The demand scan keys on provider MODE, not plan action — noop live rows
  * still demand (their runtime proxies need live credentials to serve), so
@@ -305,20 +305,17 @@ export const demandCredentials = Effect.fn("Alchemy.demandCredentials")(
             );
           }
           // Read-only precheck of the two non-CI configuration sources the
-          // resolution precedence below consults: a profile entry, or —
-          // when no profile was explicitly selected — exported environment
-          // credentials. "Nothing configured" fails with the actionable
+          // resolution precedence below consults: environment credentials
+          // (which win regardless of the selected profile), or a profile
+          // entry. "Nothing configured" fails with the actionable
           // {@link CredentialsRequired} here, WITHOUT entering
           // `resolveProviderConfig`: its profile path goes through
           // `ensureProfile`, which fails a nonexistent profile with a
           // generic ProfileError that would bury which resources demanded
           // credentials and what command fixes it.
           const envUsable =
-            Option.isNone(configuredProfile) &&
             auth.readEnvironment !== undefined &&
-            (yield* Effect.sync(() =>
-              presentEnvironment(auth.environment, process.env),
-            )) !== undefined;
+            (yield* presentEnvironment(auth.environment)) !== undefined;
           const existing = yield* profile.getProfile(profileName);
           if (existing?.providers[auth.name] == null && !envUsable) {
             return yield* credentialsRequired(demand, profileName);
@@ -349,6 +346,36 @@ export const demandCredentials = Effect.fn("Alchemy.demandCredentials")(
     );
   },
 );
+
+/**
+ * Plan-time seam for `Alchemy.remote()` rows. The planner probes every new
+ * resource with its provider's `read` (engine-level adoption) — for a
+ * live-mode row in a dev run that is a real cloud call, made BEFORE
+ * {@link demandPlanCredentials} could run in apply. Demanding here first
+ * turns "nothing configured" into the typed {@link CredentialsRequired}
+ * (naming the rows and the exact `alchemy profile edit` command) instead
+ * of whatever raw error the first credential-less read produces. Bindings
+ * and live deletions are still gated in apply — nothing reads for them
+ * during plan.
+ */
+export const demandRemoteCredentials = (
+  resources: ReadonlyArray<{ readonly Type: string; readonly FQN: string }>,
+) => {
+  const byProvider = new Map<string, DemandingResource[]>();
+  for (const resource of resources) {
+    const provider = cloudOf(resource.Type);
+    byProvider.set(provider, [
+      ...(byProvider.get(provider) ?? []),
+      { fqn: resource.FQN, reason: "remote" },
+    ]);
+  }
+  return demandCredentials(
+    [...byProvider.entries()].map(([provider, resources]) => ({
+      provider,
+      resources,
+    })),
+  );
+};
 
 /**
  * The one-call seam wired into the dev path: scan the plan for live

--- a/packages/alchemy/src/Auth/Resolve.ts
+++ b/packages/alchemy/src/Auth/Resolve.ts
@@ -1,6 +1,5 @@
 import * as Config from "effect/Config";
 import * as ConfigProvider from "effect/ConfigProvider";
-import * as Console from "effect/Console";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 import {
@@ -50,8 +49,11 @@ export const resolveProfileName = Effect.fn(function* (
 
 /**
  * The shared preamble of every per-cloud `fromAuthProvider` /
- * `fromEnvironment` layer. Precedence remains CI environment, explicitly
- * exported local environment credentials, then the selected profile.
+ * `fromEnvironment` layer. Precedence: environment credentials (process
+ * environment plus `.env` / `--env-file`) whenever the provider's declared
+ * contract is fully present — CI or not, selected profile or not — then, in
+ * CI, the provider's environment resolution alone (profiles do not exist
+ * there), otherwise the selected profile.
  */
 export const resolveProviderConfig = <
   C extends { method: string } = any,
@@ -61,6 +63,19 @@ export const resolveProviderConfig = <
 ) =>
   Effect.gen(function* () {
     const auth = yield* getAuthProvider<C, Credentials>(providerName);
+    if (auth.readEnvironment !== undefined) {
+      const used = yield* presentEnvironment(auth.environment);
+      if (used !== undefined) {
+        yield* logEnvironmentCredentials(providerName, used);
+        return {
+          auth,
+          profileName: undefined,
+          config: undefined,
+          resolve: auth.readEnvironment,
+          source: "environment" as const,
+        };
+      }
+    }
     const ci = yield* Config.boolean("CI").pipe(Config.withDefault(false));
     if (ci) {
       if (auth.readEnvironment === undefined) {
@@ -79,33 +94,6 @@ export const resolveProviderConfig = <
       };
     }
     const profile = yield* ProfileStore;
-    const configuredProfile = yield* Config.option(ALCHEMY_PROFILE).pipe(
-      Effect.mapError(
-        (cause) =>
-          new ProfileError({
-            message: "Could not resolve ALCHEMY_PROFILE.",
-            cause,
-          }),
-      ),
-    );
-    if (
-      Option.isNone(configuredProfile) &&
-      auth.readEnvironment !== undefined
-    ) {
-      const used = yield* Effect.sync(() =>
-        presentEnvironment(auth.environment, process.env),
-      );
-      if (used !== undefined) {
-        yield* warnEnvironmentCredentials(providerName, used);
-        return {
-          auth,
-          profileName: undefined,
-          config: undefined,
-          resolve: auth.readEnvironment,
-          source: "environment" as const,
-        };
-      }
-    }
     const selection = yield* profile.current;
     const profileName = selection.name;
     const config = yield* profile.loadProviderConfig(auth, profileName);
@@ -128,16 +116,19 @@ export const resolveProviderConfig = <
     };
   });
 
-const warnEnvironmentCredentials = (
+const logEnvironmentCredentials = (
   provider: string,
   used: ReadonlyArray<string>,
 ) =>
   Effect.gen(function* () {
+    // The profile hub inspects providers with this suppression on — it must
+    // stay quiet, the run's own resolution logs.
     if (yield* SuppressMissingProviderConfig) return;
-    yield* Console.warn(
-      `${provider}: using credentials from environment variables (${used.join(", ")}) — ` +
-        `the '${DEFAULT_PROFILE_NAME}' profile was not used. Pass --profile <name> (or unset ` +
-        "the variables) to use stored profile credentials.",
+    // Per provider: only this provider skips the profile. Others in the
+    // same run still resolve from it, so a Cloudflare token in `.env` can
+    // sit alongside a profile-stored AWS SSO session.
+    yield* Effect.logInfo(
+      `${provider}: using environment variables (${used.join(", ")}) instead of the profile.`,
     );
   });
 

--- a/packages/alchemy/src/Auth/StoredAuthProvider.ts
+++ b/packages/alchemy/src/Auth/StoredAuthProvider.ts
@@ -239,7 +239,7 @@ export const makeStoredAuthProvider = <Resolved>(
             )
           : Effect.fail(
               new AuthError({
-                message: `${provider}: unknown method '${input.method}'. Only 'stored' is supported.`,
+                message: `${provider}: unknown method '${input.method}'. Valid methods: stored.`,
               }),
             );
 

--- a/packages/alchemy/src/Cloudflare/Auth/AuthProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Auth/AuthProvider.ts
@@ -176,16 +176,21 @@ const accountIdField: ConfigureField = {
   validate: validateAccountIdField,
 };
 
-/** `--set` fields for `--method api-token`. */
-const apiTokenFields: ReadonlyArray<ConfigureField> = [
-  { name: "apiToken", label: "Cloudflare API Token", secret: true },
-  accountIdField,
-];
-
-/** `--set` fields for `--method api-key`. */
-const apiKeyFields: ReadonlyArray<ConfigureField> = [
-  { name: "apiKey", label: "Cloudflare API Key", secret: true },
-  { name: "email", label: "Cloudflare Email" },
+/**
+ * `--set` fields for `--method stored`. The persisted `credentialType` is
+ * inferred from which secret is supplied: `apiToken` alone, or `apiKey`
+ * together with `email`.
+ */
+const storedFields: ReadonlyArray<ConfigureField> = [
+  {
+    name: "apiToken",
+    label: "Cloudflare API Token",
+    description: "Pass either apiToken, or apiKey together with email.",
+    secret: true,
+    optional: true,
+  },
+  { name: "apiKey", label: "Cloudflare API Key", secret: true, optional: true },
+  { name: "email", label: "Cloudflare Email", optional: true },
   accountIdField,
 ];
 
@@ -194,8 +199,7 @@ const apiKeyFields: ReadonlyArray<ConfigureField> = [
  * interactive-only (browser grant).
  */
 const configureMethods: ReadonlyArray<ConfigureMethod> = [
-  { method: "api-token", fields: apiTokenFields },
-  { method: "api-key", fields: apiKeyFields },
+  { method: "stored", fields: storedFields },
 ];
 
 const promptOAuthScopes = (currentConfig?: CloudflareAuthConfig) =>
@@ -793,10 +797,9 @@ export const CloudflareAuth = AuthProviderLayer<
       );
 
     /**
-     * Persist flag-provided stored credentials (`--method api-token` /
-     * `--method api-key`). Writes the same `cloudflare-stored` file the
-     * interactive stored path writes; OAuth is interactive-only and not
-     * accepted here.
+     * Persist flag-provided stored credentials (`--method stored`). Writes
+     * the same `cloudflare-stored` file the interactive stored path writes;
+     * OAuth is interactive-only and not accepted here.
      */
     const configureWith = (
       profileName: string,
@@ -809,57 +812,57 @@ export const CloudflareAuth = AuthProviderLayer<
         store
           .delete(profileName, STATE_STORE_CREDENTIALS_FILE)
           .pipe(Effect.ignore, Effect.as(config));
-      return Match.value(input.method).pipe(
-        Match.when("api-token", () =>
-          validateFieldValues(
-            CLOUDFLARE_AUTH_PROVIDER_NAME,
-            apiTokenFields,
-            input.values,
-          ).pipe(
-            Effect.flatMap((values) =>
-              persist({
-                method: "stored",
-                credentialType: "apiToken",
-                apiToken: Redacted.value(
-                  storedSecret(values.apiToken) ?? Redacted.make(""),
-                ),
-                accountId: (storedValueText(values.accountId) ?? "")
-                  .trim()
-                  .toLowerCase(),
-              }),
-            ),
-          ),
-        ),
-        Match.when("api-key", () =>
-          validateFieldValues(
-            CLOUDFLARE_AUTH_PROVIDER_NAME,
-            apiKeyFields,
-            input.values,
-          ).pipe(
-            Effect.flatMap((values) =>
-              persist({
-                method: "stored",
-                credentialType: "apiKey",
-                apiKey: Redacted.value(
-                  storedSecret(values.apiKey) ?? Redacted.make(""),
-                ),
-                email: Redacted.value(
-                  storedSecret(values.email) ?? Redacted.make(""),
-                ),
-                accountId: (storedValueText(values.accountId) ?? "")
-                  .trim()
-                  .toLowerCase(),
-              }),
-            ),
-          ),
-        ),
-        Match.orElse(() =>
-          Effect.fail(
+      if (input.method !== "stored") {
+        return Effect.fail(
+          new AuthError({
+            message: `Cloudflare: unknown method '${input.method}'. Valid methods: stored. (OAuth is interactive-only.)`,
+          }),
+        );
+      }
+      return validateFieldValues(
+        CLOUDFLARE_AUTH_PROVIDER_NAME,
+        storedFields,
+        input.values,
+      ).pipe(
+        Effect.flatMap((values) => {
+          const accountId = (storedValueText(values.accountId) ?? "")
+            .trim()
+            .toLowerCase();
+          const apiToken = storedSecret(values.apiToken);
+          const apiKey = storedSecret(values.apiKey);
+          const email = storedValueText(values.email);
+          if (
+            apiToken !== undefined &&
+            apiKey === undefined &&
+            email === undefined
+          ) {
+            return persist({
+              method: "stored",
+              credentialType: "apiToken",
+              apiToken: Redacted.value(apiToken),
+              accountId,
+            });
+          }
+          if (
+            apiToken === undefined &&
+            apiKey !== undefined &&
+            email !== undefined
+          ) {
+            return persist({
+              method: "stored",
+              credentialType: "apiKey",
+              apiKey: Redacted.value(apiKey),
+              email,
+              accountId,
+            });
+          }
+          return Effect.fail(
             new AuthError({
-              message: `Cloudflare: unknown method '${input.method}'. Valid methods: api-token, api-key. (OAuth is interactive-only.)`,
+              message:
+                "Cloudflare: pass either --set apiToken=<token>, or both --set apiKey=<key> and --set email=<email>.",
             }),
-          ),
-        ),
+          );
+        }),
       );
     };
 

--- a/packages/alchemy/src/GitHub/AuthProvider.ts
+++ b/packages/alchemy/src/GitHub/AuthProvider.ts
@@ -492,9 +492,7 @@ export const makeGitHubAuth = (authOptions?: GitHubAuthOptions) =>
             )
           : Effect.fail(
               new AuthError({
-                message:
-                  `GitHub: unknown method '${input.method}'. Only 'stored' supports ` +
-                  "flag-driven configuration; use interactive configure for 'gh-cli'.",
+                message: `GitHub: unknown method '${input.method}'. Valid methods: stored. (gh-cli is interactive-only.)`,
               }),
             );
 

--- a/packages/alchemy/src/Plan.ts
+++ b/packages/alchemy/src/Plan.ts
@@ -17,6 +17,7 @@ import {
   Unowned,
 } from "./AdoptPolicy.ts";
 import { AlchemyContext } from "./AlchemyContext.ts";
+import { demandRemoteCredentials } from "./Auth/Demand.ts";
 import {
   Artifacts,
   ArtifactStore,
@@ -432,6 +433,20 @@ export const make = <A>(
       const provider = yield* providerForMode(base, mode);
       return { provider, mode };
     });
+
+    // Credential-free dev: the adoption probe below runs each new row's
+    // `read` — for `Alchemy.remote()` rows that is a real cloud call, and
+    // it happens before apply's demand gate. Demand those credentials up
+    // front so a dev plan with nothing configured fails with the typed
+    // CredentialsRequired rather than the first read's raw auth error.
+    if (runDefaultMode === "local") {
+      const remote: Array<{ Type: string; FQN: string }> = [];
+      for (const resource of resources) {
+        const { mode } = yield* resolveProviderAndMode(resource);
+        if (mode === "live") remote.push(resource);
+      }
+      if (remote.length > 0) yield* demandRemoteCredentials(remote);
+    }
 
     /**
      * Has this resource switched provider modes since it was last

--- a/packages/alchemy/src/Planetscale/AuthProvider.ts
+++ b/packages/alchemy/src/Planetscale/AuthProvider.ts
@@ -303,7 +303,7 @@ export const PlanetscaleAuth = AuthProviderLayer<
       );
 
     /**
-     * Flag-driven (`--method service-token --set ...`) fields, mirroring the
+     * Flag-driven (`--method stored --set ...`) fields, mirroring the
      * interactive service-token prompts. OAuth requires a browser and stays
      * interactive-only, so it is deliberately absent from
      * {@link configureMethods}.
@@ -315,7 +315,7 @@ export const PlanetscaleAuth = AuthProviderLayer<
     ];
 
     const configureMethods: ReadonlyArray<ConfigureMethod> = [
-      { method: "service-token", fields: serviceTokenFields },
+      { method: "stored", fields: serviceTokenFields },
     ];
 
     const configureWith = (
@@ -329,7 +329,7 @@ export const PlanetscaleAuth = AuthProviderLayer<
       AuthError,
       Interaction.Interaction
     > =>
-      input.method === "service-token"
+      input.method === "stored"
         ? validateFieldValues(
             PLANETSCALE_AUTH_PROVIDER_NAME,
             serviceTokenFields,
@@ -351,7 +351,7 @@ export const PlanetscaleAuth = AuthProviderLayer<
           )
         : Effect.fail(
             new AuthError({
-              message: `Planetscale: unknown method '${input.method}'. Only 'service-token' is supported (OAuth is interactive-only).`,
+              message: `Planetscale: unknown method '${input.method}'. Valid methods: stored. (OAuth is interactive-only.)`,
             }),
           );
 

--- a/packages/alchemy/src/Railway/AuthProvider.ts
+++ b/packages/alchemy/src/Railway/AuthProvider.ts
@@ -267,7 +267,7 @@ export const RailwayAuth = AuthProviderLayer<
       );
 
     /**
-     * Flag-driven (`--method token --set ...` / `--method env`) fields,
+     * Flag-driven (`--method stored --set ...` / `--method env`) fields,
      * mirroring the interactive prompts. OAuth requires a browser and stays
      * interactive-only, so it is deliberately absent.
      */
@@ -282,7 +282,7 @@ export const RailwayAuth = AuthProviderLayer<
     ];
 
     const configureMethods: ReadonlyArray<ConfigureMethod> = [
-      { method: "token", fields: tokenFields },
+      { method: "stored", fields: tokenFields },
       { method: "env", fields: [] },
     ];
 
@@ -293,7 +293,7 @@ export const RailwayAuth = AuthProviderLayer<
         readonly values: Record<string, string>;
       },
     ): Effect.Effect<RailwayAuthConfig, AuthError, Interaction.Interaction> =>
-      input.method === "token"
+      input.method === "stored"
         ? validateFieldValues(
             RAILWAY_AUTH_PROVIDER_NAME,
             tokenFields,
@@ -314,7 +314,7 @@ export const RailwayAuth = AuthProviderLayer<
           ? Effect.succeed({ method: "env" as const })
           : Effect.fail(
               new AuthError({
-                message: `Railway: unknown method '${input.method}'. Only 'token' and 'env' are supported (OAuth is interactive-only).`,
+                message: `Railway: unknown method '${input.method}'. Valid methods: stored, env. (OAuth is interactive-only.)`,
               }),
             );
 

--- a/packages/alchemy/test/AWS/Local/CredentialFreeDev.local.test.ts
+++ b/packages/alchemy/test/AWS/Local/CredentialFreeDev.local.test.ts
@@ -1,7 +1,7 @@
 /**
  * Credential-free `alchemy dev` for AWS.
  *
- * THE RULING: `{ method: "local" }` is invisible plumbing — `alchemy dev`
+ * THE RULING: local emulation is invisible plumbing — `alchemy dev`
  * with zero AWS credentials must work, landing every emulatable resource in
  * the local floci emulator, while `Alchemy.remote()` resources demand real
  * credentials up front with a typed, actionable error.

--- a/packages/alchemy/test/AWS/Local/FlociSmoke.test.ts
+++ b/packages/alchemy/test/AWS/Local/FlociSmoke.test.ts
@@ -3,7 +3,7 @@
  *
  * Deploys real AWS resources (S3 Bucket, SQS Queue, DynamoDB Table) through
  * the regular live providers, but pointed at a locally-running floci emulator
- * via the `{ method: "local" }` AWS auth method.
+ * via the floci-scoped environment the local AWS providers carry.
  *
  * ## How local mode is activated
  *
@@ -17,8 +17,8 @@
  *
  * ## Why no real-AWS calls can happen
  *
- * The `local` method's credentials are hardcoded dummies and its accountId is
- * fixed — it never calls STS. Every SDK call carries the emulator endpoint
+ * The floci environment's credentials are hardcoded dummies and its accountId
+ * is fixed — it never calls STS. Every SDK call carries the emulator endpoint
  * (via `Endpoint.fromEnvironment`); if any call ever escaped to real AWS it
  * would fail auth immediately (the dummy keys exist in no real account).
  *

--- a/packages/alchemy/test/Auth/Demand.test.ts
+++ b/packages/alchemy/test/Auth/Demand.test.ts
@@ -207,27 +207,11 @@ it.live(
   { exclusive: true },
 );
 
-/** Set a process env var for the duration of the surrounding scope. */
-const withProcessEnv = (name: string, value: string) =>
-  Effect.acquireRelease(
-    Effect.sync(() => {
-      const previous = process.env[name];
-      process.env[name] = value;
-      return previous;
-    }),
-    (previous) =>
-      Effect.sync(() => {
-        if (previous === undefined) delete process.env[name];
-        else process.env[name] = previous;
-      }),
-  );
-
 it.live(
   "exported env credentials satisfy the gate when no profile is selected",
   () =>
     withTempHome(
       Effect.gen(function* () {
-        yield* withProcessEnv(ENV_PROBE_TOKEN, "token");
         yield* demandCredentials([
           {
             provider: ENV_PROBE,
@@ -238,6 +222,7 @@ it.live(
         // same source the run's lazy resolution will use.
         expect(envState.reads).toBe(1);
       }),
+      { [ENV_PROBE_TOKEN]: "token" },
     ),
   { exclusive: true },
 );

--- a/packages/alchemy/test/Auth/Profile.test.ts
+++ b/packages/alchemy/test/Auth/Profile.test.ts
@@ -123,21 +123,6 @@ const withTempHome = <A, E, R>(
     return yield* effect.pipe(Effect.provide(makeTestLayer(config)));
   }).pipe(Effect.scoped, Effect.provide(NodeServices.layer));
 
-/** Set a process env var for the duration of the surrounding scope. */
-const withProcessEnv = (name: string, value: string) =>
-  Effect.acquireRelease(
-    Effect.sync(() => {
-      const previous = process.env[name];
-      process.env[name] = value;
-      return previous;
-    }),
-    (previous) =>
-      Effect.sync(() => {
-        if (previous === undefined) delete process.env[name];
-        else process.env[name] = previous;
-      }),
-  );
-
 it.live(
   "loadProviderConfig requires profiles to be explicitly created",
   () =>
@@ -535,35 +520,58 @@ it.effect("resolves the profile from env files and --profile overrides", () =>
 );
 
 it.live(
-  "explicitly exported provider variables work without a profile",
+  "provider variables present in config resolve without a profile",
   () =>
     withTempHome(
       Effect.gen(function* () {
-        yield* withProcessEnv("FAKE_ENV_TOKEN", "from-env");
         const resolved = yield* resolveProviderConfig(ENV_PROVIDER);
         expect(resolved.source).toBe("environment");
         expect(yield* resolved.resolve).toBe("environment-credentials");
       }),
+      // Environment credentials are read through the config provider —
+      // the process environment, `.env`, and `--env-file` alike.
+      { FAKE_ENV_TOKEN: "from-env" },
     ),
   { exclusive: true },
 );
 
 it.live(
-  "an explicit profile selection ignores provider environment variables",
+  "provider environment variables take precedence over a selected profile",
   () =>
     withTempHome(
       Effect.gen(function* () {
-        yield* withProcessEnv("FAKE_ENV_TOKEN", "from-env");
-        // ALCHEMY_PROFILE (the --profile mechanism) selects the profile
-        // explicitly, so the exported variable must NOT short-circuit —
-        // the unconfigured provider fails with the connect hint instead.
-        const error = yield* resolveProviderConfig(ENV_PROVIDER).pipe(
-          Effect.flip,
-        );
-        expect(error).toBeInstanceOf(AuthError);
-        expect((error as AuthError).message).toContain("--add");
+        // ALCHEMY_PROFILE (the --profile mechanism) selects a profile, but
+        // a fully present environment contract still wins — the profile
+        // is never consulted, so its unconfigured provider cannot fail.
+        const resolved = yield* resolveProviderConfig(ENV_PROVIDER);
+        expect(resolved.source).toBe("environment");
+        expect(resolved.profileName).toBeUndefined();
+        expect(yield* resolved.resolve).toBe("environment-credentials");
       }),
-      { ALCHEMY_PROFILE: "default" },
+      { ALCHEMY_PROFILE: "default", FAKE_ENV_TOKEN: "from-env" },
+    ),
+  { exclusive: true },
+);
+
+it.live(
+  "providers mix: one from environment variables, the rest from the profile",
+  () =>
+    withTempHome(
+      Effect.gen(function* () {
+        const profile = yield* ProfileStore;
+        yield* profile.setProviderConfig("default", FAKE_PROVIDER, {
+          method: "stored",
+        });
+        // Precedence is decided per provider, not per run: the provider
+        // whose contract is present resolves from the environment while a
+        // provider without those variables still comes from the profile.
+        const fromEnv = yield* resolveProviderConfig(ENV_PROVIDER);
+        expect(fromEnv.source).toBe("environment");
+        const fromProfile = yield* resolveProviderConfig(FAKE_PROVIDER);
+        expect(fromProfile.source).toBe("profile");
+        expect(fromProfile.profileName).toBe("default");
+      }),
+      { FAKE_ENV_TOKEN: "from-env" },
     ),
   { exclusive: true },
 );

--- a/website/src/content/docs/cli/profile.mdx
+++ b/website/src/content/docs/cli/profile.mdx
@@ -133,10 +133,28 @@ configured entirely from flags: `--method` picks the provider's configure
 method and repeatable `--set` supplies its fields. Values come in three
 forms so secrets stay out of shell history: a literal (`name=value`), an
 environment variable (`name=env:VAR`, resolved from the environment and
-`--env-file`), or stdin (`name=-`, one field at most). Each provider
-documents its methods and fields in `alchemy profile edit --help`; when a
-provider has exactly one method, `--method` can be omitted. Browser-OAuth
-methods stay interactive-only.
+`--env-file`), or stdin (`name=-`, one field at most). `--method` is
+required whenever `--set` is used. Browser-OAuth and `gh auth` methods stay
+interactive-only.
+
+`--method` is the same `method` value the provider writes to its file under
+`~/.alchemy/credentials/<profile>/`, and `--set` keys are that file's
+properties. `stored` is the pasted-credential method every provider shares:
+
+| Provider    | `--method` | `--set` fields                                                       |
+| ----------- | ---------- | -------------------------------------------------------------------- |
+| AWS         | `stored`   | `accessKeyId`, `secretAccessKey`, `region`, optional `sessionToken`  |
+| AWS         | `sso`      | `ssoProfile` (from `~/.aws/config`)                                  |
+| Axiom       | `stored`   | `token`, optional `orgId`, `apiBaseUrl`                              |
+| Cloudflare  | `stored`   | `accountId` plus either `apiToken`, or `apiKey` and `email`          |
+| Fly         | `stored`   | `apiKey`, optional `apiBaseUrl`                                      |
+| GitHub      | `stored`   | `token`, optional `baseUrl`                                          |
+| Hetzner     | `stored`   | `token`, optional `apiBaseUrl`                                       |
+| Neon        | `stored`   | `apiKey`                                                             |
+| Planetscale | `stored`   | `tokenId`, `token`, `organization`                                   |
+| Prisma      | `stored`   | `serviceToken`                                                       |
+| Railway     | `stored`   | `token`, optional `apiBaseUrl`                                       |
+| Railway     | `env`      | none (reads `RAILWAY_API_TOKEN` on every run)                        |
 
 In a non-interactive session (no terminal, CI, coding agents), the menu can't
 open. The command prints its usage and exits non-zero. Use the action flags.
@@ -168,11 +186,11 @@ alchemy profile edit --remove cloudflare
 alchemy profile edit --remove cloudflare --add github
 
 # Fully non-interactive: an agent connects Cloudflare with an API token
-alchemy profile edit --add cloudflare --method api-token \
+alchemy profile edit --add cloudflare --method stored \
   --set apiToken=env:CLOUDFLARE_API_TOKEN --set accountId=0123456789abcdef0123456789abcdef
 
-# Single-method providers don't need --method; secret via stdin
-op read op://vault/neon/key | alchemy profile edit --add neon --set apiKey=-
+# Secret via stdin
+op read op://vault/neon/key | alchemy profile edit --add neon --method stored --set apiKey=-
 ```
 
 ## profile refresh

--- a/website/src/content/docs/environments/auth-providers.mdx
+++ b/website/src/content/docs/environments/auth-providers.mdx
@@ -57,10 +57,10 @@ automatically.
 `details` and `read` use the tagged `NeedsReauth` error for missing, expired,
 or rotated credentials. The profile UI renders it as "needs re-login."
 
-`readEnvironment` never receives or creates a profile. It is used when
-`CI=true`, and outside CI when every required variable in the provider's
-contract is explicitly exported in the process environment and no profile
-was explicitly selected. See
+`readEnvironment` never receives or creates a profile. It is used whenever
+every required variable in the provider's contract is present in config (the
+process environment, `.env`, or `--env-file`), taking precedence over any
+selected profile, and always when `CI=true`. See
 [environment variables outside CI](/environments/profiles#environment-variables-outside-ci).
 `environment` declares every variable `readEnvironment` consumes
 (`name`, `required`, `secret`, `description`, `alternatives`). Alchemy validates
@@ -210,11 +210,12 @@ the provider's `readEnvironment` capability. It does not manufacture an
 [provider environment-variable table](/environments/profiles#ci-environment-variables-by-provider)
 for the exact inputs.
 
-Outside CI, the same capability runs when the provider's required variables
-are all explicitly exported in `process.env` **and** no profile was selected
-explicitly. Alchemy prints a warning that names the variables it used. Passing
-`--profile` (or setting `ALCHEMY_PROFILE`) restores the profile's authority
-and the variables are ignored.
+Outside CI, the same capability runs first whenever the provider's required
+variables are all present in config (process environment, `.env`, or
+`--env-file`) — even when `--profile` or `ALCHEMY_PROFILE` selected a
+profile. The check is per provider, so one provider can come from the
+environment while the others in the same run come from the profile. Alchemy
+logs the variables it used. Unset them to fall back to the profile.
 
 ## Refresh in practice
 

--- a/website/src/content/docs/environments/custom-auth-provider.mdx
+++ b/website/src/content/docs/environments/custom-auth-provider.mdx
@@ -67,7 +67,6 @@ export type StripeResolvedCredentials = {
 export const { layer: StripeAuth, storedSchema: StripeStoredCredentials } =
   makeStoredAuthProvider<StripeResolvedCredentials>({
     provider: STRIPE_AUTH_PROVIDER_NAME,
-    storageKey: "stripe-stored",
     fields: [
       {
         name: "apiKey",
@@ -100,7 +99,9 @@ export const { layer: StripeAuth, storedSchema: StripeStoredCredentials } =
   });
 ```
 
-`fields` drive interactive prompts and `--set`; validation applies to both.
+`fields` drive interactive prompts and `--set`; each field name is also the
+property persisted in the credentials file, alongside `method: "stored"`
+(the `--method` value). Validation applies to both paths.
 The generated `storedSchema` validates credential reads and writes.
 `readEnvironment` resolves CI credentials, while `environment` documents
 the variables it consumes. Missing stored credentials appear as
@@ -214,8 +215,8 @@ alchemy profile refresh --provider Stripe    # re-authenticate without changing 
 alchemy profile edit --reconfigure Stripe    # replace the stored credentials interactively
 
 # non-interactive (agents, scripts): value from env, stdin, or a literal
-alchemy profile edit --add stripe --set apiKey=env:STRIPE_API_KEY
-op read op://vault/stripe/key | alchemy profile edit --add stripe --set apiKey=-
+alchemy profile edit --add stripe --method stored --set apiKey=env:STRIPE_API_KEY
+op read op://vault/stripe/key | alchemy profile edit --add stripe --method stored --set apiKey=-
 
 alchemy profile show       # renders your provider's details
 alchemy provider check-env --provider stripe   # CI preflight for STRIPE_API_KEY

--- a/website/src/content/docs/environments/profiles.mdx
+++ b/website/src/content/docs/environments/profiles.mdx
@@ -136,16 +136,22 @@ This moves the profile's credential directory. It does not rewrite an
 
 ### Environment variables outside CI
 
-Complete provider credentials exported in the process environment override
-an implicitly selected profile:
+Provider credentials in the environment always win. When every required
+variable in a provider's contract is set — in the process environment, a
+`.env` file, or `--env-file` — alchemy resolves that provider from the
+variables and never consults the profile, whether or not `--profile` or
+`ALCHEMY_PROFILE` selected one. It logs which variables it used:
 
 ```text
-Cloudflare: using credentials from environment variables (CLOUDFLARE_API_TOKEN,
-CLOUDFLARE_ACCOUNT_ID) — the 'default' profile was not used.
+Cloudflare: using environment variables (CLOUDFLARE_API_TOKEN,
+CLOUDFLARE_ACCOUNT_ID) instead of the profile.
 ```
 
-Pass `--profile <name>` or set `ALCHEMY_PROFILE` to use the profile instead.
-Values supplied only through `--env-file` do not trigger this local override.
+The decision is per provider, so mixing is fine: a Cloudflare token in
+`.env` overrides only Cloudflare, while AWS, Neon, or any other provider in
+the same run still resolves from the profile. Unset the variables to use the
+profile's stored credentials for that provider too. A partial set (a required
+variable missing) is ignored and the profile applies.
 
 ### CI
 
@@ -171,6 +177,9 @@ directly from environment variables and nothing is read from or written to
 | PlanetScale | `PLANETSCALE_API_TOKEN_ID`, `PLANETSCALE_API_TOKEN`, `PLANETSCALE_ORGANIZATION` | `PLANETSCALE_API_BASE_URL` |
 | Prisma | `PRISMA_SERVICE_TOKEN` or `PRISMA_API_TOKEN` | `PRISMA_API_URL` or `PRISMA_MANAGEMENT_API_URL` |
 | Axiom | `AXIOM_TOKEN` or `AXIOM_API_KEY` | `AXIOM_ORG_ID` (required when the token is a personal access token), `AXIOM_URL` for self-hosted or regional deployments |
+| Fly | `FLY_API_TOKEN` | `FLY_API_HOSTNAME` overrides the Machines API root |
+| Hetzner | `HCLOUD_TOKEN` | `HCLOUD_ENDPOINT` overrides the API base URL |
+| Railway | `RAILWAY_API_TOKEN` (account or workspace token) | `RAILWAY_API_URL` overrides the GraphQL host |
 
 These variables are a CI credential source, not a profile authentication
 method. They are never persisted into `profiles.json` or the credentials

--- a/website/src/content/docs/fly/setup.mdx
+++ b/website/src/content/docs/fly/setup.mdx
@@ -81,22 +81,15 @@ Sprite.
 
 There is no separate credentials step. The first time you run
 `alchemy deploy` (or `plan`, `dev`, `destroy`) on a stack that uses
-`Fly.providers()`, alchemy walks you through an interactive login
-with two options:
-
-- **API Token** — paste the token you generated above. It's verified
-  against the Machines API and saved under
-  `~/.alchemy/credentials/<profile>/`.
-- **Environment Variables** — reads `FLY_API_TOKEN` from the
-  environment on every run (plus an optional `FLY_API_HOSTNAME` to
-  override the Machines API root, default
-  `https://api.machines.dev/v1`). This is the method for CI — when
-  alchemy detects `CI=true` it skips the prompt and uses the
-  environment automatically.
-
-Either choice is saved to your **`default`**
+`Fly.providers()`, alchemy prompts for the token you generated above
+(and, optionally, a Machines API hostname — default
+`https://api.machines.dev/v1`). It is saved under
+`~/.alchemy/credentials/<profile>/` in your **`default`**
 [profile](/environments/profiles) and reused on every subsequent
 command.
+
+In CI (`CI=true`) alchemy skips the prompt and reads `FLY_API_TOKEN`
+(plus an optional `FLY_API_HOSTNAME`) from the environment instead.
 
 To re-run the setup later (e.g. to rotate the token, or configure a
 separate `prod` profile):
@@ -108,6 +101,9 @@ alchemy profile edit --reconfigure Fly
 # Or connect Fly in a separate `prod` profile
 alchemy profile create prod
 alchemy profile edit --profile prod --add Fly
+
+# Non-interactive (scripts, agents)
+alchemy profile edit --add Fly --method stored --set apiKey=env:FLY_API_TOKEN
 ```
 
 Inspect what's stored (secrets are redacted):

--- a/website/src/content/docs/hetzner/setup.mdx
+++ b/website/src/content/docs/hetzner/setup.mdx
@@ -77,28 +77,27 @@ Inside the project:
 
 There is no separate credentials step. The first time you run
 `alchemy deploy` (or `plan`, `dev`, `destroy`) on a stack that uses
-`Hetzner.providers()`, alchemy walks you through an interactive
-login with two options:
+`Hetzner.providers()`, alchemy prompts for the token you generated
+above (and, optionally, an API endpoint override). It is saved under
+`~/.alchemy/credentials/<profile>/` in the selected
+[profile](/environments/profiles) and reused on subsequent commands.
 
-- **API Token** — paste the token you generated above. It's
-  verified against the Hetzner API and saved under
-  `~/.alchemy/credentials/<profile>/`.
-- **Environment Variables** — reads `HCLOUD_TOKEN` from the
-  environment on every run (plus an optional `HCLOUD_ENDPOINT` to
-  override the API base URL). This is the method for CI — when
-  alchemy detects `CI=true` it skips the prompt and uses the
-  environment automatically.
-
-Either choice is saved to the selected [profile](/environments/profiles) and
-reused on subsequent commands.
+In CI (`CI=true`) alchemy skips the prompt and reads `HCLOUD_TOKEN`
+(plus an optional `HCLOUD_ENDPOINT`) from the environment instead.
 
 To re-run the setup later (e.g. to rotate the token, or configure a
 separate `prod` profile):
 
 ```sh
-alchemy profile
+# Re-run the interactive setup (e.g. to rotate the token)
+alchemy profile edit --reconfigure Hetzner
+
+# Or connect Hetzner in a separate `prod` profile
 alchemy profile create prod
-alchemy profile edit --profile prod
+alchemy profile edit --profile prod --add Hetzner
+
+# Non-interactive (scripts, agents)
+alchemy profile edit --add Hetzner --method stored --set token=env:HCLOUD_TOKEN
 ```
 
 Inspect what's stored (secrets are redacted):

--- a/website/src/content/docs/railway/setup.mdx
+++ b/website/src/content/docs/railway/setup.mdx
@@ -86,14 +86,16 @@ The official environment variable is `RAILWAY_API_TOKEN`. An optional
 There is no separate credentials step. The first time you run
 `alchemy deploy` (or `plan`, `dev`, `destroy`) on a stack that uses
 `Railway.providers()`, alchemy walks you through an interactive login
-with two options:
+with three options:
 
+- **OAuth** — opens `railway.com/cli-login` and pairs the CLI with
+  your account. No pre-existing token needed.
 - **API Token** — paste the token you generated above. It's saved
   under `~/.alchemy/credentials/<profile>/`.
 - **Environment Variables** — reads `RAILWAY_API_TOKEN` from the
   environment on every run (plus an optional `RAILWAY_API_URL`).
-  This is the method for CI — when alchemy detects `CI=true` it
-  skips the prompt and uses the environment automatically.
+  In CI (`CI=true`) alchemy skips the prompt and uses the
+  environment automatically.
 
 Either choice is saved to your **`default`**
 [profile](/environments/profiles) and reused on every subsequent
@@ -109,6 +111,9 @@ alchemy profile edit --reconfigure Railway
 # Or connect Railway in a separate `prod` profile
 alchemy profile create prod
 alchemy profile edit --profile prod --add Railway
+
+# Non-interactive (scripts, agents)
+alchemy profile edit --add Railway --method stored --set token=env:RAILWAY_API_TOKEN
 ```
 
 Inspect what's stored (secrets are redacted):


### PR DESCRIPTION
- Register Fly and Railway auth in the built-in profile list so they always
  appear in `alchemy profile`.
- Align every provider's `--method` value with the literal it persists
  (`stored`, `sso`, `local`→removed, `env`), with a uniform unknown-method error.
- Environment credentials take precedence over the profile for any provider
  outside CI (not just when CI is set), decided per provider so mixtures work
  (e.g. Cloudflare from env, AWS from the profile). Logs which variables it used.
- Remove the AWS `local` auth method; floci is wired automatically via the
  local provider's own environment, so the profile method was redundant.
- Fix credential-free `alchemy dev`: resolve the AWS environment lazily and
  demand credentials for `Alchemy.remote()` rows at plan time.
- Docs: per-provider method/field table, env-precedence rules, Fly/Hetzner/
  Railway setup and CI env-var updates.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>