### PR TITLE
fix(cloudflare): preserve RpcWorker logical ID

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/RpcWorker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/RpcWorker.ts
@@ -14,6 +14,7 @@ import type * as RpcClientError from "effect/unstable/rpc/RpcClientError";
 import type { Dependencies } from "../../Dependencies.ts";
 import type { HttpEffect } from "../../Http.ts";
 import type { InputProps } from "../../Input.ts";
+import type { Named } from "../../Named.ts";
 import type { Rpc as RpcShape } from "../../Rpc.ts";
 import { effectClass, taggedFunction } from "../../Util/effect.ts";
 import type { Worker, WorkerProps } from "./Worker.ts";
@@ -53,17 +54,25 @@ const SchemaSymbol = Symbol.for("alchemy.RpcWorker.schema");
 // `Deps` mirrors `Cloudflare.Worker<Self, Bindings, Deps>` — declares
 // the DOs / Workers this script publishes for cross-script binding so
 // `Counter.from(WorkerA)` type-checks from another script.
+//
+// `Id` is the const logical id (`Named<Id>`), matching `Cloudflare.Worker`.
 export interface RpcWorkerYieldable<
   Self,
   Rpcs extends Rpc.Any,
   Deps = never,
-> extends Effect.Effect<
-  Worker<{}> & RpcShape<Self> & Dependencies<Deps>,
-  never,
-  any
-> {
+  Id extends string = string,
+>
+  extends
+    Effect.Effect<Worker<{}> & RpcShape<Self> & Dependencies<Deps>, never, any>,
+    Named<Id> {
   /** @internal */
   readonly [SchemaSymbol]: RpcGroup.RpcGroup<Rpcs>;
+  /**
+   * Logical id of the Worker this class declares. Copied from the
+   * underlying `Cloudflare.Worker` so callers can read it off the
+   * class without yielding (e.g. `transferredFrom: TaskWorker`).
+   */
+  readonly LogicalId: Id;
 }
 
 /**
@@ -98,11 +107,11 @@ export interface RpcWorkerClass extends Effect.Effect<
      * `Layer.Layer<Self>` so consumers that don't host the worker can
      * import the class without pulling its runtime into their bundle.
      */
-    <Rpcs extends Rpc.Any>(
-      id: string,
+    <const Id extends string, Rpcs extends Rpc.Any>(
+      id: Id,
       props: RpcWorkerProps<Rpcs>,
-    ): RpcWorkerYieldable<Self, Rpcs, Deps> & {
-      new (_: never): {};
+    ): RpcWorkerYieldable<Self, Rpcs, Deps, Id> & {
+      new (_: never): Named<Id>;
       make<InnerR = never, InitReq = never>(
         props: InputProps<WorkerProps>,
         impl: Effect.Effect<
@@ -113,20 +122,26 @@ export interface RpcWorkerClass extends Effect.Effect<
       ): Layer.Layer<Self, never, Exclude<InitReq | InnerR, never>>;
     };
     /** Inline-impl form. */
-    <Rpcs extends Rpc.Any, InnerR = never, InitReq = never>(
-      id: string,
+    <
+      const Id extends string,
+      Rpcs extends Rpc.Any,
+      InnerR = never,
+      InitReq = never,
+    >(
+      id: Id,
       props: RpcWorkerProps<Rpcs> & InputProps<WorkerProps>,
       impl: Effect.Effect<
         Effect.Effect<HttpEffect<InnerR>, never, InnerR>,
         ConfigError,
         InitReq
       >,
-    ): RpcWorkerYieldable<Self, Rpcs, Deps> & {
+    ): RpcWorkerYieldable<Self, Rpcs, Deps, Id> & {
       // Phantom — `class X extends RpcWorker<X>()(...)` carries `X`
       // through the result type via `Rpc<Self>` on the binding side;
-      // the instance shape itself is empty (no methods exposed on
-      // `new X(...)` — everything goes through `fetch`).
-      new (_: never): {};
+      // the instance shape itself is empty besides `Named<Id>` (no
+      // methods exposed on `new X(...)` — everything goes through
+      // `fetch`).
+      new (_: never): Named<Id>;
     };
   };
 
@@ -514,6 +529,17 @@ const wrapImpl = (impl: Effect.Effect<Effect.Effect<HttpEffect<any>>>) =>
     (fetch) => ({ fetch }) as unknown as { fetch: HttpEffect<any> },
   );
 
+// `effectClass` does not copy statics from the underlying Worker.
+const stampLogicalId = (
+  klass: Record<symbol | string, unknown>,
+  source: { LogicalId?: unknown },
+  id: string,
+) => {
+  klass.LogicalId =
+    typeof source.LogicalId === "string" ? source.LogicalId : id;
+  return klass;
+};
+
 const buildModular = (id: string, props: RpcWorkerProps<any>) => {
   const { schema } = props;
   // Delegate to `Cloudflare.Worker<Self>()(id, props)` (modular form)
@@ -531,7 +557,7 @@ const buildModular = (id: string, props: RpcWorkerProps<any>) => {
     ): Layer.Layer<any, never, any> => Underlying.make(props, wrapImpl(impl));
   } as unknown as Record<symbol | string, unknown>;
   klass[SchemaSymbol] = schema;
-  return klass;
+  return stampLogicalId(klass, Underlying, id);
 };
 
 const build = (
@@ -560,7 +586,7 @@ const build = (
   // still works.) `underlying` is already an Effect, so pass it directly.
   const klass = effectClass(
     underlying as Effect.Effect<Worker>,
-  ) as unknown as Record<symbol, unknown>;
+  ) as unknown as Record<symbol | string, unknown>;
   klass[SchemaSymbol] = schema;
-  return klass;
+  return stampLogicalId(klass, underlying, id);
 };

