### PR TITLE
fix(cloudflare): run Durable Object callbacks with the caller's context

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/DurableObjectState.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/DurableObjectState.ts
@@ -36,9 +36,16 @@ export class DurableObjectState extends Context.Service<
      * The raw workerd DurableObjectState, for interop with async APIs.
      */
     readonly raw: cf.DurableObjectState;
-    blockConcurrencyWhile<T>(
-      callback: () => Effect.Effect<T, never, RuntimeContext>,
-    ): Effect.Effect<T, never, RuntimeContext>;
+    /**
+     * Run `callback` while workerd holds every other event on this object.
+     * The callback runs with the caller's full context (services, tracing),
+     * as `waitUntil` does, so a service provided to the calling fiber is
+     * visible inside the gate. A defect in the callback rejects the gate
+     * and workerd resets the object, which is the platform's contract.
+     */
+    blockConcurrencyWhile<T, R = never>(
+      callback: () => Effect.Effect<T, never, R>,
+    ): Effect.Effect<T, never, R | RuntimeContext>;
     acceptWebSocket(
       ws: WebSocket,
       tags?: string[],
@@ -99,10 +106,19 @@ export const fromDurableObjectState = (
         ),
       );
     }),
-  blockConcurrencyWhile: <T>(callback: () => Effect.Effect<T>) =>
-    Effect.tryPromise(() =>
-      state.blockConcurrencyWhile(() => Effect.runPromise(callback())),
-    ),
+  blockConcurrencyWhile: <T, R = never>(
+    callback: () => Effect.Effect<T, never, R>,
+  ) =>
+    Effect.gen(function* () {
+      const context = yield* Effect.context<R>();
+      // The failure is typed away as before: a rejected gate is the
+      // platform resetting the object, not a value a caller handles.
+      return yield* Effect.tryPromise<T, never>(() =>
+        state.blockConcurrencyWhile(() =>
+          Effect.runPromise(callback().pipe(Effect.provide(context))),
+        ),
+      );
+    }),
   acceptWebSocket: (ws: WebSocket, tags?: string[]) =>
     Effect.sync(() => state.acceptWebSocket(ws.ws, tags)),
   getWebSockets: (tag?: string) =>

