### PR TITLE
fix(auth): deduplicate environment credential notices

### DIFF
--- a/packages/alchemy/src/Auth/AuthProvider.ts
+++ b/packages/alchemy/src/Auth/AuthProvider.ts
@@ -188,10 +188,6 @@ export interface ProviderDetails {
 export interface ConfigureField {
   /** `--set` key and, for stored-credential providers, the stored JSON property. */
   readonly name: string;
-  /** Log each environment contract once per built provider layer. */
-  readonly logEnvironmentCredentials: (
-    used: ReadonlyArray<string>,
-  ) => Effect.Effect<void>;
   /** Human prompt label, e.g. "Cloudflare API Token". */
   readonly label: string;
   /** Secondary guidance shown beneath the interactive input. */
@@ -318,6 +314,10 @@ export interface AuthProvider<
 > extends AuthProviderImpl<Config, Credentials> {
   readonly kind: "AuthProvider";
   readonly name: string;
+  /** Log each environment contract once per built provider layer. */
+  readonly logEnvironmentCredentials: (
+    used: ReadonlyArray<string>,
+  ) => Effect.Effect<void>;
   /**
    * The provider's declared CI environment contract. Empty when the
    * provider does not support environment credentials.

--- a/packages/alchemy/src/Auth/AuthProvider.ts
+++ b/packages/alchemy/src/Auth/AuthProvider.ts
@@ -1,3 +1,4 @@
+import { cachedFunction } from "../Util/cached-function.ts";
 import * as Config from "effect/Config";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
@@ -187,6 +188,10 @@ export interface ProviderDetails {
 export interface ConfigureField {
   /** `--set` key and, for stored-credential providers, the stored JSON property. */
   readonly name: string;
+  /** Log each environment contract once per built provider layer. */
+  readonly logEnvironmentCredentials: (
+    used: ReadonlyArray<string>,
+  ) => Effect.Effect<void>;
   /** Human prompt label, e.g. "Cloudflare API Token". */
   readonly label: string;
   /** Secondary guidance shown beneath the interactive input. */
@@ -391,6 +396,13 @@ export const AuthProvider =
       }
 
       const provider: AuthProvider<Config, Credentials> = {
+        logEnvironmentCredentials: yield* cachedFunction(
+          (used: ReadonlyArray<string>) =>
+            Effect.logInfo(
+              `${name}: using environment variables (${used.join(", ")}) instead of the profile.`,
+            ),
+          { key: ([used]) => JSON.stringify(used.toSorted()) },
+        ),
         kind: "AuthProvider",
         name,
         // configure/login can wait minutes on a browser grant, so they hold

--- a/packages/alchemy/src/Auth/Resolve.ts
+++ b/packages/alchemy/src/Auth/Resolve.ts
@@ -116,6 +116,10 @@ export const resolveProviderConfig = <
     };
   });
 
