### PR TITLE
feat(planetscale): declare Postgres cluster parameters

### DIFF
--- a/packages/alchemy/src/Planetscale/Branch.ts
+++ b/packages/alchemy/src/Planetscale/Branch.ts
@@ -12,6 +12,7 @@ import { hashImports, hashMigrations } from "../SQL/SqlFile.ts";
 import { recordsEqual } from "../Util/equal.ts";
 import { ensureMySQLProductionBranchClusterSize } from "./MySQL/MySQLClusterSize.ts";
 import {
+  ensurePostgresBranchParameters,
   ensurePostgresProductionBranchClusterSize,
   toPostgresClusterSku,
   waitForPendingPostgresChanges,
@@ -606,6 +607,18 @@ export const makeBranchProvider = <R extends ResourceLike>(opts: {
             news.clusterSize,
           );
         }
+      }
+
+      // Sync cluster parameters — Postgres only, and after the resize,
+      // which is the operation that can replace the cluster the
+      // parameters are written to.
+      if (current.kind === "postgresql" && news.parameters) {
+        yield* ensurePostgresBranchParameters(
+          organization,
+          databaseName,
+          branchName,
+          news.parameters,
+        );
       }
 
       // Re-read so the returned attributes reflect any mutation.

--- a/packages/alchemy/src/Planetscale/Postgres/PostgresBranch.ts
+++ b/packages/alchemy/src/Planetscale/Postgres/PostgresBranch.ts
@@ -5,7 +5,10 @@ import {
   makeBranchProvider,
 } from "../Branch.ts";
 import type { Providers } from "../Providers.ts";