--- a/packages/alchemy/src/Cloudflare/Workers/DurableObjectStorage.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/DurableObjectStorage.ts
@@ -152,11 +152,15 @@ export interface DurableObjectStorage {
   deleteAll(
     options?: cf.DurableObjectPutOptions,
   ): Effect.Effect<void, never, RuntimeContext>;
-  transaction<T>(
-    closure: (
-      txn: DurableObjectTransaction,
-    ) => Effect.Effect<T, never, RuntimeContext>,
-  ): Effect.Effect<T, never, RuntimeContext>;
+  /**
+   * Run `closure` inside a storage transaction. The closure runs with the
+   * caller's full context (services, tracing), as `waitUntil` does, so a
+   * service provided to the calling fiber is visible inside the transaction.
+   * A defect in the closure rolls the transaction back.
+   */
+  transaction<T, R = never>(
+    closure: (txn: DurableObjectTransaction) => Effect.Effect<T, never, R>,
+  ): Effect.Effect<T, never, R | RuntimeContext>;
   getAlarm(
     options?: cf.DurableObjectGetAlarmOptions,
   ): Effect.Effect<number | null, never, RuntimeContext>;
@@ -249,14 +253,23 @@ export const fromDurableObjectStorage = (
     Effect.tryPromise(() => storage.delete(keyOrKeys as any, options))) as any,
   deleteAll: (options?: cf.DurableObjectPutOptions) =>
     Effect.tryPromise(() => storage.deleteAll(options)),
-  transaction: <T>(
-    closure: (txn: DurableObjectTransaction) => Effect.Effect<T>,
+  transaction: <T, R = never>(
+    closure: (txn: DurableObjectTransaction) => Effect.Effect<T, never, R>,
   ) =>
-    Effect.tryPromise(() =>
-      storage.transaction((txn) =>
-        Effect.runPromise(closure(fromDurableObjectTransaction(txn))),
-      ),
-    ),
+    Effect.gen(function* () {
+      const context = yield* Effect.context<R>();
+      // The failure is typed away as before: a rejected transaction has
+      // rolled back, and the rejection reaches the caller as a defect.
+      return yield* Effect.tryPromise<T, never>(() =>
+        storage.transaction((txn) =>
+          Effect.runPromise(
+            closure(fromDurableObjectTransaction(txn)).pipe(
+              Effect.provide(context),
+            ),
+          ),
+        ),
+      );
+    }),
   getAlarm: (options?: cf.DurableObjectGetAlarmOptions) =>
     Effect.tryPromise(() => storage.getAlarm(options)),
   setAlarm: (

--- a/packages/alchemy/test/Cloudflare/Workers/DurableObjectCallbackContext.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/DurableObjectCallbackContext.test.ts
@@ -1,0 +1,57 @@
+import { fromDurableObjectState } from "@/Cloudflare/Workers/DurableObjectState.ts";
+import { fromDurableObjectStorage } from "@/Cloudflare/Workers/DurableObjectStorage.ts";
+import { RuntimeContext } from "@/RuntimeContext.ts";
+import { describe, expect, it } from "alchemy-test";
+import * as Context from "effect/Context";
+import * as Effect from "effect/Effect";
+
+/**
+ * `waitUntil` captures the caller's context and provides it to the Effect it
+ * runs. `blockConcurrencyWhile` and `storage.transaction` run their closures
+ * through a bare `Effect.runPromise` on the raw platform promise, so a service
+ * provided to the calling fiber (a request-scoped deadline, a tracer, an alarm
+ * floor) must reach those closures the same way.
+ */
+class Marker extends Context.Service<Marker, { readonly value: string }>()(
+  "test/Marker",
+) {}
+
+const readMarker = Effect.map(Marker, (marker) => marker.value);
+
+describe("Durable Object callbacks run with the caller's context", () => {
+  it.effect("blockConcurrencyWhile provides the calling fiber's services", () =>
+    Effect.gen(function* () {
+      const state = fromDurableObjectState({
+        id: { toString: () => "id" },
+        storage: { sql: {} },
+        blockConcurrencyWhile: <T>(callback: () => Promise<T>) => callback(),
+      } as never);
+
+      const value = yield* state.blockConcurrencyWhile(() => readMarker);
+
+      expect(value).toBe("inside the gate");
+    }).pipe(
+      Effect.provideService(Marker, { value: "inside the gate" }),
+      Effect.provide(RuntimeContext.phantom),
+    ),
+  );
+
+  it.effect("storage.transaction provides the calling fiber's services", () =>
+    Effect.gen(function* () {
+      const txn = { getAlarm: () => Promise.resolve(42) };
+      const storage = fromDurableObjectStorage({
+        sql: {},
+        transaction: <T>(closure: (txn: unknown) => Promise<T>) => closure(txn),
+      } as never);
+
+      const value = yield* storage.transaction((transaction) =>
+        Effect.all([readMarker, transaction.getAlarm()]),
+      );
+
+      expect(value).toEqual(["inside the transaction", 42]);
+    }).pipe(
+      Effect.provideService(Marker, { value: "inside the transaction" }),
+      Effect.provide(RuntimeContext.phantom),
+    ),
+  );
+});


### PR DESCRIPTION
## What

`DurableObjectState.blockConcurrencyWhile` and `DurableObjectStorage.transaction` now run their closures with the caller's context, the way `DurableObjectState.waitUntil` already does, and their signatures carry the closure's requirements `R` through to the caller.

## Why

Both ran their closure through a bare `Effect.runPromise` on the raw platform promise, so any service provided to the calling fiber (a request-scoped deadline, a tracer, a scheduling floor) was gone inside the gate and the transaction. `waitUntil` captures `Effect.context<R>()` and provides it; the other two did not, and their signatures pinned the closure to `Effect<T, never, RuntimeContext>`, so a closure that needed a service could not even be typed.

## How

- `blockConcurrencyWhile<T, R = never>(callback: () => Effect<T, never, R>): Effect<T, never, R | RuntimeContext>` captures the caller's context and provides it to the callback.
- `transaction<T, R = never>(closure: (txn) => Effect<T, never, R>): Effect<T, never, R | RuntimeContext>` does the same for the transaction closure.
- The failure channel stays typed away as before: a rejected gate is the platform resetting the object, a rejected transaction has rolled back.
- Unit test `test/Cloudflare/Workers/DurableObjectCallbackContext.test.ts`: a service provided to the calling fiber is visible inside both closures.

## Checks

- `pnpm test test/Cloudflare/Workers/DurableObjectCallbackContext.test.ts` and `DurableObjectState.test.ts` pass (bun 1.3.13).
- `tsc -b packages/alchemy` clean (apart from the pre-existing `@alchemy.run/floci` resolution errors on a checkout without the floci submodule).
- `oxfmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
