### PR TITLE
fix(aws/lambda): flush telemetry before a Lambda timeout

### DIFF
--- a/packages/alchemy/src/AWS/Lambda/DurableBridge.ts
+++ b/packages/alchemy/src/AWS/Lambda/DurableBridge.ts
@@ -40,7 +40,7 @@ import {
   type DurableRetryPolicy,
   type DurableStepOptions,
 } from "./Durable.ts";
-import { HandlerContext } from "./Function.ts";
+import { HandlerContext } from "./InvocationDeadline.ts";
 
 /** Module id of AWS's Durable Execution SDK (an optional peer dependency). */
 export const DURABLE_SDK_MODULE = "@aws/durable-execution-sdk-js";

--- a/packages/alchemy/src/AWS/Lambda/DurableFunction.ts
+++ b/packages/alchemy/src/AWS/Lambda/DurableFunction.ts
@@ -24,8 +24,8 @@ import {
   Function,
   type FunctionProps,
   type FunctionServices,
-  type HandlerContext,
 } from "./Function.ts";
+import type { HandlerContext } from "./InvocationDeadline.ts";
 
 type TypeId = "AWS.Lambda.DurableFunction";
 const TypeId = "AWS.Lambda.DurableFunction" as const;

--- a/packages/alchemy/src/AWS/Lambda/Function.ts
+++ b/packages/alchemy/src/AWS/Lambda/Function.ts
@@ -60,6 +60,12 @@ import {
   makeFunctionImage,
 } from "./FunctionImage.ts";
 import { makeFunctionHttpHandler } from "./HttpServer.ts";
+import {
+  HandlerContext,
+  TIMEOUT_MARGIN_ENV,
+  toTimeoutMarginMillis,
+  withInvocationDeadline,
+} from "./InvocationDeadline.ts";
 
 export type { FunctionImageSource } from "./FunctionImage.ts";
 
@@ -74,11 +80,6 @@ class FunctionUpdateFailed extends Data.TaggedError("FunctionUpdateFailed")<{
   functionName: string;
   reason?: string;
 }> {}
