### PR TITLE
feat(cloudflare): add opt-in Local Explorer

### DIFF
--- a/packages/cloudflare-runtime/README.md
+++ b/packages/cloudflare-runtime/README.md
@@ -6,6 +6,60 @@ Cloudflare Workers runtime and build integrations for Alchemy.
 - `@alchemy.run/cloudflare-runtime/rolldown` — Rolldown plugin
 - `@alchemy.run/cloudflare-runtime/vite` — Vite plugin
 
+## Local Explorer (experimental)
+
+Enable Local Explorer when starting local development:
+
+```sh
+CLOUDFLARE_RUNTIME_LOCAL_EXPLORER=true alchemy dev
+```
+
+Open `/cdn-cgi/local/explorer/` on any local Worker. Direct runtime callers can
+set `RuntimeWorker.localExplorer: true`; `false` overrides the environment flag.
+The feature is disabled by default and has no effect on deployed Workers.
+Each enabled Worker logs its direct Local Explorer URL once its runtime starts.
+The URL uses the actual bound port; it is printed again when the runtime restarts.
+
+- KV: namespaces, key pagination/prefixes, values, metadata, expiration, and create/update/delete.
+- SQLite Durable Objects: persisted instances, table browsing, and SQL queries.
+- D1: table browsing and SQL queries.
+- R2: object browsing, metadata, downloads, uploads, and deletion.
+- Workflows: instance status and step history; create, pause, resume, restart,
+  terminate, send events, and delete individual/batches/all instances.
+- Email: sent and received messages, bodies and attachment metadata, simulated
+  incoming delivery, and captured rejection/forward/reply results.
+
+Workers sharing the same local storage directory discover each other through
+Alchemy's dev registry. Queries go to the Worker that owns the resource.
+Durable Object SQL runs through the live object, retaining its namespace key and
+storage location. Names first observed while inspection is enabled are persisted
+using Miniflare's internal `__miniflare_do_name` table; older objects may appear by
+ID until accessed by name. Listing persisted objects can activate their constructors.
+
+D1 and Durable Object SQL consoles and resource controls can modify local data.
+Workflow deletion stops execution and clears state through the live Engine;
+empty SQLite files may remain on disk and are excluded from instance listings.
+Legacy Durable Object namespaces can be listed, but
+only SQLite objects support SQL inspection; ephemeral objects are omitted.
+Opt in to persisted traces and events separately with
+`CLOUDFLARE_RUNTIME_LOCAL_EXPLORER_OBSERVABILITY=true` alongside the Explorer flag.
+Workers sharing local storage forward to a single leased collector process, which
+can be replaced when its owning runtime exits. SQL queries are read-only; the
+clear-history action clears traces/logs for that shared storage directory.
+
+Email capture uses a persistent store per Worker and aggregates through the same
+registry. Local `send_email` bindings retain their sender/recipient restrictions;
+remote bindings are not intercepted. Incoming test emails can be sent through
+Explorer or `/cdn-cgi/handler/email` (`/cdn-cgi/local/email` is also accepted).
+Delivery, forwarding, and replies are simulated locally. Messages saved before
+capture was enabled remain on disk but are not backfilled into Explorer. Capture
+size limits and truncation indicators follow the pinned Miniflare implementation.
+Queues, cron controls, and JavaScript inspection are not included.
+Telemetry is disabled.
+
+The Explorer assets and Durable Object wrapper use the pinned Miniflare package;
+upgrading it requires rerunning the runtime Explorer integration tests.
+
 ## Upstream references
 
 - Cloudflare Workers SDK: [`b7b4ff84477982e7c770bb93928287893fcf2e03`](https://github.com/cloudflare/workers-sdk/tree/b7b4ff84477982e7c770bb93928287893fcf2e03)

--- a/packages/cloudflare-runtime/README.md
+++ b/packages/cloudflare-runtime/README.md
@@ -17,8 +17,11 @@ CLOUDFLARE_RUNTIME_LOCAL_EXPLORER=true alchemy dev
 Open `/cdn-cgi/local/explorer/` on any local Worker. Direct runtime callers can
 set `RuntimeWorker.localExplorer: true`; `false` overrides the environment flag.
 The feature is disabled by default and has no effect on deployed Workers.
-Each enabled Worker logs its direct Local Explorer URL once its runtime starts.
-The URL uses the actual bound port; it is printed again when the runtime restarts.
+One shared Local Explorer URL is logged for each local storage directory.
+Browser visits to Worker Explorer routes redirect to that address; the dropdown
+selects any Worker. Resource API handlers remain available on each Worker.
+The host survives individual Worker restarts. If its owning runtime exits, another
+runtime takes over the same port (with a brief interruption during failover).
 
 - KV: namespaces, key pagination/prefixes, values, metadata, expiration, and create/update/delete.
 - SQLite Durable Objects: persisted instances, table browsing, and SQL queries.

--- a/packages/cloudflare-runtime/package.json
+++ b/packages/cloudflare-runtime/package.json
@@ -50,7 +50,9 @@
     "sharp": "catalog:cloudflare-runtime",
     "unenv": "catalog:cloudflare-runtime",
     "workerd": "catalog:cloudflare-runtime",
-    "yauzl": "catalog:cloudflare-runtime"
+    "yauzl": "catalog:cloudflare-runtime",
+    "miniflare": "5.20260903.0-alpha",
+    "proper-lockfile": "4.1.2"
   },
   "devDependencies": {
     "@cloudflare/vitest-plugin": "catalog:cloudflare-runtime",
@@ -75,7 +77,8 @@
     "typescript": "catalog:build",
     "vite": "catalog:build",
     "vitest": "catalog:testing",
-    "ws": "catalog:cloudflare-runtime"
+    "ws": "catalog:cloudflare-runtime",
+    "@types/proper-lockfile": "4.1.4"
   },
   "peerDependencies": {
     "@distilled.cloud/cloudflare": "workspace:*",

--- a/packages/cloudflare-runtime/src/core/LocalExplorer.ts
+++ b/packages/cloudflare-runtime/src/core/LocalExplorer.ts
@@ -28,6 +28,7 @@ export const LOCAL_EXPLORER_FLAGS = [
 ];
 
 export const LOCAL_EXPLORER_SERVICE = "local-explorer:router";
+export const LOCAL_EXPLORER_PUBLIC_SERVICE = "local-explorer:public";
 
 // Alchemy carries the resource ID in service props; Miniflare sends it in
 // MF-Namespace. Reuse the exact resolved local service designator, including
@@ -152,6 +153,7 @@ export const prepareLocalExplorer = Effect.fn("LocalExplorer.prepare")(
     upstream: string,
     storage: Service,
     resolvedBindings: ReadonlyArray<Worker_Binding>,
+    explorerUrl: string,
     collector?: Effect.Success<ReturnType<typeof makeLocalExplorerCollector>>,
   ) {
     const loopback = yield* context.get(Loopback);
@@ -469,6 +471,41 @@ export const prepareLocalExplorer = Effect.fn("LocalExplorer.prepare")(
       services: [
         ...email.services,
         {
+          name: LOCAL_EXPLORER_PUBLIC_SERVICE,
+          worker: {
+            compatibilityDate: "2026-01-01",
+            modules: [
+              {
+                name: "public.js",
+                esModule: `
+export default {
+  fetch(request, env) {
+    const url = new URL(request.url);
+    // Keep API requests on the internal adapter. Redirecting multipart writes
+    // can cause clients to regenerate a body with the old boundary header.
+    if (url.pathname.startsWith("/cdn-cgi/local/explorer/api/")) return env.EXPLORER.fetch(request);
+    for (const prefix of ["/cdn-cgi/local/explorer", "/cdn-cgi/explorer"]) {
+      if (url.pathname === prefix || url.pathname.startsWith(prefix + "/")) {
+        const target = new URL(env.URL);
+        target.pathname = "/cdn-cgi/local/explorer" + url.pathname.slice(prefix.length);
+        target.search = url.search;
+        return Response.redirect(target, 307);
+      }
+    }
+    if (url.pathname === "/cdn-cgi/handler/email" || url.pathname === "/cdn-cgi/local/email") return env.EXPLORER.fetch(request);
+    return env.UPSTREAM.fetch(request);
+  }
+};`,
+              },
+            ],
+            bindings: [
+              { name: "URL", text: explorerUrl },
+              { name: "EXPLORER", service: { name: LOCAL_EXPLORER_SERVICE } },
+              { name: "UPSTREAM", service: { name: upstream } },
+            ],
+          },
+        },
+        {
           name: "local-explorer:loopback",
           worker: {
             compatibilityDate: "2026-01-01",
@@ -509,10 +546,11 @@ export const prepareLocalExplorer = Effect.fn("LocalExplorer.prepare")(
               {
                 name: "entry.js",
                 esModule:
-                  "export default { fetch(request, env) { return env.EXPLORER.fetch(request); } };",
+                  "export default { fetch(request, env) { if (new URL(request.url).pathname === '/_alchemy/explorer/health') return Response.json({ id: env.ID }); return env.EXPLORER.fetch(request); } };",
               },
             ],
             bindings: [
+              { name: "ID", text: instanceId },
               { name: "EXPLORER", service: { name: LOCAL_EXPLORER_SERVICE } },
             ],
           },

--- a/packages/cloudflare-runtime/src/core/LocalExplorer.ts
+++ b/packages/cloudflare-runtime/src/core/LocalExplorer.ts
@@ -1,0 +1,657 @@
+import {
+  prepareExplorerEmail,
+  handleExplorerEmailLoopback,
+} from "./LocalExplorerEmail.ts";
+import { explorerWorkflowLoopback } from "./LocalExplorerWorkflows.ts";
+import type { makeLocalExplorerCollector } from "./LocalExplorerCollector.ts";
+import * as Effect from "effect/Effect";
+import {
+  defaultDurableObjectUniqueKey,
+  SERVICE_USER_WORKER,
+} from "./internal/constants.ts";
+import * as Schema from "effect/Schema";
+import { createRequire } from "node:module";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { RegistryProxy } from "./registry/RegistryProxy.ts";
+import { kVoid } from "./workerd/Config.ts";
+import { Loopback } from "./globals/Loopback.ts";
+import type { PluginContext } from "./PluginContext.ts";
+import type { RuntimeWorker } from "./RuntimeWorker.ts";
+import { ConfigError, SystemError } from "./RuntimeError.shared.ts";
+import type { Service, Worker_Binding } from "./workerd/Config.ts";
+
+export const LOCAL_EXPLORER_COLLECTOR = "local-explorer:collector";
+export const LOCAL_EXPLORER_FLAGS = [
+  "streaming_tail_worker",
+  "tail_worker_user_spans",
+];
+
+export const LOCAL_EXPLORER_SERVICE = "local-explorer:router";
+
+// Alchemy carries the resource ID in service props; Miniflare sends it in
+// MF-Namespace. Reuse the exact resolved local service designator, including
+// its props, instead of opening a second simulator or guessing storage IDs.
+const storageRouter = `
+export default {
+  fetch(request, env) {
+    const id = request.headers.get("MF-Namespace");
+    const name = Object.hasOwn(env.RESOURCES, id) ? env.RESOURCES[id] : undefined;
+    if (!name) return new Response("Unknown local resource", { status: 404 });
+    return env[name].fetch(request);
+  }
+};
+`;
+const collectorBridge = `
+import { WorkerEntrypoint } from "cloudflare:workers";
+function serialize(event) {
+  return JSON.parse(JSON.stringify(event, function(key, value) {
+    if (this[key] instanceof Date) return { __date: this[key].getTime() };
+    if (typeof value === "bigint") return { __bigint: value.toString() };
+    return value;
+  }), (_key, value) => {
+    if (value && typeof value === "object") {
+      if ("__date" in value) return new Date(value.__date);
+      if ("__bigint" in value) return BigInt(value.__bigint);
+    }
+    return value;
+  });
+}
+export default class extends WorkerEntrypoint {
+  async target() {
+    const response = await this.env.LOOPBACK.fetch("http://localhost/core/observability-collector");
+    if (!response.ok) throw new Error("Local trace collector is unavailable");
+    const { address } = await response.json();
+    return this.env.DEBUG.connect(address).getEntrypoint("local-explorer:collector", undefined, this.ctx.props);
+  }
+  async fetch(request) { return (await this.target()).fetch(request); }
+  async tailStream(onset) {
+    const handler = await (await this.target()).tailStream(serialize(onset));
+    return (event) => handler(serialize(event));
+  }
+}
+`;
+const d1Props = Schema.Struct({ databaseId: Schema.String });
+const r2Props = Schema.Struct({ bucketName: Schema.String });
+const kvProps = Schema.Struct({ namespaceId: Schema.String });
+
+// Miniflare owns the UI and API contract. This adapter only supplies Alchemy's
+// live Engine namespaces and its different persistence directory layout.
+const router = `
+import explorer, { handleEmail } from "./explorer.worker.js";
+export default {
+  async fetch(request, env, ctx) {
+    const url = new URL(request.url);
+    const legacy = "/cdn-cgi/explorer";
+    const prefix = "/cdn-cgi/local/explorer";
+    if (url.pathname === legacy || url.pathname.startsWith(legacy + "/")) {
+      url.pathname = prefix + url.pathname.slice(legacy.length);
+      return Response.redirect(url, 302);
+    }
+    if (url.pathname === "/cdn-cgi/handler/email" || url.pathname === "/cdn-cgi/local/email") {
+      return handleEmail(url.searchParams, request,
+        env["MINIFLARE_EXPLORER_USER_WORKER_" + env.LOCAL_EXPLORER_WORKER_NAMES[0]],
+        env.LOCAL_EXPLORER_WORKER_NAMES[0], env, ctx);
+    }
+    if (url.pathname !== prefix && !url.pathname.startsWith(prefix + "/")) {
+      return env.UPSTREAM.fetch(request);
+    }
+    // The pinned native backend validates routes, methods and payloads. Keep
+    // its OpenAPI specification consistent with the operations we expose.
+    const resource = /^\\/cdn-cgi\\/local\\/explorer\\/api\\/(d1\\/database|r2\\/buckets|storage\\/kv\\/namespaces|workflows)\\/([^/]+)/.exec(url.pathname);
+    if (resource) {
+      const kind = resource[1] === "d1/database" ? "d1" : resource[1] === "r2/buckets" ? "r2" : resource[1] === "workflows" ? "workflows" : "kv";
+      const id = decodeURIComponent(resource[2]);
+      if (!Object.hasOwn(env.LOCAL_EXPLORER_BINDING_MAP[kind], id)) {
+        const noAggregate = "X-Miniflare-Explorer-No-Aggregate";
+        if (!request.headers.has(noAggregate)) {
+          const registryResponse = await env.MINIFLARE_LOOPBACK.fetch("http://localhost/core/dev-registry");
+          const peers = await registryResponse.json();
+          for (const [name, peer] of Object.entries(peers)) {
+            if (env.LOCAL_EXPLORER_WORKER_NAMES.includes(name)) continue;
+            const entry = env.DEV_REGISTRY_DEBUG_PORT.connect(peer.debugPortAddress).getEntrypoint("core:entry");
+            const headers = { [noAggregate]: "true", Host: "localhost" };
+            let listing;
+            try {
+              const response = await entry.fetch("http://localhost" + prefix + "/api/" + resource[1], { headers });
+              if (!response.ok) continue;
+              listing = (await response.json()).result;
+            } catch { continue; } // A peer may stop while discovery is in flight.
+            const owned = kind === "d1" ? listing.some((db) => db.uuid === id) : kind === "r2" ? listing.buckets.some((bucket) => bucket.name === id) : kind === "workflows" ? listing.some((workflow) => workflow.name === id) : listing.some((ns) => ns.id === id);
+            if (owned) {
+              const forwarded = new Request(request);
+              forwarded.headers.set(noAggregate, "true");
+              return entry.fetch(forwarded);
+            }
+          }
+        }
+        return Response.json({ success: false, result: null, errors: [{ code: 10001, message: "Unknown local resource" }], messages: [] }, { status: 404 });
+      }
+    }
+    // Miniflare's clear-workflow handler ignores a non-OK loopback response.
+    // Surface failed deletions instead of reporting success to the browser.
+    const checkedLoopback = {
+      async fetch(input, init) {
+        const response = await env.MINIFLARE_LOOPBACK.fetch(input, init);
+        const method = init?.method ?? input?.method;
+        if (method === "DELETE" && !response.ok && response.status !== 404) {
+          throw new Error("Failed to delete local Workflow state");
+        }
+        return response;
+      }
+    };
+    return explorer.fetch(request, { ...env, MINIFLARE_LOOPBACK: checkedLoopback }, ctx);
+  }
+};
+`;
+
+export const prepareLocalExplorer = Effect.fn("LocalExplorer.prepare")(
+  function* (
+    worker: RuntimeWorker,
+    context: PluginContext["Service"],
+    upstream: string,
+    storage: Service,
+    resolvedBindings: ReadonlyArray<Worker_Binding>,
+    collector?: Effect.Success<ReturnType<typeof makeLocalExplorerCollector>>,
+  ) {
+    const loopback = yield* context.get(Loopback);
+    const scope = yield* Effect.scope;
+    const workflows = worker.workflows ?? [];
+    const require = createRequire(import.meta.url);
+    const miniflareDist = yield* Effect.try({
+      try: () => path.dirname(require.resolve("miniflare")),
+      catch: (cause) =>
+        new ConfigError({
+          subtag: "LocalExplorer",
+          message:
+            "Install the pinned Miniflare dependency to use Local Explorer.",
+          cause,
+        }),
+    });
+    const [backend, shared, durableObjectWrapper, emailStore, sendEmail] =
+      yield* Effect.tryPromise({
+        try: () =>
+          Promise.all([
+            fs.readFile(
+              path.join(
+                miniflareDist,
+                "workers/local-explorer/explorer.worker.js",
+              ),
+              "utf8",
+            ),
+            fs.readFile(
+              path.join(miniflareDist, "workers/shared/index.worker.js"),
+              "utf8",
+            ),
+            fs.readFile(
+              path.join(miniflareDist, "workers/core/do-wrapper.worker.js"),
+              "utf8",
+            ),
+            fs.readFile(
+              path.join(miniflareDist, "workers/email/email-store.worker.js"),
+              "utf8",
+            ),
+            fs.readFile(
+              path.join(miniflareDist, "workers/email/send_email.worker.js"),
+              "utf8",
+            ),
+          ]),
+        catch: (cause) =>
+          new SystemError({
+            subtag: "LocalExplorer",
+            message: "Unable to load Miniflare's Local Explorer assets.",
+            cause,
+          }),
+      });
+    const storagePath = "disk" in storage ? storage.disk?.path : undefined;
+    if (!storagePath)
+      return yield* new ConfigError({
+        subtag: "LocalExplorer",
+        message: "Local Explorer requires disk-backed storage.",
+      });
+
+    const kvMap: Record<string, string> = Object.create(null);
+    const kvBindings: Worker_Binding[] = [];
+    const d1Map: Record<string, string> = Object.create(null);
+    const r2Map: Record<string, string> = Object.create(null);
+    const d1Bindings: Worker_Binding[] = [];
+    const r2Bindings: Worker_Binding[] = [];
+    for (const binding of resolvedBindings) {
+      if (!binding.name) continue;
+      const d1 =
+        "wrapped" in binding
+          ? binding.wrapped?.innerBindings?.find(
+              (inner) => inner.name === "fetcher",
+            )
+          : undefined;
+      if (d1 && "service" in d1 && d1.service?.name === "d1") {
+        const props = yield* Schema.decodeUnknownEffect(
+          Schema.fromJsonString(d1Props),
+        )(d1.service.props?.json).pipe(
+          Effect.mapError(
+            (cause) =>
+              new ConfigError({
+                subtag: "LocalExplorer",
+                message: "Invalid local D1 binding props.",
+                cause,
+              }),
+          ),
+        );
+        d1Map[props.databaseId] = binding.name;
+        d1Bindings.push({
+          name: `RESOURCE_${d1Bindings.length}`,
+          service: d1.service,
+        });
+      }
+      if ("kvNamespace" in binding && binding.kvNamespace?.name === "kv") {
+        const props = yield* Schema.decodeUnknownEffect(
+          Schema.fromJsonString(kvProps),
+        )(binding.kvNamespace.props?.json).pipe(
+          Effect.mapError(
+            (cause) =>
+              new ConfigError({
+                subtag: "LocalExplorer",
+                message: "Invalid local KV binding props.",
+                cause,
+              }),
+          ),
+        );
+        kvMap[props.namespaceId] = binding.name;
+        kvBindings.push({
+          name: `RESOURCE_${kvBindings.length}`,
+          service: binding.kvNamespace,
+        });
+      }
+      if ("r2Bucket" in binding && binding.r2Bucket?.name === "r2") {
+        const props = yield* Schema.decodeUnknownEffect(
+          Schema.fromJsonString(r2Props),
+        )(binding.r2Bucket.props?.json).pipe(
+          Effect.mapError(
+            (cause) =>
+              new ConfigError({
+                subtag: "LocalExplorer",
+                message: "Invalid local R2 binding props.",
+                cause,
+              }),
+          ),
+        );
+        r2Map[props.bucketName] = binding.name;
+        r2Bindings.push({
+          name: `RESOURCE_${r2Bindings.length}`,
+          service: binding.r2Bucket,
+        });
+      }
+    }
+    // Only namespaces hosted here are advertised. Cross-worker consumers are
+    // discovered via their owner so no second actor opens the same database.
+    const namespaces = (worker.durableObjectNamespaces ?? []).filter(
+      (ns) => !ns.ephemeralLocal,
+    );
+    const doMap = Object.fromEntries(
+      namespaces.map((ns, index) => [
+        ns.uniqueKey ??
+          defaultDurableObjectUniqueKey(worker.name, ns.className),
+        {
+          binding: `DO_${index}`,
+          className: ns.className,
+          scriptName: worker.name,
+          useSQLite: ns.sql ?? false,
+        },
+      ]),
+    );
+    const doBindings: Worker_Binding[] = namespaces.map((ns, index) => ({
+      name: `DO_${index}`,
+      durableObjectNamespace: {
+        className: ns.className,
+        serviceName: SERVICE_USER_WORKER,
+      },
+    }));
+    const registry = yield* context.get(RegistryProxy);
+    const storageScope = path.resolve(storagePath);
+    const instanceId = crypto.randomUUID();
+    yield* registry.api.configureLocalExplorer({ storageScope, instanceId });
+
+    // A distinct target plus scoped unregistration prevents both cross-worker
+    // overwrites and retained handlers after hot reload.
+    const loopbackBinding = yield* loopback.api.route(
+      `local-explorer:${worker.name}:${crypto.randomUUID()}`,
+      async (request, response) => {
+        const url = new URL(request.url ?? "/", "http://localhost");
+        const send = (status: number, body: unknown) => {
+          response.writeHead(status, { "content-type": "application/json" });
+          response.end(JSON.stringify(body));
+        };
+        if (
+          await handleExplorerEmailLoopback(
+            request,
+            response,
+            url,
+            storagePath,
+            worker.name,
+          )
+        )
+          return;
+        if (request.method !== "GET")
+          return send(405, { error: "Read-only endpoint" });
+        if (url.pathname === "/core/observability-collector") {
+          if (!collector)
+            return send(404, { error: "Local observability is disabled" });
+          return send(200, await Effect.runPromise(collector.get));
+        }
+        if (url.pathname === "/core/dev-registry") {
+          const entries = await Effect.runPromise(
+            registry.api.localExplorerEntries,
+          );
+          response.setHeader(
+            "X-Miniflare-Dev-Registry-Instance-Id",
+            instanceId,
+          );
+          return send(
+            200,
+            Object.fromEntries(
+              entries
+                .filter(
+                  (entry) => entry.localExplorer?.storageScope === storageScope,
+                )
+                .map((entry) => [
+                  entry.scriptName,
+                  {
+                    debugPortAddress: entry.debugPortAddress,
+                    ...entry.localExplorer,
+                  },
+                ]),
+            ),
+          );
+        }
+        const match = /^\/core\/(workflow-storage|do-storage)\/([^/]+)$/.exec(
+          url.pathname,
+        );
+        const id = match?.[2] && decodeURIComponent(match[2]);
+        const kind = match?.[1];
+        const owned =
+          id &&
+          (kind === "workflow-storage"
+            ? workflows.some((workflow) => workflow.workflowName === id)
+            : Object.hasOwn(doMap, id));
+        if (!owned) return send(404, { error: "Unknown local resource" });
+        // Only filenames are read here. Queries use live Engine/DO RPC and
+        // never open a competing SQLite connection to an active actor.
+        const directory =
+          kind === "workflow-storage"
+            ? path.resolve(storagePath, "workflows", encodeURIComponent(id))
+            : path.resolve(storagePath, id);
+        if (!directory.startsWith(path.resolve(storagePath) + path.sep)) {
+          return send(400, { error: "Invalid storage path" });
+        }
+        try {
+          const entries = await fs.readdir(directory, { withFileTypes: true });
+          const files = entries.filter(
+            (entry) =>
+              entry.isFile() && /^[a-f0-9]{64}\.sqlite$/i.test(entry.name),
+          );
+          const records = await Promise.all(
+            files.map(async (entry) => {
+              const stat = await fs.stat(path.join(directory, entry.name));
+              return {
+                name: entry.name,
+                type: "file",
+                birthtimeMs: stat.birthtimeMs,
+              };
+            }),
+          );
+          return send(200, records);
+        } catch (error) {
+          if (
+            error instanceof Error &&
+            "code" in error &&
+            error.code === "ENOENT"
+          )
+            return send(200, []);
+          throw error;
+        }
+      },
+      scope,
+    );
+
+    const workflowMap = Object.fromEntries(
+      workflows.map((workflow, index) => [
+        workflow.workflowName,
+        {
+          name: workflow.workflowName,
+          className: workflow.className,
+          scriptName: worker.name,
+          engineBinding: `ENGINE_${index}`,
+          binding: `WORKFLOW_${index}`,
+        },
+      ]),
+    );
+    const engineBindings: Worker_Binding[] = workflows.map(
+      (workflow, index) => ({
+        name: `ENGINE_${index}`,
+        durableObjectNamespace: {
+          className: "Engine",
+          serviceName: `workflows:${workflow.workflowName}`,
+        },
+      }),
+    );
+    const workflowBindings: Worker_Binding[] = workflows.map(
+      (workflow, index) => ({
+        name: `WORKFLOW_${index}`,
+        wrapped: {
+          moduleName: "cloudflare-runtime:workflows-wrapped-binding",
+          innerBindings: [
+            {
+              name: "binding",
+              service: {
+                name: `workflows:${workflow.workflowName}`,
+                entrypoint: "WorkflowBinding",
+              },
+            },
+          ],
+        },
+      }),
+    );
+    const email = prepareExplorerEmail(
+      worker.name,
+      storage,
+      resolvedBindings,
+      loopbackBinding,
+      emailStore,
+      sendEmail,
+    );
+    const jsonBinding = (name: string, value: unknown): Worker_Binding => ({
+      name,
+      json: JSON.stringify(value),
+    });
+    return {
+      durableObjectWrapper,
+      bindings: email.userBindings,
+      services: [
+        ...email.services,
+        {
+          name: "local-explorer:loopback",
+          worker: {
+            compatibilityDate: "2026-01-01",
+            modules: [
+              { name: "loopback.js", esModule: explorerWorkflowLoopback },
+            ],
+            bindings: [
+              { name: "LOOPBACK", service: loopbackBinding },
+              jsonBinding("WORKFLOWS", workflowMap),
+              ...engineBindings,
+            ],
+          },
+        },
+        ...(collector
+          ? [
+              {
+                name: LOCAL_EXPLORER_COLLECTOR,
+                worker: {
+                  compatibilityDate: "2026-01-01",
+                  modules: [
+                    { name: "collector-bridge.js", esModule: collectorBridge },
+                  ],
+                  bindings: [
+                    { name: "DEBUG", workerdDebugPort: kVoid },
+                    { name: "LOOPBACK", service: loopbackBinding },
+                  ],
+                },
+              } satisfies Service,
+            ]
+          : []),
+        {
+          // Miniflare's existing aggregation protocol resolves this service over
+          // the debug port. Only peers sharing this storage scope are advertised.
+          name: "core:entry",
+          worker: {
+            compatibilityDate: "2026-01-01",
+            modules: [
+              {
+                name: "entry.js",
+                esModule:
+                  "export default { fetch(request, env) { return env.EXPLORER.fetch(request); } };",
+              },
+            ],
+            bindings: [
+              { name: "EXPLORER", service: { name: LOCAL_EXPLORER_SERVICE } },
+            ],
+          },
+        },
+        ...[
+          { name: "local-explorer:d1", resources: d1Map, bindings: d1Bindings },
+          { name: "local-explorer:r2", resources: r2Map, bindings: r2Bindings },
+          { name: "local-explorer:kv", resources: kvMap, bindings: kvBindings },
+        ].map(({ name, resources, bindings }) => ({
+          name,
+          worker: {
+            compatibilityDate: "2026-01-01",
+            modules: [{ name: "storage-router.js", esModule: storageRouter }],
+            bindings: [
+              jsonBinding(
+                "RESOURCES",
+                Object.fromEntries(
+                  bindings.map((binding) => {
+                    const props = JSON.parse(
+                      "service" in binding
+                        ? (binding.service?.props?.json ?? "{}")
+                        : "{}",
+                    );
+                    return [
+                      props.databaseId ?? props.bucketName ?? props.namespaceId,
+                      binding.name,
+                    ];
+                  }),
+                ),
+              ),
+              ...bindings,
+            ],
+          },
+        })),
+        {
+          name: "local-explorer:assets",
+          disk: {
+            path: path.resolve(miniflareDist, "../local-explorer-ui"),
+            writable: false,
+          },
+        },
+        {
+          name: LOCAL_EXPLORER_SERVICE,
+          worker: {
+            compatibilityDate: "2026-01-01",
+            compatibilityFlags: ["nodejs_compat"],
+            modules: [
+              { name: "router.worker.js", esModule: router },
+              {
+                name: "explorer.worker.js",
+                esModule: backend + "\nexport { handleEmail };",
+              },
+            ],
+            bindings: [
+              { name: "UPSTREAM", service: { name: upstream } },
+              { name: "DEV_REGISTRY_DEBUG_PORT", workerdDebugPort: kVoid },
+              { name: "MINIFLARE_D1", service: { name: "local-explorer:d1" } },
+              { name: "MINIFLARE_KV", service: { name: "local-explorer:kv" } },
+              { name: "MINIFLARE_R2", service: { name: "local-explorer:r2" } },
+              ...(collector
+                ? [
+                    {
+                      name: "MINIFLARE_OBSERVABILITY_COLLECTOR",
+                      service: { name: LOCAL_EXPLORER_COLLECTOR },
+                    },
+                  ]
+                : []),
+              {
+                name: "MINIFLARE_LOOPBACK",
+                service: { name: "local-explorer:loopback" },
+              },
+              {
+                name: "MINIFLARE_EMAIL_STORE",
+                service: { name: "email:store" },
+              },
+              {
+                name: `MINIFLARE_EXPLORER_USER_WORKER_${worker.name}`,
+                service: { name: SERVICE_USER_WORKER },
+              },
+              {
+                name: "MINIFLARE_EXPLORER_DISK",
+                service: { name: "local-explorer:assets" },
+              },
+              jsonBinding("MINIFLARE_TELEMETRY_CONFIG", { enabled: false }),
+              jsonBinding("LOCAL_EXPLORER_WORKER_NAMES", [worker.name]),
+              jsonBinding("LOCAL_EXPLORER_BINDING_MAP", {
+                workflows: workflowMap,
+                d1: d1Map,
+                kv: kvMap,
+                r2: r2Map,
+                do: doMap,
+              }),
+              jsonBinding("MINIFLARE_EXPLORER_WORKER_OPTS", {
+                [worker.name]: {
+                  d1: Object.entries(d1Map).map(([id, bindingName]) => ({
+                    id,
+                    bindingName,
+                  })),
+                  r2: Object.entries(r2Map).map(([id, bindingName]) => ({
+                    id,
+                    bindingName,
+                  })),
+                  kv: Object.entries(kvMap).map(([id, bindingName]) => ({
+                    id,
+                    bindingName,
+                  })),
+                  do: Object.entries(doMap).map(([id, ns]) => ({
+                    id,
+                    className: ns.className,
+                    scriptName: ns.scriptName,
+                    useSqlite: ns.useSQLite,
+                    bindingName:
+                      resolvedBindings.find(
+                        (binding) =>
+                          "durableObjectNamespace" in binding &&
+                          !binding.durableObjectNamespace?.serviceName &&
+                          binding.durableObjectNamespace?.className ===
+                            ns.className,
+                      )?.name ?? ns.className,
+                  })),
+                  sendEmail: email.sendEmail,
+                  workflows: workflows.map((workflow) => ({
+                    id: workflow.workflowName,
+                    bindingName: workflow.className,
+                    className: workflow.className,
+                    scriptName: worker.name,
+                  })),
+                },
+              }),
+              ...engineBindings,
+              ...workflowBindings,
+              ...doBindings,
+            ],
+          },
+        },
+      ] satisfies Service[],
+      extensions: [
+        { modules: [{ name: "miniflare:shared", esModule: shared }] },
+      ],
+    };
+  },
+);

--- a/packages/cloudflare-runtime/src/core/LocalExplorerCollector.ts
+++ b/packages/cloudflare-runtime/src/core/LocalExplorerCollector.ts
@@ -1,0 +1,222 @@
+import * as Exit from "effect/Exit";
+import * as Effect from "effect/Effect";
+import * as Schedule from "effect/Schedule";
+import * as Schema from "effect/Schema";
+import * as Scope from "effect/Scope";
+import * as Semaphore from "effect/Semaphore";
+import { createRequire } from "node:module";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { SystemError } from "./RuntimeError.shared.ts";
+import { Workerd } from "./workerd/Workerd.ts";
+import type { Service } from "./workerd/Config.ts";
+
+const metadataSchema = Schema.Struct({
+  id: Schema.String,
+  address: Schema.String,
+  health: Schema.String,
+});
+const host = `
+import Collector from "./collector.worker.js";
+export { TraceStore } from "./collector.worker.js";
+export default class extends Collector {
+  fetch(request) {
+    if (new URL(request.url).pathname === "/health") return Response.json({ id: this.env.COLLECTOR_ID });
+    return super.fetch(request);
+  }
+  tailStream(onset) {
+    const handler = super.tailStream(onset);
+    // Return an RPC callback instead of serializing the collector's class.
+    return (event) => {
+      const method = handler[event.event.type];
+      if (typeof method === "function") return method.call(handler, event);
+    };
+  }
+}
+`;
+
+// Every Worker (including a separate Vite process) uses one live collector.
+// A filesystem lease elects the owner; health checks and scoped cleanup let a
+// follower take over when the owner exits. Never open the same SQLite actor in
+// multiple workerd processes: its local VFS assumes a single actor owner.
+export const makeLocalExplorerCollector = Effect.fn("LocalExplorer.collector")(
+  function* (storage: Service) {
+    const workerd = yield* Workerd;
+    const lifetime = yield* Effect.scope;
+    const mutex = yield* Semaphore.make(1);
+    const storagePath = "disk" in storage ? storage.disk?.path : undefined;
+    if (!storagePath)
+      return yield* new SystemError({
+        subtag: "LocalExplorer",
+        message: "Collector requires disk-backed storage.",
+      });
+    const directory = path.resolve(storagePath, "observability");
+    const record = path.join(directory, "collector.json");
+    const require = createRequire(import.meta.url);
+    const io = <A>(operation: () => Promise<A>) =>
+      Effect.tryPromise({
+        try: operation,
+        catch: (cause) =>
+          new SystemError({
+            subtag: "LocalExplorerCollector",
+            message: "Unable to start or locate the local trace collector.",
+            cause,
+          }),
+      });
+    yield* io(() => fs.mkdir(directory, { recursive: true }));
+    const lockfile: typeof import("proper-lockfile") = require("proper-lockfile");
+    let owned: Scope.Closeable | undefined;
+    const get = Effect.gen(function* () {
+      // The persisted record is only trusted after its live endpoint confirms
+      // the random identity, so a reused port cannot select another service.
+      const current = yield* io(async () => {
+        try {
+          const value = Schema.decodeUnknownSync(
+            Schema.fromJsonString(metadataSchema),
+          )(await fs.readFile(record, "utf8"));
+          const response = await fetch(value.health, {
+            signal: AbortSignal.timeout(500),
+          });
+          const health = Schema.decodeUnknownSync(
+            Schema.Struct({ id: Schema.String }),
+          )(await response.json());
+          return response.ok && health.id === value.id ? value : undefined;
+        } catch {
+          return undefined;
+        }
+      });
+      if (current) return current;
+      if (owned) {
+        const failed = owned;
+        owned = undefined;
+        yield* Scope.close(failed, Exit.void);
+      }
+      const release = yield* Effect.tryPromise({
+        try: () =>
+          lockfile.lock(directory, {
+            realpath: true,
+            retries: 0,
+            stale: 5000,
+            update: 1000,
+          }),
+        catch: (cause) =>
+          new SystemError({
+            subtag:
+              cause instanceof Error &&
+              "code" in cause &&
+              cause.code === "ELOCKED"
+                ? "CollectorStarting"
+                : "LocalExplorerCollector",
+            message:
+              "The local trace collector is starting or its previous lease is expiring.",
+            cause,
+          }),
+      });
+      const scope = yield* Scope.fork(lifetime);
+      owned = scope;
+      const id = crypto.randomUUID();
+      yield* Scope.addFinalizer(
+        scope,
+        Effect.promise(async () => {
+          if (owned === scope) owned = undefined;
+          try {
+            const value = Schema.decodeUnknownSync(
+              Schema.fromJsonString(metadataSchema),
+            )(await fs.readFile(record, "utf8"));
+            if (value.id === id) await fs.unlink(record);
+          } catch (cause) {
+            if (
+              !(
+                cause instanceof Error &&
+                "code" in cause &&
+                cause.code === "ENOENT"
+              )
+            )
+              console.error(
+                "Unable to clean up local collector metadata",
+                cause,
+              );
+          } finally {
+            await release();
+          }
+        }),
+      );
+      return yield* Effect.gen(function* () {
+        const miniflareDist = path.dirname(require.resolve("miniflare"));
+        const collector = yield* io(() =>
+          fs.readFile(
+            path.join(
+              miniflareDist,
+              "workers/observability/collector.worker.js",
+            ),
+            "utf8",
+          ),
+        );
+        const ports = yield* workerd.serve(
+          {
+            sockets: [
+              {
+                name: "collector",
+                address: "127.0.0.1:0",
+                service: { name: "local-explorer:collector" },
+              },
+            ],
+            services: [
+              { name: "storage", disk: { path: directory, writable: true } },
+              {
+                name: "local-explorer:collector",
+                worker: {
+                  compatibilityDate: "2026-01-01",
+                  compatibilityFlags: ["nodejs_compat"],
+                  modules: [
+                    { name: "host.js", esModule: host },
+                    { name: "collector.worker.js", esModule: collector },
+                  ],
+                  durableObjectNamespaces: [
+                    {
+                      className: "TraceStore",
+                      uniqueKey: "miniflare-wobs-trace-store",
+                      enableSql: true,
+                      preventEviction: true,
+                    },
+                  ],
+                  durableObjectStorage: { localDisk: "storage" },
+                  bindings: [
+                    {
+                      name: "TRACE_STORE",
+                      durableObjectNamespace: { className: "TraceStore" },
+                    },
+                    { name: "COLLECTOR_ID", text: id },
+                  ],
+                },
+              },
+            ],
+          },
+          { "debug-port": "127.0.0.1:0" },
+        );
+        const value = {
+          id,
+          address: `127.0.0.1:${ports["debug-port"]}`,
+          health: `http://127.0.0.1:${ports.collector}/health`,
+        };
+        yield* io(async () => {
+          const pending = `${record}.${id}`;
+          await fs.writeFile(pending, JSON.stringify(value));
+          await fs.rename(pending, record);
+        });
+        return value;
+      }).pipe(
+        Effect.provideService(Scope.Scope, scope),
+        Effect.onError((cause) => Scope.close(scope, Exit.failCause(cause))),
+      );
+    }).pipe(
+      mutex.withPermits(1),
+      Effect.retry({
+        times: 100,
+        schedule: Schedule.spaced("100 millis"),
+        while: (error) => error.subtag === "CollectorStarting",
+      }),
+    );
+    return { get };
+  },
+);

--- a/packages/cloudflare-runtime/src/core/LocalExplorerDurableObjects.ts
+++ b/packages/cloudflare-runtime/src/core/LocalExplorerDurableObjects.ts
@@ -1,0 +1,62 @@
+import * as Effect from "effect/Effect";
+import { ConfigError } from "./RuntimeError.shared.ts";
+import type { DurableObjectNamespace } from "./RuntimeWorker.ts";
+import type { Worker_Module } from "./workerd/Config.ts";
+
+/**
+ * Add Miniflare's local SQL/name RPC methods to the exported DO classes.
+ * All bindings, namespace keys and storage services still point at the
+ * original worker. Re-exporting its other exports preserves named entrypoints.
+ */
+export const wrapDurableObjectModules = Effect.fn(
+  "LocalExplorer.wrapDurableObjects",
+)(function* (
+  modules: Worker_Module[],
+  namespaces: ReadonlyArray<DurableObjectNamespace>,
+  wrapper: string,
+) {
+  const classes = [
+    ...new Set(
+      namespaces
+        .filter((ns) => ns.sql && !ns.ephemeralLocal)
+        .map((ns) => ns.className),
+    ),
+  ];
+  if (!classes.length) return modules;
+  if (!modules[0] || !("esModule" in modules[0])) {
+    return yield* new ConfigError({
+      subtag: "LocalExplorer",
+      message: "Durable Object inspection requires an ES module entrypoint.",
+    });
+  }
+  const entryName = "__alchemy_explorer_entry.js";
+  const wrapperName = "__alchemy_explorer_do.js";
+  if (
+    modules.some(
+      (module) => module.name === entryName || module.name === wrapperName,
+    )
+  ) {
+    return yield* new ConfigError({
+      subtag: "LocalExplorer",
+      message: "Worker modules use a reserved Local Explorer module name.",
+    });
+  }
+  const original = JSON.stringify(`./${modules[0].name}`);
+  const source = [
+    `import { createDurableObjectWrapper } from "./${wrapperName}";`,
+    `import * as original from ${original};`,
+    `export * from ${original};`,
+    ...(classes.includes("default")
+      ? []
+      : ["export default original.default;"]),
+    ...classes.map(
+      (name, index) =>
+        `const DO_${index} = createDurableObjectWrapper(original[${JSON.stringify(name)}]);\nexport { DO_${index} as ${JSON.stringify(name)} };`,
+    ),
+  ].join("\n");
+  return [
+    { name: entryName, esModule: source },
+    { name: wrapperName, esModule: wrapper },
+    ...modules,
+  ] satisfies Worker_Module[];
+});

--- a/packages/cloudflare-runtime/src/core/LocalExplorerEmail.ts
+++ b/packages/cloudflare-runtime/src/core/LocalExplorerEmail.ts
@@ -1,0 +1,132 @@
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { createWriteStream } from "node:fs";
+import { pipeline } from "node:stream/promises";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type {
+  Service,
+  ServiceDesignator,
+  Worker_Binding,
+} from "./workerd/Config.ts";
+
+// Reuse the pinned Miniflare email simulator and capture store. Each worker
+// owns its store; Explorer's native peer protocol aggregates them by source ID.
+export function prepareExplorerEmail(
+  workerName: string,
+  storage: Service,
+  bindings: ReadonlyArray<Worker_Binding>,
+  loopback: ServiceDesignator,
+  storeSource: string,
+  sendSource: string,
+) {
+  const services: Service[] = [
+    {
+      name: "email:store",
+      worker: {
+        compatibilityDate: "2026-01-01",
+        compatibilityFlags: ["nodejs_compat"],
+        modules: [{ name: "email-store.js", esModule: storeSource }],
+        durableObjectNamespaces: [
+          {
+            className: "EmailStore",
+            uniqueKey: `alchemy:explorer:email:${encodeURIComponent(workerName)}`,
+            enableSql: true,
+          },
+        ],
+        durableObjectStorage: { localDisk: storage.name },
+        bindings: [
+          {
+            name: "EMAIL_STORE_DO",
+            durableObjectNamespace: { className: "EmailStore" },
+          },
+        ],
+      },
+    },
+  ];
+  const sendEmail: { bindingName: string }[] = [];
+  const userBindings = bindings.map((binding) => {
+    if (
+      !binding.name ||
+      !("service" in binding) ||
+      binding.service?.name !== "send-email" ||
+      binding.service.entrypoint !== "SendEmailBinding"
+    )
+      return binding;
+    const name = `local-explorer:send-email:${sendEmail.length}`;
+    sendEmail.push({ bindingName: binding.name });
+    // Address restrictions still come from the original service props.
+    services.push({
+      name,
+      worker: {
+        compatibilityDate: "2026-01-01",
+        compatibilityFlags: ["nodejs_compat"],
+        modules: [
+          {
+            name: "entry.js",
+            esModule: `import { SendEmailBinding } from "./send.js";
+export default class extends SendEmailBinding {
+  constructor(ctx, env) { super(ctx, { ...env, ...ctx.props }); }
+}`,
+          },
+          { name: "send.js", esModule: sendSource },
+        ],
+        bindings: [
+          { name: "MINIFLARE_LOOPBACK", service: loopback },
+          { name: "MINIFLARE_EMAIL_STORE", service: { name: "email:store" } },
+          { name: "SEND_EMAIL_OWNER_WORKER", text: workerName },
+        ],
+      },
+    });
+    return {
+      name: binding.name,
+      service: { name, props: binding.service.props },
+    };
+  });
+  return { services, userBindings, sendEmail };
+}
+
+// These endpoints are behind the authenticated, scoped Alchemy loopback.
+export async function handleExplorerEmailLoopback(
+  request: IncomingMessage,
+  response: ServerResponse,
+  url: URL,
+  storagePath: string,
+  workerName: string,
+): Promise<boolean> {
+  if (request.method !== "POST") return false;
+  if (url.pathname === "/core/log") {
+    let message = "";
+    for await (const chunk of request) {
+      if (message.length < 65536)
+        message += String(chunk).slice(0, 65536 - message.length);
+    }
+    console.log(`[${workerName}] ${message}`);
+    response.writeHead(204).end();
+    return true;
+  }
+  if (url.pathname !== "/core/store-temp-file") return false;
+  const prefix = url.searchParams.get("prefix") ?? "";
+  const extension = url.searchParams.get("extension") ?? "";
+  const id = url.searchParams.get("id") ?? crypto.randomUUID();
+  if (
+    !/^email\/(email|text|html|attachment|reply)$/.test(prefix) ||
+    !/^[a-zA-Z0-9]{1,16}$/.test(extension) ||
+    !/^[a-zA-Z0-9@._+-]{1,240}$/.test(id) ||
+    id === "." ||
+    id === ".."
+  ) {
+    response.writeHead(400).end("Invalid email file path");
+    return true;
+  }
+  const kind = prefix.slice("email/".length);
+  const directory = path.join(
+    storagePath,
+    "email",
+    ...(kind === "email" ? [] : [kind]),
+  );
+  await fs.mkdir(directory, { recursive: true });
+  const file = path.join(directory, `${id}.${extension}`);
+  await pipeline(request, createWriteStream(file));
+  response.writeHead(200, { "content-type": "text/plain" }).end(file);
+  return true;
+}

--- a/packages/cloudflare-runtime/src/core/LocalExplorerHost.ts
+++ b/packages/cloudflare-runtime/src/core/LocalExplorerHost.ts
@@ -1,0 +1,215 @@
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Schedule from "effect/Schedule";
+import * as Schema from "effect/Schema";
+import * as Scope from "effect/Scope";
+import * as Semaphore from "effect/Semaphore";
+import { createRequire } from "node:module";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { Loopback } from "./globals/Loopback.ts";
+import type { PluginContext } from "./PluginContext.ts";
+import { RegistryProxy } from "./registry/RegistryProxy.ts";
+import { SystemError } from "./RuntimeError.shared.ts";
+import { kVoid, type Service } from "./workerd/Config.ts";
+import { Workerd } from "./workerd/Workerd.ts";
+
+const metadata = Schema.Struct({ id: Schema.String, port: Schema.Number });
+const prefix = "/cdn-cgi/local/explorer";
+const host = `
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+    if (url.pathname === "/_alchemy/explorer/health") return Response.json({ id: env.ID });
+    if (url.pathname === "/") return Response.redirect(new URL("${prefix}/", url), 302);
+    if (url.pathname !== "${prefix}" && !url.pathname.startsWith("${prefix}/")) return new Response("Not found", { status: 404 });
+    const response = await env.REGISTRY.fetch("http://localhost/");
+    const peers = await response.json();
+    // Probe before forwarding. Never retry the user's request: it may mutate
+    // storage even if the connection fails before a response arrives.
+    for (const peer of peers) {
+      const entry = env.DEBUG.connect(peer.debugPortAddress).getEntrypoint("core:entry");
+      try {
+        const health = await entry.fetch("http://localhost/_alchemy/explorer/health");
+        if (!health.ok || (await health.json()).id !== peer.localExplorer.instanceId) continue;
+      } catch { continue; }
+      return entry.fetch(request);
+    }
+    return new Response("Local Workers are starting. Please retry shortly.", { status: 503, headers: { "Retry-After": "1" } });
+  }
+};
+`;
+
+// One browser endpoint per storage directory, shared by separate CLI/Vite
+// processes. Its lifetime is the Runtime layer, not an individual Worker.
+// Followers take over the same port when the owning process exits.
+export const makeLocalExplorerHost = Effect.fn("LocalExplorer.host")(function* (
+  storage: Service,
+  context: PluginContext["Service"],
+) {
+  const workerd = yield* Workerd;
+  const lifetime = yield* Effect.scope;
+  const mutex = yield* Semaphore.make(1);
+  const storagePath = "disk" in storage ? storage.disk?.path : undefined;
+  if (!storagePath)
+    return yield* new SystemError({
+      subtag: "LocalExplorer",
+      message: "Local Explorer requires disk-backed storage.",
+    });
+  const storageScope = path.resolve(storagePath);
+  const directory = path.join(storageScope, "local-explorer");
+  const record = path.join(directory, "host.json");
+  const io = <A>(operation: () => Promise<A>) =>
+    Effect.tryPromise({
+      try: operation,
+      catch: (cause) =>
+        new SystemError({
+          subtag: "LocalExplorerHost",
+          message: "Unable to start or locate Local Explorer.",
+          cause,
+        }),
+    });
+  yield* io(() => fs.mkdir(directory, { recursive: true }));
+  const loopback = yield* context.get(Loopback);
+  const registry = yield* context.get(RegistryProxy);
+  const registryBinding = yield* loopback.api.route(
+    `explorer-host:${crypto.randomUUID()}`,
+    async (_request, response) => {
+      const entries = await Effect.runPromise(
+        registry.api.localExplorerEntries,
+      );
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(
+        JSON.stringify(
+          entries
+            .filter(
+              (entry) => entry.localExplorer?.storageScope === storageScope,
+            )
+            .sort((a, b) => a.scriptName.localeCompare(b.scriptName)),
+        ),
+      );
+    },
+    lifetime,
+  );
+  const lockfile: typeof import("proper-lockfile") = createRequire(
+    import.meta.url,
+  )("proper-lockfile");
+  let owned: Scope.Closeable | undefined;
+  const get = Effect.gen(function* () {
+    const previous = yield* io(async () => {
+      try {
+        return Schema.decodeUnknownSync(Schema.fromJsonString(metadata))(
+          await fs.readFile(record, "utf8"),
+        );
+      } catch {
+        return undefined;
+      }
+    });
+    if (previous) {
+      const alive = yield* io(async () => {
+        try {
+          const response = await fetch(
+            `http://127.0.0.1:${previous.port}/_alchemy/explorer/health`,
+            { signal: AbortSignal.timeout(500) },
+          );
+          return (
+            response.ok &&
+            Schema.decodeUnknownSync(Schema.Struct({ id: Schema.String }))(
+              await response.json(),
+            ).id === previous.id
+          );
+        } catch {
+          return false;
+        }
+      });
+      if (alive) return `http://127.0.0.1:${previous.port}${prefix}/`;
+    }
+    if (owned) {
+      const failed = owned;
+      owned = undefined;
+      yield* Scope.close(failed, Exit.void);
+    }
+    const release = yield* Effect.tryPromise({
+      try: () =>
+        lockfile.lock(directory, {
+          realpath: true,
+          retries: 0,
+          stale: 5000,
+          update: 1000,
+        }),
+      catch: (cause) =>
+        new SystemError({
+          subtag:
+            cause instanceof Error &&
+            "code" in cause &&
+            cause.code === "ELOCKED"
+              ? "ExplorerStarting"
+              : "LocalExplorerHost",
+          message:
+            "Local Explorer is starting or its previous lease is expiring.",
+          cause,
+        }),
+    });
+    const scope = yield* Scope.fork(lifetime);
+    owned = scope;
+    yield* Scope.addFinalizer(
+      scope,
+      Effect.promise(() => release()),
+    );
+    return yield* Effect.gen(function* () {
+      const id = crypto.randomUUID();
+      const ports = yield* workerd.serve({
+        sockets: [
+          {
+            name: "explorer",
+            address: `127.0.0.1:${previous?.port ?? 0}`,
+            service: { name: "explorer-host" },
+          },
+        ],
+        services: [
+          ...(loopback.services ?? []),
+          {
+            name: "explorer-host",
+            worker: {
+              compatibilityDate: "2026-01-01",
+              modules: [{ name: "host.js", esModule: host }],
+              bindings: [
+                { name: "ID", text: id },
+                { name: "DEBUG", workerdDebugPort: kVoid },
+                { name: "REGISTRY", service: registryBinding },
+              ],
+            },
+          },
+        ],
+      });
+      const port = ports.explorer;
+      yield* io(async () => {
+        const pending = `${record}.${id}`;
+        await fs.writeFile(pending, JSON.stringify({ id, port }));
+        await fs.rename(pending, record);
+      });
+      const url = `http://127.0.0.1:${port}${prefix}/`;
+      yield* Effect.logInfo(`Local Explorer: ${url}`);
+      return url;
+    }).pipe(
+      Effect.provideService(Scope.Scope, scope),
+      Effect.onError((cause) => Scope.close(scope, Exit.failCause(cause))),
+    );
+  }).pipe(
+    mutex.withPermits(1),
+    Effect.retry({
+      times: 100,
+      schedule: Schedule.spaced("100 millis"),
+      while: (error) => error.subtag === "ExplorerStarting",
+    }),
+  );
+  const url = yield* get;
+  yield* get.pipe(
+    Effect.catch((error) =>
+      Effect.logWarning("Local Explorer host unavailable", error),
+    ),
+    Effect.repeat(Schedule.spaced("1 second")),
+    Effect.forkScoped,
+  );
+  return url;
+});

--- a/packages/cloudflare-runtime/src/core/LocalExplorerWorkflows.ts
+++ b/packages/cloudflare-runtime/src/core/LocalExplorerWorkflows.ts
@@ -1,0 +1,46 @@
+// Keep workflow deletion inside the live Engine. Unlinking its SQLite file
+// while workerd owns it leaves active execution and cached state behind.
+export const explorerWorkflowLoopback = `
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+    const match = /^\\/core\\/workflow-storage\\/([^/]+)(?:\\/([a-f0-9]{64}))?$/.exec(url.pathname);
+    if (!match) return env.LOOPBACK.fetch(request);
+    const info = env.WORKFLOWS[decodeURIComponent(match[1])];
+    if (!info) return new Response("Unknown workflow", { status: 404 });
+    const namespace = env[info.engineBinding];
+    const directoryUrl = new URL(request.url);
+    directoryUrl.pathname = "/core/workflow-storage/" + match[1];
+    const response = await env.LOOPBACK.fetch(directoryUrl);
+    if (!response.ok) return response;
+    const files = await response.json();
+    const live = [];
+    for (const file of files) {
+      const id = file.name.slice(0, -7);
+      if (match[2] && id !== match[2]) continue;
+      const stub = namespace.get(namespace.idFromString(id));
+      try {
+        const metadata = await stub.getInstanceMetadata();
+        // Empty database files can remain after deleteAll(), including after
+        // a restart. They are not instances and must not appear in the UI.
+        if (!metadata.instanceId) continue;
+      } catch (error) {
+        if (String(error).includes("instance.not_found") || String(error).includes("Engine was never started")) continue;
+        throw error;
+      }
+      if (request.method === "DELETE") {
+        try { await stub.deleteInstance(); }
+        catch (error) {
+          if (!String(error).includes("Aborting engine: User called delete")) throw error;
+        }
+      }
+      live.push(file);
+    }
+    if (request.method === "GET") return Response.json(live);
+    if (request.method === "DELETE") return match[2] && !live.length
+      ? new Response("Unknown instance", { status: 404 })
+      : Response.json({ success: true });
+    return new Response("Method not allowed", { status: 405 });
+  }
+};
+`;

--- a/packages/cloudflare-runtime/src/core/Runtime.ts
+++ b/packages/cloudflare-runtime/src/core/Runtime.ts
@@ -1,11 +1,13 @@
 import { makeLocalExplorerCollector } from "./LocalExplorerCollector.ts";
+import { makeLocalExplorerHost } from "./LocalExplorerHost.ts";
 import * as Config from "effect/Config";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
-import type * as Scope from "effect/Scope";
+import * as Scope from "effect/Scope";
+import * as Semaphore from "effect/Semaphore";
 import {
-  LOCAL_EXPLORER_SERVICE,
+  LOCAL_EXPLORER_PUBLIC_SERVICE,
   LOCAL_EXPLORER_COLLECTOR,
   LOCAL_EXPLORER_FLAGS,
   prepareLocalExplorer,
@@ -75,6 +77,19 @@ export const RuntimeLive = Layer.effect(
     );
     const workerd = yield* Workerd.Workerd;
     const storage = yield* Storage.Storage;
+    const lifetime = yield* Effect.scope;
+    const explorerHostLock = yield* Semaphore.make(1);
+    let explorerUrl: string | undefined;
+    const getExplorerUrl = (context: PluginContext.PluginContext["Service"]) =>
+      Effect.gen(function* () {
+        return (explorerUrl ??= yield* makeLocalExplorerHost(
+          storage,
+          context,
+        ).pipe(
+          Effect.provideService(Scope.Scope, lifetime),
+          Effect.provideService(Workerd.Workerd, workerd),
+        ));
+      }).pipe(explorerHostLock.withPermits(1));
     const collector = observabilityEnabled
       ? yield* makeLocalExplorerCollector(storage)
       : undefined;
@@ -251,6 +266,7 @@ export const RuntimeLive = Layer.effect(
                 config.entry ?? SERVICE_USER_WORKER,
                 storage,
                 bindings,
+                yield* getExplorerUrl(context),
                 collector,
               )
             : undefined;
@@ -262,7 +278,7 @@ export const RuntimeLive = Layer.effect(
                 address: "127.0.0.1:0",
                 service: {
                   name: explorer
-                    ? LOCAL_EXPLORER_SERVICE
+                    ? LOCAL_EXPLORER_PUBLIC_SERVICE
                     : (config.entry ?? SERVICE_USER_WORKER),
                 },
               },
@@ -355,11 +371,6 @@ export const RuntimeLive = Layer.effect(
         );
         yield* context.start(ports);
         const url = new URL(`http://127.0.0.1:${ports[SOCKET_USER_ENTRY]}`);
-        if (explorer) {
-          yield* Effect.logInfo(
-            `[${worker.name}] Local Explorer: ${new URL("/cdn-cgi/local/explorer/", url)}`,
-          );
-        }
         return url;
       }),
     });

--- a/packages/cloudflare-runtime/src/core/Runtime.ts
+++ b/packages/cloudflare-runtime/src/core/Runtime.ts
@@ -1,7 +1,16 @@
+import { makeLocalExplorerCollector } from "./LocalExplorerCollector.ts";
+import * as Config from "effect/Config";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import type * as Scope from "effect/Scope";
+import {
+  LOCAL_EXPLORER_SERVICE,
+  LOCAL_EXPLORER_COLLECTOR,
+  LOCAL_EXPLORER_FLAGS,
+  prepareLocalExplorer,
+} from "./LocalExplorer.ts";
+import { wrapDurableObjectModules } from "./LocalExplorerDurableObjects.ts";
 import * as Docker from "./Docker.ts";
 import type * as Globals from "./globals/Globals.ts";
 import * as Storage from "./globals/Storage.ts";
@@ -37,8 +46,38 @@ type BindingRequirements<B extends BindingHooks> =
 export const RuntimeLive = Layer.effect(
   Runtime,
   Effect.gen(function* () {
+    const localExplorerEnabled = yield* Config.boolean(
+      "CLOUDFLARE_RUNTIME_LOCAL_EXPLORER",
+    ).pipe(
+      Config.withDefault(false),
+      Effect.mapError(
+        (cause) =>
+          new SystemError({
+            subtag: "LocalExplorer",
+            message: "Invalid CLOUDFLARE_RUNTIME_LOCAL_EXPLORER setting.",
+            cause,
+          }),
+      ),
+    );
+    const observabilityEnabled = yield* Config.boolean(
+      "CLOUDFLARE_RUNTIME_LOCAL_EXPLORER_OBSERVABILITY",
+    ).pipe(
+      Config.withDefault(false),
+      Effect.mapError(
+        (cause) =>
+          new SystemError({
+            subtag: "LocalExplorer",
+            message:
+              "Invalid CLOUDFLARE_RUNTIME_LOCAL_EXPLORER_OBSERVABILITY setting.",
+            cause,
+          }),
+      ),
+    );
     const workerd = yield* Workerd.Workerd;
     const storage = yield* Storage.Storage;
+    const collector = observabilityEnabled
+      ? yield* makeLocalExplorerCollector(storage)
+      : undefined;
     const docker = yield* Docker.Docker;
     const plugins =
       yield* PluginContext.pickPluginsFromContext<Globals.Globals>();
@@ -204,13 +243,28 @@ export const RuntimeLive = Layer.effect(
             concurrency: "unbounded",
           },
         );
+        const explorer =
+          (worker.localExplorer ?? localExplorerEnabled)
+            ? yield* prepareLocalExplorer(
+                worker,
+                context,
+                config.entry ?? SERVICE_USER_WORKER,
+                storage,
+                bindings,
+                collector,
+              )
+            : undefined;
         const ports = yield* workerd.serve(
           {
             sockets: [
               {
                 name: SOCKET_USER_ENTRY,
                 address: "127.0.0.1:0",
-                service: { name: config.entry ?? SERVICE_USER_WORKER },
+                service: {
+                  name: explorer
+                    ? LOCAL_EXPLORER_SERVICE
+                    : (config.entry ?? SERVICE_USER_WORKER),
+                },
               },
               ...config.sockets,
             ],
@@ -220,7 +274,7 @@ export const RuntimeLive = Layer.effect(
                 worker: {
                   compatibilityDate: worker.compatibilityDate,
                   compatibilityFlags: worker.compatibilityFlags,
-                  bindings,
+                  bindings: explorer?.bindings ?? bindings,
                   modules: worker.modules.map(moduleToWorkerd),
                   durableObjectNamespaces: worker.durableObjectNamespaces?.map(
                     (namespace) => {
@@ -247,11 +301,51 @@ export const RuntimeLive = Layer.effect(
                   streamingTails,
                   ...config.userWorker,
                   ...worker.unsafe,
+                  ...(explorer && collector
+                    ? {
+                        compatibilityFlags: [
+                          ...new Set([
+                            ...(worker.unsafe?.compatibilityFlags ??
+                              config.userWorker.compatibilityFlags ??
+                              worker.compatibilityFlags),
+                            ...LOCAL_EXPLORER_FLAGS,
+                          ]),
+                        ],
+                        streamingTails: [
+                          ...(worker.unsafe?.streamingTails ??
+                            config.userWorker.streamingTails ??
+                            streamingTails ??
+                            []),
+                          {
+                            name: LOCAL_EXPLORER_COLLECTOR,
+                            props: {
+                              json: JSON.stringify({ worker: worker.name }),
+                            },
+                          },
+                        ],
+                      }
+                    : {}),
+                  ...(explorer
+                    ? {
+                        modules: yield* wrapDurableObjectModules(
+                          (worker.unsafe && "modules" in worker.unsafe
+                            ? worker.unsafe.modules
+                            : undefined) ??
+                            ("modules" in config.userWorker
+                              ? config.userWorker.modules
+                              : undefined) ??
+                            worker.modules.map(moduleToWorkerd),
+                          worker.durableObjectNamespaces ?? [],
+                          explorer.durableObjectWrapper,
+                        ),
+                      }
+                    : {}),
                 },
               },
               ...config.services,
+              ...(explorer?.services ?? []),
             ],
-            extensions: config.extensions,
+            extensions: [...config.extensions, ...(explorer?.extensions ?? [])],
           },
           {
             "debug-port": "127.0.0.1:0",
@@ -260,7 +354,13 @@ export const RuntimeLive = Layer.effect(
           { onOutput: worker.logging?.onOutput },
         );
         yield* context.start(ports);
-        return new URL(`http://127.0.0.1:${ports[SOCKET_USER_ENTRY]}`);
+        const url = new URL(`http://127.0.0.1:${ports[SOCKET_USER_ENTRY]}`);
+        if (explorer) {
+          yield* Effect.logInfo(
+            `[${worker.name}] Local Explorer: ${new URL("/cdn-cgi/local/explorer/", url)}`,
+          );
+        }
+        return url;
       }),
     });
   }),

--- a/packages/cloudflare-runtime/src/core/RuntimeWorker.ts
+++ b/packages/cloudflare-runtime/src/core/RuntimeWorker.ts
@@ -11,6 +11,14 @@ export interface RuntimeWorker<B extends BindingHooks = BindingHooks> {
   readonly compatibilityFlags: Array<string>;
   readonly bindings: B;
   readonly modules: ReadonlyArray<Module>;
+  /**
+   * Serve Cloudflare's Local Explorer at `/cdn-cgi/local/explorer`.
+   * Opt-in local inspection and management of KV, R2, D1, Workflows,
+   * SQLite Durable Objects, and email. Resource controls can modify local data.
+   * Inherits the
+   * `CLOUDFLARE_RUNTIME_LOCAL_EXPLORER` setting (default `false`).
+   */
+  readonly localExplorer?: boolean;
   readonly assets?: Assets;
   readonly hyperdrives?: Record<string, HyperdriveOrigin>;
   readonly durableObjectNamespaces?: ReadonlyArray<DurableObjectNamespace>;

--- a/packages/cloudflare-runtime/src/core/bindings/workflows/wrapped-binding.worker.ts
+++ b/packages/cloudflare-runtime/src/core/bindings/workflows/wrapped-binding.worker.ts
@@ -1,6 +1,7 @@
 import type {
   WorkflowBinding,
   WorkflowInstanceRestartOptions,
+  WorkflowInstanceTerminateOptions,
 } from "../../../internal/workflows-shared/binding.ts";
 import type { WorkflowIntrospectionOperation } from "../../../internal/workflows-shared/types.ts";
 
@@ -110,9 +111,11 @@ class InstanceImpl implements WorkflowInstance {
     await instance.resume();
   }
 
-  public async terminate(): Promise<void> {
+  public async terminate(
+    options?: WorkflowInstanceTerminateOptions,
+  ): Promise<void> {
     using instance = await this.getInstance();
-    await instance.terminate();
+    await instance.terminate(options);
   }
 
   public async restart(

--- a/packages/cloudflare-runtime/src/core/globals/Loopback.ts
+++ b/packages/cloudflare-runtime/src/core/globals/Loopback.ts
@@ -1,3 +1,4 @@
+import type * as Scope from "effect/Scope";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import { DEFAULT_COMPATIBILITY_DATE } from "../internal/constants.ts";
@@ -12,6 +13,7 @@ export class Loopback extends Plugin.Service<
     readonly route: (
       target: string,
       handler: LoopbackServer.RouteHandler,
+      scope?: Scope.Scope,
     ) => Effect.Effect<WorkerdConfig.ServiceDesignator>;
   }
 >()("cloudflare-runtime/plugin/Loopback") {}
@@ -65,8 +67,8 @@ export const LoopbackLive = Layer.effect(
         },
       ],
       api: {
-        route: (target, handler) =>
-          loopbackServer.route(target, handler).pipe(
+        route: (target, handler, scope) =>
+          loopbackServer.route(target, handler, scope).pipe(
             Effect.map(() => ({
               name: "loopback:fetcher",
               props: { json: JSON.stringify({ target }) },

--- a/packages/cloudflare-runtime/src/core/globals/LoopbackServer.ts
+++ b/packages/cloudflare-runtime/src/core/globals/LoopbackServer.ts
@@ -1,6 +1,7 @@
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Scope from "effect/Scope";
 import * as MutableHashMap from "effect/MutableHashMap";
 import * as HttpServerError from "effect/unstable/http/HttpServerError";
 import type * as HttpServerRequest from "effect/unstable/http/HttpServerRequest";
@@ -20,6 +21,7 @@ export class LoopbackServer extends Context.Service<
     readonly route: (
       name: string,
       handler: RouteHandler,
+      ownerScope?: Scope.Scope,
     ) => Effect.Effect<void>;
   }
 >()("cloudflare-runtime/LoopbackServer") {}
@@ -147,18 +149,24 @@ export const LoopbackServerLive = Layer.effect(
     return LoopbackServer.of({
       address,
       secret,
-      route: (name, handler) =>
-        Effect.isEffect(handler)
-          ? makeHandler(handler, { scope }).pipe(
-              Effect.map((handler) => {
-                MutableHashMap.set(routes, name, handler);
-                return Effect.void;
+      route: (name, handler, ownerScope) =>
+        Effect.gen(function* () {
+          const resolved = Effect.isEffect(handler)
+            ? yield* makeHandler(handler, { scope: ownerScope ?? scope })
+            : handler;
+          MutableHashMap.set(routes, name, resolved);
+          if (ownerScope) {
+            yield* Scope.addFinalizer(
+              ownerScope,
+              Effect.sync(() => {
+                const current = MutableHashMap.get(routes, name);
+                if (current._tag === "Some" && current.value === resolved) {
+                  MutableHashMap.remove(routes, name);
+                }
               }),
-            )
-          : Effect.sync(() => {
-              MutableHashMap.set(routes, name, handler);
-              return Effect.void;
-            }),
+            );
+          }
+        }),
     });
   }),
 );

--- a/packages/cloudflare-runtime/src/core/registry/Registry.ts
+++ b/packages/cloudflare-runtime/src/core/registry/Registry.ts
@@ -27,6 +27,7 @@ export class Registry extends Context.Service<
     /**
      * Reads the registry and returns the resolved targets for the given subscribers.
      */
+    readonly entries: Effect.Effect<ReadonlyArray<RegistryEntry>>;
     readonly read: (
       subscribers: ReadonlyArray<Subscriber>,
     ) => Effect.Effect<ResolvedTargetMap>;
@@ -135,6 +136,9 @@ export const RegistryLive = Layer.effect(
     ).pipe(Stream.runDrain, Effect.forkScoped);
 
     return Registry.of({
+      entries: SubscriptionRef.get(ref).pipe(
+        Effect.map((entries) => [...MutableHashMap.values(entries)]),
+      ),
       read: (subscribers) =>
         SubscriptionRef.get(ref).pipe(
           Effect.map(pickSubscriberServices(subscribers)),

--- a/packages/cloudflare-runtime/src/core/registry/RegistryProxy.ts
+++ b/packages/cloudflare-runtime/src/core/registry/RegistryProxy.ts
@@ -22,14 +22,22 @@ import { PluginContext } from "../PluginContext.ts";
 import { SystemError } from "../RuntimeError.shared.ts";
 import * as WorkerdConfig from "../workerd/Config.ts";
 import * as Registry from "./Registry.ts";
-import type { ResolvedTargetMap, Subscriber } from "./RegistryTypes.shared.ts";
+import type {
+  RegistryEntry,
+  ResolvedTargetMap,
+  Subscriber,
+} from "./RegistryTypes.shared.ts";
 
 export class RegistryProxy extends Plugin.Service<
   RegistryProxy,
   {
-    /**
-     * Declares a service, belonging to the current worker, that will be published to the registry proxy.
-     */
+    /** Publish this worker's Explorer instance and storage scope for peer discovery. */
+    readonly configureLocalExplorer: (
+      metadata: NonNullable<RegistryEntry["localExplorer"]>,
+    ) => Effect.Effect<void>;
+    /** Snapshot of registered local workers, filtered by the Explorer adapter. */
+    readonly localExplorerEntries: Effect.Effect<ReadonlyArray<RegistryEntry>>;
+    /** Declares a service hosted by this worker for the dev registry. */
     readonly publish: (service: PublishedService) => Effect.Effect<void>;
     /**
      * Declares an external service that will be consumed by the current worker.
@@ -76,6 +84,7 @@ export const RegistryProxyLive = Layer.effect(
               defaultDurableObjectUniqueKey(worker.name, namespace.className),
           })) ?? [];
         const subscribed: Array<Subscriber> = [];
+        let localExplorer: RegistryEntry["localExplorer"];
 
         return {
           defer: Effect.gen(function* () {
@@ -138,6 +147,7 @@ export const RegistryProxyLive = Layer.effect(
                   }
                   yield* registry.write({
                     scriptName: worker.name,
+                    localExplorer,
                     debugPortAddress: `127.0.0.1:${debugPort}`,
                     services: [
                       {
@@ -181,6 +191,11 @@ export const RegistryProxyLive = Layer.effect(
               { concurrency: "unbounded" },
             ),
           api: {
+            configureLocalExplorer: (metadata) =>
+              Effect.sync(() => {
+                localExplorer = metadata;
+              }),
+            localExplorerEntries: registry.entries,
             publish: (entry) =>
               Effect.sync(() => {
                 published.push(entry);

--- a/packages/cloudflare-runtime/src/core/registry/RegistryTypes.shared.ts
+++ b/packages/cloudflare-runtime/src/core/registry/RegistryTypes.shared.ts
@@ -30,6 +30,10 @@ export declare namespace Subscriber {
 
 export interface RegistryEntry {
   readonly scriptName: string;
+  readonly localExplorer?: {
+    readonly storageScope: string;
+    readonly instanceId: string;
+  };
   readonly debugPortAddress: string;
   readonly services: [RegistryEntry.Worker, ...Array<RegistryEntry.Service>];
 }

--- a/packages/cloudflare-runtime/src/core/test/LocalExplorer.test.ts
+++ b/packages/cloudflare-runtime/src/core/test/LocalExplorer.test.ts
@@ -1,0 +1,314 @@
+import { expect, layer } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Schedule from "effect/Schedule";
+import * as Scope from "effect/Scope";
+import * as DurableObjectNamespace from "../bindings/DurableObjectNamespace.ts";
+import * as KvNamespace from "../bindings/kv-namespace/KvNamespace.ts";
+import type { RuntimeWorker } from "../RuntimeWorker.ts";
+import { localRuntimeLayer, startTestWorker } from "./helpers/runtime.ts";
+
+const API = "/cdn-cgi/local/explorer/api";
+const KV_ID = "explorer:kv/with spaces";
+const DO_ID = "explorer-counter";
+const kv = `${API}/storage/kv/namespaces/${encodeURIComponent(KV_ID)}`;
+const durable = `${API}/workers/durable_objects/namespaces/${DO_ID}`;
+const script = `
+import { DurableObject } from "cloudflare:workers";
+class BaseCounter extends DurableObject {
+  #tag = "private-field";
+  constructor(ctx, env) {
+    super(ctx, env);
+    ctx.storage.sql.exec("CREATE TABLE IF NOT EXISTS counter (value INTEGER)");
+    ctx.storage.sql.exec("INSERT INTO counter SELECT 0 WHERE NOT EXISTS (SELECT 1 FROM counter)");
+  }
+  increment() {
+    this.ctx.storage.sql.exec("UPDATE counter SET value = value + 1");
+    return { value: this.ctx.storage.sql.exec("SELECT value FROM counter").one().value, tag: this.#tag, id: this.ctx.id.toString() };
+  }
+  fetch() { return Response.json(this.increment()); }
+}
+export class Counter extends BaseCounter {}
+// Like Alchemy's bridge, the constructor returns a Proxy that binds declared
+// methods to the target and dynamically resolves application RPC methods.
+export class BridgeCounter extends BaseCounter {
+  constructor(ctx, env) {
+    super(ctx, env);
+    return new Proxy(this, { get(target, prop) {
+      if (prop in target) {
+        const value = Reflect.get(target, prop, target);
+        return typeof value === "function" ? value.bind(target) : value;
+      }
+      if (prop === "dynamicIncrement") return () => target.increment();
+    } });
+  }
+}
+export class Legacy extends DurableObject {
+  async fetch() {
+    await this.ctx.storage.put("legacy", true);
+    return new Response("legacy");
+  }
+}
+export default {
+  async fetch(request, env) {
+    const path = new URL(request.url).pathname;
+    if (path === "/seed") {
+      await env.RESOURCES.put("folder/a ?é", "hello KV", { metadata: { kind: "test" }, expirationTtl: 3600 });
+      for (let i = 0; i < 10; i++) await env.RESOURCES.put("folder/b" + i, "second");
+      await env.RESOURCES.put("outside", "other");
+      return Response.json(await env.COUNTER.getByName("named-counter").increment());
+    }
+    if (path === "/bridge") return Response.json(await env.BRIDGE.getByName("named-bridge").dynamicIncrement());
+    if (path === "/legacy") return env.LEGACY.getByName("legacy").fetch(request);
+    if (path === "/counter") return env.COUNTER.getByName("named-counter").fetch(request);
+    return new Response("application response");
+  }
+};
+`;
+const owner: RuntimeWorker = {
+  name: "explorer-owner",
+  compatibilityDate: "2026-08-31",
+  compatibilityFlags: [],
+  localExplorer: true,
+  bindings: [
+    KvNamespace.local({ binding: "RESOURCES", id: KV_ID }),
+    DurableObjectNamespace.local({ binding: "COUNTER", className: "Counter" }),
+    DurableObjectNamespace.local({
+      binding: "BRIDGE",
+      className: "BridgeCounter",
+    }),
+    DurableObjectNamespace.local({ binding: "LEGACY", className: "Legacy" }),
+  ],
+  modules: [{ name: "nested/main.js", type: "ESModule", content: script }],
+  durableObjectNamespaces: [
+    { className: "Counter", uniqueKey: DO_ID, sql: true },
+    { className: "BridgeCounter", uniqueKey: "explorer-bridge", sql: true },
+    { className: "Legacy", uniqueKey: "explorer-legacy", sql: false },
+  ],
+};
+const query = (sql: string, id: string) => ({
+  method: "POST",
+  headers: { "content-type": "application/json" },
+  body: JSON.stringify({ durable_object_id: id, queries: [{ sql }] }),
+});
+
+layer(localRuntimeLayer)("Local Explorer", (it) => {
+  it.effect(
+    "browses live KV and Durable Objects through another worker and survives restart",
+    () =>
+      Effect.gen(function* () {
+        const ownerScope = yield* Scope.make();
+        yield* Effect.addFinalizer(() => Scope.close(ownerScope, Exit.void));
+        const worker = yield* startTestWorker(owner).pipe(
+          Effect.provideService(Scope.Scope, ownerScope),
+        );
+        const peer = yield* startTestWorker({
+          name: "explorer-peer",
+          localExplorer: true,
+          compatibilityDate: "2026-08-31",
+          compatibilityFlags: [],
+          bindings: [
+            DurableObjectNamespace.local({
+              binding: "COUNTER",
+              className: "Counter",
+              scriptName: owner.name,
+              uniqueKey: DO_ID,
+            }),
+          ],
+          modules: [
+            {
+              name: "peer.js",
+              type: "ESModule",
+              content: `export default { async fetch(request, env) { return Response.json(await env.COUNTER.getByName("named-counter").increment()); } };`,
+            },
+          ],
+        });
+        expect(yield* worker.fetchText("/")).toBe("application response");
+        const seeded = yield* worker.fetchJson<{
+          id: string;
+          value: number;
+          tag: string;
+        }>("/seed");
+        expect(seeded).toMatchObject({ value: 1, tag: "private-field" });
+        const bridge = yield* worker.fetchJson<{ id: string; value: number }>(
+          "/bridge",
+        );
+        expect(bridge.value).toBe(1);
+        expect(yield* worker.fetchText("/legacy")).toBe("legacy");
+
+        // The registry watcher is asynchronous; wait on the actual discovery result.
+        const list = yield* peer
+          .fetchJson<{ result: { id: string }[] }>(
+            `${API}/storage/kv/namespaces`,
+          )
+          .pipe(
+            Effect.repeat({
+              while: (body) => !body.result.some((ns) => ns.id === KV_ID),
+              schedule: Schedule.spaced("100 millis"),
+              times: 50,
+            }),
+          );
+        expect(list.result.some((ns) => ns.id === KV_ID)).toBe(true);
+        const workers = yield* peer.fetchJson<{
+          result: {
+            name: string;
+            bindings: { kv: unknown[]; do: unknown[] };
+          }[];
+        }>(`${API}/local/workers`);
+        expect(
+          workers.result.find((entry) => entry.name === owner.name)?.bindings
+            .kv,
+        ).toContainEqual({
+          id: KV_ID,
+          bindingName: "RESOURCES",
+        });
+        expect(
+          workers.result.find((entry) => entry.name === owner.name)?.bindings
+            .do,
+        ).toContainEqual({
+          id: DO_ID,
+          bindingName: "COUNTER",
+          className: "Counter",
+          scriptName: owner.name,
+          useSqlite: true,
+        });
+        const keys = yield* peer.fetchJson<{
+          result: { name: string; metadata?: unknown; expiration?: number }[];
+          result_info: { cursor: string };
+        }>(`${kv}/keys?prefix=folder%2F&limit=10`);
+        expect(keys.result, JSON.stringify(keys)).toHaveLength(10);
+        expect(keys.result[0]).toMatchObject({
+          name: "folder/a ?é",
+          metadata: { kind: "test" },
+        });
+        expect(keys.result[0].expiration).toBeTypeOf("number");
+        expect(keys.result_info.cursor).not.toBe("");
+        const next = yield* peer.fetchJson<{ result: { name: string }[] }>(
+          `${kv}/keys?prefix=folder%2F&limit=10&cursor=${encodeURIComponent(keys.result_info.cursor)}`,
+        );
+        expect(next.result.map((key) => key.name)).toEqual(["folder/b9"]);
+        expect(
+          yield* peer.fetchText(
+            `${kv}/values/${encodeURIComponent("folder/a ?é")}`,
+          ),
+        ).toBe("hello KV");
+        expect(
+          yield* peer.fetchJson(`${kv}/bulk/get`, {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ keys: ["folder/a ?é", "missing"] }),
+          }),
+        ).toMatchObject({
+          result: { values: { "folder/a ?é": "hello KV", missing: null } },
+        });
+        expect((yield* peer.fetch(`${kv}/values/missing`)).status).toBe(404);
+        expect(
+          (yield* peer.fetch(`${kv}/values/outside`, {
+            method: "PUT",
+            body: "edited",
+          })).status,
+        ).toBe(200);
+        expect(yield* peer.fetchText(`${kv}/values/outside`)).toBe("edited");
+        const objects = yield* peer.fetchJson<{
+          result: { id: string; name: string }[];
+        }>(`${durable}/objects`);
+        expect(objects.result).toContainEqual({
+          id: seeded.id,
+          name: "named-counter",
+          hasStoredData: true,
+        });
+        const sql = yield* peer.fetchJson(
+          `${durable}/query`,
+          query("SELECT value FROM counter", seeded.id),
+        );
+        expect(sql).toMatchObject({
+          success: true,
+          result: [{ columns: ["value"], rows: [[1]] }],
+        });
+        expect(
+          yield* peer.fetchJson(
+            `${API}/workers/durable_objects/namespaces/explorer-bridge/query`,
+            query("SELECT value FROM counter", bridge.id),
+          ),
+        ).toMatchObject({ success: true, result: [{ rows: [[1]] }] });
+        const incremented = yield* peer.fetchJson<{ value: number }>("/");
+        expect(incremented.value).toBe(2);
+        expect(
+          (yield* peer.fetch(
+            `${API}/workers/durable_objects/namespaces/explorer-legacy/query`,
+            query("SELECT 1", seeded.id),
+          )).status,
+        ).toBe(400);
+        expect(
+          (yield* peer.fetch(
+            `${API}/workers/durable_objects/namespaces/missing/objects`,
+          )).status,
+        ).toBe(404);
+        expect(
+          (yield* peer.fetch(`${API}/storage/kv/namespaces/missing/keys`))
+            .status,
+        ).toBe(404);
+
+        // Queries execute on the real actor, including transactional rollback.
+        const failed = yield* peer.fetch(`${durable}/query`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            durable_object_id: seeded.id,
+            queries: [
+              { sql: "UPDATE counter SET value = 99" },
+              { sql: "SELECT * FROM missing_table" },
+            ],
+          }),
+        });
+        expect(failed.status).toBe(400);
+        expect(
+          yield* peer.fetchJson(
+            `${durable}/query`,
+            query("SELECT value FROM counter", seeded.id),
+          ),
+        ).toMatchObject({ result: [{ rows: [[2]] }] });
+        yield* Scope.close(ownerScope, Exit.void);
+        const restarted = yield* startTestWorker(owner);
+        expect(
+          yield* restarted.fetchText(
+            `${kv}/values/${encodeURIComponent("folder/a ?é")}`,
+          ),
+        ).toBe("hello KV");
+        expect(yield* restarted.fetchJson(`${durable}/objects`)).toMatchObject({
+          result: [{ id: seeded.id, name: "named-counter" }],
+        });
+        expect(
+          yield* restarted.fetchJson(
+            `${durable}/query`,
+            query("SELECT value FROM counter", seeded.id),
+          ),
+        ).toMatchObject({ result: [{ rows: [[2]] }] });
+      }),
+    { timeout: 60_000 },
+  );
+
+  it.effect(
+    "leaves the application route alone when inspection is disabled",
+    () =>
+      Effect.gen(function* () {
+        const worker = yield* startTestWorker({
+          name: "explorer-disabled",
+          compatibilityDate: "2026-08-31",
+          compatibilityFlags: [],
+          bindings: [],
+          modules: [
+            {
+              name: "main.js",
+              type: "ESModule",
+              content:
+                'export default { fetch() { return new Response("application route"); } };',
+            },
+          ],
+        });
+        expect(yield* worker.fetchText(`${API}/storage/kv/namespaces`)).toBe(
+          "application route",
+        );
+      }),
+  );
+});

--- a/packages/cloudflare-runtime/src/core/test/LocalExplorerActions.test.ts
+++ b/packages/cloudflare-runtime/src/core/test/LocalExplorerActions.test.ts
@@ -113,9 +113,10 @@ layer(localRuntimeLayer)("Local Explorer actions", (it) => {
         const form = new FormData();
         form.set("value", "from explorer");
         form.set("metadata", JSON.stringify({ source: "test" }));
-        expect(
-          (yield* peer.fetch(kvValue, { method: "PUT", body: form })).status,
-        ).toBe(200);
+        const write = yield* peer.fetch(kvValue, { method: "PUT", body: form });
+        expect(write.status, yield* Effect.promise(() => write.text())).toBe(
+          200,
+        );
         expect(
           yield* worker.fetchText(`/kv?key=${encodeURIComponent(key)}`),
         ).toBe("from explorer");

--- a/packages/cloudflare-runtime/src/core/test/LocalExplorerActions.test.ts
+++ b/packages/cloudflare-runtime/src/core/test/LocalExplorerActions.test.ts
@@ -1,0 +1,471 @@
+import { expect, layer } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as Scope from "effect/Scope";
+import * as KvNamespace from "../bindings/kv-namespace/KvNamespace.ts";
+import * as R2Bucket from "../bindings/r2-bucket/R2Bucket.ts";
+import * as SendEmail from "../bindings/send-email/SendEmail.ts";
+import type { RuntimeWorker } from "../RuntimeWorker.ts";
+import { localRuntimeLayer, poll, startTestWorker } from "./helpers/runtime.ts";
+
+const API = "/cdn-cgi/local/explorer/api";
+const json = (body: unknown, method = "POST") => ({
+  method,
+  headers: { "content-type": "application/json" },
+  body: JSON.stringify(body),
+});
+const owner: RuntimeWorker = {
+  name: "explorer-actions-owner",
+  localExplorer: true,
+  compatibilityDate: "2026-08-31",
+  compatibilityFlags: ["nodejs_compat"],
+  workflows: [{ workflowName: "explorer-actions-flow", className: "Flow" }],
+  bindings: [
+    KvNamespace.local({ binding: "KV", id: "actions-kv" }),
+    R2Bucket.local({ binding: "R2", id: "actions-r2" }),
+    SendEmail.local({
+      binding: "MAIL",
+      allowedSenderAddresses: ["sender@example.com"],
+    }),
+  ],
+  modules: [
+    {
+      name: "main.js",
+      type: "ESModule",
+      content: `
+import { WorkflowEntrypoint } from "cloudflare:workers";
+import { EmailMessage } from "cloudflare:email";
+export class Flow extends WorkflowEntrypoint {
+  async run(event, step) {
+    await step.do("start", async () => event.payload, { rollback: async () => this.env.KV.put("rollback", "completed") });
+    if (event.payload.wait) return (await step.waitForEvent("approval", { type: "approve", timeout: "1 hour" })).payload;
+    return event.payload;
+  }
+}
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+    if (url.pathname === "/send") {
+      try { return Response.json(await env.MAIL.send(await request.json())); }
+      catch (error) { return new Response(error.message, { status: 400 }); }
+    }
+    if (url.pathname === "/raw") {
+      return Response.json(await env.MAIL.send(new EmailMessage("sender@example.com", "recipient@example.com", await request.text())));
+    }
+    if (url.pathname === "/kv") return new Response(await env.KV.get(url.searchParams.get("key")));
+    if (url.pathname === "/r2") {
+      const object = await env.R2.get(url.searchParams.get("key"));
+      return object ? new Response(object.body) : new Response("missing", { status: 404 });
+    }
+    return new Response("ok");
+  },
+  async email(message, env) {
+    const subject = message.headers.get("subject");
+    await env.KV.put("incoming", subject);
+    if (subject === "reject") message.setReject("Test rejection");
+    if (subject === "forward") await message.forward("forward@example.com");
+    if (subject === "reply") {
+      const raw = ["From: recipient@example.com", "To: sender@example.com", "Message-ID: <reply@example.com>",
+        "In-Reply-To: " + message.headers.get("message-id"), "Subject: Re: reply", "", "Reply body"].join("\\r\\n");
+      await message.reply(new EmailMessage("recipient@example.com", "sender@example.com", raw));
+    }
+    if (subject === "exception") throw new Error("Test email failure");
+  }
+};
+`,
+    },
+  ],
+};
+const peerConfig: RuntimeWorker = {
+  name: "explorer-actions-peer",
+  localExplorer: true,
+  compatibilityDate: "2026-08-31",
+  compatibilityFlags: [],
+  bindings: [],
+  modules: [
+    {
+      name: "main.js",
+      type: "ESModule",
+      content: "export default { fetch() { return new Response('peer'); } };",
+    },
+  ],
+};
+
+layer(localRuntimeLayer)("Local Explorer actions", (it) => {
+  it.effect(
+    "edits live KV/R2 and captures email across workers and restart",
+    () =>
+      Effect.gen(function* () {
+        const scope = yield* Scope.make();
+        yield* Effect.addFinalizer(() => Scope.close(scope, Exit.void));
+        const worker = yield* startTestWorker(owner).pipe(
+          Effect.provideService(Scope.Scope, scope),
+        );
+        const peer = yield* startTestWorker(peerConfig);
+        yield* poll<{ result: { name: string }[] }>(
+          peer,
+          `${API}/local/workers`,
+          (body) => body.result.some((w) => w.name === owner.name),
+        );
+        const key = "folder/a ?é";
+        const kv = `${API}/storage/kv/namespaces/actions-kv`;
+        const kvValue = `${kv}/values/${encodeURIComponent(key)}`;
+        const form = new FormData();
+        form.set("value", "from explorer");
+        form.set("metadata", JSON.stringify({ source: "test" }));
+        expect(
+          (yield* peer.fetch(kvValue, { method: "PUT", body: form })).status,
+        ).toBe(200);
+        expect(
+          yield* worker.fetchText(`/kv?key=${encodeURIComponent(key)}`),
+        ).toBe("from explorer");
+        expect(yield* peer.fetchJson(`${kv}/keys`)).toMatchObject({
+          result: [{ name: key, metadata: { source: "test" } }],
+        });
+        expect(
+          (yield* peer.fetch(kvValue, { method: "PUT", body: "updated" }))
+            .status,
+        ).toBe(200);
+        expect(
+          yield* worker.fetchText(`/kv?key=${encodeURIComponent(key)}`),
+        ).toBe("updated");
+        expect((yield* peer.fetch(kvValue, { method: "DELETE" })).status).toBe(
+          200,
+        );
+        expect((yield* peer.fetch(kvValue)).status).toBe(404);
+        const r2 = `${API}/r2/buckets/actions-r2/objects`;
+        const object = `${r2}/${encodeURIComponent(key)}`;
+        expect(
+          (yield* peer.fetch(object, {
+            method: "PUT",
+            headers: {
+              "content-type": "application/octet-stream",
+              "cf-r2-custom-metadata": JSON.stringify({ source: "test" }),
+            },
+            body: new Uint8Array([0, 1, 255]),
+          })).status,
+        ).toBe(200);
+        expect(
+          Array.from(
+            new Uint8Array(
+              yield* Effect.promise(() =>
+                globalThis
+                  .fetch(
+                    new URL(
+                      `/r2?key=${encodeURIComponent(key)}`,
+                      worker.baseUrl,
+                    ),
+                  )
+                  .then((r) => r.arrayBuffer()),
+              ),
+            ),
+          ),
+        ).toEqual([0, 1, 255]);
+        expect((yield* peer.fetch(r2, json([key], "DELETE"))).status).toBe(200);
+        expect(
+          (yield* worker.fetch(`/r2?key=${encodeURIComponent(key)}`)).status,
+        ).toBe(404);
+
+        const email = {
+          from: "sender@example.com",
+          to: ["recipient@example.com"],
+          subject: "Explorer email",
+          text: "Plain body",
+          html: "<p>HTML body</p>",
+          attachments: [
+            {
+              filename: "test.txt",
+              type: "text/plain",
+              content: "YXR0YWNobWVudA==",
+            },
+          ],
+        };
+        const sent = yield* worker.fetchJson<{ messageId: string }>(
+          "/send",
+          json(email),
+        );
+        expect(sent.messageId).toBeTruthy();
+        expect(
+          (yield* worker.fetch(
+            "/send",
+            json({ ...email, from: "denied@example.com" }),
+          )).status,
+        ).toBe(400);
+        const sending = `${API}/local/email/sending`;
+        expect(yield* peer.fetchJson(sending)).toMatchObject({
+          result: [
+            {
+              messageId: sent.messageId,
+              worker: owner.name,
+              subject: email.subject,
+            },
+          ],
+        });
+        expect(
+          yield* peer.fetchJson(
+            `${sending}?worker=${owner.name}&email_id=${encodeURIComponent(sent.messageId)}`,
+          ),
+        ).toMatchObject({
+          result: {
+            text: email.text,
+            html: email.html,
+            attachments: [{ filename: "test.txt" }],
+          },
+        });
+        expect(
+          yield* peer.fetchJson(`${sending}?worker=${peerConfig.name}`),
+        ).toMatchObject({ result: [] });
+        const routing = `${API}/local/email/routing`;
+        for (const subject of [
+          "receive",
+          "reject",
+          "forward",
+          "reply",
+          "exception",
+        ]) {
+          const delivered = yield* peer.fetchJson<{
+            result: {
+              messageId: string;
+              outcome: string;
+              rejectReason?: string;
+            };
+          }>(
+            `${routing}/send?worker=${owner.name}`,
+            json({ ...email, subject }),
+          );
+          expect(delivered.result, JSON.stringify(delivered)).toMatchObject({
+            outcome: subject === "exception" ? "exception" : "ok",
+          });
+          if (subject === "reject")
+            expect(delivered.result.rejectReason).toBe("Test rejection");
+          expect(yield* worker.fetchText("/kv?key=incoming")).toBe(subject);
+          const captured = yield* peer.fetchJson<{
+            result: {
+              subject: string;
+              raw: string;
+              replies: unknown[];
+              forwards: unknown[];
+            };
+          }>(
+            `${routing}?worker=${owner.name}&email_id=${encodeURIComponent(delivered.result.messageId)}`,
+          );
+          expect(captured.result.subject).toBe(subject);
+          expect(captured.result.raw).toContain("Subject: " + subject);
+          if (subject === "reply")
+            expect(captured.result.replies).toHaveLength(1);
+          if (subject === "forward")
+            expect(captured.result.forwards).toHaveLength(1);
+        }
+        expect(
+          (yield* peer.fetch(
+            `${routing}/send?worker=${peerConfig.name}`,
+            json(email),
+          )).status,
+        ).toBe(400);
+        expect(
+          (yield* peer.fetch(
+            `${routing}/send?worker=${owner.name}`,
+            json({ ...email, to: [] }),
+          )).status,
+        ).toBe(400);
+        const raw =
+          "From: sender@example.com\r\nTo: recipient@example.com\r\nMessage-ID: <raw-test@example.com>\r\nSubject: raw test\r\n\r\nRaw body";
+        const rawSent = yield* worker.fetchJson<{ messageId: string }>("/raw", {
+          method: "POST",
+          body: raw,
+        });
+        expect(
+          yield* peer.fetchJson(
+            `${sending}?email_id=${encodeURIComponent(rawSent.messageId)}`,
+          ),
+        ).toMatchObject({
+          result: {
+            raw: expect.stringContaining("Raw body"),
+            rawBase64: expect.any(String),
+          },
+        });
+        expect(
+          (yield* worker.fetch(
+            "/cdn-cgi/handler/email?from=sender@example.com&to=recipient@example.com",
+            { method: "POST", body: raw },
+          )).status,
+        ).toBe(200);
+        expect(
+          yield* peer.fetchJson(
+            `${routing}?email_id=${encodeURIComponent("<raw-test@example.com>")}`,
+          ),
+        ).toMatchObject({ result: { subject: "raw test" } });
+        yield* Scope.close(scope, Exit.void);
+        const restarted = yield* startTestWorker(owner);
+        expect(
+          yield* restarted.fetchJson(
+            `${sending}?email_id=${encodeURIComponent(sent.messageId)}`,
+          ),
+        ).toMatchObject({ result: { subject: email.subject } });
+        expect(
+          yield* restarted.fetchJson(
+            `${routing}?email_id=${encodeURIComponent("<raw-test@example.com>")}`,
+          ),
+        ).toMatchObject({ result: { subject: "raw test" } });
+      }),
+    { timeout: 90_000 },
+  );
+
+  it.effect(
+    "creates, controls, signals and deletes live Workflow instances",
+    () =>
+      Effect.gen(function* () {
+        const worker = yield* startTestWorker({
+          ...owner,
+          name: "explorer-workflow-owner",
+        });
+        const peer = yield* startTestWorker({
+          ...peerConfig,
+          name: "explorer-workflow-peer",
+        });
+        const workflow = `${API}/workflows/explorer-actions-flow`;
+        yield* poll<{ result: { name: string }[] }>(
+          peer,
+          `${API}/workflows`,
+          (body) => body.result.some((w) => w.name === "explorer-actions-flow"),
+        );
+        const instances = `${workflow}/instances`;
+        expect(
+          yield* peer.fetchJson(
+            instances,
+            json({ id: "controlled", params: { wait: true } }),
+          ),
+        ).toMatchObject({ result: { id: "controlled" } });
+        const instance = `${instances}/controlled`;
+        yield* poll<{ result: { steps: { type: string }[] } }>(
+          peer,
+          instance,
+          (body) => body.result.steps.some((s) => s.type === "waitForEvent"),
+        );
+        for (const action of ["pause", "resume", "terminate", "restart"]) {
+          expect(
+            yield* peer.fetchJson(
+              `${instance}/status`,
+              json({ action }, "PATCH"),
+            ),
+          ).toMatchObject({ success: true });
+        }
+        yield* poll<{ result: { steps: { type: string }[] } }>(
+          peer,
+          instance,
+          (body) => body.result.steps.some((s) => s.type === "waitForEvent"),
+        );
+        expect(
+          yield* peer.fetchJson(
+            `${instance}/events/approve`,
+            json({ approved: true }),
+          ),
+        ).toMatchObject({ success: true });
+        yield* poll<{ result: { status: string; output: unknown } }>(
+          peer,
+          instance,
+          (body) => body.result.status === "complete",
+        );
+        expect((yield* peer.fetch(instance, { method: "DELETE" })).status).toBe(
+          200,
+        );
+        expect((yield* peer.fetch(instance)).status).toBe(404);
+        expect(yield* peer.fetchJson(instances)).toMatchObject({ result: [] });
+        // Reuse a deleted ID: cleared actors must not retain old execution state.
+        expect(
+          yield* peer.fetchJson(
+            instances,
+            json({ id: "controlled", params: { wait: false } }),
+          ),
+        ).toMatchObject({ result: { id: "controlled" } });
+        expect(
+          yield* peer.fetchJson(
+            `${instances}/batch/delete`,
+            json({ instances: ["controlled"] }),
+          ),
+        ).toMatchObject({
+          result: { deleted: [{ id: "controlled" }], errors: [] },
+        });
+        expect(yield* peer.fetchJson(instances)).toMatchObject({ result: [] });
+        yield* peer.fetch(
+          instances,
+          json({ id: "rollback", params: { wait: true } }),
+        );
+        yield* poll<{ result: { steps: { type: string }[] } }>(
+          peer,
+          `${instances}/rollback`,
+          (body) => body.result.steps.some((s) => s.type === "waitForEvent"),
+        );
+        expect(
+          yield* peer.fetchJson(
+            `${instances}/rollback/status`,
+            json({ action: "terminate", rollback: true }, "PATCH"),
+          ),
+        ).toMatchObject({ success: true });
+        expect(yield* worker.fetchText("/kv?key=rollback")).toBe("completed");
+        yield* peer.fetch(
+          instances,
+          json({ id: "clear-all", params: { wait: true } }),
+        );
+        expect((yield* peer.fetch(workflow, { method: "DELETE" })).status).toBe(
+          200,
+        );
+        expect(yield* peer.fetchJson(instances)).toMatchObject({ result: [] });
+      }),
+    { timeout: 90_000 },
+  );
+
+  it.effect(
+    "paginates captured email from multiple owners without duplicates",
+    () =>
+      Effect.gen(function* () {
+        const mailWorker = (name: string): RuntimeWorker => ({
+          ...owner,
+          name,
+          workflows: [],
+          bindings: [SendEmail.local({ binding: "MAIL" })],
+        });
+        const first = yield* startTestWorker(mailWorker("email-page-first"));
+        const second = yield* startTestWorker(mailWorker("email-page-second"));
+        yield* poll<{ result: { name: string }[] }>(
+          first,
+          `${API}/local/workers`,
+          (body) => body.result.some((w) => w.name === "email-page-second"),
+        );
+        const ids: string[] = [];
+        for (const worker of [first, second, first, second]) {
+          const sent = yield* worker.fetchJson<{ messageId: string }>(
+            "/send",
+            json({
+              from: "sender@example.com",
+              to: "recipient@example.com",
+              subject: "page",
+              text: "body",
+            }),
+          );
+          ids.push(sent.messageId);
+        }
+        const found: string[] = [];
+        let cursor: string | undefined;
+        for (let page = 0; page < 5; page++) {
+          const result = yield* first.fetchJson<{
+            result: { messageId: string }[];
+            result_info: { has_more: boolean; cursor?: string };
+          }>(
+            `${API}/local/email/sending?limit=1${cursor ? `&cursor=${encodeURIComponent(cursor)}` : ""}`,
+          );
+          found.push(...result.result.map((email) => email.messageId));
+          if (!result.result_info.has_more) break;
+          cursor = result.result_info.cursor;
+          expect(cursor).toBeTruthy();
+        }
+        expect(found.sort()).toEqual(ids.sort());
+        expect(
+          yield* first.fetchJson(
+            `${API}/local/email/sending?worker=unknown-worker`,
+          ),
+        ).toMatchObject({ result: [] });
+      }),
+    { timeout: 30_000 },
+  );
+});

--- a/packages/cloudflare-runtime/src/core/test/LocalExplorerHost.test.ts
+++ b/packages/cloudflare-runtime/src/core/test/LocalExplorerHost.test.ts
@@ -1,0 +1,226 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import * as ConfigProvider from "effect/ConfigProvider";
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Schedule from "effect/Schedule";
+import * as Scope from "effect/Scope";
+import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
+import { expect, test } from "vitest";
+import * as Docker from "../Docker.ts";
+import * as Globals from "../globals/Globals.ts";
+import * as Internet from "../globals/Internet.ts";
+import * as Storage from "../globals/Storage.ts";
+import * as Paths from "../internal/Paths.ts";
+import * as Runtime from "../Runtime.ts";
+import * as RuntimeServices from "../RuntimeServices.ts";
+import type { RuntimeWorker } from "../RuntimeWorker.ts";
+import * as Workerd from "../workerd/Workerd.ts";
+import * as KvNamespace from "../bindings/kv-namespace/KvNamespace.ts";
+
+const runtimeLayer = (storage: string, home: string) =>
+  Runtime.RuntimeLive.pipe(
+    Layer.provideMerge(RuntimeServices.layerLocalBindings()),
+    Layer.provideMerge(RuntimeServices.layerProxy()),
+    Layer.provide(Globals.GlobalsLive),
+    Layer.provideMerge(RuntimeServices.layerLoopback()),
+    Layer.provide(Storage.layerDisk(storage)),
+    Layer.provide(Internet.InternetLive),
+    Layer.provideMerge(RuntimeServices.layerRegistry()),
+    Layer.provide(Paths.PathsLive),
+    Layer.provide(Docker.DockerLive),
+    Layer.provide(Workerd.WorkerdLive),
+    Layer.provide(
+      ConfigProvider.layer(
+        ConfigProvider.fromUnknown({ CLOUDFLARE_RUNTIME_HOME: home }),
+      ),
+    ),
+    Layer.provide(Layer.mergeAll(NodeServices.layer, FetchHttpClient.layer)),
+  );
+const worker = (name: string): RuntimeWorker => ({
+  name,
+  localExplorer: true,
+  compatibilityDate: "2026-08-31",
+  compatibilityFlags: [],
+  bindings: [KvNamespace.local({ binding: "KV", id: name })],
+  modules: [
+    {
+      name: "main.js",
+      type: "ESModule",
+      content: `export default { async fetch(request, env) { return new Response(await env.KV.get("test") ?? "app"); } };`,
+    },
+  ],
+});
+const request = (url: string | URL, init?: RequestInit) =>
+  Effect.tryPromise(() =>
+    fetch(url, { ...init, signal: AbortSignal.timeout(2000) }),
+  );
+
+test("elects one host during concurrent startup and isolates storage directories", async () => {
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const directory = yield* fs.makeTempDirectoryScoped({
+        prefix: "explorer-host-race",
+      });
+      const lifetime = yield* Effect.scope;
+      const contexts = yield* Effect.forEach(
+        ["shared", "shared", "separate"],
+        (storage) =>
+          Layer.buildWithScope(
+            runtimeLayer(`${directory}/${storage}`, `${directory}/home`),
+            lifetime,
+          ),
+      );
+      const urls = yield* Effect.forEach(
+        contexts,
+        (context, index) =>
+          Runtime.Runtime.use((runtime) =>
+            runtime.start(worker(`race-${index}`)),
+          ).pipe(Effect.provideContext(context)),
+        { concurrency: "unbounded" },
+      );
+      const locations = yield* Effect.forEach(urls, (url) =>
+        request(new URL("/cdn-cgi/local/explorer/", url), {
+          redirect: "manual",
+        }).pipe(Effect.map((response) => response.headers.get("location"))),
+      );
+      expect(locations[0]).toBeTruthy();
+      expect(locations[0]).toBe(locations[1]);
+      expect(locations[2]).not.toBe(locations[0]);
+      const isolated = locations[2];
+      if (!isolated)
+        return yield* Effect.fail(new Error("Missing isolated Explorer URL"));
+      const response = yield* request(new URL("api/local/workers", isolated));
+      expect(yield* Effect.promise(() => response.json())).toMatchObject({
+        result: [{ name: "race-2" }],
+      });
+      expect(
+        (yield* request(
+          new URL("api/storage/kv/namespaces/race-0/keys", isolated),
+        )).status,
+      ).toBe(404);
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+}, 30_000);
+
+test("shares one browser URL across runtimes, preserves writes, and takes over the same port", async () => {
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem;
+      const directory = yield* fs.makeTempDirectoryScoped({
+        prefix: "explorer-host-test",
+      });
+      const home = `${directory}/home`;
+      const storage = `${directory}/storage`;
+      const lifetime = yield* Effect.scope;
+      const firstScope = yield* Scope.fork(lifetime);
+      const secondScope = yield* Scope.fork(lifetime);
+      const first = yield* Layer.buildWithScope(
+        runtimeLayer(storage, home),
+        firstScope,
+      );
+      const second = yield* Layer.buildWithScope(
+        runtimeLayer(storage, home),
+        secondScope,
+      );
+      const firstWorkerScope = yield* Scope.fork(firstScope);
+      const start = (config: RuntimeWorker) =>
+        Runtime.Runtime.use((runtime) => runtime.start(config));
+      const one = yield* start(worker("a-first")).pipe(
+        Effect.provideContext(first),
+        Scope.provide(firstWorkerScope),
+      );
+      const two = yield* start(worker("z-second")).pipe(
+        Effect.provideContext(second),
+        Scope.provide(secondScope),
+      );
+      const route = "/cdn-cgi/local/explorer/";
+      const firstRedirect = yield* request(
+        new URL(`${route}kv?worker=z-second`, one),
+        { redirect: "manual" },
+      );
+      const secondRedirect = yield* request(
+        new URL(`${route}kv?worker=z-second`, two),
+        { redirect: "manual" },
+      );
+      expect(firstRedirect.status).toBe(307);
+      expect(secondRedirect.headers.get("location")).toBe(
+        firstRedirect.headers.get("location"),
+      );
+      const location = firstRedirect.headers.get("location");
+      if (!location)
+        return yield* Effect.fail(new Error("Missing Explorer redirect"));
+      const explorer = new URL(location);
+      expect(explorer.searchParams.get("worker")).toBe("z-second");
+      const api = new URL(`${route}api/`, explorer);
+      const list = Effect.gen(function* () {
+        const response = yield* request(new URL("local/workers", api));
+        if (!response.ok)
+          return yield* Effect.fail(
+            new Error(`Explorer returned ${response.status}`),
+          );
+        return yield* Effect.promise(
+          () => response.json() as Promise<{ result: { name: string }[] }>,
+        );
+      });
+      const discovered = yield* list.pipe(
+        Effect.repeat({
+          while: (body) => body.result.length !== 2,
+          schedule: Schedule.spaced("100 millis"),
+          times: 50,
+        }),
+      );
+      expect(discovered.result.map((entry) => entry.name).sort()).toEqual([
+        "a-first",
+        "z-second",
+      ]);
+      const form = new FormData();
+      form.set("value", "shared host write");
+      const write = yield* request(
+        new URL("storage/kv/namespaces/z-second/values/test", api),
+        { method: "PUT", body: form },
+      );
+      expect(write.status, yield* Effect.promise(() => write.text())).toBe(200);
+      expect(yield* Effect.promise(async () => (await fetch(two)).text())).toBe(
+        "shared host write",
+      );
+      // The first Worker's shutdown must not own the browser endpoint's lifetime.
+      yield* Scope.close(firstWorkerScope, Exit.void);
+      expect((yield* request(new URL(route, explorer))).status).toBe(200);
+      const restarted = yield* start(worker("a-first")).pipe(
+        Effect.provideContext(first),
+        Scope.provide(firstScope),
+      );
+      expect(
+        (yield* request(new URL(`${route}kv?worker=z-second`, restarted), {
+          redirect: "manual",
+        })).headers.get("location"),
+      ).toBe(location);
+      // Close the owning runtime, then check automatic failover.
+      yield* Scope.close(firstScope, Exit.void);
+      const afterFirst = yield* list.pipe(
+        Effect.retry({ times: 100, schedule: Schedule.spaced("100 millis") }),
+      );
+      expect(afterFirst.result.map((entry) => entry.name)).toContain(
+        "z-second",
+      );
+      expect(
+        (yield* request(new URL(`${route}kv?worker=z-second`, two), {
+          redirect: "manual",
+        })).headers.get("location"),
+      ).toBe(location);
+      // The endpoint still serves the original resource after host replacement.
+      expect(
+        yield* Effect.promise(async () =>
+          (
+            await fetch(
+              new URL("storage/kv/namespaces/z-second/values/test", api),
+            )
+          ).text(),
+        ),
+      ).toBe("shared host write");
+    }).pipe(Effect.scoped, Effect.provide(NodeServices.layer)),
+  );
+}, 30_000);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5187,6 +5187,12 @@ importers:
       magic-string:
         specifier: catalog:cloudflare-runtime
         version: 0.30.21
+      miniflare:
+        specifier: 5.20260903.0-alpha
+        version: 5.20260903.0-alpha
+      proper-lockfile:
+        specifier: 4.1.2
+        version: 4.1.2
       sharp:
         specifier: catalog:cloudflare-runtime
         version: 0.35.3(@types/node@26.2.0)
@@ -5224,6 +5230,9 @@ importers:
       '@types/node':
         specifier: catalog:tooling
         version: 26.2.0
+      '@types/proper-lockfile':
+        specifier: 4.1.4
+        version: 4.1.4
       '@types/ws':
         specifier: catalog:cloudflare-runtime
         version: 8.18.1
@@ -11827,6 +11836,9 @@ packages:
   '@types/picomatch@4.0.3':
     resolution: {integrity: sha512-iG0T6+nYJ9FAPmx9SsUlnwcq1ZVRuCXcVEvWnntoPlrOpwtSTKNDC9uVAxTsC3PUvJ+99n4RpAcNgBbHX3JSnQ==}
 
+  '@types/proper-lockfile@4.1.4':
+    resolution: {integrity: sha512-uo2ABllncSqg9F1D4nugVl9v93RmjxF6LJzQLMLDdPaXCUIDPeOJ21Gbqi43xNKzBi/WQ0Q0dICqufzQbMjipQ==}
+
   '@types/react-dom@19.2.7':
     resolution: {integrity: sha512-I8bPpDLcHBv1qiIiXDCy71Rt8eQDKJP0sMSWJphDdAcdqiJ1sGpZamavoEIRZmYzjia9LuEb2HlYdDpmoENpvQ==}
     peerDependencies:
@@ -11837,6 +11849,9 @@ packages:
 
   '@types/resolve@1.20.2':
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
+
+  '@types/retry@0.12.5':
+    resolution: {integrity: sha512-3xSjTp3v03X/lSQLkczaN9UIEwJMoMCA1+Nb5HfbJEQWogdeQIyVtTvxPXDQjZ5zws8rFQfVfRdz03ARihPJgw==}
 
   '@types/sax@1.2.7':
     resolution: {integrity: sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==}
@@ -15462,6 +15477,10 @@ packages:
 
   miniflare@5.20260828.0-alpha:
     resolution: {integrity: sha512-6nbxhZEcz/UET3Y1OnYPsrAUjUmuFoib3ynUqteRdn1YnDxsLg8cwgZJZCk9QmtOmGzXwzXzgE/d/C0dJAPtVw==}
+    engines: {node: '>=22.0.0'}
+
+  miniflare@5.20260903.0-alpha:
+    resolution: {integrity: sha512-VCZIFxOqFXeibRBJWwTlppqbv2lkeO10IX3QBRGK9j1QiMAfH/OSsCvbjp1MslBMhVZmy2VTRlVaVnsKnbDp6A==}
     engines: {node: '>=22.0.0'}
 
   minimatch@10.2.6:
@@ -26616,6 +26635,10 @@ snapshots:
 
   '@types/picomatch@4.0.3': {}
 
+  '@types/proper-lockfile@4.1.4':
+    dependencies:
+      '@types/retry': 0.12.5
+
   '@types/react-dom@19.2.7(@types/react@19.2.18)':
     dependencies:
       '@types/react': 19.2.18
@@ -26625,6 +26648,8 @@ snapshots:
       csstype: 3.2.3
 
   '@types/resolve@1.20.2': {}
+
+  '@types/retry@0.12.5': {}
 
   '@types/sax@1.2.7':
     dependencies:
@@ -30946,6 +30971,18 @@ snapshots:
       - utf-8-validate
 
   miniflare@5.20260828.0-alpha:
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      sharp: 0.35.2
+      undici: 7.29.0
+      workerd: 1.20260901.1
+      ws: 8.21.0
+      youch: 4.1.0-beta.10
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  miniflare@5.20260903.0-alpha:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       sharp: 0.35.2


### PR DESCRIPTION
Expose Cloudflare's Local Explorer from Alchemy's local runtime, using the pinned Miniflare UI and backend against Alchemy's live resources. Workers sharing local storage use one Explorer URL, logged at startup, with a dropdown to switch between Workers.

Addresses the Local Explorer portion of [alchemy-run/alchemy#1315](https://github.com/alchemy-run/alchemy/issues/1315). JavaScript debugging, CPU profiling, and memory inspection remain outside this change.

```sh
CLOUDFLARE_RUNTIME_LOCAL_EXPLORER=true alchemy dev
```

Direct runtime callers can set `RuntimeWorker.localExplorer: true`. The feature is disabled by default and only affects local development.

Browser visits to a Worker's `/cdn-cgi/local/explorer/` route redirect to the shared host. The URL survives Worker restarts, and another runtime takes over the same port if the host exits. Resource API handlers stay with their owning Workers.

- Browse and edit D1, SQLite Durable Objects, KV, and R2.
- Inspect and control Workflow runs, including events, rollback on termination, and deletion through the live engine.
- Capture sent/received email and simulate incoming delivery, forwarding, replies, and rejection.
- Inspect persisted traces/logs and clear history with the additional `CLOUDFLARE_RUNTIME_LOCAL_EXPLORER_OBSERVABILITY=true` setting. Workers share a collector with owner failover.

The integration is experimental and relies on internal assets and protocols from the pinned Miniflare version. Dependency upgrades require compatibility validation. Queues and cron controls are not included.

<img width="891" height="688" alt="Screenshot 2026-09-08 at 7 47 53 AM" src="https://github.com/user-attachments/assets/e2079a0d-1656-4144-9a7c-9ddd8d4a6e20" />
<img width="1714" height="716" alt="Screenshot 2026-09-08 at 7 48 23 AM" src="https://github.com/user-attachments/assets/7cdc18c1-565d-48fa-aa20-a28025dd8f6b" />

