### PR TITLE
fix(cloudflare): wrap WorkerLoader.get() as a WorkerStub

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/WorkerLoader.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerLoader.ts
@@ -200,6 +200,32 @@ export interface WorkerLoaderClass extends Context.Service<
  * );
  * ```
  *
+ * ### Caching a Worker
+ * Call `loader.get(id, getCode)` to address a dynamic Worker by
+ * name. If an isolate with that id is already warm it is reused;
+ * `getCode` runs only on a cold start. The returned stub is a
+ * `WorkerStub`: call `.fetch()` on it directly, or
+ * `.getEntrypoint()` for a named export.
+ *
+ * **Example:** Loading a cached dynamic Worker
+ * ```typescript
+ * const worker = yield* loader.get("eval", () => ({
+ *   compatibilityDate: "2026-08-31",
+ *   mainModule: "worker.js",
+ *   modules: {
+ *     "worker.js": `export default {
+ *       async fetch() {
+ *         return new Response("cached");
+ *       }
+ *     }`,
+ *   },
+ * }));
+ *
+ * const response = yield* worker.fetch(
+ *   HttpClientRequest.get("https://worker/"),
+ * );
+ * ```
+ *
  * ### Sandboxing
  * Set `globalOutbound` to `null` to block all outbound network
  * access from the dynamic Worker, or pass an RPC stub to intercept
@@ -273,13 +299,19 @@ export const WorkerLoader: WorkerLoaderClass = Object.assign(
               Effect.sync(() =>
                 wrapWorkerStub(loader.load(unwrapWorkerLoader(options))),
               ),
-            get: <Req = never, Err = never>(
-              name: string,
-              getCode: () => Effect.Effect<WorkerLoaderWorkerCode, Err, Req>,
+            get: <Err = never, Req = never>(
+              name: string | null,
+              getCode: () =>
+                | WorkerLoaderWorkerCode
+                | Effect.Effect<WorkerLoaderWorkerCode, Err, Req>,
             ) =>
               Effect.flatMap(Effect.context<Req>(), (context) =>
                 Effect.sync(() =>
-                  wrapDynamicWorkerEntrypoint(
+                  // Native get() returns a WorkerStub, not a Fetcher. The
+                  // stub's fetcher is getEntrypoint(); wrapping the stub
+                  // itself as a Fetcher makes worker.fetch throw
+                  // "fetcher.fetch is not a function" (#1382).
+                  wrapWorkerStub(
                     loader.get(name, () =>
                       asEffect(getCode()).pipe(
                         Effect.provide(context),

--- a/packages/alchemy/test/Cloudflare/Workers/WorkerLoader.local.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/WorkerLoader.local.test.ts
@@ -1,0 +1,94 @@
+import * as Cloudflare from "@/Cloudflare/index.ts";
+import * as Test from "@/Test/Alchemy";
+import { expect } from "alchemy-test";
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+import { MinimumLogLevel } from "effect/References";
+import * as Schedule from "effect/Schedule";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import DynamicLoaderGetWorker from "./fixtures/dynamic-worker-loader/get-worker.ts";
+
+// `dev: true` runs local providers behind the RPC sidecar proxy by default,
+// matching the process topology of the real `alchemy dev` command.
+const { test } = Test.make({
+  providers: Cloudflare.providers(),
+  dev: true,
+});
+
+const logLevel = Effect.provideService(
+  MinimumLogLevel,
+  process.env.DEBUG ? "Debug" : "Info",
+);
+
+class WorkerNotReady extends Data.TaggedError("WorkerNotReady")<{
+  status: number;
+  body: string;
+}> {}
+
+const getJsonReady = (url: string) =>
+  Effect.gen(function* () {
+    const client = yield* HttpClient.HttpClient;
+    const res = yield* client.get(url).pipe(
+      Effect.flatMap((res) =>
+        res.status === 200
+          ? Effect.succeed(res)
+          : res.text.pipe(
+              Effect.flatMap((body) =>
+                Effect.fail(new WorkerNotReady({ status: res.status, body })),
+              ),
+            ),
+      ),
+      Effect.retry({
+        while: (e): e is WorkerNotReady => e instanceof WorkerNotReady,
+        schedule: Schedule.max([
+          Schedule.min([
+            Schedule.exponential("500 millis"),
+            Schedule.spaced("2 seconds"),
+          ]),
+          Schedule.recurs(10),
+        ]),
+      }),
+    );
+    return yield* res.json;
+  }).pipe(Effect.orDie);
+
+/**
+ * Deploys an Effect-native Worker that calls `loader.get()` then
+ * `worker.fetch()` against local workerd. Native get() returns a WorkerStub
+ * (fetcher is getEntrypoint()); wrapping it as a Fetcher made fetch throw
+ * (#1382). A second request with the same id must reuse the isolate.
+ */
+test.provider(
+  "local worker get() fetch works and reuses the isolate",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const deployed = yield* stack.deploy(
+        Effect.gen(function* () {
+          const worker = yield* DynamicLoaderGetWorker;
+          return { worker };
+        }),
+      );
+
+      expect(deployed.worker.url).toMatch(/^http:\/\/localhost:\d+$/);
+
+      const first = (yield* getJsonReady(
+        `${deployed.worker.url}/?id=local-reuse`,
+      )) as { id: string; hits: number };
+      expect(first).toEqual({ id: "local-reuse", hits: 1 });
+
+      const second = (yield* getJsonReady(
+        `${deployed.worker.url}/?id=local-reuse`,
+      )) as { id: string; hits: number };
+      expect(second).toEqual({ id: "local-reuse", hits: 2 });
+
+      const named = (yield* getJsonReady(
+        `${deployed.worker.url}/?id=local-named&entrypoint=1`,
+      )) as { id: string; hits: number };
+      expect(named).toEqual({ id: "local-named", hits: 1 });
+
+      yield* stack.destroy();
+    }).pipe(logLevel),
+  { timeout: 180_000 },
+);

--- a/packages/alchemy/test/Cloudflare/Workers/WorkerLoader.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/WorkerLoader.test.ts
@@ -64,11 +64,33 @@ test(
 );
 
 test(
-  "effect worker get() returns a WorkerStub whose fetch works",
+  "effect worker get() fetch proxies to a cached dynamic worker",
   Effect.gen(function* () {
-    const { effectWorkerUrl } = yield* stack;
-    const body = yield* readJson(`${effectWorkerUrl}/get`);
-    expect(body).toMatchObject({ mode: "get", ok: true });
+    const { getWorkerUrl } = yield* stack;
+    const body = yield* readJson(`${getWorkerUrl}/?id=stub`);
+    expect(body).toMatchObject({ id: "stub", hits: 1 });
+  }),
+  { timeout: 180_000 },
+);
+
+test(
+  "effect worker get() reuses the isolate for the same id",
+  Effect.gen(function* () {
+    const { getWorkerUrl } = yield* stack;
+    const first = yield* readJson(`${getWorkerUrl}/?id=reuse`);
+    const second = yield* readJson(`${getWorkerUrl}/?id=reuse`);
+    expect(first).toMatchObject({ id: "reuse", hits: 1 });
+    expect(second).toMatchObject({ id: "reuse", hits: 2 });
+  }),
+  { timeout: 180_000 },
+);
+
+test(
+  "effect worker get() getEntrypoint() fetch works",
+  Effect.gen(function* () {
+    const { getWorkerUrl } = yield* stack;
+    const body = yield* readJson(`${getWorkerUrl}/?id=named&entrypoint=1`);
+    expect(body).toMatchObject({ id: "named", hits: 1 });
   }),
   { timeout: 180_000 },
 );

--- a/packages/alchemy/test/Cloudflare/Workers/WorkerLoader.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/WorkerLoader.test.ts
@@ -63,6 +63,16 @@ test(
   { timeout: 180_000 },
 );
 
+test(
+  "effect worker get() returns a WorkerStub whose fetch works",
+  Effect.gen(function* () {
+    const { effectWorkerUrl } = yield* stack;
+    const body = yield* readJson(`${effectWorkerUrl}/get`);
+    expect(body).toMatchObject({ mode: "get", ok: true });
+  }),
+  { timeout: 180_000 },
+);
+
 // `globalOutbound: null` must reach the runtime as `null` — coercing it to
 // `undefined` (the old `?.raw` behavior) silently restores default outbound
 // access for workers meant to be sandboxed (#746). The fixture's dynamic

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/dynamic-worker-loader/effect-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/dynamic-worker-loader/effect-worker.ts
@@ -22,6 +22,23 @@ export default class DynamicLoaderEffectWorker extends Cloudflare.Worker<Dynamic
       fetch: Effect.gen(function* () {
         const request = yield* HttpServerRequest;
 
+        // `/get` pins #1382: native get() returns a WorkerStub whose
+        // fetcher is getEntrypoint(), so worker.fetch() must still work.
+        if (request.url.startsWith("/get")) {
+          const worker = yield* loader.get("cached-effect", () => ({
+            compatibilityDate: "2026-01-28",
+            mainModule: "worker.js",
+            modules: {
+              "worker.js": `export default {
+                async fetch() {
+                  return Response.json({ mode: "get", ok: true });
+                }
+              }`,
+            },
+          }));
+          return yield* worker.fetch(request).pipe(Effect.orDie);
+        }
+
         // Probe routes: the dynamic worker attempts an outbound fetch and
         // reports whether the runtime allowed it. `/outbound/sandboxed` loads
         // it with `globalOutbound: null` (network access must be blocked);

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/dynamic-worker-loader/effect-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/dynamic-worker-loader/effect-worker.ts
@@ -22,23 +22,6 @@ export default class DynamicLoaderEffectWorker extends Cloudflare.Worker<Dynamic
       fetch: Effect.gen(function* () {
         const request = yield* HttpServerRequest;
 
-        // `/get` pins #1382: native get() returns a WorkerStub whose
-        // fetcher is getEntrypoint(), so worker.fetch() must still work.
-        if (request.url.startsWith("/get")) {
-          const worker = yield* loader.get("cached-effect", () => ({
-            compatibilityDate: "2026-01-28",
-            mainModule: "worker.js",
-            modules: {
-              "worker.js": `export default {
-                async fetch() {
-                  return Response.json({ mode: "get", ok: true });
-                }
-              }`,
-            },
-          }));
-          return yield* worker.fetch(request).pipe(Effect.orDie);
-        }
-
         // Probe routes: the dynamic worker attempts an outbound fetch and
         // reports whether the runtime allowed it. `/outbound/sandboxed` loads
         // it with `globalOutbound: null` (network access must be blocked);

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/dynamic-worker-loader/get-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/dynamic-worker-loader/get-worker.ts
@@ -1,0 +1,55 @@
+import * as Cloudflare from "@/Cloudflare";
+import * as Effect from "effect/Effect";
+import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
+
+/**
+ * Effect-native Worker whose fetch handler uses `loader.get()` — not
+ * `load()` — then proxies through `worker.fetch()`. Native `get()` returns
+ * a WorkerStub whose fetcher is `getEntrypoint()`; wrapping the stub as a
+ * Fetcher made the first `worker.fetch(...)` throw
+ * `TypeError: fetcher.fetch is not a function` (#1382).
+ *
+ * Isolate id is `?id=`; `?entrypoint=1` goes through `getEntrypoint().fetch()`
+ * instead. The dynamic Worker keeps a module-scope hit counter so a second
+ * request with the same id proves the isolate was reused.
+ */
+export default class DynamicLoaderGetWorker extends Cloudflare.Worker<DynamicLoaderGetWorker>()(
+  "DynamicLoaderGetWorker",
+  {
+    main: import.meta.url,
+  },
+  Effect.gen(function* () {
+    const loader = yield* Cloudflare.WorkerLoader("LOADER");
+
+    return {
+      fetch: Effect.gen(function* () {
+        const request = yield* HttpServerRequest;
+        const url = new URL(request.url, "http://worker");
+        const id = url.searchParams.get("id") ?? "default";
+        const viaEntrypoint = url.searchParams.get("entrypoint") === "1";
+
+        const worker = yield* loader.get(id, () => ({
+          compatibilityDate: "2026-01-28",
+          mainModule: "worker.js",
+          modules: {
+            "worker.js": `let hits = 0;
+export default {
+  async fetch() {
+    hits += 1;
+    return Response.json({ id: ${JSON.stringify(id)}, hits }, {
+      headers: { "cache-control": "no-store" },
+    });
+  }
+}`,
+          },
+        }));
+
+        return yield* (
+          viaEntrypoint
+            ? worker.getEntrypoint().fetch(request)
+            : worker.fetch(request)
+        ).pipe(Effect.orDie);
+      }),
+    };
+  }),
+) {}

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/dynamic-worker-loader/stack.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/dynamic-worker-loader/stack.ts
@@ -3,6 +3,7 @@ import * as Alchemy from "@/index";
 import * as Effect from "effect/Effect";
 import * as pathe from "pathe";
 import DynamicLoaderEffectWorker from "./effect-worker.ts";
+import DynamicLoaderGetWorker from "./get-worker.ts";
 
 export const AsyncWorker = Cloudflare.Worker("DynamicLoaderAsyncWorker", {
   main: pathe.resolve(import.meta.dirname, "async-worker.ts"),
@@ -22,10 +23,12 @@ export default Alchemy.Stack(
   Effect.gen(function* () {
     const asyncWorker = yield* AsyncWorker;
     const effectWorker = yield* DynamicLoaderEffectWorker;
+    const getWorker = yield* DynamicLoaderGetWorker;
 
     return {
       asyncWorkerUrl: asyncWorker.url.as<string>(),
       effectWorkerUrl: effectWorker.url.as<string>(),
+      getWorkerUrl: getWorker.url.as<string>(),
     };
   }),
 );


### PR DESCRIPTION
Native `loader.get()` returns a WorkerStub whose fetcher is `getEntrypoint()`. `get()` was wrapping that stub with `wrapDynamicWorkerEntrypoint` / `fromCloudflareFetcher`, so the first `worker.fetch(...)` threw `TypeError: fetcher.fetch is not a function`.

`load()` already uses `wrapWorkerStub`. `get()` now does too.

```ts
wrapWorkerStub(
  loader.get(name, () =>
    asEffect(getCode()).pipe(
      Effect.provide(context),
      Effect.map(unwrapWorkerLoader),
      Effect.runPromise,
    ),
  ),
)
```

Fixes #1382