+// Layer rebuilds and separate account/credential lookups share this notice.
+// Keep only provider/variable names here, never credential values or resolvers.
+const loggedEnvironmentCredentials = new Set<string>();
+
 const logEnvironmentCredentials = (
   provider: string,
   used: ReadonlyArray<string>,
@@ -124,6 +128,9 @@ const logEnvironmentCredentials = (
     // The profile hub inspects providers with this suppression on — it must
     // stay quiet, the run's own resolution logs.
     if (yield* SuppressMissingProviderConfig) return;
+    const key = JSON.stringify([provider, ...used.toSorted()]);
+    if (loggedEnvironmentCredentials.has(key)) return;
+    loggedEnvironmentCredentials.add(key);
     // Per provider: only this provider skips the profile. Others in the
     // same run still resolve from it, so a Cloudflare token in `.env` can
     // sit alongside a profile-stored AWS SSO session.

--- a/packages/alchemy/src/Auth/Resolve.ts
+++ b/packages/alchemy/src/Auth/Resolve.ts
@@ -66,7 +66,9 @@ export const resolveProviderConfig = <
     if (auth.readEnvironment !== undefined) {
       const used = yield* presentEnvironment(auth.environment);
       if (used !== undefined) {
-        yield* logEnvironmentCredentials(providerName, used);
+        if (!(yield* SuppressMissingProviderConfig)) {
+          yield* auth.logEnvironmentCredentials(used);
+        }
         return {
           auth,
           profileName: undefined,
@@ -114,29 +116,6 @@ export const resolveProviderConfig = <
       ),
       source: "profile" as const,
     };
-  });
-
-// Layer rebuilds and separate account/credential lookups share this notice.
-// Keep only provider/variable names here, never credential values or resolvers.
-const loggedEnvironmentCredentials = new Set<string>();
-
-const logEnvironmentCredentials = (
-  provider: string,
-  used: ReadonlyArray<string>,
-) =>
-  Effect.gen(function* () {
-    // The profile hub inspects providers with this suppression on — it must
-    // stay quiet, the run's own resolution logs.
-    if (yield* SuppressMissingProviderConfig) return;
-    const key = JSON.stringify([provider, ...used.toSorted()]);
-    if (loggedEnvironmentCredentials.has(key)) return;
-    loggedEnvironmentCredentials.add(key);
-    // Per provider: only this provider skips the profile. Others in the
-    // same run still resolve from it, so a Cloudflare token in `.env` can
-    // sit alongside a profile-stored AWS SSO session.
-    yield* Effect.logInfo(
-      `${provider}: using environment variables (${used.join(", ")}) instead of the profile.`,
-    );
   });
 
 /** Let an explicit profile override configured selection without disturbing other keys. */

--- a/packages/alchemy/test/Auth/Profile.test.ts
+++ b/packages/alchemy/test/Auth/Profile.test.ts
@@ -1,5 +1,6 @@
 import {
   AuthError,
+  AuthProvider,
   AuthProviderLayer,
   AuthProviders,
   getAuthProvider,
@@ -522,43 +523,42 @@ it.effect("resolves the profile from env files and --profile overrides", () =>
 );
 
 it.live(
-  "environment notices are deduplicated across concurrent lookups without suppressing other providers",
+  "environment notices share a provider cache and reset when its layer is rebuilt",
   () => {
     const messages: unknown[] = [];
-    return withTempHome(
+    const run = withTempHome(
       Effect.gen(function* () {
         const auth = yield* getAuthProvider(ENV_PROVIDER);
-        const resolve = resolveProviderConfig("NoticeProvider");
-        yield* Effect.gen(function* () {
-          yield* resolve.pipe(
-            Effect.provideService(SuppressMissingProviderConfig, true),
-          );
-          expect(messages).toEqual([]);
-          const results = yield* Effect.all(
-            Array.from({ length: 10 }, () => resolve),
-            { concurrency: "unbounded" },
-          );
-          for (const result of results) {
-            expect(yield* result.resolve).toBe("environment-credentials");
-          }
-          yield* resolveProviderConfig("OtherNoticeProvider");
-          expect(messages).toEqual([
-            [
-              "NoticeProvider: using environment variables (FAKE_ENV_TOKEN) instead of the profile.",
-            ],
-            [
-              "OtherNoticeProvider: using environment variables (FAKE_ENV_TOKEN) instead of the profile.",
-            ],
-          ]);
-        }).pipe(
-          Effect.provideService(AuthProviders, {
-            NoticeProvider: auth,
-            OtherNoticeProvider: auth,
-          }),
+        yield* AuthProvider()("OtherNoticeProvider", auth);
+        const resolve = resolveProviderConfig(ENV_PROVIDER);
+        yield* resolve.pipe(
+          Effect.provideService(SuppressMissingProviderConfig, true),
         );
+        expect(messages).toEqual([]);
+        const results = yield* Effect.all(
+          Array.from({ length: 10 }, () => resolve),
+          { concurrency: "unbounded" },
+        );
+        for (const result of results) {
+          expect(yield* result.resolve).toBe("environment-credentials");
+        }
+        yield* resolveProviderConfig("OtherNoticeProvider");
+        expect(messages).toEqual([
+          [
+            "FakeEnvAuthProvider: using environment variables (FAKE_ENV_TOKEN) instead of the profile.",
+          ],
+          [
+            "OtherNoticeProvider: using environment variables (FAKE_ENV_TOKEN) instead of the profile.",
+          ],
+        ]);
       }),
       { FAKE_ENV_TOKEN: "from-env" },
-    ).pipe(
+    );
+    return Effect.gen(function* () {
+      yield* run;
+      messages.length = 0;
+      yield* run;
+    }).pipe(
       Effect.provide(
         Logger.layer([
           Logger.make<unknown, void>((options) => {

--- a/packages/alchemy/test/Auth/Profile.test.ts
+++ b/packages/alchemy/test/Auth/Profile.test.ts
@@ -13,6 +13,7 @@ import {
   ProfileError,
   ProfileStore,
   ProfileStoreLive,
+  SuppressMissingProviderConfig,
   validateProfileName,
 } from "@/Auth/Profile.ts";
 import { resolveProfileName, resolveProviderConfig } from "@/Auth/Resolve.ts";
@@ -22,6 +23,7 @@ import * as ConfigProvider from "effect/ConfigProvider";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
+import * as Logger from "effect/Logger";
 import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
 import path from "pathe";
@@ -517,6 +519,56 @@ it.effect("resolves the profile from env files and --profile overrides", () =>
       "from-cli",
     );
   }).pipe(Effect.scoped, Effect.provide(makeTestLayer())),
+);
+
+it.live(
+  "environment notices are deduplicated across concurrent lookups without suppressing other providers",
+  () => {
+    const messages: unknown[] = [];
+    return withTempHome(
+      Effect.gen(function* () {
+        const auth = yield* getAuthProvider(ENV_PROVIDER);
+        const resolve = resolveProviderConfig("NoticeProvider");
+        yield* Effect.gen(function* () {
+          yield* resolve.pipe(
+            Effect.provideService(SuppressMissingProviderConfig, true),
+          );
+          expect(messages).toEqual([]);
+          const results = yield* Effect.all(
+            Array.from({ length: 10 }, () => resolve),
+            { concurrency: "unbounded" },
+          );
+          for (const result of results) {
+            expect(yield* result.resolve).toBe("environment-credentials");
+          }
+          yield* resolveProviderConfig("OtherNoticeProvider");
+          expect(messages).toEqual([
+            [
+              "NoticeProvider: using environment variables (FAKE_ENV_TOKEN) instead of the profile.",
+            ],
+            [
+              "OtherNoticeProvider: using environment variables (FAKE_ENV_TOKEN) instead of the profile.",
+            ],
+          ]);
+        }).pipe(
+          Effect.provideService(AuthProviders, {
+            NoticeProvider: auth,
+            OtherNoticeProvider: auth,
+          }),
+        );
+      }),
+      { FAKE_ENV_TOKEN: "from-env" },
+    ).pipe(
+      Effect.provide(
+        Logger.layer([
+          Logger.make<unknown, void>((options) => {
+            messages.push(options.message);
+          }),
+        ]),
+      ),
+    );
+  },
+  { exclusive: true },
 );
 
 it.live(


### PR DESCRIPTION
Repeated Cloudflare account and credential lookups emitted the same environment-variable notice. Cache the notice with an Effect function created when the auth provider layer is built, so lookups sharing that provider emit each environment-variable combination once.

The cache belongs to the provider layer and resets with a fresh layer. Profile-hub suppression remains outside the cache, and credential resolution and profile precedence are unchanged.

basically dont print 
```
[19:33:47.987] INFO (#7): Cloudflare: using environment variables (CLOUDFLARE_ACCOUNT_ID, CLOUDFLARE_API_TOKEN) instead of the profile.
[19:33:47.989] INFO (#7): Cloudflare: using environment variables (CLOUDFLARE_ACCOUNT_ID, CLOUDFLARE_API_TOKEN) instead of the profile.
[19:33:47.992] INFO (#7): Cloudflare: using environment variables (CLOUDFLARE_ACCOUNT_ID, CLOUDFLARE_API_TOKEN) instead of the profile.
[19:33:47.993] INFO (#7): Cloudflare: using environment variables (CLOUDFLARE_ACCOUNT_ID, CLOUDFLARE_API_TOKEN) instead of the profile.
[19:33:47.993] INFO (#7): Cloudflare: using environment variables (CLOUDFLARE_ACCOUNT_ID, CLOUDFLARE_API_TOKEN) instead of the profile.
[19:33:47.993] INFO (#7): Cloudflare: using environment variables (CLOUDFLARE_ACCOUNT_ID, CLOUDFLARE_API_TOKEN) instead of the profile.
[01:03:48.522] INFO (#14): Cloudflare: using environment variables (CLOUDFLARE_ACCOUNT_ID, CLOUDFLARE_API_TOKEN) instead of the profile.
[01:03:48.523] INFO (#15): Cloudflare: using environment variables (CLOUDFLARE_ACCOUNT_ID, CLOUDFLARE_API_TOKEN) instead of the profile.
```