### PR TITLE
fix(cloudflare): export container builds directly to registries

### DIFF
--- a/packages/alchemy/src/Cloudflare/Containers/ContainerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Containers/ContainerProvider.ts
@@ -2,6 +2,7 @@ import * as Containers from "@distilled.cloud/cloudflare/containers";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
+import type { PlatformError } from "effect/PlatformError";
 import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
 import * as Schedule from "effect/Schedule";
@@ -320,7 +321,7 @@ export const LiveContainerProvider = () =>
             ),
             HttpClientRequest.setHeader(
               "Accept",
-              "application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json",
+              "application/vnd.oci.image.index.v1+json, application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.list.v2+json, application/vnd.docker.distribution.manifest.v2+json",
             ),
           );
           const response = yield* http.execute(request).pipe(
@@ -546,6 +547,27 @@ export const LiveContainerProvider = () =>
           };
         }
 
+        const credentials = yield* registryCredentials(props, ["pull", "push"]);
+        // Registry blob HEAD probes can transiently fail during publication.
+        // Retry both BuildKit exports and Engine pushes with the same bound.
+        const retryPublication = <A, R>(
+          publication: Effect.Effect<A, PlatformError, R>,
+        ) =>
+          Effect.retry(publication, {
+            while: (error) => {
+              const message = String(error).toLowerCase();
+              return (
+                message.includes("500") ||
+                message.includes("internal server error") ||
+                message.includes("unexpected status")
+              );
+            },
+            schedule: Schedule.max([
+              Schedule.spaced("3 seconds"),
+              Schedule.recurs(5),
+            ]),
+          });
+
         if (build.kind === "remote") {
           // Pull the pre-built image and re-tag it to the Cloudflare registry
           // reference; nothing is built locally.
@@ -557,6 +579,17 @@ export const LiveContainerProvider = () =>
           }
           yield* docker.image.pull(build.image, platform);
           yield* docker.image.tag(build.image, imageRef);
+          yield* Effect.logInfo(
+            `Cloudflare Container image: pushing ${imageRef}`,
+          );
+          if (session) {
+            yield* session.note(`Pushing container image ${imageRef}...`);
+          }
+          // Push the same platform that was pulled. A containerd image store
+          // may also hold a host-architecture variant under this tag.
+          yield* docker.image
+            .push(imageRef, credentials, platform)
+            .pipe(retryPublication);
         } else if (build.kind === "external") {
           // Build the user's Dockerfile directly against their context dir so
           // relative `COPY`/`ADD` paths resolve as the author intended.
@@ -566,12 +599,18 @@ export const LiveContainerProvider = () =>
           if (session) {
             yield* session.note(`Building container image ${imageRef}...`);
           }
-          yield* docker.image.build({
-            tag: imageRef,
-            context: build.context,
-            platform,
-            file: build.dockerfile,
-          });
+          yield* docker.image
+            .build(
+              {
+                tag: imageRef,
+                context: build.context,
+                platform,
+                file: build.dockerfile,
+              },
+              undefined,
+              credentials,
+            )
+            .pipe(retryPublication);
         } else {
           // Effect-native program: materialize the generated Dockerfile and
           // bundled chunks into a stable staging dir, then build.
@@ -601,57 +640,19 @@ export const LiveContainerProvider = () =>
               content: f.content,
             })),
           });
-          yield* docker.image.build({
-            tag: imageRef,
-            context: contextDir,
-            platform,
-          });
-        }
-
-        yield* Effect.logInfo(
-          `Cloudflare Container image: pushing ${imageRef}`,
-        );
-        if (session) {
-          yield* session.note(`Pushing container image ${imageRef}...`);
-        }
-
-        const credentials = yield* registryCredentials(props, ["pull", "push"]);
-
-        // Cloudflare's container registry intermittently answers blob HEAD
-        // probes with 500 under concurrent suite push load. Ride that out
-        // with a bounded retry rather than failing the whole deploy.
-        //
-        // Push the SAME platform we pulled/built. With Docker's containerd
-        // image store a tag can hold several platform variants (e.g. a stray
-        // host-arch `docker pull` adds arm64 next to our amd64), and an
-        // un-scoped push then ships the wrong variant — Cloudflare's amd64
-        // hosts never boot it and the app 503s "provisioning" forever.
-        yield* docker.image
-          .push(
-            imageRef,
-            {
-              username: credentials.username,
-              password: credentials.password,
-              server: credentials.server,
-            },
-            platform,
-          )
-          .pipe(
-            Effect.retry({
-              while: (e) => {
-                const msg = String(e).toLowerCase();
-                return (
-                  msg.includes("500") ||
-                  msg.includes("internal server error") ||
-                  msg.includes("unexpected status")
-                );
+          yield* docker.image
+            .build(
+              {
+                tag: imageRef,
+                context: contextDir,
+                platform,
               },
-              schedule: Schedule.max([
-                Schedule.spaced("3 seconds"),
-                Schedule.recurs(5),
-              ]),
-            }),
-          );
+              undefined,
+              credentials,
+            )
+            .pipe(retryPublication);
+        }
+
         // Resolve the pushed manifest digest from the registry itself rather
         // than scraping `docker push` output: one mechanism for every image
         // source (local build, remote re-push, pre-pushed tag), and the

