### PR TITLE
fix(cli): bindings state, persist plan collapse state

### DIFF
--- a/packages/alchemy/src/Alchemist/Progress.ts
+++ b/packages/alchemy/src/Alchemist/Progress.ts
@@ -68,9 +68,6 @@ const spanEventOf = (
           ...(event.message === undefined
             ? {}
             : { "alchemy.apply.message": event.message }),
-          ...(event.bindingId === undefined
-            ? {}
-            : { "alchemy.binding.id": event.bindingId }),
         },
       };
     case "apply.resource.note":

--- a/packages/alchemy/src/Cli/LoggingCli.ts
+++ b/packages/alchemy/src/Cli/LoggingCli.ts
@@ -315,9 +315,7 @@ export const LoggingCli = Layer.effect(
                         `${tag(event.fqn)} ${blue(event.message)}`,
                       );
                     }
-                    const id = event.bindingId
-                      ? `${event.fqn}/${event.bindingId}`
-                      : event.fqn;
+                    const id = event.fqn;
                     const mode = modeSuffix({
                       mode: event.providerMode,
                       priorMode: event.fromProviderMode,

--- a/packages/alchemy/src/Cli/components/view/PlanTree.ts
+++ b/packages/alchemy/src/Cli/components/view/PlanTree.ts
@@ -1,4 +1,3 @@
-import * as Predicate from "effect/Predicate";
 import type { ActionApply, ActionDelete, CRUD, Plan } from "../../../Plan.ts";
 import type {
   ApplyEvent,
@@ -43,6 +42,12 @@ export type PlanRow =
       id: string;
       depth: number;
       action: "create" | "update" | "delete" | "noop";
+      /**
+       * Row key of the resource that carries this binding. Bindings have no
+       * lifecycle of their own — the host provider reconciles them — so the
+       * row mirrors the host's apply status instead of tracking its own.
+       */
+      hostKey: string;
     }
   | {
       key: string;
@@ -54,11 +59,13 @@ export type PlanRow =
 
 export type ResourceRow = Extract<PlanRow, { type: "resource" }>;
 
-const isProgressRow = Predicate.not(
-  (row: PlanRow) =>
-    row.type === "namespace" ||
-    (row.type === "binding" && row.action === "noop"),
-);
+/**
+ * Only resources and actions receive apply events and settle. Namespaces are
+ * grouping only, and bindings are reconciled by their host resource, so
+ * counting them would leave the progress total unreachable.
+ */
+const isProgressRow = (row: PlanRow) =>
+  row.type === "resource" || row.type === "task";
 
 export interface RowState extends Required<
   Pick<ResourceStatusChanged, "id" | "status">
@@ -97,6 +104,12 @@ export interface PlanTreeOptions {
   readonly titleDetail?: string;
   readonly viewport?: PlanViewport;
   readonly busy?: boolean;
+  /**
+   * Initial collapse state of a collapsible tree. Dev passes the user's
+   * last choice so a hot reload doesn't bring back a widget they hid.
+   * @default true
+   */
+  readonly expanded?: boolean;
 }
 
 const getRowKey = (item: FlattenedItem) => item.path.join("/");
@@ -138,6 +151,7 @@ const buildRows = (plan: Plan, detailed: boolean): PlanRow[] => {
         id: item.bindingSid ?? item.id,
         depth: item.depth,
         action: item.action as "create" | "update" | "delete" | "noop",
+        hostKey: item.path.slice(0, -1).join("/"),
       };
     }
     if (item.type === "action") {
@@ -182,18 +196,6 @@ const buildInitialTasks = (rows: readonly PlanRow[]) =>
     rows.flatMap((row): Array<[string, RowState]> => {
       if (row.type === "resource")
         return [[row.key, initialResourceState(row)]];
-      if (row.type === "binding") {
-        return [
-          [
-            row.key,
-            {
-              key: row.key,
-              id: row.id,
-              status: row.action === "noop" ? "created" : "pending",
-            },
-          ],
-        ];
-      }
       if (row.type === "task") {
         return [
           [
@@ -233,7 +235,7 @@ export class PlanTree {
     this.state = {
       tasks: buildInitialTasks(this.rows),
       label: options.label ?? "Plan",
-      expanded: true,
+      expanded: options.expanded ?? true,
       viewport: options.viewport ?? "virtual",
       busy: options.busy ?? false,
       outcome: undefined,
@@ -315,12 +317,11 @@ export class PlanTree {
     };
 
     if (event._tag === "apply.resource.status") {
-      const rowKey = event.bindingId ? `${key}/${event.bindingId}` : key;
-      const current = tasks.get(rowKey);
+      const current = tasks.get(key);
       if (current) {
-        tasks.set(rowKey, {
-          key: rowKey,
-          id: event.bindingId ?? event.id,
+        tasks.set(key, {
+          key,
+          id: event.id,
           status: event.status,
           message: event.message ?? current.message,
           ...timing(current, event.status),

--- a/packages/alchemy/src/Cli/components/view/PlanView.tsx
+++ b/packages/alchemy/src/Cli/components/view/PlanView.tsx
@@ -36,7 +36,12 @@ import type { ActionVerb, PlanSummaryCounts } from "../../NamespaceTree.ts";
 import { formatModeNote } from "../../ModeTag.ts";
 import { theme } from "../../CliKit/index.ts";
 import { formatElapsed } from "../../Format.ts";
-import { actionStyle, applyStatusColor, isInProgress } from "./statusStyle.ts";
+import {
+  actionStyle,
+  applyStatusColor,
+  isInProgress,
+  isTerminalStatus,
+} from "./statusStyle.ts";
 import { matchYamlChange, matchYamlKey } from "../../PropertyDiff.ts";
 import { NamespaceRow, namespaceStyle } from "./PlanRow.tsx";
 import { StackOutputs } from "./StackOutputs.tsx";
@@ -290,7 +295,9 @@ function PlanContent(props: {
             row={row}
             mode={tree.mode}
             detailed={tree.detailed}
-            state={state.tasks.get(row.key)}
+            state={state.tasks.get(
+              row.type === "binding" ? row.hostKey : row.key,
+            )}
             defaultMode={tree.plan.defaultMode}
           />
         ))
@@ -303,7 +310,9 @@ function PlanContent(props: {
               mode={tree.mode}
               detailed={tree.detailed}
               includeYaml={false}
-              state={state.tasks.get(line.row.key)}
+              state={state.tasks.get(
+                line.row.type === "binding" ? line.row.hostKey : line.row.key,
+              )}
               defaultMode={tree.plan.defaultMode}
             />
           ) : line.kind === "yaml" ? (
@@ -367,27 +376,26 @@ function PlanRowView(props: {
         </Row>
       );
     }
-    const status: ApplyStatus =
-      state?.status ?? (row.action === "noop" ? "created" : "pending");
-    const displayStatus =
-      row.action === "noop" && (status === "created" || status === "updated")
-        ? ("no change" as const)
-        : status;
+    // `state` is the HOST resource's row state: a binding is reconciled by
+    // the resource that carries it, so it settles exactly when the host does.
+    const hostStatus: ApplyStatus = state?.status ?? "pending";
+    const status: ApplyStatus | "no change" =
+      row.action === "noop" ? "no change" : hostStatus;
     const color =
-      row.action === "delete"
-        ? theme.color.muted
-        : applyStatusColor(displayStatus);
+      row.action === "delete" ? theme.color.muted : applyStatusColor(status);
     const bindingStatus =
       row.action !== "delete"
-        ? displayStatus
-        : status === "deleted"
-          ? "unbound"
-          : status === "deleting"
-            ? "unbinding"
-            : "unbind";
+        ? status
+        : hostStatus === "fail"
+          ? "fail"
+          : isTerminalStatus(hostStatus)
+            ? "unbound"
+            : isInProgress(hostStatus)
+              ? "unbinding"
+              : "unbind";
     return (
       <TaskRow
-        spinning={isInProgress(status)}
+        spinning={status !== "no change" && isInProgress(hostStatus)}
         icon={
           status === "pending"
             ? glyphs.bullet
@@ -405,13 +413,9 @@ function PlanRowView(props: {
             {row.id}
           </Text>
         }
-        detail={rowDetail(status, state?.message)}
         depth={row.depth}
       >
         <Text color={color}>{bindingStatus}</Text>
-        {state?.elapsedMs === undefined ? null : (
-          <Text tone="muted">({formatElapsed(state.elapsedMs)})</Text>
-        )}
       </TaskRow>
     );
   }

--- a/packages/alchemy/src/Cli/components/view/SigilCli.tsx
+++ b/packages/alchemy/src/Cli/components/view/SigilCli.tsx
@@ -12,19 +12,29 @@ import { formatElapsed } from "../../Format.ts";
 import { approvePlanScreen } from "./ApprovePlan.tsx";
 import { Plan as PlanComponent, PlanTree } from "./PlanView.tsx";
 
+/**
+ * UI choices that outlive a single apply session. `alchemy dev` opens a new
+ * session (and a new plan widget) on every hot reload; without this the
+ * widget would reappear after the user hid it with `p`.
+ */
+interface SessionPreferences {
+  planExpanded: boolean;
+}
+
 export const sigilCli = () =>
   Layer.effect(
     Cli,
-    Effect.map(CliKit, (cli) =>
-      Cli.of({
+    Effect.map(CliKit, (cli) => {
+      const preferences: SessionPreferences = { planExpanded: true };
+      return Cli.of({
         startPlanningSession: (label, detail, title) =>
           startPlanningSession(cli, label, detail, title),
         approvePlan: (plan, options) => approvePlan(cli, plan, options),
         displayPlan: (plan, options) => displayPlan(cli, plan, options),
         startApplySession: (plan, options) =>
-          startApplySession(cli, plan, options),
-      }),
-    ),
+          startApplySession(cli, plan, options, preferences),
+      });
+    }),
   );
 
 const approvePlan = Effect.fn(function* <P extends Plan>(
@@ -107,7 +117,8 @@ const startPlanningSession = Effect.fn(function* (
 const startApplySession = Effect.fn(function* <P extends Plan>(
   cli: CliKit["Service"],
   plan: P,
-  options?: import("../../../Report.ts").PlanDisplayOptions,
+  options: import("../../../Report.ts").PlanDisplayOptions | undefined,
+  preferences: SessionPreferences,
 ) {
   // Detailed applies render their YAML diffs inline in the progress tree.
   // One-shot operations persist the final render; dev keeps its live block
@@ -135,6 +146,12 @@ const startApplySession = Effect.fn(function* <P extends Plan>(
     label: labels.active,
     titleDetail: options?.stage,
     busy: true,
+    expanded: preferences.planExpanded,
+  });
+  // Remember the collapse toggle as it happens, so the next hot-reload
+  // generation opens the way the user left this one.
+  progress.subscribe(() => {
+    preferences.planExpanded = progress.snapshot().expanded;
   });
   // The session outlives this effect — the caller settles it via `done` on
   // every exit path (Apply.ts's onExit). live.open is Scope-bound, so give

--- a/packages/alchemy/src/Report.ts
+++ b/packages/alchemy/src/Report.ts
@@ -60,7 +60,6 @@ export interface ResourceStatusChanged {
   type: string; // resource type (e.g. "AWS::Lambda::Function", "Cloudflare::Worker")
   status: ApplyStatus;
   message?: string; // optional details
-  bindingId?: string; // if this event is for a binding
   /**
    * The {@link ProviderMode} this node's provider was resolved for.
    * `undefined` for mode-agnostic providers (a single implementation serves

--- a/packages/alchemy/test/Cli/CliKit.test.tsx
+++ b/packages/alchemy/test/Cli/CliKit.test.tsx
@@ -31,6 +31,7 @@ import {
 import { tabsWindow } from "@/Cli/components/ui/Layout.tsx";
 import { makeRuntime } from "@/Cli/components/view/Runtime.tsx";
 import { sigilCli } from "@/Cli/components/view/SigilCli.tsx";
+import { Cli } from "@/Report.ts";
 import { renderApply } from "@/Cli/commands/render.ts";
 import { isInProgress } from "@/Cli/components/view/statusStyle.ts";
 import { spinnerFramesFor } from "@/Util/Theme.ts";
@@ -411,14 +412,62 @@ it("keeps apply totals on top and destroy progress on the last row", () => {
   );
 });
 
-it("includes binding work in apply totals and failures", () => {
+it("binding rows mirror their host resource and stay out of totals", () => {
   const { service } = makeStatic();
   const worker = {
-    ...noopNode({}, "Worker"),
+    ...updateNode({ a: 1 }, { a: 2 }, "Worker"),
     bindings: [
       { sid: "BUCKET", action: "update" as const, data: {} },
+      { sid: "OLD", action: "delete" as const, data: {} },
       { sid: "STABLE", action: "noop" as const, data: {} },
     ],
+  };
+  const tree = new PlanTree(planWith([worker]), {
+    mode: "apply",
+    label: "Deploying stack",
+    busy: true,
+  });
+  const render = () =>
+    service.output.format(<Plan tree={tree} />, { columns: 80 });
+
+  // Three bindings never inflate the total: only the host is work.
+  expect(tree.progress()).toEqual({ completed: 0, failures: 0, total: 1 });
+  let output = render();
+  expect(output).toContain("Deploying stack (0/1)");
+  expect(output).toContain("unbind");
+  expect(output).toContain("no change");
+
+  tree.emit({
+    _tag: "apply.resource.status",
+    fqn: "Worker",
+    id: "Worker",
+    type: "Test.Resource",
+    status: "updating",
+  });
+  output = render();
+  expect(output).toContain("unbinding");
+  expect(output).toContain("Deploying stack (0/1)");
+
+  tree.emit({
+    _tag: "apply.resource.status",
+    fqn: "Worker",
+    id: "Worker",
+    type: "Test.Resource",
+    status: "updated",
+  });
+  expect(tree.progress()).toEqual({ completed: 1, failures: 0, total: 1 });
+  output = render();
+  expect(output).toContain("Deploying stack (1/1)");
+  expect(output).toContain("unbound");
+  expect(output).toContain("1 updated");
+  expect(output).not.toContain("pending");
+});
+
+it("binding rows follow a failed host", () => {
+  const { service } = makeStatic();
+  const worker = {
+    ...updateNode({ a: 1 }, { a: 2 }, "Worker"),
+    bindings: [{ sid: "BUCKET", action: "update" as const, data: {} }],
   };
   const tree = new PlanTree(planWith([worker]), {
     mode: "apply",
@@ -430,17 +479,16 @@ it("includes binding work in apply totals and failures", () => {
     fqn: "Worker",
     id: "Worker",
     type: "Test.Resource",
-    bindingId: "BUCKET",
     status: "fail",
-    message: "binding failed",
+    message: "worker failed",
   });
 
   const output = service.output.format(<Plan tree={tree} />, { columns: 80 });
+  expect(tree.progress()).toEqual({ completed: 1, failures: 1, total: 1 });
   expect(output).toContain("1 fail");
-  expect(output).toContain("1 no change");
-  expect(output).not.toContain("2 no change");
   expect(output).toContain("Deploying stack (1/1)");
-  expect(output).toContain("binding failed");
+  expect(output).toContain("worker failed");
+  expect(output).not.toContain("pending");
 });
 
 it.effect("keeps native progress active until the apply outcome settles", () =>
@@ -542,6 +590,39 @@ it.effect("removes the dev apply widget when its generation scope closes", () =>
     // Nothing else is live once the generation is gone, so the renderer
     // unmounts and restores the cursor.
     expect(stdout.output.slice(settledAt)).toContain("[?25h");
+  }),
+);
+
+// `p` hides the dev widget; a hot reload opens a fresh session and must not
+// bring it back — the user's choice outlives the generation that made it.
+it.effect("keeps the dev plan widget hidden across hot reloads", () =>
+  Effect.gen(function* () {
+    const stdin = new InputStream();
+    const { service, stdout } = yield* makeLive({ stdin });
+    const plan = {
+      ...planWith([updateNode({ version: 1 }, { version: 2 })]),
+      defaultMode: "local" as const,
+    };
+    const cli = sigilCli().pipe(Layer.provide(Layer.succeed(CliKit, service)));
+    yield* Effect.gen(function* () {
+      const { startApplySession } = yield* Cli;
+      const first = yield* startApplySession(plan, { dev: true });
+      yield* first.done("success");
+      yield* Effect.promise(() => stdout.waitFor("p hide widget"));
+      yield* Effect.promise(() => stdin.ready);
+      yield* Effect.sync(() => stdin.write("p"));
+      yield* Effect.promise(() => stdout.waitFor("p show plan/output"));
+      yield* first.close!;
+
+      const reloadedAt = stdout.output.length;
+      const second = yield* startApplySession(plan, { dev: true });
+      yield* second.done("success");
+      yield* Effect.promise(() => stdout.waitFor("Dev stack ready"));
+      const reloaded = stdout.output.slice(reloadedAt);
+      expect(reloaded).toContain("p show plan/output");
+      expect(reloaded).not.toContain("p hide widget");
+      yield* second.close!;
+    }).pipe(Effect.provide(cli));
   }),
 );
 


### PR DESCRIPTION
Binding rows no longer count toward apply progress, and the dev plan widget stays hidden across hot reloads.

Bindings have no lifecycle of their own — the host provider reconciles them in `reconcile` — but #1458 started seeding them as `pending` rows in the progress total. Nothing in the engine ever emitted a `bindingId` status event, so a worker with four changed bindings showed `9/13` forever.

```ts
// PlanTree: only rows that receive apply events are work
const isProgressRow = (row: PlanRow) =>
  row.type === "resource" || row.type === "task";
```

- Binding rows now render from their host resource's status via `hostKey`: `updating → updated`, delete bindings go `unbind → unbinding → unbound`, noop stays `no change`, a failed host paints its bindings failed.
- Drop the dead `bindingId` field from `ResourceStatusChanged` and its consumers in `PlanTree`, `LoggingCli`, and the Alchemist span attributes.
- `sigilCli` keeps the plan's expanded state across apply sessions, so pressing `p` in `alchemy dev` survives the next hot reload instead of the widget reopening on every generation.

```ts
const progress = new PlanTree(plan, { ..., expanded: preferences.planExpanded });
progress.subscribe(() => {
  preferences.planExpanded = progress.snapshot().expanded;
});
```
