### PR TITLE
feat(cloudflare/workflows): support native cron schedules

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/WorkerAsyncBindings.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerAsyncBindings.ts
@@ -215,6 +215,7 @@ export const bindWorkerAsyncBindings = Effect.fn(function* (
               className,
               scriptName: resource.workerName,
               limits: binding.limits,
+              schedules: binding.schedules,
             });
           }
         }

--- a/packages/alchemy/src/Cloudflare/Workflows/Workflow.ts
+++ b/packages/alchemy/src/Cloudflare/Workflows/Workflow.ts
@@ -40,12 +40,27 @@ export class WorkflowEvent extends Context.Service<
     timestamp: Date;
     instanceId: string;
     workflowName: string;
+    /**
+     * Present when Cloudflare created this instance from a native
+     * {@link WorkflowProps.schedules} cron expression. Absent for
+     * instances started with `create` / `createBatch`.
+     */
     schedule?: WorkflowCronSchedule;
   }
 >()("Cloudflare.Workflows.WorkflowEvent") {}
 
+/**
+ * Cron trigger metadata on a Workflow instance created by a native
+ * `schedules` expression. Mirrors Cloudflare's `event.schedule`.
+ */
 export interface WorkflowCronSchedule {
+  /**
+   * The matching cron expression that created this instance.
+   */
   cron: string;
+  /**
+   * The scheduled fire time, milliseconds since the Unix epoch.
+   */
   scheduledTime: number;
 }
 
@@ -319,6 +334,20 @@ export interface WorkflowRefProps {
    * the Worker that declares the binding; ignored when `scriptName` is set.
    */
   limits?: WorkflowLimits;
+  /**
+   * Cron expressions that create a new Workflow instance on each match.
+   * Wrangler-compatible: `schedules: ["0 * * * *"]`.
+   *
+   * Native Workflow schedules replace a Worker Cron Trigger whose
+   * `scheduled` handler called `workflow.create()`. Pass an empty
+   * array to remove all schedules.
+   *
+   * Only applies when the workflow is hosted by the Worker that declares
+   * the binding; ignored when `scriptName` is set.
+   *
+   * Account-wide limit: 100 cron expressions.
+   */
+  schedules?: string[];
 }
 
 /**
@@ -331,6 +360,17 @@ export interface WorkflowProps {
    * Limits applied to the workflow.
    */
   limits?: WorkflowLimits;
+  /**
+   * Cron expressions that create a new Workflow instance on each match.
+   * Wrangler-compatible: `schedules: ["0 * * * *"]`.
+   *
+   * Native Workflow schedules replace a Worker Cron Trigger whose
+   * `scheduled` handler called `workflow.create()`. Pass an empty
+   * array to remove all schedules.
+   *
+   * Account-wide limit: 100 cron expressions.
+   */
+  schedules?: string[];
 }
 
 /**
@@ -350,6 +390,8 @@ export interface WorkflowLike<Params = unknown> {
   scriptName?: Input<string>;
   /** @internal phantom */
   limits?: WorkflowLimits;
+  /** @internal phantom */
+  schedules?: string[];
   /** @internal phantom */
   Params?: Params;
 }
@@ -561,6 +603,26 @@ export class WorkflowScope extends Context.Service<
  * ) {}
  * ```
  *
+ * ### Scheduling instances
+ * Each matching cron expression creates a new instance automatically —
+ * no Worker Cron Trigger or `scheduled` handler required.
+ * **Example:** Native cron schedules
+ * ```typescript
+ * export default class HourlyWorkflow extends Cloudflare.Workflow<HourlyWorkflow>()(
+ *   "HourlyWorkflow",
+ *   { schedules: ["0 * * * *"] },
+ *   Effect.gen(function* () {
+ *     return Effect.fn(function* () {
+ *       const event = yield* Cloudflare.Workflows.WorkflowEvent;
+ *       if (event.schedule) {
+ *         return { cron: event.schedule.cron };
+ *       }
+ *       return {};
+ *     });
+ *   }),
+ * ) {}
+ * ```
+ *
  * ### Step Primitives
  * **Example:** Running a named task
  * ```typescript
@@ -729,6 +791,19 @@ export class WorkflowScope extends Context.Service<
  * });
  * ```
  *
+ * **Example:** Native cron schedules on an async Workflow binding
+ * ```typescript
+ * export const Worker = Cloudflare.Worker("Worker", {
+ *   main: "./src/worker.ts",
+ *   env: {
+ *     HOURLY: Cloudflare.Workflow("HourlyWorkflow", {
+ *       className: "HourlyWorkflow",
+ *       schedules: ["0 * * * *"],
+ *     }),
+ *   },
+ * });
+ * ```
+ *
  * **Example:** Using the Workflow from a plain async handler
  * ```typescript
  * // src/worker.ts