--- a/packages/alchemy/test/Cloudflare/Workers/RpcWorker.identity.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/RpcWorker.identity.test.ts
@@ -1,0 +1,43 @@
+import * as Cloudflare from "@/Cloudflare";
+import { normalizeTransferredFrom } from "@/Cloudflare/Workers/DurableObject";
+import { expect, test } from "alchemy-test";
+import * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
+import * as Rpc from "effect/unstable/rpc/Rpc";
+import * as RpcGroup from "effect/unstable/rpc/RpcGroup";
+import * as RpcServer from "effect/unstable/rpc/RpcServer";
+
+const ping = Rpc.make("ping", {
+  success: Schema.Void,
+  payload: {},
+});
+
+class PingRpcs extends RpcGroup.make(ping) {}
+
+class ModularRpcWorker extends Cloudflare.RpcWorker<ModularRpcWorker>()(
+  "ModularRpcWorker",
+  { schema: PingRpcs },
+) {}
+
+class InlineRpcWorker extends Cloudflare.RpcWorker<InlineRpcWorker>()(
+  "InlineRpcWorker",
+  { main: import.meta.url, schema: PingRpcs },
+  Effect.succeed(RpcServer.toHttpEffect(PingRpcs)),
+) {}
+
+test("RpcWorker modular class copies LogicalId from the underlying Worker", () => {
+  expect(ModularRpcWorker.LogicalId).toBe("ModularRpcWorker");
+});
+
+test("RpcWorker inline class copies LogicalId from the underlying Worker", () => {
+  expect(InlineRpcWorker.LogicalId).toBe("InlineRpcWorker");
+});
+
+test("RpcWorker class is a transferredFrom source by logical id", () => {
+  expect(normalizeTransferredFrom(ModularRpcWorker)).toEqual([
+    "ModularRpcWorker",
+  ]);
+  expect(normalizeTransferredFrom(InlineRpcWorker)).toEqual([
+    "InlineRpcWorker",
+  ]);
+});

--- a/packages/alchemy/test/Cloudflare/Workers/RpcWorker.types.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/RpcWorker.types.ts
@@ -1,0 +1,48 @@
+import * as Cloudflare from "@/Cloudflare";
+import type { Named } from "@/Named";
+import * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
+import * as Rpc from "effect/unstable/rpc/Rpc";
+import * as RpcGroup from "effect/unstable/rpc/RpcGroup";
+import * as RpcServer from "effect/unstable/rpc/RpcServer";
+
+const ping = Rpc.make("ping", {
+  success: Schema.Void,
+  payload: {},
+});
+
+class PingRpcs extends RpcGroup.make(ping) {}
+
+class ModularRpcWorker extends Cloudflare.RpcWorker<ModularRpcWorker>()(
+  "ModularRpcWorker",
+  { schema: PingRpcs },
+) {}
+
+class InlineRpcWorker extends Cloudflare.RpcWorker<InlineRpcWorker>()(
+  "InlineRpcWorker",
+  { main: import.meta.url, schema: PingRpcs },
+  Effect.succeed(RpcServer.toHttpEffect(PingRpcs)),
+) {}
+
+type Assert<T extends true> = T;
+
+type _ModularNamed = Assert<
+  ModularRpcWorker extends Named<"ModularRpcWorker"> ? true : false
+>;
+type _ModularLogicalId = Assert<
+  typeof ModularRpcWorker extends { readonly LogicalId: "ModularRpcWorker" }
+    ? true
+    : false
+>;
+type _InlineNamed = Assert<
+  InlineRpcWorker extends Named<"InlineRpcWorker"> ? true : false
+>;
+type _InlineLogicalId = Assert<
+  typeof InlineRpcWorker extends { readonly LogicalId: "InlineRpcWorker" }
+    ? true
+    : false
+>;
+// Widening to `string` would still satisfy Named<string>; pin the literal.
+type _ModularIdIsNotWidened = Assert<
+  ModularRpcWorker extends Named<"other"> ? false : true
+>;


### PR DESCRIPTION
RpcWorker class wrappers now keep a const logical id, the `Named<Id>` contract, and a runtime `LogicalId` copied from the underlying Worker.

```ts
class TaskWorker extends Cloudflare.RpcWorker<TaskWorker>()(
  "TaskWorker",
  { schema: TaskRpcs },
) {}

TaskWorker.LogicalId // "TaskWorker"
```

Fixes: #1391
