### PR TITLE
fix(cloudflare): keep toRpcAsync views from being mistaken for thenables

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/RpcAsync.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/RpcAsync.ts
@@ -83,6 +83,14 @@ export const toRpcAsync = <W>(stub: any): RpcAsync<Rpc.Shape<W>> & Service =>
         const value = (target as any)[prop];
         return typeof value === "function" ? value.bind(target) : value;
       }
+      // Every other string key becomes an RPC method, so the runtime's own
+      // protocol probes must be answered with `undefined`: a `then` method
+      // makes the view a thenable, and `await view` (or returning it from an
+      // async function) then calls `then` as an RPC and never settles.
+      // `toJSON` likewise must not turn `JSON.stringify(view)` into a call.
+      if (prop === "then" || prop === "toJSON") {
+        return undefined;
+      }
 
       return async (...args: unknown[]) => {
         const result = await (target as any)[prop](...args);

--- a/packages/alchemy/test/Cloudflare/Workers/RpcAsync.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/RpcAsync.test.ts
@@ -1,0 +1,46 @@
+/**
+ * `toRpcAsync` turns every string key into an RPC method. Without a guard
+ * that includes `then`, so the runtime treats the view as a thenable:
+ * `await view` and `return view` from an async function call `then` as an
+ * RPC and never settle. The view must answer the runtime's protocol probes
+ * with `undefined` while still forwarding real method calls.
+ */
+import { toRpcAsync } from "@/Cloudflare/Workers/RpcAsync.ts";
+import { expect, test } from "alchemy-test";
+
+interface Backend {
+  hello(name: string): Promise<string>;
+}
+
+/**
+ * Stands in for a Cloudflare RPC stub, which answers any property with a
+ * remote call: `then` would be one too, so the hang can only be prevented
+ * on the view's side.
+ */
+const stub = new Proxy(
+  {},
+  {
+    get:
+      (_target, prop) =>
+      (...args: unknown[]) => {
+        if (prop === "hello") return Promise.resolve(`hello ${args[0]}`);
+        return new Promise(() => {}); // a remote call that never returns
+      },
+  },
+);
+
+test("a toRpcAsync view is not a thenable", async () => {
+  const view = toRpcAsync<Backend>(stub);
+
+  expect((view as { then?: unknown }).then).toBeUndefined();
+  expect((view as { toJSON?: unknown }).toJSON).toBeUndefined();
+
+  const awaited = await Promise.resolve(view);
+  expect(awaited).toBe(view);
+
+  const returned = await (async () => view)();
+  expect(returned).toBe(view);
+
+  // Real methods still go through as Promise-returning RPC calls.
+  expect(await view.hello("world")).toBe("hello world");
+});


### PR DESCRIPTION
`toRpcAsync` wraps a Worker RPC stub in a Proxy whose `get` trap turns every string key into a `Promise`-returning RPC method. That includes `then`, so the JavaScript runtime treats the view as a thenable: `await view`, `Promise.resolve(view)`, or `return view` from an `async` function calls `view.then(resolve, reject)`, which forwards to the stub as an RPC named `then` and never settles. Anything that hands a view across an `await` boundary (a helper that returns the client, a route loader that resolves it) hangs.

## Fix

The `get` trap answers `then` with `undefined` so the view is not a thenable. `toJSON` gets the same treatment so `JSON.stringify(view)` does not turn into a call. Symbols, `fetch` and `connect` keep passing through to the underlying binding as before; every other key still becomes an RPC method.

## Tests

`test/Cloudflare/Workers/RpcAsync.test.ts` builds a view over a stub that, like a real RPC stub, answers any property with a never-returning call, and asserts that `then`/`toJSON` are `undefined`, that `await Promise.resolve(view)` and `return view` from an async function both yield the view itself, and that a real method still forwards as a Promise. Before the fix the awaited cases never settle (checked with a race against a timeout on the unguarded proxy shape).

Validation run locally: `pnpm tsc -b`, `pnpm docs:check-jsdoc`, `pnpm format`, and the test file above under Bun 1.3.13.