-import type { PostgresClusterSize } from "./PostgresClusterSize.ts";
+import type {
+  PostgresClusterParameters,
+  PostgresClusterSize,
+} from "./PostgresClusterSize.ts";
 import type { PostgresDatabase } from "./PostgresDatabase.ts";
 import {
   runPostgresImports,
@@ -28,6 +31,18 @@ export interface PostgresBranchProps extends BaseBranchProps {
    * requires the full SKU (e.g. `"M1_10_AWS_ARM_D_METAL_10"`).
    */
   clusterSize?: PostgresClusterSize;
+
+  /**
+   * Cluster configuration parameters for the branch, nested by namespace
+   * (`patroni`, `pgconf`, `pgbouncer`).
+   *
+   * Only the parameters declared here are managed; one left out keeps its
+   * current value rather than reverting to its default. Applied through
+   * the same change-request API as {@link clusterSize}, after it.
+   *
+   * @see https://planetscale.com/docs/postgres/cluster-configuration/parameters
+   */
+  parameters?: PostgresClusterParameters;
 
   /**
    * Total number of replicas for the branch. `0` creates or converges the

--- a/packages/alchemy/src/Planetscale/Postgres/PostgresClusterSize.ts
+++ b/packages/alchemy/src/Planetscale/Postgres/PostgresClusterSize.ts
@@ -263,3 +263,115 @@ export const ensurePostgresProductionBranchClusterSize = Effect.fn(function* (
     change.id,
   );
 });
+
+/**
+ * Cluster configuration parameters, nested by namespace.
+ *
+ * Values are strings because that is what the parameters API returns and
+ * accepts, whatever a parameter's declared type is: `"40"`, `"on"`,
+ * `"1GB"`.
+ *
+ * @see https://planetscale.com/docs/postgres/cluster-configuration/parameters
+ *
+ * @example
+ * ```ts
+ * const parameters = {
+ *   pgconf: { max_connections: "50" },
+ *   // Cap the server connections PSBouncer opens across every user, so a
+ *   // fleet of poolers cannot oversubscribe `max_connections`.
+ *   pgbouncer: { max_db_connections: "40" },
+ * }
+ * ```
+ */
+export interface PostgresClusterParameters {
+  readonly patroni?: Readonly<Record<string, string>>;
+  readonly pgconf?: Readonly<Record<string, string>>;
+  readonly pgbouncer?: Readonly<Record<string, string>>;
+}
+
+/**
+ * Ensures a PostgreSQL branch carries the declared cluster parameters,
+ * queuing the change via the change-request API when any of them drifts.
+ *
+ * Only declared parameters are compared and sent. The API upserts, so a
+ * parameter left out of `parameters` keeps whatever value it has instead
+ * of falling back to its default — declaring one knob does not hand the
+ * whole configuration to the resource.
+ *
+ * A parameter whose change needs a restart (`restart: true` in the
+ * listing, e.g. `pgconf.max_connections`) restarts the branch's Postgres
+ * when it is applied. That is the API's behaviour, not this function's;
+ * the note names the parameters so a deploy log says why a branch bounced.
+ */
+export const ensurePostgresBranchParameters = Effect.fn(function* (
+  organization: string,
+  database: string,
+  branch: string,
+  parameters: PostgresClusterParameters,
+) {
+  const desired = Object.entries(parameters).flatMap(([namespace, values]) =>
+    Object.entries(values ?? {}).map(
+      ([name, value]) => [namespace, name, value] as const,
+    ),
+  );
+  if (desired.length === 0) {
+    return;
+  }
+
+  // A freshly-forked branch has no parameters to list yet, and a change
+  // request queued against it would sit pending until the poll budget
+  // runs out.
+  yield* waitForBranchReady(organization, database, branch);
+
+  const observed = yield* planetscale.listParameters({
+    organization,
+    database,
+    branch,
+  });
+  const observedValues = new Map(
+    observed.map((parameter) => [
+      `${parameter.namespace}.${parameter.name}`,
+      parameter,
+    ]),
+  );
+
+  const drifted = desired.filter(([namespace, name, value]) => {
+    const parameter = observedValues.get(`${namespace}.${name}`);
+    // An unknown parameter is sent as declared: the API is the authority
+    // on which names exist, and it rejects the ones that do not.
+    return parameter === undefined || parameter.value !== value;
+  });
+  if (drifted.length === 0) {
+    return;
+  }
+
+  const restarts = drifted.filter(
+    ([namespace, name]) =>
+      observedValues.get(`${namespace}.${name}`)?.restart === true,
+  );
+  if (restarts.length > 0) {
+    yield* Effect.logInfo(
+      `Applying parameters that restart Postgres on branch "${branch}": ` +
+        restarts.map(([ns, name]) => `${ns}.${name}`).join(", "),
+    );
+  }
+
+  const payload: Record<string, Record<string, string>> = {};
+  for (const [namespace, name, value] of drifted) {
+    (payload[namespace] ??= {})[name] = value;
+  }
+
+  yield* waitForPendingPostgresChanges(organization, database, branch);
+  const change = yield* planetscale.updateBranchChangeRequest({
+    organization,
+    database,
+    branch,
+    parameters: payload,
+  });
+  yield* waitForPendingPostgresChanges(
+    organization,
+    database,
+    branch,
+    change.id,
+  );
+});

--- a/packages/alchemy/src/Planetscale/Postgres/PostgresClusterSize.ts
+++ b/packages/alchemy/src/Planetscale/Postgres/PostgresClusterSize.ts
@@ -310,7 +310,7 @@ export const ensurePostgresBranchParameters = Effect.fn(function* (
   parameters: PostgresClusterParameters,
 ) {
   const desired = Object.entries(parameters).flatMap(([namespace, values]) =>
-    Object.entries(values ?? {}).map(
+    Object.entries<string>(values ?? {}).map(
       ([name, value]) => [namespace, name, value] as const,
     ),
   );

--- a/packages/alchemy/src/Planetscale/Postgres/PostgresDatabase.ts
+++ b/packages/alchemy/src/Planetscale/Postgres/PostgresDatabase.ts
@@ -22,8 +22,10 @@ import {
   waitForDatabaseReady,
 } from "../Util.ts";
 import {
+  ensurePostgresBranchParameters,
   ensurePostgresProductionBranchClusterSize,
   toPostgresClusterSku,
+  type PostgresClusterParameters,
   type PostgresClusterSize,
 } from "./PostgresClusterSize.ts";
 import {
@@ -47,6 +49,34 @@ export interface PostgresDatabaseProps extends BaseDatabaseProps {
    * @see {@link PostgresClusterSize}
    */
   clusterSize: PostgresClusterSize;
+
+  /**
+   * Cluster configuration parameters for the default branch, nested by
+   * namespace (`patroni`, `pgconf`, `pgbouncer`).
+   *
+   * Only the parameters declared here are managed. One left out keeps
+   * whatever value it has rather than reverting to its default, so a
+   * stack can own a single knob without owning the configuration.
+   *
+   * Applied through the same change-request API as {@link clusterSize}.
+   * A parameter marked `restart` restarts the branch's Postgres when it
+   * changes; `pgconf.max_connections` is one.
+   *
+   * @see https://planetscale.com/docs/postgres/cluster-configuration/parameters
+   *
+   * @example
+   * ```ts
+   * const db = yield* Planetscale.PostgresDatabase("Db", {
+   *   clusterSize: "PS_10",
+   *   parameters: {
+   *     // Bound the server connections PSBouncer opens across all users,
+   *     // so several poolers cannot oversubscribe `max_connections`.
+   *     pgbouncer: { max_db_connections: "40" },
+   *   },
+   * })
+   * ```
+   */
+  parameters?: PostgresClusterParameters;
 
   /**
    * PostgreSQL major version. Defaults to the latest available major
@@ -359,6 +389,18 @@ export const PostgresDatabaseProvider = () =>
         branch,
         news.clusterSize,
       );
+
+      // Parameters follow the resize: both queue change requests on the
+      // same branch, and the resize is the one that can replace the
+      // cluster the parameters are written to.
+      if (news.parameters) {
+        yield* ensurePostgresBranchParameters(
+          organization,
+          updated.name,
+          branch,
+          news.parameters,
+        );
+      }
 
       const migrationTarget = {
         organization,


### PR DESCRIPTION
## What

`Planetscale.PostgresDatabase` and `Planetscale.PostgresBranch` accept a `parameters` prop for PlanetScale's cluster configuration parameters, nested by namespace:

```ts
const db = yield* Planetscale.PostgresDatabase("Db", {
  clusterSize: "PS_10",
  parameters: {
    pgbouncer: { max_db_connections: "40" },
  },
})
```

## Why

A Postgres branch's behaviour under load is set by these parameters, and today they are reachable only from the dashboard or the API. Everything around them is already declarative: cluster size, replicas, major version, roles, migrations. The parameter that decides whether the database survives its own connection load is the one thing that lives outside the program.

The case that prompted this: seven Hyperdrive configurations on one PS-10 branch, each with Cloudflare's default origin limit, against `max_connections` 50. `pgbouncer.max_db_connections` is the only control that bounds the total across all poolers, and until now nothing in the stack could state it. A value set by hand in a dashboard is a value nobody reviews and nothing restores.

## How

- `ensurePostgresBranchParameters` in `PostgresClusterSize.ts`, built exactly like the existing `ensurePostgresProductionBranchClusterSize`: wait for the branch to be ready, compare, queue one change request, wait for it to reach a terminal state.
- Only declared parameters are read and sent. The API upserts, so an undeclared parameter keeps its current value instead of reverting to a default. Verified against the live API: a PATCH carrying only `pgbouncer.max_db_connections` left `pgbouncer.default_pool_size` at its configured value.
- Nothing is sent when nothing drifted, so a converged stack makes one `listParameters` call and stops.
- A parameter whose listing says `restart: true` (`pgconf.max_connections`, for instance) restarts Postgres when the API applies it. That is the API's behaviour, not this function's, so the change is applied and logged by name rather than refused, and a deploy log says why a branch bounced.
- On the branch resource the call sits behind `expectedKind === "postgresql"`, next to the existing Postgres-only `replicas` branch in the shared provider, and runs after the cluster resize, which is the operation that can replace the cluster the parameters are written to.

`@distilled.cloud/planetscale` already exposes both `listParameters` and the `parameters` field on `updateBranchChangeRequest`, so the generated client is untouched.

## Verification

- `pnpm tsc -b` passes locally on this branch (pnpm 11.24.0, Bun 1.3.14).
- No test added: the existing Planetscale tests provision real branches, and a meaningful test here would need a live branch and a parameter change to converge against. Happy to add one under `test.provider` if you want it in the same shape as the cluster-size coverage.
- The behaviour was exercised against a live PlanetScale Postgres branch through the same REST endpoint the client calls, including the partial-upsert semantics above.

## Notes

Left out on purpose: no validation of parameter names or ranges against the listing's `min`/`max`/`options`, and no handling of `immutable`. The API rejects those and its message is better than anything I would synthesize.
