### PR TITLE
fix(state): keep HTTP state payloads out of errors

### DIFF
--- a/packages/alchemy/src/Cloudflare/StateStore/State.ts
+++ b/packages/alchemy/src/Cloudflare/StateStore/State.ts
@@ -12,7 +12,6 @@ import crypto from "node:crypto";
 
 import * as Config from "effect/Config";
 import * as Option from "effect/Option";
-import { isHttpClientError } from "effect/unstable/http/HttpClientError";
 import { adopt } from "../../AdoptPolicy.ts";
 import { AlchemyContext } from "../../AlchemyContext.ts";
 import { AuthError } from "../../Auth/AuthProvider.ts";
@@ -31,7 +30,11 @@ import {
   type HttpStateStoreCredentials,
 } from "../../State/HttpStateStore.ts";
 import { makeLocalState } from "../../State/LocalState.ts";
-import { State, type StateService } from "../../State/State.ts";
+import {
+  State,
+  type StateService,
+  type StateStoreError,
+} from "../../State/State.ts";
 import {
   recordStateStoreInit,
   recordStateStoreOp,
@@ -657,18 +660,14 @@ const deployWithLocalState = ({
  *
  * @internal exported for unit testing.
  */
-export const isTransientBootstrapWriteError = (error: {
-  cause?: unknown;
-}): boolean => {
-  const cause = error.cause;
-  if (cause == null) return false;
-  const tag = (cause as { _tag?: unknown })._tag;
-  if (typeof tag === "string" && tag.startsWith("Unauthorized")) return true;
-  if (isHttpClientError(cause)) {
-    const status = cause.response?.status;
-    return status === undefined || status === 404 || status >= 500;
-  }
-  return false;
+export const isTransientBootstrapWriteError = (
+  error: Pick<StateStoreError, "http">,
+): boolean => {
+  if (error.http === undefined) return false;
+  const { status } = error.http;
+  return (
+    status === undefined || status === 401 || status === 404 || status >= 500
+  );
 };
 
 // check if there's a local stack that wasn't properly hoisted

--- a/packages/alchemy/src/State/HttpStateStore.ts
+++ b/packages/alchemy/src/State/HttpStateStore.ts
@@ -2,8 +2,10 @@ import * as Effect from "effect/Effect";
 import { identity } from "effect/Function";
 import * as Schedule from "effect/Schedule";
 import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as HttpClientError from "effect/unstable/http/HttpClientError";
 import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
 import * as HttpApiClient from "effect/unstable/httpapi/HttpApiClient";
+import * as HttpApiError from "effect/unstable/httpapi/HttpApiError";
 import { profileCommandHint } from "../Util/interactive.ts";
 import { StateApi } from "./HttpStateApi.ts";
 
@@ -233,57 +235,42 @@ const retryTransient = <A, Err, Req>(eff: Effect.Effect<A, Err, Req>) =>
   });
 
 /**
- * Human-readable description of a state-store client failure.
- *
- * Several of the errors the HTTP client can raise carry an empty
- * `message` (e.g. the no-content `Unauthorized` the store returns on a
- * bad bearer token), which used to surface as a blank
- * `StateStoreError` with nothing to act on. Always produce a
- * non-empty message: prefer the error's own message, fall back to its
- * `_tag`/name, and append the HTTP status and any distinct `cause`
- * message when available.
+ * Describe a state-store failure using only its known kind and HTTP status.
+ * Client/decoder messages and causes can contain serialized state, including
+ * secrets unwrapped by encodeState, so they must not become diagnostics.
  */
 export const describeStateStoreFailure = (
   e: unknown,
   profileCommand = "alchemy profile edit",
 ): string => {
-  if (!(e instanceof Error)) return String(e);
-  const tag = (e as { _tag?: unknown })._tag;
-  let message =
-    e.message.trim() ||
-    (typeof tag === "string" ? tag : undefined) ||
-    e.name ||
-    "Unknown error";
-  if (typeof tag === "string" && tag.startsWith("Unauthorized")) {
-    message =
+  if (e instanceof HttpApiError.Unauthorized) {
+    return (
       "State store rejected the request as unauthorized. " +
-      `The stored state-store credentials may be stale. Run \`${profileCommand}\` to reconfigure them.`;
+      `The stored state-store credentials may be stale. Run \`${profileCommand}\` to reconfigure them.`
+    );
   }
-  const status = (e as { response?: { status?: unknown } }).response?.status;
-  if (typeof status === "number" && !message.includes(String(status))) {
-    message += ` (HTTP ${status})`;
+  if (HttpClientError.isHttpClientError(e)) {
+    const status = e.response?.status;
+    return `State store request failed (${e.reason._tag}${status === undefined ? "" : `, HTTP ${status}`}).`;
   }
-  if (e.cause instanceof Error) {
-    const causeMessage = e.cause.message.trim();
-    if (causeMessage && !message.includes(causeMessage)) {
-      message += ` — caused by: ${causeMessage}`;
-    }
-  }
-  return message;
+  return "State store request failed.";
 };
 
 /** Collapse any client failure into a {@link StateStoreError}. */
 const mapStateStoreError = <A, E, R>(eff: Effect.Effect<A, E, R>) =>
   eff.pipe(
     retryTransient,
-    Effect.tapError(Effect.log),
     Effect.catch((e: E) =>
       Effect.gen(function* () {
         const command = yield* profileCommandHint("alchemy profile edit");
         return yield* Effect.fail(
           new StateStoreError({
             message: describeStateStoreFailure(e, command),
-            cause: e instanceof Error ? e : undefined,
+            http: HttpClientError.isHttpClientError(e)
+              ? { status: e.response?.status }
+              : e instanceof HttpApiError.Unauthorized
+                ? { status: 401 }
+                : undefined,
           }),
         );
       }),

--- a/packages/alchemy/src/State/State.ts
+++ b/packages/alchemy/src/State/State.ts
@@ -21,6 +21,11 @@ export const isResourceState = (
 export class StateStoreError extends Data.TaggedError("StateStoreError")<{
   message: string;
   cause?: Error;
+  /** HTTP failure metadata without the request, response body, or credentials. */
+  http?: {
+    /** Undefined when the HTTP client failed before receiving a response. */
+    status?: number;
+  };
 }> {}
 
 export class State extends Context.Service<

--- a/packages/alchemy/test/Cloudflare/StateStore/TransientErrors.test.ts
+++ b/packages/alchemy/test/Cloudflare/StateStore/TransientErrors.test.ts
@@ -22,7 +22,7 @@ import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
  *   ("Secret probe returned 400/502: <!DOCTYPE html>..."), session
  *   creation flakes and transport errors ("fetch failed").
  *
- * `isTransientBootstrapWriteError` inspects the `cause` of the
+ * `isTransientBootstrapWriteError` inspects the safe HTTP metadata on the
  * `StateStoreError` the real HTTP client produces, so each case drives
  * an actual `makeHttpStateStore().set` against a stubbed fetch and
  * feeds the resulting failure into the predicate.
@@ -94,8 +94,8 @@ describe("isTransientBootstrapWriteError", () => {
     60_000,
   );
 
-  it("does not retry errors without a cause", () => {
-    expect(isTransientBootstrapWriteError({ cause: undefined })).toBe(false);
+  it("does not retry errors without HTTP failure metadata", () => {
+    expect(isTransientBootstrapWriteError({ http: undefined })).toBe(false);
   });
 });
 

--- a/packages/alchemy/test/State/HttpStateStore.test.ts
+++ b/packages/alchemy/test/State/HttpStateStore.test.ts
@@ -6,7 +6,13 @@ import {
 import { describe, expect, it } from "alchemy-test";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Logger from "effect/Logger";
+import * as Redacted from "effect/Redacted";
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
+import * as HttpClientError from "effect/unstable/http/HttpClientError";
+import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
+import * as HttpClientResponse from "effect/unstable/http/HttpClientResponse";
+import * as HttpApiError from "effect/unstable/httpapi/HttpApiError";
 
 /**
  * Hermetic tests driven by the production failure modes observed in
@@ -62,47 +68,96 @@ describe("describeStateStoreFailure", () => {
     }
     const message = describeStateStoreFailure(new Empty());
     expect(message.length).toBeGreaterThan(0);
-    expect(message).toContain("SomeTaggedError");
   });
 
-  it("maps Unauthorized-tagged errors to an actionable message", () => {
-    class Unauthorized extends Error {
-      readonly _tag = "Unauthorized";
-      constructor() {
-        super("");
-      }
-    }
-    const message = describeStateStoreFailure(new Unauthorized());
+  it("maps Unauthorized errors to an actionable message", () => {
+    const message = describeStateStoreFailure(new HttpApiError.Unauthorized());
     expect(message).toContain("unauthorized");
     expect(message).toContain("alchemy profile edit");
   });
 
   it("appends the HTTP status when the error carries a response", () => {
-    class WithResponse extends Error {
-      readonly _tag = "HttpClientError";
-      readonly response = { status: 500 };
-      constructor() {
-        super("something broke");
-      }
-    }
-    expect(describeStateStoreFailure(new WithResponse())).toContain("500");
+    const request = HttpClientRequest.put("https://state-store.test");
+    const response = HttpClientResponse.fromWeb(
+      request,
+      new Response(null, { status: 500 }),
+    );
+    const error = new HttpClientError.HttpClientError({
+      reason: new HttpClientError.StatusCodeError({ request, response }),
+    });
+    expect(describeStateStoreFailure(error)).toContain("500");
   });
 
-  it("appends a distinct cause message", () => {
-    const cause = new Error("connection reset by peer");
-    const outer = new Error("fetch failed");
+  it("omits arbitrary error and cause messages", () => {
+    const cause = new Error("secret cause");
+    const outer = new Error("secret message");
     outer.cause = cause;
     const message = describeStateStoreFailure(outer);
-    expect(message).toContain("fetch failed");
-    expect(message).toContain("connection reset by peer");
+    expect(message).not.toContain("secret");
+    expect(message.length).toBeGreaterThan(0);
   });
 
-  it("stringifies non-Error failures", () => {
-    expect(describeStateStoreFailure("boom")).toBe("boom");
+  it("omits non-Error failures that may contain state", () => {
+    expect(describeStateStoreFailure("secret state")).not.toContain("secret");
   });
 });
 
 describe("makeHttpStateStore", () => {
+  // Regression: https://github.com/reve-ai/kommunikasie/commit/f2e7320ff261833092b84d8aa25e3563710661e8
+  // State encoding unwraps Redacted values before HTTP. Neither the request
+  // object nor transport/decoder messages may escape through diagnostics.
+  for (const failure of ["status", "decode", "transport"] as const) {
+    it.live(
+      `does not expose serialized state after a ${failure} failure`,
+      () => {
+        const secret = "STATE_PAYLOAD_SENTINEL_91f4";
+        const logs: string[] = [];
+        let requestBody = "";
+        const logger = Logger.make(({ cause, message }) => {
+          logs.push(JSON.stringify({ cause, message }));
+        });
+        const stub: FetchStub = async (_input, init) => {
+          requestBody = await new Response(init?.body).text();
+          if (failure === "transport") throw new Error(secret);
+          return new Response(secret, {
+            status: failure === "status" ? 400 : 200,
+            headers: { "content-type": "application/json" },
+          });
+        };
+        return Effect.gen(function* () {
+          const store = yield* makeStore;
+          const error = yield* store
+            .set({
+              stack: "s",
+              stage: "dev",
+              fqn: "secret",
+              value: {
+                kind: "action",
+                actionType: "SecretState",
+                namespace: undefined,
+                fqn: "secret",
+                logicalId: "secret",
+                status: "ran",
+                downstream: [],
+                inputHash: "input-hash",
+                input: { token: Redacted.make(secret) },
+                output: null,
+              },
+            })
+            .pipe(Effect.flip);
+          expect(requestBody).toContain(secret);
+          expect(JSON.stringify({ error, logs })).not.toContain(secret);
+          expect(error.cause).toBeUndefined();
+          expect(error.message).not.toContain(secret);
+          expect(error.message.length).toBeGreaterThan(0);
+        }).pipe(
+          Effect.provide(stubHttpClient(stub)),
+          Effect.provide(Logger.layer([logger])),
+        );
+      },
+    );
+  }
+
   it.live("retries transient 5xx and then succeeds", () => {
     let calls = 0;
     const stub: FetchStub = async () => {


### PR DESCRIPTION
HTTP state-store writes serialize `Redacted` values before sending them. Failed requests now report only a known failure kind and HTTP status, without logging or retaining request/response objects or arbitrary error messages.

Preserve Cloudflare bootstrap retries through safe HTTP status metadata on `StateStoreError`.