--- a/packages/alchemy/src/Docker/Docker.ts
+++ b/packages/alchemy/src/Docker/Docker.ts
@@ -1,6 +1,7 @@
 import * as Config from "effect/Config";
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
+import * as Encoding from "effect/Encoding";
 import * as FileSystem from "effect/FileSystem";
 import { flow } from "effect/Function";
 import * as Layer from "effect/Layer";
@@ -11,12 +12,24 @@ import {
   type SystemErrorTag,
 } from "effect/PlatformError";
 import * as Redacted from "effect/Redacted";
+import * as Result from "effect/Result";
+import * as Schema from "effect/Schema";
 import * as Sink from "effect/Sink";
 import * as Stream from "effect/Stream";
 import * as ChildProcess from "effect/unstable/process/ChildProcess";
 import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
 import type { ScopedPlanStatusSession } from "../Report.ts";
 import { createPhysicalName } from "../PhysicalName.ts";
+
+/** Credentials for a single image registry, scoped to a Docker command. */
+export interface RegistryCredentials {
+  /** Registry hostname, without a URL scheme. */
+  server: string;
+  /** Registry authentication username. */
+  username: string;
+  /** Registry password or access token. */
+  password: string | Redacted.Redacted<string>;
+}
 
 export class Docker extends Context.Service<
   Docker,
@@ -80,7 +93,11 @@ export class Docker extends Context.Service<
       ) => Effect.Effect<CommandOutput, PlatformError>;
     };
     readonly image: {
-      /** Builds a new image. If a session is provided, build logs will be emitted as session notes. */
+      /**
+       * Builds locally, or exports directly to a registry when credentials are
+       * supplied. Registry exports require Buildx 0.26.0 or newer. If a session
+       * is provided, build logs will be emitted as session notes.
+       */
       readonly build: (
         options: {
           context: string;
@@ -95,6 +112,7 @@ export class Docker extends Context.Service<
           engineContext?: string;
         },
         session?: ScopedPlanStatusSession,
+        registry?: RegistryCredentials,
       ) => Effect.Effect<CommandOutput, PlatformError>;
       /** Pulls an image. */
       readonly pull: (
@@ -113,11 +131,7 @@ export class Docker extends Context.Service<
        */
       readonly push: (
         ref: string,
-        credentials: {
-          server: string;
-          username: string;
-          password: string | Redacted.Redacted<string>;
-        },
+        credentials: RegistryCredentials,
         platform?: string,
         context?: string,
       ) => Effect.Effect<CommandOutput, PlatformError>;
@@ -560,6 +574,93 @@ export const DockerLive = Layer.effect(
         }),
       );
 
