### PR TITLE
fix(planetscale): replace or fail on rewritten branch migration history

### DIFF
--- a/packages/alchemy/src/Planetscale/Branch.ts
+++ b/packages/alchemy/src/Planetscale/Branch.ts
@@ -8,7 +8,7 @@ import { havePropsChanged, isResolved } from "../Diff.ts";
 import { createPhysicalName } from "../PhysicalName.ts";
 import * as Provider from "../Provider.ts";
 import type { ResourceClass, ResourceLike } from "../Resource.ts";
-import { hashImports, hashMigrations } from "../SQL/SqlFile.ts";
+import { hashImports } from "../SQL/SqlFile.ts";
 import { recordsEqual } from "../Util/equal.ts";
 import { ensureMySQLProductionBranchClusterSize } from "./MySQL/MySQLClusterSize.ts";
 import {
@@ -17,9 +17,11 @@ import {
   waitForPendingPostgresChanges,
 } from "./Postgres/PostgresClusterSize.ts";
 import {
-  diffMigrations,
+  classifyMigrationHistory,
+  describeRewrittenHistory,
   migrationsAttrs,
   migrationsInputOf,
+  RewrittenMigrationHistoryError,
   stampedOf,
   type MigrationRun,
   type MigrationsInput,
@@ -70,6 +72,11 @@ export interface BaseBranchProps {
    * a `Drizzle.Schema` resource, or `{ dir, table? }`. Bookkeeping lives
    * in Alchemy's `__alchemy_migrations` table; drizzle/prisma history is
    * converted one-way on first deploy.
+   *
+   * Adding a file is an in-place update. Editing or removing an
+   * already-applied file replaces a non-production branch (re-forked from
+   * its parent) and fails on a current or desired production branch — add
+   * a forward migration instead.
    */
   migrations?: MigrationsInput;
 
@@ -328,7 +335,31 @@ export const makeBranchProvider = <R extends ResourceLike>(opts: {
         }
       }
 
-      if (yield* diffMigrations({ news, output })) {
+      const migrationChange = yield* classifyMigrationHistory({
+        news,
+        output,
+      });
+      if (migrationChange.kind === "rewritten") {
+        // Editing or deleting an already-applied file cannot be replayed
+        // in place (apply is name-keyed). Development branches re-fork
+        // from the parent and apply from scratch; production must add a
+        // forward migration instead.
+        const production =
+          output?.production === true || news.isProduction === true;
+        if (production) {
+          return yield* new RewrittenMigrationHistoryError({
+            changed: migrationChange.changed,
+            removed: migrationChange.removed,
+            message:
+              `Cannot rewrite applied migration history on production PlanetScale branch ` +
+              `"${output?.name ?? news.name ?? "unknown"}" ` +
+              `(${describeRewrittenHistory(migrationChange)}). ` +
+              "Add a new forward migration instead of editing or deleting already-applied files.",
+          });
+        }
+        return { action: "replace" } as const;
+      }
+      if (migrationChange.kind === "pending") {
         return { action: "update", stables } as const;
       }
       if (news.importFiles?.length) {

--- a/packages/alchemy/src/SQL/Migrations/AlchemyFormat.ts
+++ b/packages/alchemy/src/SQL/Migrations/AlchemyFormat.ts
@@ -6,8 +6,10 @@ import {
   toTimestampString,
 } from "./Convert.ts";
 import {
+  describeRewrittenHistory,
   MigrationError,
-  MigrationHistoryConflictError,
+  RewrittenMigrationHistoryError,
+  type MigrationApplyError,
   type MigrationDialect,
   type MigrationRecord,
   type SqlExecutor,
@@ -195,20 +197,44 @@ const ensureTable = (options: {
     }
   });
 
-const appliedNames = (executor: SqlExecutor, table: string) =>
+const aliasesOf = (name: string): readonly string[] => [
+  name,
+  `${name}/migration.sql`,
+  name.replace(/\/migration\.sql$/, ""),
+];
+
+const appliedHistory = (executor: SqlExecutor, table: string) =>
   executor
-    .query(`SELECT name FROM ${quoteIdentifier(table, executor.dialect)};`)
+    .query(
+      `SELECT name, hash FROM ${quoteIdentifier(table, executor.dialect)};`,
+    )
     .pipe(
-      Effect.map(
-        (rows) =>
-          new Set(
-            rows
-              .map((row) => row.name)
-              .filter((name) => name !== null && name !== undefined)
-              .map(String),
-          ),
-      ),
+      Effect.map((rows) => {
+        const byName = new Map<string, string | undefined>();
+        for (const row of rows) {
+          if (row.name === null || row.name === undefined) continue;
+          byName.set(
+            String(row.name),
+            row.hash === null || row.hash === undefined
+              ? undefined
+              : String(row.hash),
+          );
+        }
+        return byName;
+      }),
     );
+
+const lookupApplied = (
+  byName: Map<string, string | undefined>,
+  name: string,
+): { name: string; hash: string | undefined } | undefined => {
+  for (const alias of aliasesOf(name)) {
+    if (byName.has(alias)) {
+      return { name: alias, hash: byName.get(alias) };
+    }
+  }
+  return undefined;
+};
 
 /**
  * Apply pending migrations with Alchemy's bookkeeping. Idempotent: each
@@ -219,25 +245,48 @@ const appliedNames = (executor: SqlExecutor, table: string) =>
  * Applied-detection is name-keyed with layout aliasing: pre-registry
  * Alchemy recorded drizzle-layout migrations under `<dir>/migration.sql`
  * while current records key them by `<dir>`, so both keys are honored.
+ * An already-applied name whose local hash changed, or a recorded name
+ * with no local file, is a hard {@link RewrittenMigrationHistoryError}
+ * rather than a silent skip that would persist the new hashes.
  */
 export const applyAlchemyFormat = (options: {
   executor: SqlExecutor;
   table: string;
   records: ReadonlyArray<MigrationRecord>;
-}): Effect.Effect<void, MigrationError | MigrationHistoryConflictError> =>
+}): Effect.Effect<void, MigrationApplyError> =>
   Effect.gen(function* () {
     const { executor, table, records } = options;
     if (records.length === 0) return;
     yield* ensureTable({ executor, table, records });
-    const applied = yield* appliedNames(executor, table);
+    const applied = yield* appliedHistory(executor, table);
+    const localNames = new Set(
+      records.flatMap((record) => aliasesOf(record.name)),
+    );
+    const changed: string[] = [];
+    const removed: string[] = [];
+    for (const name of applied.keys()) {
+      if (!localNames.has(name)) removed.push(name);
+    }
     for (const record of records) {
-      if (
-        applied.has(record.name) ||
-        applied.has(`${record.name}/migration.sql`) ||
-        applied.has(record.name.replace(/\/migration\.sql$/, ""))
-      ) {
-        continue;
+      const row = lookupApplied(applied, record.name);
+      if (row?.hash && row.hash !== record.hash) {
+        changed.push(record.name);
       }
+    }
+    if (changed.length > 0 || removed.length > 0) {
+      changed.sort();
+      removed.sort();
+      return yield* new RewrittenMigrationHistoryError({
+        changed,
+        removed,
+        message:
+          `Applied migration history in "${table}" does not match the local files ` +
+          `(${describeRewrittenHistory({ changed, removed })}). ` +
+          "Add a new forward migration instead of editing or deleting already-applied files.",
+      });
+    }
+    for (const record of records) {
+      if (lookupApplied(applied, record.name)) continue;
       yield* executor.batch([
         ...record.statements,
         insertSql(table, executor.dialect, record),

--- a/packages/alchemy/src/SQL/Migrations/Format.ts
+++ b/packages/alchemy/src/SQL/Migrations/Format.ts
@@ -84,6 +84,38 @@ export class MigrationHistoryConflictError extends Data.TaggedError(
   message: string;
 }> {}
 
+/**
+ * Already-applied migration files were edited or removed. History is
+ * forward-only: add a new migration instead of rewriting files that have
+ * already run. PlanetScale development branches replace rather than
+ * raising this; production branches (and in-place apply on any target)
+ * fail with it.
+ */
+export class RewrittenMigrationHistoryError extends Data.TaggedError(
+  "RewrittenMigrationHistoryError",
+)<{
+  changed: ReadonlyArray<string>;
+  removed: ReadonlyArray<string>;
+  message: string;
+}> {}
+
+/** Human-readable `changed X; removed Y` fragment for rewritten-history errors. */
+export const describeRewrittenHistory = (options: {
+  changed: ReadonlyArray<string>;
+  removed: ReadonlyArray<string>;
+}): string =>
+  [
+    options.changed.length > 0
+      ? `changed ${options.changed.join(", ")}`
+      : undefined,
+    options.removed.length > 0
+      ? `removed ${options.removed.join(", ")}`
+      : undefined,
+  ]
+    .filter((part): part is string => part !== undefined)
+    .join("; ");
+
 export type MigrationApplyError =
   | MigrationError
-  | MigrationHistoryConflictError;
+  | MigrationHistoryConflictError
+  | RewrittenMigrationHistoryError;

--- a/packages/alchemy/src/SQL/Migrations/Registry.ts
+++ b/packages/alchemy/src/SQL/Migrations/Registry.ts
@@ -8,7 +8,7 @@ import { detectLayout } from "./Detect.ts";
 import {
   MigrationError,
   type DrizzleV0LayoutError,
-  type MigrationHistoryConflictError,
+  type MigrationApplyError,
   type SqlExecutor,
 } from "./Format.ts";
 import { readDrizzleDirRecords, readFlatRecords } from "./Records.ts";
@@ -106,7 +106,7 @@ export const applyMigrations = (options: {
   executor: SqlExecutor;
 }): Effect.Effect<
   void,
-  MigrationError | MigrationHistoryConflictError | DrizzleV0LayoutError,
+  MigrationApplyError | DrizzleV0LayoutError,
   FileSystem.FileSystem | Path.Path
 > =>
   Effect.gen(function* () {
@@ -156,7 +156,7 @@ export const runMigrations = <E, R>(options: {
       executor: SqlExecutor,
     ) => Effect.Effect<
       void,
-      MigrationError | MigrationHistoryConflictError | DrizzleV0LayoutError,
+      MigrationApplyError | DrizzleV0LayoutError,
       FileSystem.FileSystem | Path.Path
     >,
   ) => Effect.Effect<void, E, R>;
@@ -177,9 +177,85 @@ export const runMigrations = <E, R>(options: {
   });
 
 /**
+ * Prior migration files whose contents changed or that disappeared from
+ * the directory, relative to the hashes persisted on the last deploy.
+ * Additive files (new names) are not rewritten history.
+ */
+export const rewrittenMigrationHistory = (
+  previous: Record<string, string> | undefined,
+  next: Record<string, string>,
+): { changed: string[]; removed: string[] } | undefined => {
+  if (previous === undefined) return undefined;
+  const changed: string[] = [];
+  const removed: string[] = [];
+  for (const name of Object.keys(previous)) {
+    const hash = next[name];
+    if (hash === undefined) removed.push(name);
+    else if (hash !== previous[name]) changed.push(name);
+  }
+  changed.sort();
+  removed.sort();
+  if (changed.length === 0 && removed.length === 0) return undefined;
+  return { changed, removed };
+};
+
+export type MigrationHistoryChange =
+  | { readonly kind: "none" }
+  | { readonly kind: "pending" }
+  | {
+      readonly kind: "rewritten";
+      readonly changed: ReadonlyArray<string>;
+      readonly removed: ReadonlyArray<string>;
+    };
+
+/**
+ * Classify the migration half of a provider `diff`:
+ * - `none` — hashes and bookkeeping table are unchanged
+ * - `pending` — new files and/or a table rename; apply in place
+ * - `rewritten` — an already-applied file was edited or removed
+ */
+export const classifyMigrationHistory = (options: {
+  news: { migrations?: MigrationsInput };
+  output:
+    | {
+        migrationsTable: string | undefined;
+        migrationsHashes: Record<string, string>;
+      }
+    | undefined;
+}): Effect.Effect<
+  MigrationHistoryChange,
+  MigrationError,
+  FileSystem.FileSystem | Path.Path
+> =>
+  Effect.gen(function* () {
+    const input = migrationsInputOf(options.news);
+    if (!input) return { kind: "none" } as const;
+    const newHashes = yield* hashMigrationsDir(input.dir);
+    const rewritten = rewrittenMigrationHistory(
+      options.output?.migrationsHashes,
+      newHashes,
+    );
+    if (rewritten) {
+      return { kind: "rewritten", ...rewritten } as const;
+    }
+    if (!recordsEqual(newHashes, options.output?.migrationsHashes ?? {})) {
+      return { kind: "pending" } as const;
+    }
+    const resolved = resolveMigrations({
+      input,
+      stamped: stampedOf(options.output),
+    });
+    return resolved.table !==
+      (options.output?.migrationsTable ?? resolved.table)
+      ? ({ kind: "pending" } as const)
+      : ({ kind: "none" } as const);
+  });
+
+/**
  * The shared migration half of a provider `diff`: true when pending file
- * changes or a bookkeeping-table move require an update. Callers decide the
- * action shape (`{ action: "update" }`, with or without stables).
+ * changes, rewritten history, or a bookkeeping-table move require an
+ * action. Callers that can replace (PlanetScale development branches)
+ * should consult {@link classifyMigrationHistory} instead of this boolean.
  */
 export const diffMigrations = (options: {
   news: { migrations?: MigrationsInput };
@@ -190,21 +266,9 @@ export const diffMigrations = (options: {
       }
     | undefined;
 }): Effect.Effect<boolean, MigrationError, FileSystem.FileSystem | Path.Path> =>
-  Effect.gen(function* () {
-    const input = migrationsInputOf(options.news);
-    if (!input) return false;
-    const newHashes = yield* hashMigrationsDir(input.dir);
-    if (!recordsEqual(newHashes, options.output?.migrationsHashes ?? {})) {
-      return true;
-    }
-    const resolved = resolveMigrations({
-      input,
-      stamped: stampedOf(options.output),
-    });
-    return (
-      resolved.table !== (options.output?.migrationsTable ?? resolved.table)
-    );
-  });
+  classifyMigrationHistory(options).pipe(
+    Effect.map((change) => change.kind !== "none"),
+  );
 
 /**
  * The migration attributes every SQL database resource persists, threaded

--- a/packages/alchemy/src/SQL/Migrations/index.ts
+++ b/packages/alchemy/src/SQL/Migrations/index.ts
@@ -7,9 +7,11 @@ export {
 } from "./Convert.ts";
 export { detectLayout, type MigrationLayout } from "./Detect.ts";
 export {
+  describeRewrittenHistory,
   DrizzleV0LayoutError,
   MigrationError,
   MigrationHistoryConflictError,
+  RewrittenMigrationHistoryError,
   type MigrationApplyError,
   type MigrationDialect,
   type MigrationRecord,
@@ -27,13 +29,16 @@ export {
 } from "./Records.ts";
 export {
   applyMigrations,
+  classifyMigrationHistory,
   diffMigrations,
   migrationsAttrs,
   migrationsInputOf,
+  rewrittenMigrationHistory,
   runMigrations,
   normalizeMigrationsInput,
   resolveMigrations,
   stampedOf,
+  type MigrationHistoryChange,
   type MigrationRun,
   type MigrationsInput,
   type NormalizedMigrationsInput,

--- a/packages/alchemy/test/Planetscale/Branch.test.ts
+++ b/packages/alchemy/test/Planetscale/Branch.test.ts
@@ -1,10 +1,14 @@
 import * as Planetscale from "@/Planetscale";
 import * as Provider from "@/Provider";
+import { hashMigrations } from "@/SQL/SqlFile.ts";
 import * as Test from "@/Test/Alchemy";
 import * as ps from "@distilled.cloud/planetscale";
 import { describe, expect } from "alchemy-test";
 import { Data, Schedule } from "effect";
 import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+import * as Result from "effect/Result";
 import { MinimumLogLevel } from "effect/References";
 
 const { test } = Test.make({ providers: Planetscale.providers() });
@@ -82,6 +86,207 @@ test.provider("diff tracks Postgres branch replica intent", () =>
       stables: ["organization", "database", "name"],
     });
   }),
+);
+
+const writeMigrationDir = (files: Record<string, string>) =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const dir = yield* fs.makeTempDirectoryScoped({
+      prefix: "alchemy-ps-branch-mig-",
+    });
+    for (const [name, sql] of Object.entries(files)) {
+      yield* fs.writeFileString(path.join(dir, name), sql);
+    }
+    const hashes = yield* hashMigrations(dir);
+    return { dir, hashes };
+  });
+
+const postgresProps = (
+  migrations: string,
+): Planetscale.PostgresBranchProps => ({
+  database: "database",
+  parentBranch: "main",
+  migrations,
+});
+
+const mysqlProps = (
+  migrations: string,
+  isProduction: boolean,
+): Planetscale.MySQLBranchProps => ({
+  database: "database",
+  parentBranch: "main",
+  isProduction,
+  migrations,
+});
+
+const diffArgs = <P, A>(news: P, olds: P, output: A) => ({
+  id: "Branch",
+  fqn: "Branch",
+  instanceId: "instance",
+  olds,
+  news,
+  oldBindings: [] as never[],
+  newBindings: [] as never[],
+  output,
+});
+
+// #1389: Branch.diff treated every migrationsHashes change as an in-place
+// update. The runner then skipped already-applied names without checking
+// hashes and persisted the rewritten hashes, silently accepting history
+// rewrites.
+test.provider(
+  "diff replaces a non-production branch when a prior migration is rewritten",
+  () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const { dir, hashes } = yield* writeMigrationDir({
+        "0001_init.sql": "CREATE TABLE users (id int);",
+      });
+      const provider = yield* Provider.findProvider(Planetscale.PostgresBranch);
+      const props = postgresProps(dir);
+      const output = branchOutput({
+        production: false,
+        migrationsDir: dir,
+        migrationsTable: "__alchemy_migrations",
+        migrationsHashes: hashes,
+      });
+
+      yield* fs.writeFileString(
+        path.join(dir, "0001_init.sql"),
+        "CREATE TABLE users (id int, name text);",
+      );
+
+      const diff = yield* provider.diff!(diffArgs(props, props, output));
+      expect(diff).toEqual({ action: "replace" });
+    }),
+);
+
+test.provider(
+  "diff replaces a non-production branch when a prior migration is removed",
+  () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const { dir, hashes } = yield* writeMigrationDir({
+        "0001_init.sql": "CREATE TABLE users (id int);",
+        "0002_posts.sql": "CREATE TABLE posts (id int);",
+      });
+      const provider = yield* Provider.findProvider(Planetscale.PostgresBranch);
+      const props = postgresProps(dir);
+      const output = branchOutput({
+        production: false,
+        migrationsDir: dir,
+        migrationsTable: "__alchemy_migrations",
+        migrationsHashes: hashes,
+      });
+
+      yield* fs.remove(path.join(dir, "0001_init.sql"));
+
+      const diff = yield* provider.diff!(diffArgs(props, props, output));
+      expect(diff).toEqual({ action: "replace" });
+    }),
+);
+
+test.provider("diff still updates when a new forward migration is added", () =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const { dir, hashes } = yield* writeMigrationDir({
+      "0001_init.sql": "CREATE TABLE users (id int);",
+    });
+    const provider = yield* Provider.findProvider(Planetscale.PostgresBranch);
+    const props = postgresProps(dir);
+    const output = branchOutput({
+      production: false,
+      migrationsDir: dir,
+      migrationsTable: "__alchemy_migrations",
+      migrationsHashes: hashes,
+    });
+
+    yield* fs.writeFileString(
+      path.join(dir, "0002_posts.sql"),
+      "CREATE TABLE posts (id int);",
+    );
+
+    const diff = yield* provider.diff!(diffArgs(props, props, output));
+    expect(diff).toEqual({
+      action: "update",
+      stables: ["organization", "database", "name"],
+    });
+  }),
+);
+
+test.provider(
+  "diff fails when a production branch's prior migration is rewritten",
+  () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const { dir, hashes } = yield* writeMigrationDir({
+        "0001_init.sql": "CREATE TABLE users (id int);",
+      });
+      const provider = yield* Provider.findProvider(Planetscale.PostgresBranch);
+      const props = postgresProps(dir);
+      const output = branchOutput({
+        production: true,
+        migrationsDir: dir,
+        migrationsTable: "__alchemy_migrations",
+        migrationsHashes: hashes,
+      });
+
+      yield* fs.writeFileString(
+        path.join(dir, "0001_init.sql"),
+        "CREATE TABLE users (id int, name text);",
+      );
+
+      const result = yield* Effect.result(
+        provider.diff!(diffArgs(props, props, output)),
+      );
+      expect(Result.isFailure(result)).toBe(true);
+      if (Result.isFailure(result)) {
+        expect(result.failure._tag).toBe("RewrittenMigrationHistoryError");
+        expect(result.failure.message).toContain("forward migration");
+        expect(result.failure.message).toContain("0001_init.sql");
+      }
+    }),
+);
+
+test.provider(
+  "diff fails when a desired production MySQL branch's prior migration is rewritten",
+  () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const { dir, hashes } = yield* writeMigrationDir({
+        "0001_init.sql": "CREATE TABLE users (id int);",
+      });
+      const provider = yield* Provider.findProvider(Planetscale.MySQLBranch);
+      const props = mysqlProps(dir, true);
+      const output: Planetscale.MySQLBranchAttributes = branchOutput({
+        production: false,
+        migrationsDir: dir,
+        migrationsTable: "__alchemy_migrations",
+        migrationsHashes: hashes,
+      });
+
+      yield* fs.writeFileString(
+        path.join(dir, "0001_init.sql"),
+        "CREATE TABLE users (id int, name text);",
+      );
+
+      const result = yield* Effect.result(
+        provider.diff!(diffArgs(props, props, output)),
+      );
+      expect(Result.isFailure(result)).toBe(true);
+      if (Result.isFailure(result)) {
+        expect(result.failure._tag).toBe("RewrittenMigrationHistoryError");
+        expect(result.failure.message).toContain(
+          "production PlanetScale branch",
+        );
+      }
+    }),
 );
 
 describe.skipIf(!process.env.PLANETSCALE_TEST)("Branch", () => {

--- a/packages/alchemy/test/SQL/Migrations/Formats.sqlite.test.ts
+++ b/packages/alchemy/test/SQL/Migrations/Formats.sqlite.test.ts
@@ -90,6 +90,70 @@ describe("alchemy format", (it) => {
     }),
   );
 
+  // #1389: name-keyed skip used to ignore content hashes, then the
+  // resource persisted the new hashes as if the rewrite had applied.
+  it.effect("fails when an already-applied migration's contents changed", () =>
+    Effect.gen(function* () {
+      const db = new Database(":memory:");
+      const executor = makeSqliteExecutor(db);
+      const records = yield* readFlatRecords(fixture("flat"));
+      yield* applyAlchemyFormat({
+        executor,
+        table: "__alchemy_migrations",
+        records,
+      });
+      const rewritten = [
+        {
+          ...records[0],
+          hash: "a".repeat(64),
+          sql: "SELECT 1;",
+          statements: ["SELECT 1;"],
+        },
+        records[1],
+      ];
+      const result = yield* Effect.result(
+        applyAlchemyFormat({
+          executor,
+          table: "__alchemy_migrations",
+          records: rewritten,
+        }),
+      );
+      expect(Result.isFailure(result)).toBe(true);
+      if (Result.isFailure(result)) {
+        expect(result.failure._tag).toBe("RewrittenMigrationHistoryError");
+        expect(result.failure.message).toContain("0001_users.sql");
+      }
+      expect(migrationRows(db).map((r) => r.hash)).toEqual(
+        records.map((r) => r.hash),
+      );
+    }),
+  );
+
+  it.effect("fails when an already-applied migration file is removed", () =>
+    Effect.gen(function* () {
+      const db = new Database(":memory:");
+      const executor = makeSqliteExecutor(db);
+      const records = yield* readFlatRecords(fixture("flat"));
+      yield* applyAlchemyFormat({
+        executor,
+        table: "__alchemy_migrations",
+        records,
+      });
+      const result = yield* Effect.result(
+        applyAlchemyFormat({
+          executor,
+          table: "__alchemy_migrations",
+          records: records.slice(1),
+        }),
+      );
+      expect(Result.isFailure(result)).toBe(true);
+      if (Result.isFailure(result)) {
+        expect(result.failure._tag).toBe("RewrittenMigrationHistoryError");
+        expect(result.failure.message).toContain("0001_users.sql");
+      }
+    }),
+  );
+
   it.effect(
     "upgrades the legacy Alchemy 3-column table in place without replaying",
     () =>

--- a/packages/alchemy/test/SQL/Migrations/History.test.ts
+++ b/packages/alchemy/test/SQL/Migrations/History.test.ts
@@ -1,0 +1,142 @@
+import {
+  classifyMigrationHistory,
+  rewrittenMigrationHistory,
+} from "@/SQL/Migrations/index.ts";
+import { hashMigrations } from "@/SQL/SqlFile.ts";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { expect, layer } from "alchemy-test";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+
+const describe = layer(NodeServices.layer);
+
+describe("rewrittenMigrationHistory", (it) => {
+  it.effect("treats missing prior hashes as not rewritten", () =>
+    Effect.sync(() => {
+      expect(
+        rewrittenMigrationHistory(undefined, { "0001.sql": "aaa" }),
+      ).toBeUndefined();
+    }),
+  );
+
+  it.effect("treats additive files as not rewritten", () =>
+    Effect.sync(() => {
+      expect(
+        rewrittenMigrationHistory(
+          { "0001.sql": "aaa" },
+          { "0001.sql": "aaa", "0002.sql": "bbb" },
+        ),
+      ).toBeUndefined();
+    }),
+  );
+
+  it.effect("detects a changed hash on an already-applied file", () =>
+    Effect.sync(() => {
+      expect(
+        rewrittenMigrationHistory(
+          { "0001.sql": "aaa", "0002.sql": "bbb" },
+          { "0001.sql": "ccc", "0002.sql": "bbb" },
+        ),
+      ).toEqual({ changed: ["0001.sql"], removed: [] });
+    }),
+  );
+
+  it.effect("detects a removed already-applied file", () =>
+    Effect.sync(() => {
+      expect(
+        rewrittenMigrationHistory(
+          { "0001.sql": "aaa", "0002.sql": "bbb" },
+          { "0002.sql": "bbb" },
+        ),
+      ).toEqual({ changed: [], removed: ["0001.sql"] });
+    }),
+  );
+});
+
+const writeDir = (files: Record<string, string>) =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const dir = yield* fs.makeTempDirectoryScoped({
+      prefix: "alchemy-mig-hist-",
+    });
+    for (const [name, sql] of Object.entries(files)) {
+      yield* fs.writeFileString(path.join(dir, name), sql);
+    }
+    return dir;
+  });
+
+describe("classifyMigrationHistory", (it) => {
+  it.effect("classifies a new file as pending", () =>
+    Effect.gen(function* () {
+      const dir = yield* writeDir({
+        "0001_init.sql": "CREATE TABLE users (id int);",
+        "0002_posts.sql": "CREATE TABLE posts (id int);",
+      });
+      const hashes = yield* hashMigrations(dir);
+      const previous = { ...hashes };
+      delete previous["0002_posts.sql"];
+      const change = yield* classifyMigrationHistory({
+        news: { migrations: dir },
+        output: {
+          migrationsTable: "__alchemy_migrations",
+          migrationsHashes: previous,
+        },
+      });
+      expect(change).toEqual({ kind: "pending" });
+    }),
+  );
+
+  it.effect("classifies an edited prior file as rewritten", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const dir = yield* writeDir({
+        "0001_init.sql": "CREATE TABLE users (id int);",
+      });
+      const previous = yield* hashMigrations(dir);
+      yield* fs.writeFileString(
+        path.join(dir, "0001_init.sql"),
+        "CREATE TABLE users (id int, name text);",
+      );
+      const change = yield* classifyMigrationHistory({
+        news: { migrations: dir },
+        output: {
+          migrationsTable: "__alchemy_migrations",
+          migrationsHashes: previous,
+        },
+      });
+      expect(change.kind).toBe("rewritten");
+      if (change.kind === "rewritten") {
+        expect(change.changed).toEqual(["0001_init.sql"]);
+        expect(change.removed).toEqual([]);
+      }
+    }),
+  );
+
+  it.effect("classifies a deleted prior file as rewritten", () =>
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const dir = yield* writeDir({
+        "0001_init.sql": "CREATE TABLE users (id int);",
+        "0002_posts.sql": "CREATE TABLE posts (id int);",
+      });
+      const previous = yield* hashMigrations(dir);
+      yield* fs.remove(path.join(dir, "0001_init.sql"));
+      const change = yield* classifyMigrationHistory({
+        news: { migrations: dir },
+        output: {
+          migrationsTable: "__alchemy_migrations",
+          migrationsHashes: previous,
+        },
+      });
+      expect(change.kind).toBe("rewritten");
+      if (change.kind === "rewritten") {
+        expect(change.changed).toEqual([]);
+        expect(change.removed).toEqual(["0001_init.sql"]);
+      }
+    }),
+  );
+});

--- a/website/src/content/docs/neon/data/migrations.mdx
+++ b/website/src/content/docs/neon/data/migrations.mdx
@@ -60,7 +60,8 @@ is frozen. Projects deployed by older Alchemy versions (which used a
 `neon_migrations` table) are upgraded in place.
 
 On each deploy, files whose names already appear in the table are
-skipped. Use `migrations: { dir, table }` to put the bookkeeping in
+skipped, and their content hashes must still match. Use
+`migrations: { dir, table }` to put the bookkeeping in
 a differently-named table:
 
 ```typescript

--- a/website/src/content/docs/planetscale/data/migrations.mdx
+++ b/website/src/content/docs/planetscale/data/migrations.mdx
@@ -55,10 +55,18 @@ Files are discovered recursively under the migrations directory and sorted by
 their numeric prefix (`0001_init.sql`, `0002_users.sql`, … — Drizzle's
 timestamp prefixes work too), falling back to name order for files
 without one. Each file's contents are SHA-256 hashed and the hashes
-are persisted in the resource's state (`migrationsHashes`), so adding
-a migration file — or editing an existing one — is what marks the
-resource for an update on the next deploy. When nothing changed, the
-migration step is skipped.
+are persisted in the resource's state (`migrationsHashes`).
+
+Adding a new file is an in-place update: already-applied names are
+skipped and only the new file runs. Editing or deleting a file that
+has already been applied is rewritten history and cannot be replayed
+in place:
+
+- A **non-production branch** is replaced (re-forked from its parent
+  and migrated from scratch).
+- A **current or desired production branch** fails the plan. Add a
+  new forward migration instead of rewriting files that have already
+  run.
 
 ## The tracking table
 
@@ -76,7 +84,9 @@ CREATE TABLE IF NOT EXISTS "__alchemy_migrations" (
 ```
 
 (The MySQL flavor is the same shape with MySQL types.) On each
-deploy, files whose names already appear in the table are skipped.
+deploy, files whose names already appear in the table are skipped
+**and** their content hashes must still match. A hash mismatch or a
+recorded name with no local file is a hard error.
 
 A database previously migrated with drizzle-kit or Prisma is
 [adopted automatically](/sql/effect-sql/migrations#adopting-an-existing-database):

--- a/website/src/content/docs/sql/effect-sql/migrations.mdx
+++ b/website/src/content/docs/sql/effect-sql/migrations.mdx
@@ -95,9 +95,13 @@ running its migrate command.
 
 Two guard rails:
 
-- Every recorded row must match a local migration file; an orphaned
-  row fails the deploy with `MigrationHistoryConflictError` — it
-  means migrations were applied that your checkout doesn't have.
+- Every recorded row must match a local migration file by name and
+  content hash. An orphaned row fails conversion with
+  `MigrationHistoryConflictError`; an already-applied file that was
+  edited or removed fails with `RewrittenMigrationHistoryError`.
+  Add a forward migration rather than rewriting history. PlanetScale
+  development branches replace (re-fork from parent) instead of
+  failing; production branches always fail.
 - A **failed** Prisma migration (`finished_at` NULL) blocks adoption
   until repaired with `prisma migrate resolve`; rolled-back rows are
   skipped.


### PR DESCRIPTION
Editing or removing an already-applied PlanetScale branch migration was planned as an in-place update. Apply then skipped by name (no hash check) and persisted the new hashes, so rewritten history was silently accepted.

Non-production branches now replace (re-fork from parent). A current or desired production branch fails and requires a forward migration.

```ts
// development branch, prior file edited or removed
{ action: "replace" }

// production branch
RewrittenMigrationHistoryError
```

The shared runner also refuses hash mismatches and missing applied names, so an in-place apply cannot persist rewritten hashes.

Fixes #1389
