### PR TITLE
feat(cloudflare): add webSocketError to the Durable Object shape and bridge

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/DurableObject.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/DurableObject.ts
@@ -115,6 +115,11 @@ export interface DurableObjectShape {
     reason: string,
     wasClean: boolean,
   ) => Effect.Effect<void>;
+  /**
+   * Called when a hibernatable WebSocket errors. The runtime closes the
+   * socket after this handler; use it to drop the peer's session state.
+   */
+  webSocketError?: (socket: WebSocket, error: unknown) => Effect.Effect<void>;
 }
 
 export type DurableObjectServices =
@@ -719,8 +724,8 @@ export class DurableObjectScope extends Context.Service<
  * Durable Objects support WebSocket hibernation — the runtime can
  * evict the object from memory while keeping connections open. Use
  * `Cloudflare.upgrade()` to accept a connection, and return
- * `webSocketMessage` / `webSocketClose` handlers to process events
- * when the object wakes back up.
+ * `webSocketMessage` / `webSocketClose` / `webSocketError` handlers to
+ * process events when the object wakes back up.
  *
  * **Example:** Accepting a WebSocket connection
  * ```typescript
@@ -751,6 +756,13 @@ export class DurableObjectScope extends Context.Service<
  *     reason: string,
  *   ) {
  *     yield* ws.close(code, reason);
+ *   }),
+ *   webSocketError: Effect.fn(function* (
+ *     ws: Cloudflare.WebSocket,
+ *     error: unknown,
+ *   ) {
+ *     // the runtime closes the socket afterwards; clear its session here
+ *     ws.serializeAttachment(null);
  *   }),
  * };
  * ```

--- a/packages/alchemy/src/Cloudflare/Workers/DurableObjectBridge.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/DurableObjectBridge.ts
@@ -216,5 +216,13 @@ export const makeDurableObjectBridge =
             ) ?? Effect.void,
         );
       }
+
+      async webSocketError(ws: WebSocket, error: unknown) {
+        return this.#execute(
+          (instance) =>
+            instance.webSocketError?.(fromWebSocket(ws as any), error) ??
+            Effect.void,
+        );
+      }
     } as any;
   };

--- a/website/src/content/docs/cloudflare/compute/hibernatable-websockets.mdx
+++ b/website/src/content/docs/cloudflare/compute/hibernatable-websockets.mdx
@@ -144,8 +144,21 @@ return {
 +    if (attachment) sessions.delete(attachment.id);
 +    yield* ws.close(code, reason);
 +  }),
++  webSocketError: Effect.fn(function* (
++    ws: Cloudflare.WebSocket,
++    error: unknown,
++  ) {
++    // Cloudflare closes an errored socket after this handler runs; only
++    // the session bookkeeping is ours to clean up.
++    const attachment = ws.deserializeAttachment<{ id: string }>();
++    if (attachment) sessions.delete(attachment.id);
++  }),
 };
 ```
+
+`webSocketError` fires when the connection fails instead of closing
+cleanly (a network reset, a protocol error). The runtime closes the
+socket afterwards, so the handler only has to drop the peer's state.
 
 ## Restore sessions after hibernation
 


### PR DESCRIPTION
## What

Adds `webSocketError(socket, error)` to `DurableObjectShape` and forwards the event in `DurableObjectBridge`, next to `webSocketMessage` and `webSocketClose`.

## Why

A hibernatable WebSocket that fails instead of closing cleanly (network reset, protocol error) reaches a Durable Object through `webSocketError`. The Effect shape had no such handler and the bridge did not forward the event, so an object could only clean up an errored peer's session on its next `getWebSockets` pass. Objects that keep per-socket state (a sessions map, awareness state, an attachment) need the event to drop it.

## How

- `DurableObjectShape.webSocketError?: (socket: WebSocket, error: unknown) => Effect<void>`.
- The bridge runs it like the other socket handlers, in its own call scope, with `fromWebSocket(ws)`.
- The runtime closes the socket after the handler, so the handler only owns the session bookkeeping; the JSDoc and the hibernatable WebSockets guide show it next to `webSocketClose`.

## Checks

- `tsc -b packages/alchemy` clean (apart from the pre-existing `@alchemy.run/floci` resolution errors on a checkout without the floci submodule).
- `oxfmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