-
-export class HandlerContext extends Context.Service<
-  HandlerContext,
-  lambda.Context
->()("AWS.Lambda.HandlerContext") {}
 
 export const isFunction = (value: any): value is Function => {
   return (
@@ -266,6 +267,26 @@ export interface FunctionCommonProps extends PlatformProps {
    * @default 3 seconds (AWS Lambda default)
    */
   timeout?: Duration.Duration;
+  /**
+   * How long before {@link timeout} telemetry is flushed for an invocation
+   * that is still running. A Lambda that hits its timeout is frozen
+   * mid-flight and its buffered spans and logs are lost; at
+   * `timeout - timeoutMargin` the runtime ends the invocation's root span
+   * with an `AWS.Lambda.InvocationTimeoutError`, logs a warning and drains
+   * the exporters, so the trace of the slow invocation is exported instead.
+   *
+   * The handler is never interrupted and the invocation's outcome is never
+   * changed. If it does finish inside the margin, its response goes out
+   * as normal and the span is re-exported with the real outcome; the
+   * earlier export (marked `aws.lambda.timeout.imminent`) is the accepted
+   * false positive.
+   *
+   * Size it for one export round-trip to your telemetry backend. Set to
+   * `Duration.zero` to disable.
+   *
+   * @default 500 millis
+   */
+  timeoutMargin?: Duration.Duration;
   /**
    * Maximum number of concurrent executions reserved for this function.
    * Omit to remove the function-level reserved concurrency limit.
@@ -992,119 +1013,138 @@ export const Function: Platform<
   {},
   FunctionZipProps
 > = Platform(FunctionTypeId, {
-  createRuntimeContext: (id: string): Serverless.FunctionContext => {
-    const listeners: Effect.Effect<Serverless.FunctionListener>[] = [];
-    const env: Record<string, any> = {};
-
-    const ctx = {
-      Type: FunctionTypeId,
-      id,
-      env,
-      set: (id: string, output: Output.Output) =>
-        Effect.sync(() => {
-          // Key is already canonical (see RuntimeContext.sanitizeKey); store it
-          // verbatim. `packEnvValue` marker-packs Redacted values so they
-          // survive the Output → Lambda env var round-trip.
-          const key = id;
-          env[key] = output.pipe(Output.map(packEnvValue));
-          return key;
-        }),
-      get: <T>(key: string) =>
-        // Key is already canonical (see RuntimeContext.sanitizeKey). Read
-        // straight from `process.env` — see `unpackEnvValue` for why this
-        // must never resolve through `Config.string`.
-        Effect.sync(() => unpackEnvValue<T>(process.env[key])),
-      serve: (handler: HttpEffect) =>
-        // @ts-ignore
-        ctx.listen(makeFunctionHttpHandler(handler)),
-      listen: ((
-        handler:
-          | Serverless.FunctionListener
-          | Effect.Effect<Serverless.FunctionListener>,
-      ) =>
-        Effect.sync(() =>
-          Effect.isEffect(handler)
-            ? listeners.push(handler)
-            : listeners.push(Effect.succeed(handler)),
-        )) as any as Serverless.FunctionContext["listen"],
-      exports: Effect.sync(() => ({
-        // construct an Effect that produces the Function's entrypoint
-        // Effect<(event, context) => Promise<any>>
-        handler: Effect.gen(function* () {
-          const handlers = yield* Effect.all(listeners, {
-            concurrency: "unbounded",
-          });
-          // Sandbox-lifetime services, captured so each invocation can
-          // build its telemetry exporters and run the handler effect
-          // against the same context the init phase saw (mirrors
-          // WorkerBridge). The build's memo map is stripped so a Layer the
-          // user `Effect.provide`s inside a handler builds per invocation.
-          const services = Context.omit(Layer.CurrentMemoMap)(
-            yield* Effect.context<never>(),
-          );
-          return async (event: any, context: lambda.Context): Promise<any> => {
-            for (const handler of handlers) {
-              const eff = handler(event);
-              if (Effect.isEffect(eff)) {
-                // Each invocation gets a fresh request scope, matching the
-                // Worker / Durable Object / Workflow bridges. The scope is
-                // settled inline before returning: a buffered Lambda
-                // response is not released to the caller until the Invoke
-                // phase completes, so deferring cleanup (e.g. via an
-                // INVOKE-subscribed extension window) shows up as response
-                // latency anyway — keep request finalizers fast. A failing
-                // finalizer is logged and ignored so it can't mask the
-                // invocation's outcome.
-                const scope = Scope.makeUnsafe();
-                const exit = await eff.pipe(
-                  Effect.provide(
-                    Layer.mergeAll(
-                      Layer.succeed(HandlerContext, context),
-                      Layer.succeed(Scope.Scope, scope),
-                      // The configured telemetry exporters, attached to the
-                      // invocation scope by `buildEventTelemetry` so
-                      // buffered spans/logs/metrics flush when it settles
-                      // below.
-                      Layer.effectContext(
-                        buildEventTelemetry(
-                          services,
-                          scope,
-                          (ctx as Serverless.FunctionContext).telemetry,
-                        ),
-                      ),
-                    ).pipe(Layer.provideMerge(Layer.succeedContext(services))),
-                  ),
-                  Effect.tap(Effect.logDebug),
-                  Effect.runPromiseExit,
-                );
-                if (!isScopeEjected(scope)) {
-                  // The HttpMiddleware tracer ends the request's root span
-                  // in a dispatcher task scheduled after the handler effect
-                  // resolves; yield one macrotask so it reaches the
-                  // telemetry exporter's buffer before the flush finalizer.
-                  await new Promise((resolve) => setTimeout(resolve, 0));
-                  await Scope.close(scope, exit).pipe(
-                    Effect.ignoreCause({
-                      log: "Warn",
-                      message: "Lambda invocation scope close failed",
-                    }),
-                    Effect.runPromise,
-                  );
-                }
-                if (Exit.isSuccess(exit)) {
-                  return exit.value;
-                }
-                throw Cause.squash(exit.cause);
-              }
-            }
-            throw new Error("No event handler found");
-          };
-        }),
-      })),
-    };
-    return ctx;
-  },
+  createRuntimeContext: (id) => createFunctionRuntimeContext(id),
 });
+
+/**
+ * The Lambda runtime context: collects the listeners registered during
+ * Construction and produces the sandbox's `handler` export — the per-
+ * invocation dispatcher. Exported so the dispatcher can be driven
+ * in-process by tests.
+ *
+ * @internal
+ */
+export const createFunctionRuntimeContext = (
+  id: string,
+): Serverless.FunctionContext => {
+  const listeners: Effect.Effect<Serverless.FunctionListener>[] = [];
+  const env: Record<string, any> = {};
+
+  const ctx = {
+    Type: FunctionTypeId,
+    id,
+    env,
+    set: (id: string, output: Output.Output) =>
+      Effect.sync(() => {
+        // Key is already canonical (see RuntimeContext.sanitizeKey); store it
+        // verbatim. `packEnvValue` marker-packs Redacted values so they
+        // survive the Output → Lambda env var round-trip.
+        const key = id;
+        env[key] = output.pipe(Output.map(packEnvValue));
+        return key;
+      }),
+    get: <T>(key: string) =>
+      // Key is already canonical (see RuntimeContext.sanitizeKey). Read
+      // straight from `process.env` — see `unpackEnvValue` for why this
+      // must never resolve through `Config.string`.
+      Effect.sync(() => unpackEnvValue<T>(process.env[key])),
+    serve: (handler: HttpEffect) =>
+      // @ts-ignore
+      ctx.listen(makeFunctionHttpHandler(handler)),
+    listen: ((
+      handler:
+        | Serverless.FunctionListener
+        | Effect.Effect<Serverless.FunctionListener>,
+    ) =>
+      Effect.sync(() =>
+        Effect.isEffect(handler)
+          ? listeners.push(handler)
+          : listeners.push(Effect.succeed(handler)),
+      )) as any as Serverless.FunctionContext["listen"],
+    exports: Effect.sync(() => ({
+      // construct an Effect that produces the Function's entrypoint
+      // Effect<(event, context) => Promise<any>>
+      handler: Effect.gen(function* () {
+        const handlers = yield* Effect.all(listeners, {
+          concurrency: "unbounded",
+        });
+        // Sandbox-lifetime services, captured so each invocation can
+        // build its telemetry exporters and run the handler effect
+        // against the same context the init phase saw (mirrors
+        // WorkerBridge). The build's memo map is stripped so a Layer the
+        // user `Effect.provide`s inside a handler builds per invocation.
+        const services = Context.omit(Layer.CurrentMemoMap)(
+          yield* Effect.context<never>(),
+        );
+        return async (event: any, context: lambda.Context): Promise<any> => {
+          for (const handler of handlers) {
+            const eff = handler(event);
+            if (Effect.isEffect(eff)) {
+              // Each invocation gets a fresh request scope, matching the
+              // Worker / Durable Object / Workflow bridges. The scope is
+              // settled inline before returning: a buffered Lambda
+              // response is not released to the caller until the Invoke
+              // phase completes, so deferring cleanup (e.g. via an
+              // INVOKE-subscribed extension window) shows up as response
+              // latency anyway — keep request finalizers fast. A failing
+              // finalizer is logged and ignored so it can't mask the
+              // invocation's outcome.
+              //
+              // The scope is ALSO what a timeout would take with it: Lambda
+              // freezes the sandbox mid-flight and the buffered telemetry
+              // never flushes. `withInvocationDeadline` flushes it
+              // `timeoutMargin` before that happens — without touching the
+              // handler or the invocation's outcome.
+              const scope = Scope.makeUnsafe();
+              const exit = await eff.pipe(
+                withInvocationDeadline,
+                Effect.provide(
+                  Layer.mergeAll(
+                    Layer.succeed(HandlerContext, context),
+                    Layer.succeed(Scope.Scope, scope),
+                    // The configured telemetry exporters, attached to the
+                    // invocation scope by `buildEventTelemetry` so
+                    // buffered spans/logs/metrics flush when it settles
+                    // below.
+                    Layer.effectContext(
+                      buildEventTelemetry(
+                        services,
+                        scope,
+                        (ctx as Serverless.FunctionContext).telemetry,
+                      ),
+                    ),
+                  ).pipe(Layer.provideMerge(Layer.succeedContext(services))),
+                ),
+                Effect.tap(Effect.logDebug),
+                Effect.runPromiseExit,
+              );
+              if (!isScopeEjected(scope)) {
+                // The HttpMiddleware tracer ends the request's root span
+                // in a dispatcher task scheduled after the handler effect
+                // resolves; yield one macrotask so it reaches the
+                // telemetry exporter's buffer before the flush finalizer.
+                await new Promise((resolve) => setTimeout(resolve, 0));
+                await Scope.close(scope, exit).pipe(
+                  Effect.ignoreCause({
+                    log: "Warn",
+                    message: "Lambda invocation scope close failed",
+                  }),
+                  Effect.runPromise,
+                );
+              }
+              if (Exit.isSuccess(exit)) {
+                return exit.value;
+              }
+              throw Cause.squash(exit.cause);
+            }
+          }
+          throw new Error("No event handler found");
+        };
+      }),
+    })),
+  };
+  return ctx;
+};
 
 export const FunctionProvider = () =>
   Provider.effect(
@@ -1369,6 +1409,16 @@ export const FunctionProvider = () =>
             ? `${current} --enable-source-maps`
             : "--enable-source-maps",
         };
+      };
+
+      // The runtime reads the invocation deadline margin per invocation
+      // (see `withInvocationDeadline`); only written when set so the
+      // runtime default applies otherwise.
+      const timeoutMarginEnv = (
+        margin: Duration.Duration | undefined,
+      ): Record<string, string> => {
+        const ms = toTimeoutMarginMillis(margin);
+        return ms === undefined ? {} : { [TIMEOUT_MARGIN_ENV]: String(ms) };
       };
 
       const retryFunctionMutation = Effect.retry({
@@ -1709,14 +1759,13 @@ export const FunctionProvider = () =>
           Layers: isFunctionImageProps(news)
             ? undefined
             : (news.layers ?? []).map(layerVersionArnOf),
-          Environment: runtimeEnv
-            ? {
-                Variables: {
-                  ...runtimeEnv,
-                  ...alchemyEnv,
-                },
-              }
-            : undefined,
+          Environment: {
+            Variables: {
+              ...runtimeEnv,
+              ...alchemyEnv,
+              ...timeoutMarginEnv(news.timeoutMargin),
+            },
+          },
           Tags: tags,
           Timeout: toTimeoutSeconds(news.timeout),
           // Always explicit so removing the `tracing` prop converges back to
@@ -2125,6 +2174,12 @@ export const FunctionProvider = () =>
           }
           if (
             toTimeoutSeconds(olds.timeout) !== toTimeoutSeconds(news.timeout)
+          ) {
+            return { action: "update" };
+          }
+          if (
+            toTimeoutMarginMillis(olds.timeoutMargin) !==
+            toTimeoutMarginMillis(news.timeoutMargin)
           ) {
             return { action: "update" };
           }

--- a/packages/alchemy/src/AWS/Lambda/HttpServer.ts
+++ b/packages/alchemy/src/AWS/Lambda/HttpServer.ts
@@ -13,6 +13,7 @@ import * as HttpMiddleware from "effect/unstable/http/HttpMiddleware";
 import * as HttpServerRequest from "effect/unstable/http/HttpServerRequest";
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 import * as Http from "../../Http.ts";
+import { withInvocationDeadline } from "./InvocationDeadline.ts";
 
 export const isFunctionURLEvent = (
   event: any,
@@ -51,7 +52,15 @@ export const makeFunctionHttpHandler = <Req>(handler: Http.HttpEffect<Req>) => {
   // fetch path. With the default no-op tracer this is free; with a telemetry
   // exporter installed the span is exported when the invocation scope
   // flushes.
-  const safeHandler = HttpMiddleware.tracer(Http.safeHttpEffect(handler));
+  //
+  // The invocation deadline flush sits INSIDE the span so it can find the
+  // `http.server` root span in context and end it — with
+  // `InvocationTimeoutError` as its status — before draining the exporters.
+  // The dispatcher's outer guard stands down when this one takes the
+  // deadline; see `withInvocationDeadline`.
+  const safeHandler = HttpMiddleware.tracer(
+    withInvocationDeadline(Http.safeHttpEffect(handler)),
+  );
   return (
     event: any,
   ):

--- a/packages/alchemy/src/AWS/Lambda/InvocationDeadline.ts
+++ b/packages/alchemy/src/AWS/Lambda/InvocationDeadline.ts
@@ -1,0 +1,250 @@
+import type * as lambda from "aws-lambda";
+import * as Clock from "effect/Clock";
+import * as Context from "effect/Context";
+import * as Data from "effect/Data";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Fiber from "effect/Fiber";
+import * as Option from "effect/Option";
+import { Flusher } from "effect/unstable/observability/OtlpExporter";
+
+/**
+ * The AWS Lambda invocation context — the `context` argument Lambda passes
+ * to the handler. Provided to every invocation's effect by the Lambda
+ * dispatcher (see `Function.ts`).
+ */
+export class HandlerContext extends Context.Service<
+  HandlerContext,
+  lambda.Context
+>()("AWS.Lambda.HandlerContext") {}
+
+/**
+ * Environment variable the deploy side writes from
+ * {@link FunctionCommonProps.timeoutMargin} and the runtime reads per
+ * invocation. Whole milliseconds; `0` disables the deadline flush.
+ */
+export const TIMEOUT_MARGIN_ENV = "ALCHEMY_LAMBDA_TIMEOUT_MARGIN_MS";
+
+/**
+ * Default deadline margin. Wide enough for one OTLP export round-trip to a
+ * remote collector (dd-trace uses 100 ms, but it flushes to a local
+ * extension over localhost).
+ */
+export const DEFAULT_TIMEOUT_MARGIN_MS = 500;
+
+/**
+ * Span attribute set on a root span the deadline flush ended early. Lets a
+ * backend tell "flushed because the invocation was about to time out" from
+ * a handler-reported failure — and, when the handler does finish inside the
+ * margin and re-ends the span successfully, explains the earlier export.
+ */
+export const TIMEOUT_IMMINENT_ATTRIBUTE = "aws.lambda.timeout.imminent";
+
+/**
+ * Recorded on the invocation's root span when the deadline flush fires:
+ * the handler was still running `marginMs` before the function's timeout.
+ *
+ * This is never thrown and never fails the invocation. The handler keeps
+ * running; the error is the span's exit status so the trace of an
+ * invocation Lambda is about to freeze exports as an errored span instead
+ * of vanishing. If the handler does finish inside the margin, its own
+ * completion ends the span again with the real outcome (see
+ * {@link withInvocationDeadline}).
+ */
+export class InvocationTimeoutError extends Data.TaggedError(
+  "AWS.Lambda.InvocationTimeoutError",
+)<{
+  readonly functionName: string;
+  readonly requestId: string;
+  /** Milliseconds the handler had been running when the flush fired. */
+  readonly budgetMs: number;
+  /** Milliseconds reserved before Lambda's hard timeout. */
+  readonly marginMs: number;
+}> {
+  override get message() {
+    return `Lambda invocation ${this.requestId} of ${this.functionName} was still running after ${this.budgetMs}ms, ${this.marginMs}ms before its timeout; telemetry was flushed early in case Lambda freezes the sandbox`;
+  }
+}
+
+interface Deadline {
+  /** Tell the enclosing guard an inner guard now owns the deadline. */
+  readonly claim: () => void;
+}
+
+/**
+ * Internal handshake between nested deadline guards. The dispatcher guards
+ * every listener; the HTTP listener guards again *inside* its `http.server`
+ * span so the flush can end that span. The inner guard claims the deadline
+ * and the outer one stands down, so the flush runs exactly once, from the
+ * innermost guard.
+ */
+class InvocationDeadline extends Context.Service<
+  InvocationDeadline,
+  Deadline
+>()("AWS.Lambda.InvocationDeadline") {}
+
+/**
+ * Parse the runtime margin from its environment variable. Unset → default;
+ * unparseable/negative → default; `0` → flush disabled.
+ */
+export const readTimeoutMargin = (raw: string | undefined): number => {
+  if (raw === undefined || raw === "") return DEFAULT_TIMEOUT_MARGIN_MS;
+  const ms = Number(raw);
+  return Number.isFinite(ms) && ms >= 0
+    ? Math.floor(ms)
+    : DEFAULT_TIMEOUT_MARGIN_MS;
+};
+
+/**
+ * Normalize a {@link FunctionCommonProps.timeoutMargin} to whole
+ * milliseconds for the env var. Handles the state-JSON `Duration` shape the
+ * same way `toTimeoutSeconds` does. Infinite → `undefined` (default).
+ */
+export const toTimeoutMarginMillis = (
+  margin: Duration.Duration | undefined,
+): number | undefined => {
+  if (margin === undefined) return undefined;
+  const json = margin as {
+    _id?: unknown;
+    _tag?: "Millis" | "Nanos" | "Infinity" | "NegativeInfinity";
+    millis?: number;
+    nanos?: string;
+  };
+  const input: Duration.Input =
+    json._id === "Duration"
+      ? json._tag === "Millis"
+        ? json.millis!
+        : json._tag === "Nanos"
+          ? BigInt(json.nanos!)
+          : "Infinity"
+      : margin;
+  const millis = Duration.toMillis(input);
+  return Number.isFinite(millis) ? Math.max(0, Math.ceil(millis)) : undefined;
+};
+
+/**
+ * Flush telemetry for an invocation that is still running `margin` before
+ * Lambda's hard timeout — without touching the handler.
+ *
+ * A Lambda that hits its timeout is frozen mid-flight: the telemetry
+ * exporter's buffer and the still-open root span die with it — precisely
+ * the invocation you most want a trace for. The deadline is known up front
+ * (`context.getRemainingTimeInMillis()`), and a sandbox only ever handles
+ * one invocation at a time, so a pre-deadline timer is race-free. It parks
+ * for `remaining - margin` and, if the handler is still running by then:
+ *
+ * 1. ends the current span (the `http.server` root span on the HTTP path)
+ *    with {@link InvocationTimeoutError} and marks it
+ *    {@link TIMEOUT_IMMINENT_ATTRIBUTE};
+ * 2. logs a warning through the invocation's logger, so the log record
+ *    carries the trace id;
+ * 3. drains every exporter through the OTLP {@link Flusher}.
+ *
+ * The handler is never interrupted and the invocation's outcome is never
+ * changed. If Lambda freezes the sandbox, the trace already exists. If the
+ * handler finishes inside the margin, its response goes out as normal and
+ * the tracer ends the span a second time with the real exit — the earlier,
+ * marked export is the accepted false positive. Spans still open at the
+ * flush (other than the root) are not exported; anything already ended,
+ * and every log record, is.
+ *
+ * The margin comes from `ALCHEMY_LAMBDA_TIMEOUT_MARGIN_MS`
+ * ({@link FunctionCommonProps.timeoutMargin} on the deploy side; default
+ * {@link DEFAULT_TIMEOUT_MARGIN_MS}); `0` disables it. Without a
+ * `HandlerContext` (unit tests, non-Lambda hosts) the effect runs
+ * unguarded.
+ *
+ * Guards nest: an inner guard (the HTTP listener's, placed inside the
+ * `http.server` span so the flush can end it) takes the deadline over from
+ * the outer one (the dispatcher's), so the flush runs once, from the
+ * innermost guard, closest to the work.
+ */
+export const withInvocationDeadline = <A, E, R>(
+  self: Effect.Effect<A, E, R>,
+): Effect.Effect<A, E, R> =>
+  Effect.gen(function* () {
+    const context = Option.getOrUndefined(
+      yield* Effect.serviceOption(HandlerContext),
+    );
+    if (
+      context === undefined ||
+      typeof context.getRemainingTimeInMillis !== "function"
+    ) {
+      return yield* self;
+    }
+    const marginMs = readTimeoutMargin(process.env[TIMEOUT_MARGIN_ENV]);
+    if (marginMs <= 0) {
+      return yield* self;
+    }
+    const remainingMs = context.getRemainingTimeInMillis();
+    const budgetMs = remainingMs - marginMs;
+    if (!(budgetMs > 0)) {
+      // A margin at or above the function's timeout would flush at t=0 on
+      // every invocation. Run unguarded and say why.
+      yield* Effect.logWarning(
+        `${TIMEOUT_MARGIN_ENV}=${marginMs} leaves no invocation budget (${remainingMs}ms remaining); the invocation deadline flush is disabled`,
+      );
+      return yield* self;
+    }
+
+    // Take the deadline over from any enclosing guard.
+    const outer = yield* Effect.serviceOption(InvocationDeadline);
+    if (Option.isSome(outer)) {
+      outer.value.claim();
+    }
+    let claimed = false;
+    const deadline: Deadline = {
+      claim: () => {
+        claimed = true;
+      },
+    };
+
+    const flushBeforeDeadline = Effect.gen(function* () {
+      const error = new InvocationTimeoutError({
+        functionName: context.functionName,
+        requestId: context.awsRequestId,
+        budgetMs,
+        marginMs,
+      });
+      // The root span is still open (that is why we are here); end it so
+      // it exports with the timeout as its status. Only `Span`s can be
+      // ended — an external parent (a propagated `traceparent` with no
+      // local span) is skipped.
+      const span = yield* Effect.option(Effect.currentSpan);
+      if (Option.isSome(span) && span.value.status._tag === "Started") {
+        span.value.attribute(TIMEOUT_IMMINENT_ATTRIBUTE, true);
+        span.value.end(yield* Clock.currentTimeNanos, Exit.fail(error));
+      }
+      yield* Effect.logWarning(error.message).pipe(
+        Effect.annotateLogs({
+          requestId: error.requestId,
+          budgetMs: error.budgetMs,
+          marginMs: error.marginMs,
+        }),
+      );
+      const flusher = yield* Effect.serviceOption(Flusher);
+      if (Option.isSome(flusher)) {
+        yield* flusher.value.flush;
+      }
+    });
+
+    // The watcher inherits this fiber's context — the invocation's logger,
+    // exporters and (on the HTTP path) the root span — and is interrupted
+    // when the handler settles. The flush itself is uninterruptible so a
+    // handler finishing mid-flush waits for the export rather than
+    // abandoning an in-flight batch.
+    const watcher = yield* Effect.forkChild(
+      Effect.sleep(Duration.millis(budgetMs)).pipe(
+        Effect.andThen(
+          Effect.suspend(() =>
+            claimed ? Effect.void : Effect.uninterruptible(flushBeforeDeadline),
+          ),
+        ),
+      ),
+    );
+    return yield* self.pipe(
+      Effect.provideService(InvocationDeadline, deadline),
+      Effect.ensuring(Fiber.interrupt(watcher)),
+    );
+  });

--- a/packages/alchemy/src/AWS/Lambda/index.ts
+++ b/packages/alchemy/src/AWS/Lambda/index.ts
@@ -30,6 +30,7 @@ export * from "./GetMicrovmImageHttp.ts";
 export * from "./GetMicrovmImageVersion.ts";
 export * from "./GetMicrovmImageVersionHttp.ts";
 export * from "./HttpServer.ts";
+export * from "./InvocationDeadline.ts";
 export * from "./InvokeFunction.ts";
 export * from "./InvokeFunctionHttp.ts";
 export * from "./InvokeWithResponseStream.ts";

--- a/packages/alchemy/test/AWS/Lambda/InvocationDeadline.dispatch.test.ts
+++ b/packages/alchemy/test/AWS/Lambda/InvocationDeadline.dispatch.test.ts
@@ -1,0 +1,220 @@
+import { createFunctionRuntimeContext } from "@/AWS/Lambda/Function.ts";
+import {
+  InvocationTimeoutError,
+  TIMEOUT_IMMINENT_ATTRIBUTE,
+  TIMEOUT_MARGIN_ENV,
+} from "@/AWS/Lambda/InvocationDeadline.ts";
+import type * as lambda from "aws-lambda";
+import { afterEach, describe, expect, it } from "alchemy-test";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Layer from "effect/Layer";
+import * as Tracer from "effect/Tracer";
+import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+import { Flusher } from "effect/unstable/observability/OtlpExporter";
+
+/**
+ * Drives the real Lambda dispatcher (`createFunctionRuntimeContext(...)
+ * .exports.handler`) in-process with a fake invocation context, pinning the
+ * end-to-end contract of the deadline flush:
+ *
+ * - a slow HTTP invocation is NOT interrupted: it completes on its own and
+ *   its response is returned;
+ * - `margin` before the deadline the `http.server` root span was ended with
+ *   `InvocationTimeoutError` (a FAILURE, marked timeout-imminent) and the
+ *   exporters were flushed, because the HTTP listener's guard sits inside
+ *   the span and the dispatcher's outer guard stands down;
+ * - the handler's completion re-ends the span with the real outcome;
+ * - a fast invocation is untouched.
+ */
+describe("AWS.Lambda dispatcher invocation deadline", () => {
+  afterEach(() => {
+    delete process.env[TIMEOUT_MARGIN_ENV];
+  });
+
+  const functionUrlEvent = (path: string): lambda.LambdaFunctionURLEvent =>
+    ({
+      version: "2.0",
+      routeKey: "$default",
+      rawPath: path,
+      rawQueryString: "",
+      headers: { host: "example.lambda-url.us-east-1.on.aws" },
+      requestContext: {
+        accountId: "123456789012",
+        apiId: "example",
+        domainName: "example.lambda-url.us-east-1.on.aws",
+        domainPrefix: "example",
+        http: {
+          method: "GET",
+          path,
+          protocol: "HTTP/1.1",
+          sourceIp: "203.0.113.42",
+          userAgent: "test",
+        },
+        requestId: "req-1",
+        routeKey: "$default",
+        stage: "$default",
+        time: "01/Jan/2026:00:00:00 +0000",
+        timeEpoch: 0,
+      },
+      isBase64Encoded: false,
+    }) as lambda.LambdaFunctionURLEvent;
+
+  const invocationContext = (remainingMs: number): lambda.Context => {
+    const startedAt = Date.now();
+    return {
+      functionName: "dispatch-fn",
+      awsRequestId: "req-1",
+      getRemainingTimeInMillis: () =>
+        Math.max(0, remainingMs - (Date.now() - startedAt)),
+    } as unknown as lambda.Context;
+  };
+
+  interface SpanEnd {
+    readonly name: string;
+    readonly exit: Exit.Exit<unknown, unknown>;
+    readonly at: number;
+  }
+
+  const setup = Effect.gen(function* () {
+    const spans: Tracer.NativeSpan[] = [];
+    const ends: SpanEnd[] = [];
+    const flushes: number[] = [];
+    const startedAt = Date.now();
+    const recordingTracer = Tracer.make({
+      span: (options) => {
+        const span = new Tracer.NativeSpan(options);
+        const end = span.end.bind(span);
+        span.end = (endTime, exit) => {
+          ends.push({ name: span.name, exit, at: Date.now() - startedAt });
+          end(endTime, exit);
+        };
+        spans.push(span);
+        return span;
+      },
+    });
+    const flusher = Flusher.of({
+      flush: Effect.sync(() => {
+        flushes.push(Date.now() - startedAt);
+      }),
+      register: () => Effect.void,
+    });
+    const finalized: string[] = [];
+
+    const ctx = createFunctionRuntimeContext("DeadlineFunction");
+    // What `Telemetry.layer` registers during Construction: composed into
+    // every invocation's request scope by `buildEventTelemetry`.
+    ctx.telemetry = Layer.mergeAll(
+      Layer.succeed(Tracer.Tracer, recordingTracer),
+      Layer.succeed(Flusher, flusher),
+    );
+    yield* ctx.serve<never>(
+      Effect.gen(function* () {
+        const request = yield* HttpServerRequest;
+        // The Function URL bridge hands the handler an absolute URL.
+        const path = new URL(request.url, "http://x").pathname;
+        yield* Effect.addFinalizer(() =>
+          Effect.sync(() => {
+            finalized.push(path);
+          }),
+        );
+        if (path === "/slow") {
+          yield* Effect.sleep("2500 millis");
+        }
+        return HttpServerResponse.text("ok");
+      }),
+    );
+    const exports = yield* ctx.exports;
+    // `exports` is untyped (`Record<string, any>`); pin the handler effect's
+    // type so the setup effect stays `R = never`.
+    const handler = yield* exports.handler as Effect.Effect<
+      (
+        event: unknown,
+        context: lambda.Context,
+      ) => Promise<lambda.LambdaFunctionURLResult>
+    >;
+    return { handler, spans, ends, flushes, finalized };
+  });
+
+  const statusOf = (result: lambda.LambdaFunctionURLResult) =>
+    typeof result === "string" ? undefined : result.statusCode;
+
+  it("flushes at the margin and still lets a slow invocation complete", async () => {
+    // 2 s remaining, default 500 ms margin: the flush fires at ~1.5 s; the
+    // handler needs 2.5 s and is left alone.
+    const { handler, ends, flushes, finalized } =
+      await Effect.runPromise(setup);
+    const startedAt = Date.now();
+    const result = await handler(
+      functionUrlEvent("/slow"),
+      invocationContext(2_000),
+    );
+    const elapsed = Date.now() - startedAt;
+
+    // Not interrupted: the real response, after the handler's own 2.5 s.
+    expect(statusOf(result)).toBe(200);
+    expect(elapsed).toBeGreaterThanOrEqual(2_400);
+    expect(finalized).toEqual(["/slow"]);
+
+    // One flush, at the margin, before the handler was done.
+    expect(flushes).toHaveLength(1);
+    expect(flushes[0]).toBeGreaterThanOrEqual(1_400);
+    expect(flushes[0]).toBeLessThan(2_400);
+
+    // The http.server root span was ended twice: first by the flush with the
+    // timeout as a real FAILURE, then by the tracer with the real outcome.
+    const rootEnds = ends.filter((e) => e.name.startsWith("http.server"));
+    expect(rootEnds).toHaveLength(2);
+    const [early, final] = rootEnds;
+    expect(Exit.isFailure(early.exit)).toBe(true);
+    if (Exit.isFailure(early.exit)) {
+      const failure = early.exit.cause.reasons.find((r) => r._tag === "Fail");
+      expect(
+        failure?._tag === "Fail" ? failure.error : undefined,
+      ).toBeInstanceOf(InvocationTimeoutError);
+    }
+    expect(early.at).toBeLessThan(flushes[0] + 50);
+    expect(Exit.isSuccess(final.exit)).toBe(true);
+    expect(final.at).toBeGreaterThanOrEqual(2_400);
+  });
+
+  it("marks the early-ended span timeout-imminent", async () => {
+    const { handler, spans } = await Effect.runPromise(setup);
+    await handler(functionUrlEvent("/slow"), invocationContext(2_000));
+    const root = spans.find((span) => span.name.startsWith("http.server"));
+    expect(root?.attributes.get(TIMEOUT_IMMINENT_ATTRIBUTE)).toBe(true);
+    expect(root?.attributes.get("http.response.status_code")).toBe(200);
+  });
+
+  it("leaves a fast invocation untouched", async () => {
+    const { handler, spans, ends, flushes, finalized } =
+      await Effect.runPromise(setup);
+    const result = await handler(
+      functionUrlEvent("/fast"),
+      invocationContext(2_000),
+    );
+    expect(statusOf(result)).toBe(200);
+    expect(finalized).toEqual(["/fast"]);
+    expect(flushes).toHaveLength(0);
+    expect(ends.filter((e) => e.name.startsWith("http.server"))).toHaveLength(
+      1,
+    );
+    const root = spans.find((span) => span.name.startsWith("http.server"));
+    expect(root?.attributes.has(TIMEOUT_IMMINENT_ATTRIBUTE)).toBe(false);
+  });
+
+  it("a margin of 0 never flushes early", async () => {
+    process.env[TIMEOUT_MARGIN_ENV] = "0";
+    const { handler, ends, flushes } = await Effect.runPromise(setup);
+    const result = await handler(
+      functionUrlEvent("/slow"),
+      invocationContext(1_000),
+    );
+    expect(statusOf(result)).toBe(200);
+    expect(flushes).toHaveLength(0);
+    expect(ends.filter((e) => e.name.startsWith("http.server"))).toHaveLength(
+      1,
+    );
+  });
+});

--- a/packages/alchemy/test/AWS/Lambda/InvocationDeadline.test.ts
+++ b/packages/alchemy/test/AWS/Lambda/InvocationDeadline.test.ts
@@ -1,0 +1,257 @@
+import {
+  DEFAULT_TIMEOUT_MARGIN_MS,
+  HandlerContext,
+  InvocationTimeoutError,
+  readTimeoutMargin,
+  TIMEOUT_IMMINENT_ATTRIBUTE,
+  TIMEOUT_MARGIN_ENV,
+  toTimeoutMarginMillis,
+  withInvocationDeadline,
+} from "@/AWS/Lambda/InvocationDeadline.ts";
+import type * as lambda from "aws-lambda";
+import { afterEach, describe, expect, it } from "alchemy-test";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Fiber from "effect/Fiber";
+import * as TestClock from "effect/testing/TestClock";
+import type * as Tracer from "effect/Tracer";
+import { Flusher } from "effect/unstable/observability/OtlpExporter";
+
+const context = (remainingMs: number): lambda.Context =>
+  ({
+    functionName: "deadline-fn",
+    awsRequestId: "req-1",
+    getRemainingTimeInMillis: () => remainingMs,
+  }) as unknown as lambda.Context;
+
+const withMargin = (value: string | undefined) => {
+  if (value === undefined) delete process.env[TIMEOUT_MARGIN_ENV];
+  else process.env[TIMEOUT_MARGIN_ENV] = value;
+};
+
+/** A `Flusher` that counts drains instead of exporting. */
+const countingFlusher = () => {
+  const counter = { flushes: 0 };
+  const flusher = Flusher.of({
+    flush: Effect.sync(() => {
+      counter.flushes++;
+    }),
+    register: () => Effect.void,
+  });
+  return { counter, flusher };
+};
+
+const timeoutFailure = (exit: Exit.Exit<unknown, unknown>) =>
+  Exit.isFailure(exit)
+    ? (
+        exit.cause.reasons.find((r) => r._tag === "Fail") as
+          | { error: unknown }
+          | undefined
+      )?.error
+    : undefined;
+
+describe("withInvocationDeadline", () => {
+  afterEach(() => withMargin(undefined));
+
+  // `it.effect` runs under a TestClock: `Effect.sleep` (and so the guard's
+  // deadline timer) only advances through `TestClock.adjust`, which makes
+  // every timing below deterministic.
+  const start = <A, E>(effect: Effect.Effect<A, E>) =>
+    Effect.forkChild(Effect.exit(effect));
+
+  it.effect("runs unguarded without a HandlerContext", () =>
+    Effect.gen(function* () {
+      const fiber = yield* start(
+        withInvocationDeadline(
+          Effect.sleep("10 seconds").pipe(Effect.as("done")),
+        ),
+      );
+      yield* TestClock.adjust("10 seconds");
+      expect(yield* Fiber.join(fiber)).toEqual(Exit.succeed("done"));
+    }),
+  );
+
+  it.effect("does nothing when the handler finishes within budget", () =>
+    Effect.gen(function* () {
+      const { counter, flusher } = countingFlusher();
+      const fiber = yield* start(
+        withInvocationDeadline(
+          Effect.sleep("20 millis").pipe(Effect.as("done")),
+        ).pipe(
+          Effect.provideService(HandlerContext, context(5_000)),
+          Effect.provideService(Flusher, flusher),
+        ),
+      );
+      yield* TestClock.adjust("20 millis");
+      expect(yield* Fiber.join(fiber)).toEqual(Exit.succeed("done"));
+      expect(counter.flushes).toBe(0);
+    }),
+  );
+
+  it.effect(
+    "at the margin: ends the current span with InvocationTimeoutError, flushes, and lets the handler finish",
+    () =>
+      Effect.gen(function* () {
+        withMargin("4900");
+        const { counter, flusher } = countingFlusher();
+        let span: Tracer.Span | undefined;
+        const fiber = yield* start(
+          withInvocationDeadline(
+            Effect.gen(function* () {
+              span = yield* Effect.currentSpan;
+              yield* Effect.sleep("10 seconds");
+              return "done late";
+            }),
+          ).pipe(
+            // The tracer middleware puts the http.server span in context
+            // OUTSIDE the guard on the real HTTP path; `withSpan` stands in.
+            Effect.withSpan("root"),
+            Effect.provideService(HandlerContext, context(5_000)),
+            Effect.provideService(Flusher, flusher),
+          ),
+        );
+
+        // 5000 remaining - 4900 margin = a 100 ms budget.
+        yield* TestClock.adjust("100 millis");
+        expect(counter.flushes).toBe(1);
+        expect(span).toBeDefined();
+        expect(span!.status._tag).toBe("Ended");
+        if (span!.status._tag === "Ended") {
+          const error = timeoutFailure(span!.status.exit);
+          expect(error).toBeInstanceOf(InvocationTimeoutError);
+          const timeout = error as InvocationTimeoutError;
+          expect(timeout._tag).toBe("AWS.Lambda.InvocationTimeoutError");
+          expect(timeout.name).toBe("AWS.Lambda.InvocationTimeoutError");
+          expect(timeout.functionName).toBe("deadline-fn");
+          expect(timeout.requestId).toBe("req-1");
+          expect(timeout.budgetMs).toBe(100);
+          expect(timeout.marginMs).toBe(4900);
+          expect(timeout.message).toContain("4900ms before its timeout");
+        }
+        expect(span!.attributes.get(TIMEOUT_IMMINENT_ATTRIBUTE)).toBe(true);
+
+        // The handler was not touched: it completes on its own schedule and
+        // its value comes back, with no second flush. (`Effect.withSpan`
+        // leaves an already-ended span alone; the HTTP tracer middleware
+        // re-ends it with the real exit — pinned by the dispatch test.)
+        yield* TestClock.adjust("10 seconds");
+        expect(yield* Fiber.join(fiber)).toEqual(Exit.succeed("done late"));
+        expect(counter.flushes).toBe(1);
+        expect(span!.attributes.get(TIMEOUT_IMMINENT_ATTRIBUTE)).toBe(true);
+      }),
+  );
+
+  it.effect("flushes without a span in context (non-HTTP listeners)", () =>
+    Effect.gen(function* () {
+      withMargin("4900");
+      const { counter, flusher } = countingFlusher();
+      const fiber = yield* start(
+        withInvocationDeadline(
+          Effect.sleep("10 seconds").pipe(Effect.as("done")),
+        ).pipe(
+          Effect.provideService(HandlerContext, context(5_000)),
+          Effect.provideService(Flusher, flusher),
+        ),
+      );
+      yield* TestClock.adjust("100 millis");
+      expect(counter.flushes).toBe(1);
+      yield* TestClock.adjust("10 seconds");
+      expect(yield* Fiber.join(fiber)).toEqual(Exit.succeed("done"));
+    }),
+  );
+
+  it.effect("a margin of 0 disables the flush", () =>
+    Effect.gen(function* () {
+      withMargin("0");
+      const { counter, flusher } = countingFlusher();
+      const fiber = yield* start(
+        withInvocationDeadline(
+          Effect.sleep("50 millis").pipe(Effect.as("done")),
+        ).pipe(
+          Effect.provideService(HandlerContext, context(10)),
+          Effect.provideService(Flusher, flusher),
+        ),
+      );
+      yield* TestClock.adjust("50 millis");
+      expect(yield* Fiber.join(fiber)).toEqual(Exit.succeed("done"));
+      expect(counter.flushes).toBe(0);
+    }),
+  );
+
+  it.effect("a margin that leaves no budget runs unguarded", () =>
+    Effect.gen(function* () {
+      // default 500 ms margin, 200 ms remaining: budget <= 0
+      const { counter, flusher } = countingFlusher();
+      const fiber = yield* start(
+        withInvocationDeadline(
+          Effect.sleep("50 millis").pipe(Effect.as("done")),
+        ).pipe(
+          Effect.provideService(HandlerContext, context(200)),
+          Effect.provideService(Flusher, flusher),
+        ),
+      );
+      yield* TestClock.adjust("50 millis");
+      expect(yield* Fiber.join(fiber)).toEqual(Exit.succeed("done"));
+      expect(counter.flushes).toBe(0);
+    }),
+  );
+
+  it.effect("the innermost guard owns the deadline", () =>
+    Effect.gen(function* () {
+      withMargin("4900");
+      const { counter, flusher } = countingFlusher();
+      const fiber = yield* start(
+        withInvocationDeadline(
+          withInvocationDeadline(
+            Effect.sleep("10 seconds").pipe(Effect.as("done")),
+          ),
+        ).pipe(
+          Effect.provideService(HandlerContext, context(5_000)),
+          Effect.provideService(Flusher, flusher),
+        ),
+      );
+      yield* TestClock.adjust("100 millis");
+      // Both timers are due; only the inner guard flushes.
+      expect(counter.flushes).toBe(1);
+      yield* TestClock.adjust("10 seconds");
+      expect(yield* Fiber.join(fiber)).toEqual(Exit.succeed("done"));
+      expect(counter.flushes).toBe(1);
+    }),
+  );
+});
+
+describe("readTimeoutMargin", () => {
+  it("defaults when unset, empty or unparseable", () => {
+    expect(readTimeoutMargin(undefined)).toBe(DEFAULT_TIMEOUT_MARGIN_MS);
+    expect(readTimeoutMargin("")).toBe(DEFAULT_TIMEOUT_MARGIN_MS);
+    expect(readTimeoutMargin("abc")).toBe(DEFAULT_TIMEOUT_MARGIN_MS);
+    expect(readTimeoutMargin("-1")).toBe(DEFAULT_TIMEOUT_MARGIN_MS);
+  });
+
+  it("parses whole milliseconds, 0 included", () => {
+    expect(readTimeoutMargin("0")).toBe(0);
+    expect(readTimeoutMargin("250")).toBe(250);
+    expect(readTimeoutMargin("250.9")).toBe(250);
+  });
+});
+
+describe("toTimeoutMarginMillis", () => {
+  it("returns undefined for undefined", () => {
+    expect(toTimeoutMarginMillis(undefined)).toBeUndefined();
+  });
+
+  it("converts a Duration to whole milliseconds", () => {
+    expect(toTimeoutMarginMillis(Duration.zero)).toBe(0);
+    expect(toTimeoutMarginMillis(Duration.millis(250))).toBe(250);
+    expect(toTimeoutMarginMillis(Duration.seconds(1))).toBe(1000);
+    expect(toTimeoutMarginMillis(Duration.infinity)).toBeUndefined();
+  });
+
+  it("converts a state-JSON rehydrated Duration", () => {
+    const json = JSON.parse(
+      JSON.stringify(Duration.millis(750)),
+    ) as Duration.Duration;
+    expect(toTimeoutMarginMillis(json)).toBe(750);
+  });
+});

--- a/packages/alchemy/test/AWS/Lambda/Telemetry.test.ts
+++ b/packages/alchemy/test/AWS/Lambda/Telemetry.test.ts
@@ -1,10 +1,11 @@
 import * as AWS from "@/AWS";
 import * as Cloudflare from "@/Cloudflare/index.ts";
 import * as Test from "@/Test/Alchemy";
-import { describe } from "alchemy-test";
+import { describe, expect } from "alchemy-test";
 import * as ConfigProvider from "effect/ConfigProvider";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as HttpClient from "effect/unstable/http/HttpClient";
 import * as pathe from "pathe";
 import { expectUrlContains } from "../../Cloudflare/Utils/Http.ts";
 import type { OtelSink } from "./fixtures/otel-collector-worker.ts";
@@ -108,6 +109,29 @@ describe("AWS.Lambda Telemetry", () => {
         yield* expectUrlContains(collected, "lambda.child-span");
         // Log record shipped by the OTLP logger.
         yield* expectUrlContains(collected, "lambda-work-log");
+
+        // A timing-out invocation: the fixture's timeout is 5 s and `/slow`
+        // sleeps 60 s, so Lambda kills it and the Function URL answers with
+        // an error. 500 ms before that the deadline flush ended the root
+        // span with the timeout and drained the exporters, so the trace
+        // exists. Without it Lambda freezes the sandbox and nothing below
+        // ever reaches the collector.
+        const client = yield* HttpClient.HttpClient;
+        const slow = yield* client.get(`${fnUrl}/slow`);
+        expect(slow.status).not.toBe(200);
+        yield* expectUrlContains(
+          collected,
+          "AWS.Lambda.InvocationTimeoutError",
+          {
+            timeout: "120 seconds",
+            label: "timed-out invocation's root span",
+          },
+        );
+        yield* expectUrlContains(collected, "aws.lambda.timeout.imminent");
+        // The child span that ended before the sleep and its log travel in
+        // the same flush.
+        yield* expectUrlContains(collected, "lambda.slow-span");
+        yield* expectUrlContains(collected, "lambda-slow-log");
       }),
     { timeout: 600_000 },
   );

--- a/packages/alchemy/test/AWS/Lambda/fixtures/otel-handler.ts
+++ b/packages/alchemy/test/AWS/Lambda/fixtures/otel-handler.ts
@@ -1,6 +1,7 @@
 import * as Lambda from "@/AWS/Lambda";
 import * as Telemetry from "@/Telemetry.ts";
 import * as Config from "effect/Config";
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
@@ -15,6 +16,11 @@ import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
  *
  * `GET /work` runs a child span and a log so the test can assert traces AND
  * logs arrive at the collector after the invocation scope flushes.
+ *
+ * `GET /slow` outlives the function's 5 s timeout. The invocation deadline
+ * flush fires `timeoutMargin` before Lambda freezes the sandbox and ships
+ * the trace — root span ended with `AWS.Lambda.InvocationTimeoutError`,
+ * the already-ended child span, the log — that would otherwise be lost.
  */
 export class OtelTestFunction extends Lambda.Function<Lambda.Function>()(
   "OtelTelemetryFunction",
@@ -24,11 +30,23 @@ export const OtelTestFunctionLive = OtelTestFunction.make(
   {
     main: import.meta.url,
     functionUrl: true,
+    timeout: Duration.seconds(5),
   },
   Effect.gen(function* () {
     const doWork = Effect.fn("lambda.child-span")(function* () {
       yield* Effect.log("lambda-work-log");
       return "lambda-did-work";
+    });
+    // A child span that has ENDED by the time the deadline flush fires is
+    // exported with the root; the sleep that outlives the timeout runs
+    // outside it (a span still open at the flush is not exported).
+    const slowSetup = Effect.fn("lambda.slow-span")(function* () {
+      yield* Effect.log("lambda-slow-log");
+    });
+    const doSlowWork = Effect.gen(function* () {
+      yield* slowSetup();
+      yield* Effect.sleep("60 seconds");
+      return "never";
     });
 
     return {
@@ -37,6 +55,10 @@ export const OtelTestFunctionLive = OtelTestFunction.make(
         const url = new URL(request.url, "http://x");
         if (url.pathname === "/work") {
           const marker = yield* doWork();
+          return yield* HttpServerResponse.json({ marker });
+        }
+        if (url.pathname === "/slow") {
+          const marker = yield* doSlowWork;
           return yield* HttpServerResponse.json({ marker });
         }
         // Readiness gate for the test: the collector's workers.dev URL

--- a/website/src/content/docs/aws/compute/lambda.mdx
+++ b/website/src/content/docs/aws/compute/lambda.mdx
@@ -293,6 +293,46 @@ the response, keep them cheap, and anything that must not be lost
 gets written durably (a queue, a table) inside the handler itself.
 :::
 
+### Timeouts still export their trace
+
+A Lambda that hits its timeout is frozen mid-flight, and its buffered
+telemetry is lost with it, on exactly the invocation you most want a
+trace for. So the runtime watches the deadline. If the handler is
+still running 500 ms before the timeout, the runtime ends the
+invocation's root span with an `AWS.Lambda.InvocationTimeoutError`,
+logs a warning, and drains the exporters. The handler is not
+interrupted and the response is not changed: if it does finish in
+that last half second, it returns as normal and the span is
+re-exported with the real outcome, the earlier one marked
+`aws.lambda.timeout.imminent`.
+
+Size the margin for one export round-trip to your telemetry backend,
+or set it to zero to turn the flush off:
+
+```typescript
+// src/api.ts
+import * as AWS from "alchemy/AWS";
+import * as Duration from "effect/Duration";
+import * as Effect from "effect/Effect";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+
+export default class Api extends AWS.Lambda.Function<Api>()(
+  "Api",
+  {
+    main: import.meta.url,
+    functionUrl: true,
+    timeout: Duration.seconds(30),
+    // flush 1 s before the deadline instead of the default 500 ms
+    timeoutMargin: Duration.seconds(1),
+  },
+  Effect.gen(function* () {
+    return {
+      fetch: Effect.succeed(HttpServerResponse.text("Hello from Lambda!")),
+    };
+  }),
+) {}
+```
+
 Construction-level finalizers run at **sandbox shutdown**. A Lambda sandbox
 with no registered extensions is killed with no signal at all, so
 the generated entry registers an internal extension with the

--- a/website/src/content/docs/infrastructure-as-effects/telemetry.mdx
+++ b/website/src/content/docs/infrastructure-as-effects/telemetry.mdx
@@ -137,7 +137,12 @@ flushed when that scope closes:
 - On Cloudflare, the flush is registered with `ctx.waitUntil`, so it
   happens after the response is sent and never adds latency.
 - On Lambda, the flush settles inline before the invocation returns —
-  the response isn't released until the invoke completes anyway.
+  the response isn't released until the invoke completes anyway. An
+  invocation still running 500 ms before its timeout (`timeoutMargin`
+  on the Function) gets an early flush: the root span is ended with a
+  timeout error and the exporters drained, so the trace arrives
+  instead of vanishing with the frozen sandbox. The handler itself is
+  left alone.
 
 This per-event lifecycle is what makes export work on workerd, where
 timers and fetches are pinned to the request that created them: a


### PR DESCRIPTION
Closes #1484

## The problem

The Lambda dispatcher gives every invocation a fresh request scope and closes it inline once the handler settles. That close is where the telemetry exporters flush:

```ts
const scope = Scope.makeUnsafe();
const exit = await eff.pipe(
  Effect.provide(
    Layer.mergeAll(
      Layer.succeed(HandlerContext, context),
      Layer.succeed(Scope.Scope, scope),
      Layer.effectContext(buildEventTelemetry(services, scope, ctx.telemetry)),
    ),
  ),
  Effect.runPromiseExit,
);
await Scope.close(scope, exit); // <- spans, logs and metrics ship here
```

When the handler outlives its timeout, Lambda freezes the sandbox mid-flight and `Scope.close` never runs. The exporter buffer and the still-open root span die with it, on exactly the invocation you most want a trace for.

## The fix: flush early, never interrupt

The deadline is known up front from `context.getRemainingTimeInMillis()`, and a sandbox only ever handles one invocation at a time, so a pre-deadline timer is race-free. `withInvocationDeadline` forks a watcher that parks for `remaining - margin` and, if the handler is still running by then, ends the root span, logs, and drains the exporters. The handler is left alone:

```ts
const watcher = yield* Effect.forkChild(
  Effect.sleep(Duration.millis(budgetMs)).pipe(
    Effect.andThen(Effect.uninterruptible(flushBeforeDeadline)),
  ),
);
return yield* self.pipe(Effect.ensuring(Fiber.interrupt(watcher)));
```

```ts
const flushBeforeDeadline = Effect.gen(function* () {
  const error = new InvocationTimeoutError({ functionName, requestId, budgetMs, marginMs });
  const span = yield* Effect.option(Effect.currentSpan); // the http.server root span
  if (Option.isSome(span) && span.value.status._tag === "Started") {
    span.value.attribute("aws.lambda.timeout.imminent", true);
    span.value.end(yield* Clock.currentTimeNanos, Exit.fail(error));
  }
  yield* Effect.logWarning(error.message);            // carries the trace id
  const flusher = yield* Effect.serviceOption(Flusher); // effect's OTLP exporter registry
  if (Option.isSome(flusher)) yield* flusher.value.flush;
});
```

If Lambda then freezes the sandbox, the trace already exists with an errored root span, the child spans that had ended, and every log record. If the handler finishes inside the margin, its response goes out exactly as before, and the HTTP tracer middleware ends the span a second time with the real outcome. That earlier export is the accepted false positive; the `aws.lambda.timeout.imminent` attribute stays on the span so a backend can tell the two apart. This is the same model dd-trace uses (it finishes the invocation span as a timeout and flushes, without cancelling the handler). Nothing about the invocation's outcome changes: no interruption, no synthetic failure, no change to Lambda's `Errors` metric.

The watcher inherits the invocation fiber's context, so it sees the invocation's logger, the exporters and, on the HTTP path, the root span. The flush is uninterruptible, so a handler that finishes mid-flush waits for the export instead of abandoning an in-flight batch. Spans still open at the flush other than the root are not exported, which is what it means to flush a running invocation.

## Why the HTTP listener guards twice

The dispatcher guards every listener effect, but the `http.server` span is created further in, by `HttpMiddleware.tracer`. To be able to end that span, the HTTP listener applies the guard inside the tracer:

```ts
const safeHandler = HttpMiddleware.tracer(
  withInvocationDeadline(Http.safeHttpEffect(handler)),
);
```

Two watchers on one invocation would flush twice, so nested guards hand the deadline down: the guard provides an internal `InvocationDeadline` service to its inner effect, an inner guard claims it, and the outer watcher does nothing when its timer fires:

```ts
const outer = yield* Effect.serviceOption(InvocationDeadline);
if (Option.isSome(outer)) outer.value.claim();
let claimed = false;
// ...
Effect.sleep(budget).pipe(
  Effect.andThen(Effect.suspend(() => (claimed ? Effect.void : flushBeforeDeadline))),
)
```

Queue, stream and other non-HTTP listeners only have the dispatcher's guard; without a span in context it logs and flushes, which still ships everything that had ended.

## Configuring the margin

The margin is a Function prop next to `timeout`, written to `ALCHEMY_LAMBDA_TIMEOUT_MARGIN_MS` at deploy time and read per invocation. Size it for one export round-trip to your telemetry backend, or set it to zero to turn the flush off:

```ts
export default class Api extends AWS.Lambda.Function<Api>()(
  "Api",
  {
    main: import.meta.url,
    timeout: Duration.seconds(30),
    timeoutMargin: Duration.seconds(1), // default 500 millis
  },
  Effect.gen(function* () {
    return { fetch: /* ... */ };
  }),
) {}
```

A margin that leaves no budget logs a warning and runs without the watcher rather than flushing at t=0 on every invocation. `HandlerContext` moved into the new `InvocationDeadline.ts` module unchanged and is still exported from `AWS.Lambda`.

## Tests

`InvocationDeadline.test.ts` covers the guard under the TestClock with a counting `Flusher`. The central case pins that the root span was ended with the timeout at the margin, that the handler still completed with its value afterwards, and that only one flush happened:

```ts
yield* TestClock.adjust("100 millis"); // 5000 remaining - 4900 margin
expect(counter.flushes).toBe(1);
expect(timeoutFailure(span.status.exit)).toBeInstanceOf(InvocationTimeoutError);
expect(span.attributes.get(TIMEOUT_IMMINENT_ATTRIBUTE)).toBe(true);

yield* TestClock.adjust("10 seconds");
expect(yield* Fiber.join(fiber)).toEqual(Exit.succeed("done late"));
expect(counter.flushes).toBe(1);
```

`InvocationDeadline.dispatch.test.ts` drives the real dispatcher export in-process with a fake invocation context, a recording tracer and a counting `Flusher`. A 2.5 s handler with 2 s remaining returns its real 200 after 2.5 s, the flush fired at ~1.5 s, and the `http.server` span was ended twice, first with the timeout as a `Fail` and then with the real success:

```ts
expect(statusOf(result)).toBe(200);
expect(flushes[0]).toBeGreaterThanOrEqual(1_400);
const [early, final] = ends.filter((e) => e.name.startsWith("http.server"));
expect(failureOf(early.exit)).toBeInstanceOf(InvocationTimeoutError);
expect(Exit.isSuccess(final.exit)).toBe(true);
```

`Telemetry.test.ts` (live) now deploys the fixture with `timeout: Duration.seconds(5)` and a `/slow` route that ends a child span, logs, then sleeps 60 s. Lambda kills it; the test asserts the collector still received `AWS.Lambda.InvocationTimeoutError`, `aws.lambda.timeout.imminent`, the child span and its log. I could not run the live test from this session because the AWS SSO token had expired; it needs a CI run.

## Docs

`aws/compute/lambda.mdx` gains a "Timeouts still export their trace" section, and the telemetry page's Lambda flush note mentions the early flush.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