@@ -838,6 +913,7 @@ export const Workflow: WorkflowClass = taggedFunction(WorkflowScope, ((
       className: refProps?.className ?? name,
       scriptName: refProps?.scriptName,
       limits: refProps?.limits,
+      schedules: refProps?.schedules,
     } satisfies WorkflowLike;
   }
   const props = Effect.isEffect(second) ? undefined : (second as WorkflowProps);
@@ -853,6 +929,7 @@ export const Workflow: WorkflowClass = taggedFunction(WorkflowScope, ((
         className: name,
         scriptName: worker.workerName,
         limits: props?.limits,
+        schedules: props?.schedules,
       });
 
       // Add the workflow binding to the Worker metadata
@@ -940,6 +1017,11 @@ export interface WorkflowResourceProps {
   className: string;
   scriptName: string;
   limits?: WorkflowLimits;
+  /**
+   * Cron expressions that create a new Workflow instance on each match.
+   * Pass an empty array to remove all schedules.
+   */
+  schedules?: string[];
 }
 
 export interface WorkflowResourceAttrs {
@@ -948,6 +1030,10 @@ export interface WorkflowResourceAttrs {
   className: string;
   scriptName: string;
   accountId: string;
+  /**
+   * Cron expressions currently attached to this Workflow.
+   */
+  schedules: string[];
 }
 
 const WorkflowResourceTypeId = "Cloudflare.Workflow";
@@ -991,6 +1077,7 @@ export const ProviderLive = () =>
                 className: wf.className ?? "",
                 scriptName: wf.scriptName ?? "",
                 accountId,
+                schedules: fromObservedSchedules(wf.schedules),
               })),
             ),
           ),
@@ -1014,6 +1101,7 @@ export const ProviderLive = () =>
             className: workflow.className,
             scriptName: workflow.scriptName,
             accountId: acct,
+            schedules: fromObservedSchedules(workflow.schedules),
           })),
           Effect.catchTag("WorkflowNotFound", () => Effect.succeed(undefined)),
         );
@@ -1033,6 +1121,13 @@ export const ProviderLive = () =>
         className: news.className,
         scriptName: news.scriptName,
         limits: news.limits,
