### PR TITLE
fix(cloudflare/durable-object): decode typed failures across the stub

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/DurableObject.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/DurableObject.ts
@@ -2,6 +2,7 @@ import type * as cf from "@cloudflare/workers-types";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import type * as Schema from "effect/Schema";
 import type { Scope } from "effect/Scope";
 import type { HttpServerError } from "effect/unstable/http/HttpServerError";
 import * as HttpServerRequest from "effect/unstable/http/HttpServerRequest";
@@ -253,6 +254,29 @@ export interface DurableObjectProps {
     | DurableObjectTransferSource
     | DurableObjectTransferSource[]
     | undefined;
+  /**
+   * Schema of the tagged errors this object's RPC methods may fail with,
+   * typically a `Schema.Union` of `Schema.TaggedError` classes (or a single
+   * class). A failure crosses the stub as a plain tagged object; with this
+   * schema the stub decodes it back into the class instance the method's
+   * type promises, so `Effect.catchTag` and `Schema`-driven consumers such
+   * as `HttpApiBuilder` see a real error. Failures the schema does not
+   * describe are delivered as-is.
+   *
+   * @example
+   * ```typescript
+   * class NotFound extends Schema.TaggedError<NotFound>()("NotFound", {
+   *   id: Schema.String,
+   * }) {}
+   *
+   * export default class Rooms extends Cloudflare.DurableObject<Rooms>()(
+   *   "Rooms",
+   *   Effect.gen(function* () { ... }),
+   *   { errors: NotFound },
+   * ) {}
+   * ```
+   */
+  errors?: Schema.ConstraintDecoder<unknown> | undefined;
   // environment?: string | undefined;
   // sqlite?: boolean | undefined;
   // namespaceId?: string | undefined;
@@ -266,7 +290,7 @@ export interface DurableObjectClass extends Effect.Effect<
   <Self, Shape>(): {
     <Name extends string>(
       name: Name,
-      props?: Pick<DurableObjectProps, "transferredFrom">,
+      props?: Pick<DurableObjectProps, "transferredFrom" | "errors">,
     ): Effect.Effect<DurableObject<Self>, never, Worker | Self> & {
       new (_: never): Shape & {
         /** @internal */
@@ -308,6 +332,7 @@ export interface DurableObjectClass extends Effect.Effect<
         never,
         Req
       >,
+      props?: Pick<DurableObjectProps, "errors">,
     ): Effect.Effect<
       DurableObject<Self>,
       never,
@@ -1150,6 +1175,7 @@ export const DurableObject: DurableObjectClass = taggedFunction(
           props?: DurableObjectProps,
           // phantom argument
           isClassForm?: true,
+          implProps?: Pick<DurableObjectProps, "errors">,
         ]
       | [
           name: string,
@@ -1158,16 +1184,26 @@ export const DurableObject: DurableObjectClass = taggedFunction(
           >,
           // phantom argument
           isClassForm?: true,
+          implProps?: Pick<DurableObjectProps, "errors">,
         ]
   ) {
     if (args.length === 0) {
-      return (name: string, propsOrImpl?: any) =>
+      return (
+        name: string,
+        propsOrImpl?: any,
+        implProps?: Pick<DurableObjectProps, "errors">,
+      ) =>
         // @ts-expect-error
-        DurableObject(name, propsOrImpl, true);
+        DurableObject(name, propsOrImpl, true, implProps);
     }
     const namespace = args[0];
     const isClassForm = args[2] === true;
     const propsOrImpl = args[1];
+    // The inline form carries the error schema beside the impl; the class and
+    // reference forms carry it in their props.
+    const errors = Effect.isEffect(propsOrImpl)
+      ? args[3]?.errors
+      : (propsOrImpl as DurableObjectProps | undefined)?.errors;
     const tag = Context.Service(namespace);
 
     const binding = (
@@ -1229,7 +1265,7 @@ export const DurableObject: DurableObjectClass = taggedFunction(
           getByName: (
             name: string,
             options?: DurableObjectGetDurableObjectOptions,
-          ) => makeRpcStub(binding.getByName(name, options)),
+          ) => makeRpcStub(binding.getByName(name, options), { errors }),
           // newUniqueId: () => use((ns) => ns.newUniqueId()),
           // idFromName: (name: string) => use((ns) => ns.idFromName(name)),
           // idFromString: (id: string) => use((ns) => ns.idFromString(id)),
@@ -1248,7 +1284,7 @@ export const DurableObject: DurableObjectClass = taggedFunction(
     const classProps =
       isClassForm && !Effect.isEffect(propsOrImpl)
         ? (propsOrImpl as
-            | Pick<DurableObjectProps, "transferredFrom">
+            | Pick<DurableObjectProps, "transferredFrom" | "errors">
             | undefined)
         : undefined;
 

--- a/packages/alchemy/src/Cloudflare/Workers/Rpc.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Rpc.ts
@@ -2,6 +2,7 @@ import type * as cf from "@cloudflare/workers-types";
 
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import type * as Schema from "effect/Schema";
 import * as HttpClient from "effect/unstable/http/HttpClient";
 import {
   RpcClient,
@@ -34,6 +35,10 @@ export * from "../../Rpc.ts";
  */
 export const makeRpcStub = <Shape>(
   stubSource: unknown | Effect.Effect<unknown, never, never>,
+  options?: {
+    /** Schema of the tagged errors the remote may fail with. See {@link decodeRpcResult}. */
+    readonly errors?: Schema.ConstraintDecoder<unknown>;
+  },
 ): Shape => {
   const isLazy = isYieldableEffect(stubSource);
   const eagerFetcher = isLazy
@@ -57,7 +62,11 @@ export const makeRpcStub = <Shape>(
               try: () => (stub as any)[prop](...args),
               catch: (cause) =>
                 new RpcCallError({ method: String(prop), cause }),
-            }).pipe(Effect.flatMap(decodeRpcResult));
+            }).pipe(
+              Effect.flatMap((value) =>
+                decodeRpcResult(value, options?.errors),
+              ),
+            );
           }),
         );
     },

--- a/packages/alchemy/src/Rpc.ts
+++ b/packages/alchemy/src/Rpc.ts
@@ -3,6 +3,7 @@ import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 import * as Result from "effect/Result";
+import * as Schema from "effect/Schema";
 import * as Sink from "effect/Sink";
 import * as Stream from "effect/Stream";
 import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
@@ -224,12 +225,28 @@ export const decodeRpcValue = (value: unknown) => {
 /**
  * Decode an RPC return value, lifting error envelopes into the Effect
  * error channel so that remote `Effect.fail(...)` values are recoverable.
+ *
+ * A failure crosses the wire as the plain object {@link encodeRpcError}
+ * produced, not as the class instance the method's type promises. When
+ * `errors` is given (a schema for the tagged errors the remote may fail
+ * with, typically a `Schema.Union` of `Schema.TaggedError` classes), the
+ * envelope is decoded through it so callers receive real instances —
+ * which is what `Schema`-driven consumers such as `HttpApiBuilder` need to
+ * encode them. A failure the schema does not describe is failed as-is.
  */
 export const decodeRpcResult = (
   value: unknown,
+  errors?: Schema.ConstraintDecoder<unknown>,
 ): Effect.Effect<unknown, unknown> => {
   if (isRpcErrorEnvelope(value)) {
-    return Effect.fail(value.error);
+    if (errors === undefined) {
+      return Effect.fail(value.error);
+    }
+    return Effect.flatMap(
+      Effect.result(Schema.decodeUnknownEffect(errors)(value.error)),
+      (decoded) =>
+        Effect.fail(Result.isSuccess(decoded) ? decoded.success : value.error),
+    );
   }
   return Effect.succeed(decodeRpcValue(value));
 };
@@ -441,6 +458,8 @@ export const makeFetchRpcStub = <Shape>(options: {
   readonly baseUrl?: string;
   /** Own properties that take precedence over remote-method dispatch. */
   readonly base?: Record<string, unknown>;
+  /** Schema of the tagged errors the remote may fail with. See {@link decodeRpcResult}. */
+  readonly errors?: Schema.ConstraintDecoder<unknown>;
 }): Shape => {
   const baseUrl = options.baseUrl ?? "http://alchemy-rpc";
   const target: Record<string, unknown> = options.base ?? {};
@@ -481,7 +500,7 @@ export const makeFetchRpcStub = <Shape>(options: {
                 (cause) => new RpcCallError({ method: prop, cause }),
               ),
             );
-            return yield* decodeRpcResult(value);
+            return yield* decodeRpcResult(value, options.errors);
           }),
         );
     },