+    const registryEnvironment = Effect.fn("registryEnvironment")(function* (
+      credentials: RegistryCredentials,
+    ) {
+      const current = yield* Config.redacted("DOCKER_AUTH_CONFIG").pipe(
+        Config.withDefault(Redacted.make("{}")),
+        Effect.flatMap((value) =>
+          Schema.decodeEffect(
+            Schema.fromJsonString(
+              Schema.Struct({
+                auths: Schema.optional(
+                  Schema.NullOr(
+                    Schema.Record(
+                      Schema.String,
+                      Schema.Struct({
+                        auth: Schema.String.check(
+                          Schema.makeFilter((value) => {
+                            const decoded = Encoding.decodeBase64(value);
+                            // Docker requires a nonempty username followed by
+                            // a colon. Retain the original encoded credentials.
+                            return (
+                              Result.isSuccess(decoded) &&
+                              decoded.success.indexOf(58) > 0
+                            );
+                          }),
+                        ),
+                      }),
+                    ),
+                  ),
+                ),
+              }),
+            ),
+            { onExcessProperty: "error" },
+          )(Redacted.value(value) || "{}"),
+        ),
+        // Schema diagnostics may include credential input. Do not retain them.
+        Effect.mapError(() =>
+          systemError({
+            _tag: "InvalidData",
+            args: ["buildx", "build"],
+            description: "Invalid DOCKER_AUTH_CONFIG; expected an auths map.",
+          }),
+        ),
+      );
+      return yield* Effect.sync(() => {
+        const password = Redacted.isRedacted(credentials.password)
+          ? Redacted.value(credentials.password)
+          : credentials.password;
+        const auth = Buffer.from(
+          `${credentials.username}:${password}`,
+        ).toString("base64");
+        // The in-memory credential store retains file/helper fallback. Leave
+        // DOCKER_CONFIG intact so contexts, builders and source auth still work.
+        return {
+          DOCKER_AUTH_CONFIG: JSON.stringify({
+            auths: { ...current.auths, [credentials.server]: { auth } },
+          }),
+        };
+      });
+    });
+
+    const requireRegistryExporter = Effect.gen(function* () {
+      const unsupported = () =>
+        systemError({
+          _tag: "InvalidData",
+          args: ["buildx", "version"],
+          description:
+            "Registry builds require Buildx 0.26.0 or newer; upgrade the Docker Buildx plugin to support DOCKER_AUTH_CONFIG.",
+        });
+      const version = yield* run(["buildx", "version"]).pipe(
+        Effect.mapError(unsupported),
+      );
+      const [, major, , minor] = yield* Schema.decodeUnknownEffect(
+        Schema.TemplateLiteralParser([
+          "github.com/docker/buildx v",
+          Schema.NumberFromString,
+          ".",
+          Schema.NumberFromString,
+          ".",
+          Schema.NumberFromString,
+          Schema.String,
+        ]),
+      )(version.stdout).pipe(Effect.mapError(unsupported));
+      // Buildx 0.26 is the first release embedding Docker CLI 28.3's
+      // DOCKER_AUTH_CONFIG credential store. Older plugins ignore it.
+      if (major < 1 && minor < 26) return yield* unsupported();
+    });
+
     return Docker.of({
       run,
       materialize: Effect.fn((options) =>
@@ -623,20 +724,26 @@ export const DockerLive = Layer.effect(
           run([...formatArgs({ context }), "container", "stop", name]),
       },
       image: {
-        build: (
+        build: Effect.fn("Docker.image.build")(function* (
           { context: buildContext, engineContext, args, ...options },
           session,
-        ) =>
-          run(
+          registry,
+        ) {
+          const env = registry
+            ? yield* registryEnvironment(registry)
+            : undefined;
+          if (registry) yield* requireRegistryExporter;
+          return yield* run(
             [
               ...formatArgs({ context: engineContext }),
-              "image",
-              "build",
+              ...(registry
+                ? ["buildx", "build", "--push"]
+                : ["image", "build"]),
               buildContext,
               ...formatArgs(options),
               ...(args ?? []),
             ],
-            undefined,
+            env,
             session
               ? Stream.tapSink(
                   Sink.make<string>()(
@@ -649,7 +756,8 @@ export const DockerLive = Layer.effect(
                   ),
                 )
               : undefined,
-          ),
+          );
+        }),
         pull: (ref, platform, context) =>
           run([
             ...formatArgs({ context }),

--- a/packages/alchemy/test/Cloudflare/Container/RegistryExport.test.ts
+++ b/packages/alchemy/test/Cloudflare/Container/RegistryExport.test.ts
@@ -1,0 +1,218 @@
+import { AlchemyContext } from "@/AlchemyContext.ts";
+import { CloudflareEnvironment } from "@/Cloudflare/CloudflareEnvironment.ts";
+import { ContainerPlatform } from "@/Cloudflare/Containers/ContainerPlatform.ts";
+import { LiveContainerProvider } from "@/Cloudflare/Containers/ContainerProvider.ts";
+import { DockerLive } from "@/Docker/Docker.ts";
+import { noopSession } from "@/Report.ts";
+import { Stack } from "@/Stack.ts";
+import { Stage } from "@/Stage.ts";
+import {
+  apiTokenCredentials,
+  Credentials,
+} from "@distilled.cloud/cloudflare/Credentials";
+import { NodeServices } from "@effect/platform-node";
+import { describe, expect, it } from "alchemy-test";
+import * as ConfigProvider from "effect/ConfigProvider";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Path from "effect/Path";
+import * as Redacted from "effect/Redacted";
+import * as Schema from "effect/Schema";
+import * as Sink from "effect/Sink";
+import * as Stream from "effect/Stream";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as HttpClientResponse from "effect/unstable/http/HttpClientResponse";
+import type * as ChildProcess from "effect/unstable/process/ChildProcess";
+import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
+
+const accountId = "0123456789abcdef0123456789abcdef";
+const digest = `sha256:${"a".repeat(64)}`;
+const indexType = "application/vnd.oci.image.index.v1+json";
+
+const exportImage = Effect.fn("exportImage")(function* (options: {
+  indexOnly?: boolean;
+  failFirstBuild?: boolean;
+}) {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const context = yield* fs.makeTempDirectoryScoped({
+    prefix: "alchemy-export-test-",
+  });
+  yield* fs.writeFileString(path.join(context, "Dockerfile"), "FROM scratch\n");
+  const commands: ChildProcess.StandardCommand[] = [];
+  let builds = 0;
+  let acceptedTypes: string | undefined;
+  const spawner = ChildProcessSpawner.make((command) =>
+    Effect.sync(() => {
+      if (command._tag !== "StandardCommand")
+        throw new Error("Unexpected pipeline");
+      commands.push(command);
+      const isBuild = command.args.includes("build");
+      if (isBuild) builds++;
+      const failed = options.failFirstBuild && isBuild && builds === 1;
+      const stdout = Stream.succeed(
+        new TextEncoder().encode(
+          command.args.includes("version")
+            ? "github.com/docker/buildx v0.26.0 abc123"
+            : "published",
+        ),
+      );
+      return ChildProcessSpawner.makeHandle({
+        pid: ChildProcessSpawner.ProcessId(123),
+        exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(failed ? 1 : 0)),
+        isRunning: Effect.succeed(false),
+        kill: () => Effect.void,
+        stdin: Sink.drain,
+        stdout,
+        stderr: failed
+          ? Stream.succeed(
+              new TextEncoder().encode(
+                "unexpected status: 500 Internal Server Error",
+              ),
+            )
+          : Stream.empty,
+        all: stdout,
+        getInputFd: () => Sink.drain,
+        getOutputFd: () => Stream.empty,
+        unref: Effect.succeed(Effect.void),
+      });
+    }),
+  );
+  const http = HttpClient.make((request) =>
+    Effect.sync(() => {
+      if (request.method === "HEAD") {
+        expect(request.url).toMatch(
+          /^https:\/\/registry\.cloudflare\.com\/v2\//,
+        );
+        acceptedTypes = request.headers.accept;
+        const status =
+          options.indexOnly && !acceptedTypes?.includes(indexType) ? 406 : 200;
+        return HttpClientResponse.fromWeb(
+          request,
+          new Response(null, {
+            status,
+            headers: {
+              "docker-content-digest": digest,
+              "content-type": indexType,
+            },
+          }),
+        );
+      }
+      let result: unknown;
+      if (request.url.endsWith("/credentials")) {
+        expect(request.method).toBe("POST");
+        result = { username: "publisher", password: "test-token" };
+      } else if (request.url.endsWith("/containers/applications")) {
+        if (request.method === "GET") {
+          result = [];
+        } else {
+          expect(request.method).toBe("POST");
+          if (request.body._tag !== "Uint8Array")
+            throw new Error("Expected JSON request");
+          const body = Schema.decodeUnknownSync(
+            Schema.fromJsonString(Schema.Record(Schema.String, Schema.Unknown)),
+          )(new TextDecoder().decode(request.body.body));
+          result = {
+            ...body,
+            id: "application-id",
+            account_id: accountId,
+            created_at: "2026-01-01T00:00:00Z",
+            version: 1,
+          };
+        }
+      } else {
+        throw new Error(`Unexpected request: ${request.method} ${request.url}`);
+      }
+      return HttpClientResponse.fromWeb(
+        request,
+        Response.json({ success: true, errors: [], messages: [], result }),
+      );
+    }),
+  );
+  const environment = Layer.mergeAll(
+    Layer.succeed(AlchemyContext, {
+      dotAlchemy: ".alchemy-test",
+      dev: false,
+      adopt: false,
+    }),
+    Layer.succeed(
+      CloudflareEnvironment,
+      Effect.succeed({
+        type: "apiToken",
+        apiToken: Redacted.make("test-token"),
+        accountId,
+        source: { type: "env" },
+      }),
+    ),
+    Layer.succeed(
+      Credentials,
+      Effect.succeed(apiTokenCredentials({ apiToken: "test-token" })),
+    ),
+    Layer.succeed(Stack, {
+      name: "RegistryExportTest",
+      stage: "test",
+      resources: {},
+      bindings: {},
+      actions: {},
+    }),
+    Layer.succeed(Stage, "test"),
+    Layer.succeed(HttpClient.HttpClient, http),
+    ConfigProvider.layer(
+      ConfigProvider.fromUnknown({ DOCKER_BIN: "docker-test" }),
+    ),
+    DockerLive.pipe(
+      Layer.provide(
+        Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner),
+      ),
+    ),
+  ).pipe(Layer.provide(NodeServices.layer));
+  const output = yield* Effect.gen(function* () {
+    const provider = yield* ContainerPlatform.Provider;
+    return yield* provider.reconcile({
+      id: "Export",
+      fqn: "Export",
+      instanceId: "0123456789abcdef0123456789abcdef",
+      news: { name: "registry-export", context },
+      olds: undefined,
+      output: undefined,
+      bindings: [],
+      session: { ...noopSession, note: () => Effect.void },
+    });
+  }).pipe(Effect.provide(LiveContainerProvider()), Effect.provide(environment));
+  return { output, commands, builds, acceptedTypes };
+});
+
+describe("Container registry export", () => {
+  it.effect("exports Dockerfiles directly and resolves OCI image indexes", () =>
+    Effect.gen(function* () {
+      const { output, commands, acceptedTypes } = yield* exportImage({
+        indexOnly: true,
+      });
+      expect(
+        commands.filter((command) => command.args.includes("--push")),
+      ).toHaveLength(1);
+      expect(commands.some((command) => command.args.includes("push"))).toBe(
+        false,
+      );
+      expect(acceptedTypes).toContain(indexType);
+      expect(acceptedTypes).toContain(
+        "application/vnd.docker.distribution.manifest.list.v2+json",
+      );
+      expect(output.configuration.image).toBe(
+        `registry.cloudflare.com/${accountId}/registry-export@${digest}`,
+      );
+      expect(output.hash?.digest).toBe(digest);
+    }).pipe(Effect.provide(NodeServices.layer)),
+  );
+
+  it.live("retries transient BuildKit registry export failures", () =>
+    Effect.gen(function* () {
+      const { builds, commands } = yield* exportImage({ failFirstBuild: true });
+      expect(builds).toBe(2);
+      expect(
+        commands.filter((command) => command.args.includes("--push")),
+      ).toHaveLength(2);
+    }).pipe(Effect.provide(NodeServices.layer)),
+  );
+});

--- a/packages/alchemy/test/Docker/DockerBuild.test.ts
+++ b/packages/alchemy/test/Docker/DockerBuild.test.ts
@@ -1,0 +1,243 @@
+import { Docker, DockerLive } from "@/Docker/Docker.ts";
+import { noopSession } from "@/Report.ts";
+import { NodeServices } from "@effect/platform-node";
+import { describe, expect, it } from "alchemy-test";
+import * as ConfigProvider from "effect/ConfigProvider";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as Redacted from "effect/Redacted";
+import * as Schema from "effect/Schema";
+import * as Sink from "effect/Sink";
+import * as Stream from "effect/Stream";
+import type * as ChildProcess from "effect/unstable/process/ChildProcess";
+import * as ChildProcessSpawner from "effect/unstable/process/ChildProcessSpawner";
+
+const credentials = {
+  server: "registry.example.test",
+  username: "publisher",
+  password: Redacted.make("REGISTRY_SECRET_SENTINEL"),
+};
+const build = {
+  context: "/project/context",
+  tag: "registry.example.test/app:latest",
+  platform: "linux/amd64",
+  file: "/project/Dockerfile",
+  engineContext: "remote-builder",
+};
+
+const harness = (options?: { auth?: string; version?: string }) => {
+  const commands: ChildProcess.StandardCommand[] = [];
+  const spawner = ChildProcessSpawner.make((command) =>
+    Effect.sync(() => {
+      if (command._tag !== "StandardCommand") {
+        throw new Error("Unexpected command pipeline");
+      }
+      commands.push(command);
+      const output = command.args.includes("version")
+        ? (options?.version ?? "github.com/docker/buildx v0.26.0 abc123")
+        : "exported image\n";
+      const stdout = Stream.succeed(new TextEncoder().encode(output));
+      return ChildProcessSpawner.makeHandle({
+        pid: ChildProcessSpawner.ProcessId(123),
+        exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(0)),
+        isRunning: Effect.succeed(false),
+        kill: () => Effect.void,
+        stdin: Sink.drain,
+        stdout,
+        stderr: Stream.empty,
+        all: stdout,
+        getInputFd: () => Sink.drain,
+        getOutputFd: () => Stream.empty,
+        unref: Effect.succeed(Effect.void),
+      });
+    }),
+  );
+  const layer = DockerLive.pipe(
+    Layer.provide(
+      Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner),
+    ),
+    Layer.provide(NodeServices.layer),
+    Layer.provideMerge(
+      ConfigProvider.layer(
+        ConfigProvider.fromUnknown({
+          DOCKER_BIN: "docker-test",
+          ...(options?.auth === undefined
+            ? {}
+            : { DOCKER_AUTH_CONFIG: options.auth }),
+        }),
+      ),
+    ),
+  );
+  return { commands, layer };
+};
+
+describe("Docker registry builds", () => {
+  it.effect(
+    "exports with BuildKit and preserves source-registry auth and Docker context",
+    () => {
+      const { commands, layer } = harness({
+        auth: JSON.stringify({
+          auths: {
+            "source.example.test": { auth: "c291cmNlOnRva2Vu" },
+            "registry.example.test": { auth: "b2xkOnRva2Vu" },
+          },
+        }),
+      });
+      const notes: string[] = [];
+
+      return Effect.gen(function* () {
+        const docker = yield* Docker;
+        yield* docker.image.build(
+          build,
+          {
+            ...noopSession,
+            note: (note) => Effect.sync(() => void notes.push(note)),
+          },
+          credentials,
+        );
+
+        const command = commands.find((entry) => entry.args.includes("--push"));
+        expect(command).toBeDefined();
+        expect(command?.command).toBe("docker-test");
+        expect(command?.args).toEqual([
+          "--context",
+          "remote-builder",
+          "buildx",
+          "build",
+          "--push",
+          "/project/context",
+          "--tag",
+          "registry.example.test/app:latest",
+          "--platform",
+          "linux/amd64",
+          "--file",
+          "/project/Dockerfile",
+        ]);
+        expect(command?.options.extendEnv).toBe(true);
+        expect(Object.keys(command?.options.env ?? {})).toEqual([
+          "DOCKER_AUTH_CONFIG",
+        ]);
+        const auth = Schema.decodeUnknownSync(
+          Schema.fromJsonString(Schema.Unknown),
+        )(command?.options.env?.DOCKER_AUTH_CONFIG);
+        expect(auth).toEqual({
+          auths: {
+            "source.example.test": { auth: "c291cmNlOnRva2Vu" },
+            "registry.example.test": {
+              auth: "cHVibGlzaGVyOlJFR0lTVFJZX1NFQ1JFVF9TRU5USU5FTA==",
+            },
+          },
+        });
+        expect(commands.flatMap((entry) => entry.args).join(" ")).not.toContain(
+          "REGISTRY_SECRET_SENTINEL",
+        );
+        expect(notes).toContain("exported image");
+        expect(commands.some((entry) => entry.args.includes("login"))).toBe(
+          false,
+        );
+      }).pipe(Effect.provide(layer));
+    },
+  );
+
+  it.effect("keeps ordinary builds local without requiring Buildx", () => {
+    const { commands, layer } = harness({ version: "old buildx" });
+    return Effect.gen(function* () {
+      const docker = yield* Docker;
+      yield* docker.image.build(build);
+
+      expect(commands).toHaveLength(1);
+      expect(commands[0]?.args.slice(0, 4)).toEqual([
+        "--context",
+        "remote-builder",
+        "image",
+        "build",
+      ]);
+      expect(commands[0]?.options.env).toBeUndefined();
+    }).pipe(Effect.provide(layer));
+  });
+
+  it.effect(
+    "rejects malformed auth configuration without exposing credentials",
+    () => {
+      const { commands, layer } = harness({
+        auth: '{"auths":{"source.example.test":{"auth":"AUTH_SECRET_SENTINEL"}},',
+      });
+      return Effect.gen(function* () {
+        const docker = yield* Docker;
+        const error = yield* docker.image
+          .build(build, undefined, credentials)
+          .pipe(Effect.flip);
+
+        expect(error.reason._tag).toBe("InvalidData");
+        expect(error.reason.description).toContain("DOCKER_AUTH_CONFIG");
+        expect(String(error)).not.toContain("AUTH_SECRET_SENTINEL");
+        expect(JSON.stringify(error)).not.toContain("AUTH_SECRET_SENTINEL");
+        expect(commands).toHaveLength(0);
+      }).pipe(Effect.provide(layer));
+    },
+  );
+
+  it.effect("rejects malformed base64 auth before launching Docker", () => {
+    const auth = "AUTH_SECRET_SENTINEL!";
+    const { commands, layer } = harness({
+      auth: JSON.stringify({ auths: { "source.example.test": { auth } } }),
+    });
+    return Effect.gen(function* () {
+      const docker = yield* Docker;
+      const error = yield* docker.image
+        .build(build, undefined, credentials)
+        .pipe(Effect.flip);
+
+      expect(error.reason._tag).toBe("InvalidData");
+      expect(error.reason.description).toContain("DOCKER_AUTH_CONFIG");
+      expect(String(error)).not.toContain(auth);
+      expect(JSON.stringify(error)).not.toContain(auth);
+      expect(commands).toHaveLength(0);
+    }).pipe(Effect.provide(layer));
+  });
+
+  it.effect(
+    "rejects decoded auth without a username/password separator",
+    () => {
+      const auth = "QVVUSF9TRUNSRVRfU0VOVElORUw=";
+      const { commands, layer } = harness({
+        auth: JSON.stringify({ auths: { "source.example.test": { auth } } }),
+      });
+      return Effect.gen(function* () {
+        const docker = yield* Docker;
+        const error = yield* docker.image
+          .build(build, undefined, credentials)
+          .pipe(Effect.flip);
+
+        expect(error.reason._tag).toBe("InvalidData");
+        expect(error.reason.description).toContain("DOCKER_AUTH_CONFIG");
+        expect(String(error)).not.toContain(auth);
+        expect(JSON.stringify(error)).not.toContain(auth);
+        expect(JSON.stringify(error)).not.toContain("AUTH_SECRET_SENTINEL");
+        expect(commands).toHaveLength(0);
+      }).pipe(Effect.provide(layer));
+    },
+  );
+
+  it.effect(
+    "rejects Buildx versions that ignore registry environment credentials",
+    () => {
+      const { commands, layer } = harness({
+        version: "github.com/docker/buildx v0.25.0 abc123",
+      });
+      return Effect.gen(function* () {
+        const docker = yield* Docker;
+        const error = yield* docker.image
+          .build(build, undefined, credentials)
+          .pipe(Effect.flip);
+
+        expect(error.reason.description).toContain("Buildx 0.26.0 or newer");
+        expect(error.reason.description).toContain("upgrade");
+        expect(commands).toHaveLength(1);
+        expect(commands[0]?.args).toEqual(["buildx", "version"]);
+        expect(commands[0]?.options.env).toBeUndefined();
+        expect(JSON.stringify(error)).not.toContain("REGISTRY_SECRET_SENTINEL");
+      }).pipe(Effect.provide(layer));
+    },
+  );
+});


### PR DESCRIPTION
Container Dockerfile and generated builds currently depend on a separate Docker Engine push after building. Export those builds directly with `docker buildx build --push`, retaining the existing bounded registry retries and accepting OCI indexes and Docker manifest lists when resolving the published digest. Remote images keep their platform-scoped pull/tag/push path.

Merge destination credentials into the child process’s `DOCKER_AUTH_CONFIG` while preserving existing registry auth, Docker contexts, builders, and file/helper credential fallback. Reject malformed auth before launching Docker. Credentialed exports require Buildx 0.26.0 or newer, which embeds the Docker CLI environment credential store; ordinary local builds retain their existing behavior.
