### PR TITLE
fix(prisma): accept any region id string on Prisma resources

### DIFF
--- a/packages/alchemy/src/Prisma/Types.ts
+++ b/packages/alchemy/src/Prisma/Types.ts
@@ -34,7 +34,11 @@ export interface ResourceRef {
   name: string;
 }
 
-export type PrismaRegionId = (typeof KNOWN_REGION_IDS)[number];
+/**
+ * The Management API is the source of truth for regions; `KNOWN_REGION_IDS`
+ * only drives editor completion, so any string is accepted.
+ */
+export type PrismaRegionId = (typeof KNOWN_REGION_IDS)[number] | (string & {});
 
 export type PrismaDatabaseRegionId = PrismaRegionId | "inherit";
 


### PR DESCRIPTION
## Summary

`PrismaRegionId` is a closed union of the region ids known when alchemy was released. `Prisma.Project`, `Prisma.App`, `Prisma.Compute`, and `Prisma.Database` all take it. When the Prisma Management API adds a region, every consumer fails to typecheck for that region until alchemy ships a new list, even though the API accepts the value.

The Management API is the source of truth for regions. It validates the value on create and returns a 422 that names the valid ids.

## What changes

- `PrismaRegionId` becomes `(typeof KNOWN_REGION_IDS)[number] | (string & {})`. Known ids still show up in editor completion; any string is accepted.
- `PrismaDatabaseRegionId` follows, since it is defined as `PrismaRegionId | "inherit"`.
- No runtime change. `KNOWN_REGION_IDS` and `REGIONS` are untouched.

## Context

Found while fixing region inheritance in Prisma Composer (prisma/composer#279). That PR does not depend on this change; it types regions with the Management API SDK's own request type. This PR stands on its own and removes the need for an alchemy release whenever the platform adds a region.

## Tests

`alchemy-test test/Prisma --exclude live`: 364 passed, 2 skipped, 2 todo. `tsc` reports no errors under `src/Prisma`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