--- a/packages/alchemy/test/Cloudflare/Workers/DurableObjectNamespace.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/DurableObjectNamespace.test.ts
@@ -71,6 +71,31 @@ test(
   { timeout: 60_000 },
 );
 
+test(
+  "typed failures cross the stub as instances of their class",
+  Effect.gen(function* () {
+    const { url } = yield* stack;
+    const client = freshConn(yield* HttpClient.HttpClient);
+
+    const res = yield* client.get(`${url}/typed-error`).pipe(
+      Effect.flatMap((res) =>
+        res.status === 200
+          ? Effect.succeed(res)
+          : Effect.fail(new Error(`Worker not ready: ${res.status}`)),
+      ),
+      Effect.retry({ schedule: readinessSchedule, times: readinessRetries }),
+    );
+
+    const body = (yield* res.json) as {
+      failed: boolean;
+      instance: boolean;
+      key?: string;
+    };
+    expect(body).toEqual({ failed: true, instance: true, key: "no-such-key" });
+  }).pipe(logLevel),
+  { timeout: 60_000 },
+);
+
 // Every name here is a fresh UUID, so each is CREATED by this test's request —
 // which is the only moment a `locationHint` has any say.
 const coloFor = (url: string, hint?: string) =>

--- a/packages/alchemy/test/Cloudflare/Workers/Rpc.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/Rpc.test.ts
@@ -22,6 +22,7 @@ import * as Cause from "effect/Cause";
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Exit from "effect/Exit";
+import * as Schema from "effect/Schema";
 import * as Stream from "effect/Stream";
 
 class MyError extends Data.TaggedError("MyError")<{
@@ -663,5 +664,72 @@ describe("stream errors", () => {
           expect(reason!.error).toBeInstanceOf(RpcRemoteStreamError);
         }
       }),