+        // Same as `limits`: only send when the prop is set. `[]` clears
+        // attached schedules; omitting the field leaves Cloudflare's
+        // current list untouched.
+        schedules:
+          news.schedules === undefined
+            ? undefined
+            : toPutSchedules(news.schedules),
       });
       return {
         workflowId: result.id,
@@ -1040,6 +1135,7 @@ export const ProviderLive = () =>
         className: result.className,
         scriptName: result.scriptName,
         accountId: acct,
+        schedules: news.schedules ?? output?.schedules ?? [],
       };
     }),
     delete: Effect.fn(function* ({ output }) {
@@ -1087,6 +1183,7 @@ export const ProviderLocal = () =>
         className: news.className,
         scriptName: news.scriptName,
         accountId: output?.accountId ?? accountId,
+        schedules: news.schedules ?? output?.schedules ?? [],
       };
     }),
     delete: Effect.fn(function* () {
@@ -1105,6 +1202,14 @@ export const WorkflowProvider = () =>
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+const toPutSchedules = (
+  schedules: string[],
+): workflows.UpdateRequestSchedulesList => schedules.map((cron) => ({ cron }));
+
+const fromObservedSchedules = (
+  schedules?: ReadonlyArray<{ cron: string }> | null,
+): string[] => (schedules ?? []).map((s) => s.cron);
 
 const wrapInstance = <Result>(raw: any): WorkflowInstance<Result> => ({
   id: raw.id,

--- a/packages/alchemy/src/Cloudflare/Workflows/WorkflowBridge.ts
+++ b/packages/alchemy/src/Cloudflare/Workflows/WorkflowBridge.ts
@@ -131,7 +131,7 @@ const wrapWorkflowEvent = (event: any): WorkflowEventService["Service"] => ({
       : new Date(event.timestamp),
   instanceId: event.instanceId ?? "",
   workflowName: event.workflowName ?? "",
-  schedule: event.schedule,
+  schedule: event.schedule ?? undefined,
 });
 
 export const wrapWorkflowStep = (step: any): WorkflowStep["Service"] => ({

--- a/packages/alchemy/test/Cloudflare/Workers/Workflow.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/Workflow.test.ts
@@ -12,6 +12,8 @@ import * as Stream from "effect/Stream";
 import * as HttpClient from "effect/unstable/http/HttpClient";
 import LimitsWorkflowWorker from "./fixtures/workflow-limits/limits-worker.ts";
 import { STEP_LIMIT } from "./fixtures/workflow-limits/limits-workflow.ts";
+import ScheduledWorkflowWorker from "./fixtures/workflow-schedules/scheduled-worker.ts";
+import { YEARLY_CRON } from "./fixtures/workflow-schedules/scheduled-workflow.ts";
 import Stack from "./fixtures/workflow/stack.ts";
 import WorkflowTestWorker from "./fixtures/workflow/workflow-worker.ts";
 
@@ -343,6 +345,57 @@ test.provider(
       const workflowName = yield* readWorkflowName(deployed.worker.workerName);
       const applied = yield* waitForAppliedStepLimit(workflowName, STEP_LIMIT);
       expect(applied).toBe(STEP_LIMIT);
+
+      yield* scratch.destroy();
+    }).pipe(logLevel),
+  { timeout: 120_000 },
+);
+
+// ---------------------------------------------------------------------------
+// #1473 regression: native Workflow schedules on the Effect-native form,
+// driven by the file-based `fixtures/workflow-schedules` worker. Deploy a
+// workflow declared with `schedules`, then read it back out-of-band from
+// getWorkflow (the read that surfaces `schedules`) to confirm it was
+// applied. The cron is yearly so the test does not wait for a fire.
+// ---------------------------------------------------------------------------
+
+const waitForAppliedSchedules = (workflowName: string, expected: string[]) =>
+  Effect.gen(function* () {
+    const { accountId } = yield* yield* CloudflareEnvironment;
+    const workflow = yield* workflows.getWorkflow({
+      accountId,
+      workflowName,
+    });
+    return (workflow.schedules ?? []).map((s) => s.cron);
+  }).pipe(
+    Effect.flatMap((crons) =>
+      crons.length === expected.length &&
+      crons.every((cron, index) => cron === expected[index])
+        ? Effect.succeed(crons)
+        : Effect.fail(
+            new Error(`schedules not applied yet: ${JSON.stringify(crons)}`),
+          ),
+    ),
+    Effect.retry({ schedule: Schedule.spaced("2 seconds"), times: 15 }),
+  );
+
+test.provider(
+  "effect-native workflow applies native cron schedules",
+  (scratch) =>
+    Effect.gen(function* () {
+      yield* scratch.destroy();
+
+      const deployed = yield* scratch.deploy(
+        Effect.gen(function* () {
+          return { worker: yield* ScheduledWorkflowWorker };
+        }),
+      );
+
+      const workflowName = yield* readWorkflowName(deployed.worker.workerName);
+      const applied = yield* waitForAppliedSchedules(workflowName, [
+        YEARLY_CRON,
+      ]);
+      expect(applied).toEqual([YEARLY_CRON]);
 
       yield* scratch.destroy();
     }).pipe(logLevel),

--- a/packages/alchemy/test/Cloudflare/Workers/WorkflowAsync.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/WorkflowAsync.test.ts
@@ -329,3 +329,75 @@ test.provider(
     }).pipe(logLevel),
   { timeout: 120_000 },
 );
+
+// ---------------------------------------------------------------------------
+// #1473 regression: native Workflow schedules on the async (props-only)
+// reference form, driven by a file-based fixture (`main`, not inline
+// `script`). Yearly crons so the test never waits for a fire; create →
+// update → clear is asserted out-of-band via getWorkflow.
+// ---------------------------------------------------------------------------
+
+const scheduledWorkflowMain = `${import.meta.dirname}/fixtures/workflow-schedules/async-worker.ts`;
+
+const waitForAppliedSchedules = (workflowName: string, expected: string[]) =>
+  Effect.gen(function* () {
+    const { accountId } = yield* yield* CloudflareEnvironment;
+    const workflow = yield* workflows.getWorkflow({
+      accountId,
+      workflowName,
+    });
+    return (workflow.schedules ?? []).map((s) => s.cron);
+  }).pipe(
+    Effect.flatMap((crons) =>
+      crons.length === expected.length &&
+      crons.every((cron, index) => cron === expected[index])
+        ? Effect.succeed(crons)
+        : Effect.fail(
+            new Error(`schedules not applied yet: ${JSON.stringify(crons)}`),
+          ),
+    ),
+    Effect.retry({ schedule: Schedule.spaced("2 seconds"), times: 15 }),
+  );
+
+test.provider(
+  "async worker workflow binding applies native cron schedules",
+  (scratch) =>
+    Effect.gen(function* () {
+      const yearly = "0 0 1 1 *";
+      const other = "0 0 2 1 *";
+
+      const deployWith = (schedules: string[]) =>
+        scratch.deploy(
+          Effect.gen(function* () {
+            return {
+              worker: yield* Cloudflare.Worker("scheduled-workflow-worker", {
+                main: scheduledWorkflowMain,
+                env: {
+                  HOURLY: Cloudflare.Workflow("HourlyWorkflow", {
+                    className: "HourlyWorkflow",
+                    schedules,
+                  }),
+                },
+              }),
+            };
+          }),
+        );
+
+      const created = yield* deployWith([yearly]);
+      const workflowName = yield* readWorkflowName(created.worker.workerName);
+      expect(yield* waitForAppliedSchedules(workflowName, [yearly])).toEqual([
+        yearly,
+      ]);
+
+      yield* deployWith([other]);
+      expect(yield* waitForAppliedSchedules(workflowName, [other])).toEqual([
+        other,
+      ]);
+
+      yield* deployWith([]);
+      expect(yield* waitForAppliedSchedules(workflowName, [])).toEqual([]);
+
+      yield* scratch.destroy();
+    }).pipe(logLevel),
+  { timeout: 180_000 },
+);

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/workflow-schedules/async-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/workflow-schedules/async-worker.ts
@@ -1,0 +1,24 @@
+import {
+  WorkflowEntrypoint,
+  type WorkflowEvent,
+  type WorkflowStep,
+} from "cloudflare:workers";
+
+/**
+ * File-based fixture for the #1473 native Workflow schedules regression on
+ * the async (props-only) binding form. The Worker source is stable; the
+ * test supplies `schedules` on the `env` Workflow ref so create → update →
+ * clear can reuse this file. Inline `script` is not a fixture and is
+ * unsupported under `alchemy dev`.
+ */
+export class HourlyWorkflow extends WorkflowEntrypoint {
+  async run(_event: Readonly<WorkflowEvent<unknown>>, step: WorkflowStep) {
+    return await step.do("noop", async () => "ok");
+  }
+}
+
+export default {
+  async fetch(): Promise<Response> {
+    return new Response("ok");
+  },
+};

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/workflow-schedules/scheduled-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/workflow-schedules/scheduled-worker.ts
@@ -1,0 +1,21 @@
+import * as Cloudflare from "@/Cloudflare";
+import * as Effect from "effect/Effect";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+import ScheduledWorkflow from "./scheduled-workflow.ts";
+
+export default class ScheduledWorkflowWorker extends Cloudflare.Worker<ScheduledWorkflowWorker>()(
+  "ScheduledWorkflowWorker",
+  {
+    main: import.meta.url,
+  },
+  Effect.gen(function* () {
+    // Registering the workflow is what drives `putWorkflow` with schedules.
+    yield* ScheduledWorkflow;
+
+    return {
+      fetch: Effect.gen(function* () {
+        return HttpServerResponse.text("ok");
+      }),
+    };
+  }),
+) {}

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/workflow-schedules/scheduled-workflow.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/workflow-schedules/scheduled-workflow.ts
@@ -1,0 +1,27 @@
+import * as Cloudflare from "@/Cloudflare";
+import * as Effect from "effect/Effect";
+
+/**
+ * Cron that will not fire during a test run (midnight UTC on 1 January).
+ * Used so native Workflow schedules can be asserted out-of-band without
+ * creating instances.
+ */
+export const YEARLY_CRON = "0 0 1 1 *";
+
+/**
+ * File-based fixture for the #1473 native Workflow schedules regression on
+ * the Effect-native form. Declares `schedules` on the Workflow props so
+ * `putWorkflow` carries them as resource state.
+ */
+export default class ScheduledWorkflow extends Cloudflare.Workflow<ScheduledWorkflow>()(
+  "ScheduledWorkflow",
+  { schedules: [YEARLY_CRON] },
+  Effect.gen(function* () {
+    return Effect.fn(function* () {
+      return yield* Cloudflare.Workflows.task(
+        "noop",
+        Effect.succeed({ ok: true }),
+      );
+    });
+  }),
+) {}

--- a/website/src/content/docs/cloudflare/compute/workflows.mdx
+++ b/website/src/content/docs/cloudflare/compute/workflows.mdx
@@ -159,6 +159,49 @@ in workflow terms). The workflow's init closure shares the isolate-lifetime
 layer build with the hosting Worker — pure assembly, no cleanup; see
 [Instance scope vs request scope](/infrastructure-as-effects/functions-and-servers#instance-scope-vs-request-scope).
 
+## Schedule a Workflow
+
+Attach cron expressions to the Workflow itself to create a new instance
+on each match — no Worker Cron Trigger and no `scheduled` handler
+that calls `workflow.create()`.
+
+```typescript
+export default class HourlyWorkflow extends Cloudflare.Workflow<HourlyWorkflow>()(
+  "HourlyWorkflow",
+  { schedules: ["0 * * * *"] },
+  Effect.gen(function* () {
+    return Effect.fn(function* () {
+      const event = yield* Cloudflare.Workflows.WorkflowEvent;
+      if (event.schedule) {
+        // Matching cron and the fire time (ms since epoch).
+        return { cron: event.schedule.cron, at: event.schedule.scheduledTime };
+      }
+      return {};
+    });
+  }),
+) {}
+```
+
+The same `schedules` array is wrangler-compatible on the async
+reference form:
+
+```typescript
+export const Worker = Cloudflare.Worker("Worker", {
+  main: "./src/worker.ts",
+  env: {
+    HOURLY: Cloudflare.Workflow("HourlyWorkflow", {
+      className: "HourlyWorkflow",
+      schedules: ["0 * * * *"],
+    }),
+  },
+});
+```
+
+Pass `schedules: []` to remove them. Cloudflare caps the account at
+100 cron expressions across all Workflows. Use a Worker
+[cron](/cloudflare/messaging/cron) only when you need custom logic
+before deciding whether to create an instance.
+
 ## Trigger from a Worker
 
 Yield the workflow class in a Worker's init phase to get a typed
@@ -275,8 +318,8 @@ Related:
   workflows call into.
 - [Queues](/cloudflare/messaging/queues) — when buffered messages are enough
   (no checkpointed steps).
-- [Cron triggers](/cloudflare/messaging/cron) — trigger workflows on a
-  schedule.
+- [Cron triggers](/cloudflare/messaging/cron) — Worker-level schedules;
+  prefer native Workflow `schedules` when the job *is* the Workflow.
 
 Reference:
 

--- a/website/src/content/docs/cloudflare/messaging/cron.mdx
+++ b/website/src/content/docs/cloudflare/messaging/cron.mdx
@@ -12,6 +12,10 @@ handler)` attaches the cron expression to the Worker at deploy time
 *and* registers the runtime `scheduled` listener that runs your
 Effect on each fire.
 
+To run a [Workflow](/cloudflare/compute/workflows#schedule-a-workflow)
+on a schedule, attach `schedules` to the Workflow itself instead of
+wrapping `workflow.create()` in a `scheduled` handler.
+
 ## Declare a cron on the Worker
 
 Call `cron` in the Worker's init phase and provide
@@ -279,6 +283,6 @@ interruption and hides intent.
   cron handlers live inside.
 - [Durable Objects](/cloudflare/compute/durable-objects) — the stateful
   building block the test uses to record fires.
-- [Workflows](/cloudflare/compute/workflows) — for multi-step jobs
-  that outgrow a single scheduled handler.
+- [Workflows](/cloudflare/compute/workflows#schedule-a-workflow) —
+  native cron schedules on the Workflow itself.
 - [cron API reference](/providers/cloudflare/workers/cron)


### PR DESCRIPTION
Expose wrangler-compatible `schedules` on Cloudflare Workflows so cron expressions create instances natively, without a Worker Cron Trigger calling `workflow.create()`.

```ts
export default class HourlyWorkflow extends Cloudflare.Workflow<HourlyWorkflow>()(
  "HourlyWorkflow",
  { schedules: ["0 * * * *"] },
  Effect.gen(function* () {
    return Effect.fn(function* () {
      const event = yield* Cloudflare.Workflows.WorkflowEvent;
      return event.schedule?.cron;
    });
  }),
) {}
```

Async Workers take the same array on the binding:

```ts
Cloudflare.Workflow("HourlyWorkflow", {
  className: "HourlyWorkflow",
  schedules: ["0 * * * *"],
})
```

`putWorkflow` already accepted `{ cron }[]`; this threads the prop through `WorkflowResource` state. Pass `schedules: []` to clear. Scheduled instances still surface `event.schedule`.

File-based fixtures under `test/Cloudflare/Workers/fixtures/workflow-schedules/` cover the Effect-native form and the async binding form (create → update → clear).

Closes #1473
