### PR TITLE
feat(cloudflare): let a class-form Durable Object keep a distinct class name

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/DurableObject.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/DurableObject.ts
@@ -266,7 +266,7 @@ export interface DurableObjectClass extends Effect.Effect<
   <Self, Shape>(): {
     <Name extends string>(
       name: Name,
-      props?: Pick<DurableObjectProps, "transferredFrom">,
+      props?: Pick<DurableObjectProps, "className" | "transferredFrom">,
     ): Effect.Effect<DurableObject<Self>, never, Worker | Self> & {
       new (_: never): Shape & {
         /** @internal */
@@ -463,6 +463,23 @@ export class DurableObjectScope extends Context.Service<
  *     return HttpServerResponse.text(String(yield* counter.get()));
  *   }),
  * };
+ * ```
+ *
+ * ### Keeping an Existing Class Name
+ * The class form names the binding (`env.Counter`, the logical id that
+ * drives migrations) and, by default, the exported class. Pass
+ * `className` when the physical class must keep a different name, for
+ * example when converting a Worker whose classes were declared with the
+ * async form: the same logical id and the same class name mean no
+ * migration, so the namespace and its stored objects are kept in place.
+ *
+ * **Example:** Converting an async-form binding without a migration
+ * ```typescript
+ * // Before: bindings: { LENS_DO: Cloudflare.DurableObject("lens", { className: "LensServer" }) }
+ * export class LensDo extends Cloudflare.DurableObject<LensDo, LensShape>()(
+ *   "LENS_DO",
+ *   { className: "LensServer" },
+ * ) {}
  * ```
  *
  * ### Cross-Worker Binding
@@ -1170,6 +1187,22 @@ export const DurableObject: DurableObjectClass = taggedFunction(
     const propsOrImpl = args[1];
     const tag = Context.Service(namespace);
 
+    // Class-form declarations (`DurableObject<Self>()("Name", props?)`) can
+    // carry `transferredFrom` so the host's local binding drives a
+    // data-preserving transfer migration, and `className` so the physical
+    // class keeps a name that differs from the logical id (the binding's
+    // name in `env`). Every place the physical name flows reads
+    // `className`: the binding, the namespace accessor, the export the
+    // generated entry turns into `export class <className>`, and the
+    // bridge's lookup of that export.
+    const classProps =
+      isClassForm && !Effect.isEffect(propsOrImpl)
+        ? (propsOrImpl as
+            | Pick<DurableObjectProps, "className" | "transferredFrom">
+            | undefined)
+        : undefined;
+    const className = classProps?.className ?? namespace;
+
     const binding = (
       scriptName?: Input<string>,
       transferredFrom?:
@@ -1184,7 +1217,7 @@ export const DurableObject: DurableObjectClass = taggedFunction(
             {
               type: "durable_object_namespace",
               name: namespace,
-              className: namespace,
+              className,
               scriptName,
               transferredFrom: normalizeTransferredFrom(transferredFrom),
             },
@@ -1221,9 +1254,10 @@ export const DurableObject: DurableObjectClass = taggedFunction(
           Type: TypeId,
           LogicalId: namespace,
           name: namespace,
+          // The provider keys the namespace map by physical class name.
           namespaceId: worker.durableObjectNamespaces.pipe(
             Output.map(
-              (durableObjectNamespaces) => durableObjectNamespaces?.[namespace],
+              (durableObjectNamespaces) => durableObjectNamespaces?.[className],
             ),
           ),
           getByName: (
@@ -1241,16 +1275,6 @@ export const DurableObject: DurableObjectClass = taggedFunction(
           //   use((ns) => ns.jurisdiction(jurisdiction) as any),
         };
       });
-
-    // Class-form declarations (`DurableObject<Self>()("Name", props?)`) can
-    // carry `transferredFrom` so the host's local binding drives a
-    // data-preserving transfer migration.
-    const classProps =
-      isClassForm && !Effect.isEffect(propsOrImpl)
-        ? (propsOrImpl as
-            | Pick<DurableObjectProps, "transferredFrom">
-            | undefined)
-        : undefined;
 
     const make = Effect.fn(function* (
       impl: Effect.Effect<
@@ -1282,7 +1306,9 @@ export const DurableObject: DurableObjectClass = taggedFunction(
           ),
         );
       }
-      yield* (yield* Worker).export(namespace, {
+      // Exports are keyed by physical class name: the generated entry emits
+      // `export class <key>` and the bridge resolves its export by that key.
+      yield* (yield* Worker).export(className, {
         kind: "durableObject",
         // initialize the object's constructor (apply infra dependencies)
         constructor,

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
@@ -3292,16 +3292,23 @@ export const LiveWorkerProvider = () =>
         const oldTags = Array.from(new Set(oldSettings?.tags ?? []));
         const oldBindings = oldSettings?.bindings ?? [];
 
-        // Parse the DO logical-id→class mapping from script tags (packed
-        // `alchemy:dos:` and legacy per-DO `alchemy:do:` formats)
-        const oldDoClassNameByLogicalId = getDurableObjectTagMap(oldTags);
+        // The class-identity plan, pure and unit-tested: a logical id that
+        // keeps its class name needs no migration, a changed class name is a
+        // rename, a logical id with no previous class is created or
+        // transferred below, and a vanished logical id is a delete candidate
+        // validated against observed namespace ownership below.
         const currentDoBindings = getDurableObjectBindings(bindings, name);
-        const currentDoClassNameByLogicalId = Object.fromEntries(
-          currentDoBindings.map((binding) => [
-            binding.logicalId,
-            binding.className,
-          ]),
-        );
+        const identity = planDurableObjectClassIdentity({
+          workerName: name,
+          oldTags,
+          oldBindings,
+          current: currentDoBindings,
+        });
+        const {
+          oldDoClassNameByLogicalId,
+          currentDoClassNameByLogicalId,
+          deletedClassCandidates,
+        } = identity;
 
         // Parse alchemy:migration-tag:{version}
         const oldMigrationTag = oldTags.flatMap((tag) =>
@@ -3310,41 +3317,6 @@ export const LiveWorkerProvider = () =>
             : [],
         )[0];
         const newMigrationTag = bumpMigrationTagVersion(oldMigrationTag);
-
-        // Compute delete-class candidates. Candidates are validated against
-        // observed namespace ownership below — a class may already have been
-        // transferred to another script by its new host's deploy.
-        const deletedClassCandidates: string[] = [];
-        for (const [logicalId, className] of Object.entries(
-          oldDoClassNameByLogicalId,
-        )) {
-          if (!currentDoClassNameByLogicalId[logicalId]) {
-            deletedClassCandidates.push(className);
-          }
-        }
-
-        // Backward compatibility for old workers that have DO bindings but no
-        // alchemy:do tags yet. Cross-script bindings (`scriptName` set to
-        // anything other than this worker) are NEVER candidates for
-        // delete-class migrations — the class lives on the foreign script
-        // and we don't own its lifecycle.
-        if (Object.keys(oldDoClassNameByLogicalId).length === 0) {
-          for (const oldBinding of oldBindings) {
-            const ownedLocally =
-              !("scriptName" in oldBinding) || oldBinding.scriptName === name;
-            if (
-              oldBinding.type === "durable_object_namespace" &&
-              "className" in oldBinding &&
-              oldBinding.className &&
-              ownedLocally &&
-              !currentDoBindings.some(
-                (binding) => binding.bindingName === oldBinding.name,
-              )
-            ) {
-              deletedClassCandidates.push(oldBinding.className);
-            }
-          }
-        }
 
         // Class names the current deploy references *cross-script* (mapped to
         // the foreign script). A class that both leaves the "hosted here" set
@@ -3452,88 +3424,49 @@ export const LiveWorkerProvider = () =>
         // Compute new, renamed, and transferred classes
         const newClasses: string[] = [];
         const newSqliteClasses: string[] = [];
-        const renamedClasses: { from: string; to: string }[] = [];
+        const renamedClasses = identity.renamedClasses;
         const transferredClasses: {
           from: string;
           fromScript: string;
           to: string;
         }[] = [];
-        for (const binding of currentDoBindings) {
-          let previousClassName: string | undefined =
-            oldDoClassNameByLogicalId[binding.logicalId];
-          if (!previousClassName) {
-            // No DO metadata tag maps this logical id to a class — the
-            // worker was created outside Alchemy (raw API / Wrangler) or
-            // before these tags existed. Fall back to matching the observed
-            // cloud binding by binding name so adoption reuses the existing
-            // class instead of asking Cloudflare to create one that already
-            // exists (which fails the migration). This is the "first deploy
-            // must match the existing class name" path; once we write the
-            // `alchemy:dos:` tag, subsequent renames are driven by logical id.
-            const observed = oldBindings.find(
-              (old) =>
-                old.type === "durable_object_namespace" &&
-                "className" in old &&
-                old.className &&
-                // Only a *locally-owned* binding proves the class exists on
-                // this script. A cross-script binding under the same name —
-                // e.g. this worker previously referenced another host's
-                // class and now hosts its own — points at a foreign
-                // namespace and must not suppress the create migration
-                // (Cloudflare rejects a local binding for a class the
-                // script isn't configured to implement).
-                (!("scriptName" in old) ||
-                  old.scriptName === undefined ||
-                  old.scriptName === name) &&
-                old.name === binding.bindingName,
-            );
-            if (observed && "className" in observed && observed.className) {
-              previousClassName = observed.className;
-            }
-          }
-          if (!previousClassName) {
-            // A class new to this script is a host move when the declaration
-            // says so: `transferredFrom` lists the former host(s) — moves
-            // are always declared, never inferred, because a class deleted
-            // on one worker and created on another is otherwise ambiguous
-            // between "move the data" and "delete + fresh namespace". The
-            // declared source must be observed to still host the namespace;
-            // otherwise (fresh stage, transfer already completed) fall
-            // through to a plain create.
-            const fromScript = dispatchNamespace
-              ? undefined
-              : yield* resolveTransferSource({
-                  accountId,
-                  selfScriptName: name,
-                  logicalId: binding.logicalId,
-                  className: binding.className,
-                  sources: normalizeTransferSources(
-                    binding.transferredFrom,
-                    name,
-                  ),
-                  observedNamespaces,
-                });
-            if (fromScript !== undefined) {
-              // Data-preserving move: ship Cloudflare's
-              // `transferred_classes` migration instead of creating a
-              // fresh class.
-              transferredClasses.push({
-                from: binding.className,
-                fromScript,
-                to: binding.className,
+        for (const binding of identity.unresolved) {
+          // A class new to this script is a host move when the declaration
+          // says so: `transferredFrom` lists the former host(s) — moves
+          // are always declared, never inferred, because a class deleted
+          // on one worker and created on another is otherwise ambiguous
+          // between "move the data" and "delete + fresh namespace". The
+          // declared source must be observed to still host the namespace;
+          // otherwise (fresh stage, transfer already completed) fall
+          // through to a plain create.
+          const fromScript = dispatchNamespace
+            ? undefined
+            : yield* resolveTransferSource({
+                accountId,
+                selfScriptName: name,
+                logicalId: binding.logicalId,
+                className: binding.className,
+                sources: normalizeTransferSources(
+                  binding.transferredFrom,
+                  name,
+                ),
+                observedNamespaces,
               });
-              continue;
-            }
-            // Default all new Durable Object classes to SQLite. Cloudflare
-            // recommends SQLite for new namespaces, and container-backed
-            // Durable Objects require it.
-            newSqliteClasses.push(binding.className);
-          } else if (previousClassName !== binding.className) {
-            renamedClasses.push({
-              from: previousClassName,
+          if (fromScript !== undefined) {
+            // Data-preserving move: ship Cloudflare's
+            // `transferred_classes` migration instead of creating a
+            // fresh class.
+            transferredClasses.push({
+              from: binding.className,
+              fromScript,
               to: binding.className,
             });
+            continue;
           }
+          // Default all new Durable Object classes to SQLite. Cloudflare
+          // recommends SQLite for new namespaces, and container-backed
+          // Durable Objects require it.
+          newSqliteClasses.push(binding.className);
         }
 
         yield* Effect.logInfo(
@@ -4627,9 +4560,12 @@ export const LiveWorkerProvider = () =>
           // cycle — which resolves `worker.durableObjectNamespaces[className]`
           // against the precreate stub rather than the final reconcile output —
           // fails because the namespace id it needs never surfaced.
+          // Exports are keyed by physical class name. A class-form object's
+          // logical id is its binding's (the `env` key), and the binding-derived
+          // entry wins the merge below, so the placeholder's tags key off it.
           const exportDerived = Object.keys(exportMap)
-            .filter((logicalId) => isDurableObjectExport(exportMap[logicalId]))
-            .map((logicalId) => ({ logicalId, className: logicalId }));
+            .filter((className) => isDurableObjectExport(exportMap[className]))
+            .map((className) => ({ logicalId: className, className }));
           // Transfer-destination classes are excluded from the placeholder
           // entirely (class list, bindings, tags): Cloudflare forbids
           // creating the destination class of a `transferred_classes`
@@ -5470,6 +5406,127 @@ function mergeDurableObjectClasses(
       ),
     ).values(),
   );
+}
+
+/**
+ * The class-identity half of a Worker's Durable Object migration plan,
+ * derived from the previous upload's `alchemy:dos:` tags (or, for a Worker
+ * deployed before those tags existed, its observed locally-owned bindings)
+ * against the classes the current deploy hosts. Pure, so the identity
+ * contract is unit-testable:
+ *
+ * - `kept`: the logical id already maps to the same class name — no
+ *   migration;
+ * - `renamedClasses`: the logical id's class name changed — a
+ *   `renamed_classes` migration;
+ * - `unresolved`: the logical id has no previous class — the caller decides
+ *   between a declared transfer and a fresh class, which needs the account's
+ *   namespace listing;
+ * - `deletedClassCandidates`: a previous logical id absent from the current
+ *   deploy — the caller validates it against observed namespace ownership.
+ *
+ * @internal exported for unit testing.
+ */
+export function planDurableObjectClassIdentity<
+  B extends { logicalId: string; bindingName: string; className: string },
+>(params: {
+  workerName: string;
+  oldTags: ReadonlyArray<string>;
+  oldBindings: ReadonlyArray<WorkerSettingsBinding>;
+  current: ReadonlyArray<B>;
+}) {
+  const { workerName, oldBindings, current } = params;
+  const oldDoClassNameByLogicalId = getDurableObjectTagMap(params.oldTags);
+  const currentDoClassNameByLogicalId = Object.fromEntries(
+    current.map((binding) => [binding.logicalId, binding.className]),
+  );
+
+  // Delete candidates: validated against observed namespace ownership by the
+  // caller — a class may already have been transferred to another script by
+  // its new host's deploy.
+  const deletedClassCandidates: string[] = [];
+  for (const [logicalId, className] of Object.entries(
+    oldDoClassNameByLogicalId,
+  )) {
+    if (!currentDoClassNameByLogicalId[logicalId]) {
+      deletedClassCandidates.push(className);
+    }
+  }
+
+  // Backward compatibility for old workers that have DO bindings but no
+  // alchemy:do tags yet. Cross-script bindings (`scriptName` set to
+  // anything other than this worker) are NEVER candidates for
+  // delete-class migrations — the class lives on the foreign script
+  // and we don't own its lifecycle.
+  if (Object.keys(oldDoClassNameByLogicalId).length === 0) {
+    for (const oldBinding of oldBindings) {
+      const ownedLocally =
+        !("scriptName" in oldBinding) || oldBinding.scriptName === workerName;
+      if (
+        oldBinding.type === "durable_object_namespace" &&
+        "className" in oldBinding &&
+        oldBinding.className &&
+        ownedLocally &&
+        !current.some((binding) => binding.bindingName === oldBinding.name)
+      ) {
+        deletedClassCandidates.push(oldBinding.className);
+      }
+    }
+  }
+
+  const kept: B[] = [];
+  const renamedClasses: { from: string; to: string }[] = [];
+  const unresolved: B[] = [];
+  for (const binding of current) {
+    let previousClassName: string | undefined =
+      oldDoClassNameByLogicalId[binding.logicalId];
+    if (!previousClassName) {
+      // No DO metadata tag maps this logical id to a class — the
+      // worker was created outside Alchemy (raw API / Wrangler) or
+      // before these tags existed. Fall back to matching the observed
+      // cloud binding by binding name so adoption reuses the existing
+      // class instead of asking Cloudflare to create one that already
+      // exists (which fails the migration). This is the "first deploy
+      // must match the existing class name" path; once we write the
+      // `alchemy:dos:` tag, subsequent renames are driven by logical id.
+      const observed = oldBindings.find(
+        (old) =>
+          old.type === "durable_object_namespace" &&
+          "className" in old &&
+          old.className &&
+          // Only a *locally-owned* binding proves the class exists on
+          // this script. A cross-script binding under the same name —
+          // e.g. this worker previously referenced another host's
+          // class and now hosts its own — points at a foreign
+          // namespace and must not suppress the create migration
+          // (Cloudflare rejects a local binding for a class the
+          // script isn't configured to implement).
+          (!("scriptName" in old) ||
+            old.scriptName === undefined ||
+            old.scriptName === workerName) &&
+          old.name === binding.bindingName,
+      );
+      if (observed && "className" in observed && observed.className) {
+        previousClassName = observed.className;
+      }
+    }
+    if (!previousClassName) {
+      unresolved.push(binding);
+    } else if (previousClassName !== binding.className) {
+      renamedClasses.push({ from: previousClassName, to: binding.className });
+    } else {
+      kept.push(binding);
+    }
+  }
+
+  return {
+    oldDoClassNameByLogicalId,
+    currentDoClassNameByLogicalId,
+    deletedClassCandidates,
+    kept,
+    renamedClasses,
+    unresolved,
+  };
 }
 
 function getDurableObjectBindings(

--- a/packages/alchemy/test/Cloudflare/Workers/DurableObjectClassName.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/DurableObjectClassName.test.ts
@@ -1,0 +1,80 @@
+import * as Cloudflare from "@/Cloudflare";
+import {
+  WorkerEnvironment,
+  WorkerTypeId,
+} from "@/Cloudflare/Workers/Worker.ts";
+import * as Output from "@/Output";
+import { Self } from "@/Self.ts";
+import { describe, expect, it } from "alchemy-test";
+import * as Effect from "effect/Effect";
+
+/**
+ * A class-form Durable Object whose physical class keeps a name distinct from
+ * its logical id, the shape a host converted from the async form declares to
+ * keep its namespace in place.
+ */
+interface LensShape {
+  readonly ping: () => Effect.Effect<string>;
+}
+
+class LensDo extends Cloudflare.DurableObject<LensDo, LensShape>()("LENS_DO", {
+  className: "OddlynewLensServer",
+}) {}
+
+describe("class-form className", () => {
+  it.effect(
+    "a cross-script binding carries the physical class and resolves its namespace id by it",
+    () =>
+      Effect.gen(function* () {
+        const bound: unknown[] = [];
+        const worker = {
+          bind:
+            (strings: TemplateStringsArray, ...args: unknown[]) =>
+            (data: unknown) =>
+              Effect.sync(() => {
+                bound.push({ sid: String.raw(strings, ...args), data });
+              }),
+          durableObjectNamespaces: Output.literal({
+            OddlynewLensServer: "ns-lens",
+          }),
+        };
+
+        // `yield* Worker` resolves the `Self` tag of the Worker type at
+        // runtime; the `Worker` requirement is a type-level marker.
+        const handle = yield* (
+          LensDo.from("host-script") as Effect.Effect<
+            Cloudflare.DurableObject<LensDo>
+          >
+        ).pipe(
+          Effect.provideService(Self(WorkerTypeId), worker as never),
+          Effect.provideService(WorkerEnvironment, undefined as never),
+        );
+
+        expect(bound).toEqual([
+          {
+            sid: "LENS_DO",
+            data: {
+              bindings: [
+                {
+                  type: "durable_object_namespace",
+                  name: "LENS_DO",
+                  className: "OddlynewLensServer",
+                  scriptName: "host-script",
+                  transferredFrom: undefined,
+                },
+              ],
+            },
+          },
+        ]);
+        expect(handle.name).toBe("LENS_DO");
+        const namespaceId = handle.namespaceId;
+        expect(Output.isApplyExpr(namespaceId)).toBe(true);
+        if (Output.isApplyExpr(namespaceId)) {
+          expect(namespaceId.f({ OddlynewLensServer: "ns-lens" })).toBe(
+            "ns-lens",
+          );
+          expect(namespaceId.f({ LENS_DO: "wrong-key" })).toBeUndefined();
+        }
+      }),
+  );
+});

--- a/packages/alchemy/test/Cloudflare/Workers/WorkerProvider.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/WorkerProvider.test.ts
@@ -2,6 +2,7 @@ import {
   encodeDurableObjectTags,
   getDurableObjectTagMap,
   normalizeStateDomains,
+  planDurableObjectClassIdentity,
   resolveWorkerDomain,
   resolveWorkerDomainZone,
   resolveWorkersDev,
@@ -449,6 +450,96 @@ describe("WorkerProvider", () => {
   // stampeded GET /accounts/{id}/workers/subdomain neighbors into 429/code 971
   // (#926). These helpers gate those observations on whether Alchemy manages
   // the surface.
+  describe("durable object class identity", () => {
+    // The identity tuple that drives class migrations is (logical id, class
+    // name): the logical id is the binding's `env` key, the class name the
+    // physical class. A class-form declaration with `className` keeps both
+    // of an async-form binding's, so converting a host yields no migration.
+    const lens = {
+      logicalId: "LENS_DO",
+      bindingName: "LENS_DO",
+      className: "OddlynewLensServer",
+    };
+    const deployedTags = ["alchemy:dos:LENS_DO=OddlynewLensServer"];
+
+    test("the same logical id and class name on the same worker yields no migration", () => {
+      const plan = planDurableObjectClassIdentity({
+        workerName: "host",
+        oldTags: deployedTags,
+        oldBindings: [],
+        current: [lens],
+      });
+      expect(plan.kept).toEqual([lens]);
+      expect(plan.renamedClasses).toEqual([]);
+      expect(plan.unresolved).toEqual([]);
+      expect(plan.deletedClassCandidates).toEqual([]);
+    });
+
+    test("the same logical id with a changed class name yields a rename", () => {
+      const plan = planDurableObjectClassIdentity({
+        workerName: "host",
+        oldTags: deployedTags,
+        oldBindings: [],
+        current: [{ ...lens, className: "LensServer" }],
+      });
+      expect(plan.renamedClasses).toEqual([
+        { from: "OddlynewLensServer", to: "LensServer" },
+      ]);
+      expect(plan.kept).toEqual([]);
+      expect(plan.unresolved).toEqual([]);
+      expect(plan.deletedClassCandidates).toEqual([]);
+    });
+
+    test("a fresh stage leaves the class unresolved for a single create", () => {
+      const plan = planDurableObjectClassIdentity({
+        workerName: "host",
+        oldTags: [],
+        oldBindings: [],
+        current: [lens],
+      });
+      expect(plan.unresolved).toEqual([lens]);
+      expect(plan.kept).toEqual([]);
+      expect(plan.renamedClasses).toEqual([]);
+      expect(plan.deletedClassCandidates).toEqual([]);
+    });
+
+    test("a logical id that left the deploy is a delete candidate", () => {
+      const plan = planDurableObjectClassIdentity({
+        workerName: "host",
+        oldTags: deployedTags,
+        oldBindings: [],
+        current: [],
+      });
+      expect(plan.deletedClassCandidates).toEqual(["OddlynewLensServer"]);
+    });
+
+    test("an untagged worker adopts the observed locally-owned class by binding name", () => {
+      const plan = planDurableObjectClassIdentity({
+        workerName: "host",
+        oldTags: [],
+        oldBindings: [
+          {
+            type: "durable_object_namespace",
+            name: "LENS_DO",
+            class_name: "OddlynewLensServer",
+            className: "OddlynewLensServer",
+          } as never,
+          {
+            type: "durable_object_namespace",
+            name: "FOREIGN_DO",
+            className: "ForeignClass",
+            scriptName: "other-host",
+          } as never,
+        ],
+        current: [lens],
+      });
+      expect(plan.kept).toEqual([lens]);
+      expect(plan.unresolved).toEqual([]);
+      // The foreign class is never a delete candidate.
+      expect(plan.deletedClassCandidates).toEqual([]);
+    });
+  });
+
   describe("shouldObserveWorkerDomains", () => {
     test("skips when neither props nor state manage custom domains", () => {
       expect(


### PR DESCRIPTION
## What

The class form `Cloudflare.DurableObject<Self, Shape>()("Name", props)` accepts `className` in its props, so the physical class can keep a name distinct from the logical id (the binding's `env` key), and the physical name flows through every place it is read.

## Why

The class form bound the logical id and the class name to the same string: `("Name")` registered a binding with `className: "Name"`, exported the class under `"Name"` and read the namespace map by `"Name"`. A Worker whose namespaces were created by the async form (`env.LENS_DO = Cloudflare.DurableObject("lens", { className: "LensServer" })`) could therefore not convert to the class form in place: the migration engine keys a class on `(logical id, class name)`, so the conversion was a delete plus a create, and a namespace with stored objects would be lost.

## How

- `DurableObject.ts`: `className` in the class-form props; the local and cross-script bindings carry it; the namespace accessor reads `durableObjectNamespaces[className]` (the provider keys that map by class name); the export is registered under the class name (the generated entry emits `export class <key>` and the bridge resolves its export by that key). A JSDoc section shows the conversion.
- `WorkerProvider.ts`: the class-identity half of the migration derivation moves into a pure `planDurableObjectClassIdentity` (kept / renamed / unresolved / delete candidates), called from `put`; the transfer resolution and the observed-namespace validation stay in the provider. The precreate placeholder's export-derived entries are documented as keyed by class name (the binding-derived entry, which carries the logical id, wins the merge as before).
- Tests: `WorkerProvider.test.ts` gains the identity matrix (same logical id and class name: no migration; changed class name: rename; fresh stage: one class to create; vanished logical id: delete candidate; untagged worker: adoption by binding name). `DurableObjectClassName.test.ts`: a cross-script `.from()` binding carries the physical class and resolves its namespace id by it.

## Checks

- `pnpm test test/Cloudflare/Workers/WorkerProvider.test.ts test/Cloudflare/Workers/DurableObjectClassName.test.ts`: 46 passed (bun 1.3.13).
- `tsc -b packages/alchemy` and `tsc -p packages/alchemy/tsconfig.test.json --noEmit` clean (apart from the pre-existing `@alchemy.run/floci` resolution errors on a checkout without the floci submodule).
- `oxfmt` clean.
- Not run: a cloud deploy that converts an async-form host in place; the identity matrix is proven on the pure planner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