+  );
+});
+
+// ---------------------------------------------------------------------------
+// decodeRpcResult with an error schema
+// ---------------------------------------------------------------------------
+
+class NotFound extends Schema.TaggedError<NotFound>()("NotFound", {
+  id: Schema.String,
+}) {}
+
+class Forbidden extends Schema.TaggedError<Forbidden>()("Forbidden", {}) {}
+
+describe("decodeRpcResult with an error schema", () => {
+  it.effect("decodes a tagged failure into its class instance", () =>
+    Effect.gen(function* () {
+      const envelope: RpcErrorEnvelope = {
+        _tag: ErrorTag,
+        error: encodeRpcError(new NotFound({ id: "42" })),
+      };
+      const exit = yield* Effect.exit(
+        decodeRpcResult(envelope, Schema.Union([NotFound, Forbidden])),
+      );
+      expect(Exit.isFailure(exit)).toBe(true);
+      if (Exit.isFailure(exit)) {
+        const failReason = exit.cause.reasons.find((r) => r._tag === "Fail");
+        const error = (failReason as any).error;
+        expect(error).toBeInstanceOf(NotFound);
+        expect(error.id).toBe("42");
+      }
+    }),
+  );
+
+  it.effect("delivers a failure the schema does not describe as-is", () =>
+    Effect.gen(function* () {
+      const envelope: RpcErrorEnvelope = {
+        _tag: ErrorTag,
+        error: { _tag: "MyError", message: "BOOF" },
+      };
+      const exit = yield* Effect.exit(decodeRpcResult(envelope, NotFound));
+      expect(Exit.isFailure(exit)).toBe(true);
+      if (Exit.isFailure(exit)) {
+        const failReason = exit.cause.reasons.find((r) => r._tag === "Fail");
+        const error = (failReason as any).error as Record<string, unknown>;
+        expect(error).not.toBeInstanceOf(NotFound);
+        expect(error._tag).toBe("MyError");
+        expect(error.message).toBe("BOOF");
+      }
+    }),
+  );
+
+  it.effect("makeRpcStub applies the schema to remote failures", () =>
+    Effect.gen(function* () {
+      const mockStub = {
+        find: async () => ({
+          _tag: ErrorTag,
+          error: encodeRpcError(new NotFound({ id: "7" })),
+        }),
+      };
+      const stub = makeRpcStub<{
+        find: () => Effect.Effect<never, NotFound>;
+      }>(mockStub, { errors: NotFound });
+
+      const error = yield* stub.find().pipe(Effect.flip);
+      expect(error).toBeInstanceOf(NotFound);
+      expect(error.id).toBe("7");
+    }),
   );
 });

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/do-rpc/object.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/do-rpc/object.ts
@@ -1,11 +1,17 @@
 import * as Cloudflare from "@/Cloudflare";
 import * as Effect from "effect/Effect";
 import * as Schedule from "effect/Schedule";
+import * as Schema from "effect/Schema";
 import * as Stream from "effect/Stream";
 
 const KV = Cloudflare.KV.Namespace("DurableObjectWorkerEnvironmentKV", {
   title: "durable-object-worker-environment-kv",
 });
+
+/** A typed failure an RPC method raises; the stub must hand callers an instance. */
+export class MissingKey extends Schema.TaggedError<MissingKey>()("MissingKey", {
+  key: Schema.String,
+}) {}
 
 export class WorkerEnvironmentKVObject extends Cloudflare.DurableObject<WorkerEnvironmentKVObject>()(
   "WorkerEnvironmentKVObject",
@@ -16,6 +22,18 @@ export class WorkerEnvironmentKVObject extends Cloudflare.DurableObject<WorkerEn
       return {
         put: (key: string, value: string) => kv.put(key, value),
         get: (key: string) => kv.get(key),
+        // Fails with a Schema.TaggedError so the test can check that the stub
+        // decodes it back into an instance (see `errors` below).
+        require: (key: string) =>
+          kv
+            .get(key)
+            .pipe(
+              Effect.flatMap((value) =>
+                value === null || value === undefined
+                  ? Effect.fail(new MissingKey({ key }))
+                  : Effect.succeed(value),
+              ),
+            ),
         // The Cloudflare colo this instance is running in, as reported by a
         // subrequest it makes itself (a subrequest is served by the
         // datacenter the caller runs in, so the trace names *this* DO's
@@ -39,4 +57,5 @@ export class WorkerEnvironmentKVObject extends Cloudflare.DurableObject<WorkerEn
       };
     });
   }).pipe(Effect.provide(Cloudflare.KV.ReadWriteNamespaceBinding)),
+  { errors: MissingKey },
 ) {}

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/do-rpc/worker.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/do-rpc/worker.ts
@@ -3,7 +3,7 @@ import * as Effect from "effect/Effect";
 import * as Stream from "effect/Stream";
 import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
-import { WorkerEnvironmentKVObject } from "./object.ts";
+import { MissingKey, WorkerEnvironmentKVObject } from "./object.ts";
 
 /** The regions a DO can be hinted toward, as `/colo` accepts them. */
 const LOCATION_HINTS: readonly Cloudflare.DurableObjectLocationHint[] = [
@@ -37,6 +37,24 @@ export default class DurableObjectWorkerEnvironmentWorker extends Cloudflare.Wor
           yield* object.put(key, "ok").pipe(Effect.orDie);
           const value = yield* object.get(key).pipe(Effect.orDie);
           return yield* HttpServerResponse.json({ value });
+        }
+
+        // A typed failure raised inside the object must reach the caller as an
+        // instance of its class, not the plain object it crossed the stub as.
+        if (request.method === "GET" && url.pathname === "/typed-error") {
+          const object = objects.getByName("default");
+          const outcome = yield* object.require("no-such-key").pipe(
+            Effect.map(() => ({ failed: false, instance: false })),
+            Effect.catchTag("MissingKey", (error) =>
+              Effect.succeed({
+                failed: true,
+                instance: error instanceof MissingKey,
+                key: error.key,
+              }),
+            ),
+            Effect.orDie,
+          );
+          return yield* HttpServerResponse.json(outcome);
         }
 
         // Create a DO instance under a `locationHint` and report the colo it


### PR DESCRIPTION
A `Schema.TaggedError` failed inside a Durable Object method reaches the caller's stub as the plain tagged object `encodeRpcError` produced, while the stub's type says it is the class instance. `Effect.catchTag` still matches on `_tag`, but anything that encodes the error through its schema rejects the plain object. With an `HttpApiBuilder` endpoint that declares the error, a 404 raised in the object becomes a 500 at the Worker:

```
SchemaError: Expected ChatNotFound
```

This adds an `errors` schema on the object. The stub decodes error envelopes through it, so callers get real instances. Failures the schema does not describe are delivered exactly as before.

```ts
class NotFound extends Schema.TaggedError<NotFound>()("NotFound", { id: Schema.String }) {}

export default class Rooms extends Cloudflare.DurableObject<Rooms>()(
  "Rooms",
  Effect.gen(function* () { ... }),
  { errors: NotFound },
) {}

// Worker: the failure now encodes through the endpoint's error schema.
rooms.getByName(id).get()
```

- `DurableObjectProps.errors` (class and reference forms) and an optional trailing `{ errors }` for the inline form.
- `decodeRpcResult(value, errors?)`, `makeRpcStub(stub, { errors })`, and `makeFetchRpcStub({ errors })` accept the schema.
- Unit tests for the decode and the stub; the `do-rpc` fixture gains a typed failure and a test asserting `instanceof` across the stub.

Overlaps #1127 in `DurableObject.ts` and `Rpc.ts`; happy to rebase onto it once it lands.
