### PR TITLE
fix: resolve example test failures

### DIFF
--- a/packages/alchemy-test/src/cli.ts
+++ b/packages/alchemy-test/src/cli.ts
@@ -154,15 +154,9 @@ const rootCommand = Command.make(
     // Environment knobs — set BEFORE any test module is imported (imports
     // happen inside `run` during collection), so `skipIf(process.env.FAST)`
     // gates and profile-dependent layers see the final values.
-    //
-    // CI=true: interactive-detection gates (`process.env.CI`, TTY probes)
-    // make tools take "inherit the terminal" paths — e.g. drizzle-kit is
-    // spawned with stdio: "inherit" when interactive — and raw child writes
-    // to our TTY corrupt the reporter/TUI. CI=true forces every such tool
-    // down its non-interactive path; anything they print through pipes or
-    // the Console service is still captured per test.
+    // Inherit CI from the caller: setting it here also disables local auth
+    // profiles, even when the caller explicitly selected one.
     yield* Effect.sync(() => {
-      process.env.CI ??= "true";
       if (Option.isSome(args.profile)) {
         process.env.ALCHEMY_PROFILE = args.profile.value;
       }

--- a/packages/alchemy/src/Cli/LoggingCli.ts
+++ b/packages/alchemy/src/Cli/LoggingCli.ts
@@ -2,6 +2,7 @@ import * as Clock from "effect/Clock";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Prompt from "effect/unstable/cli/Prompt";
+import { inspect } from "node:util";
 import type { ActionApply, ActionDelete, CRUD, Plan } from "../Plan.ts";
 import { Cli, type PlanDisplayOptions } from "../Report.ts";
 import { canPromptOnStdin } from "../Util/interactive.ts";
@@ -294,6 +295,8 @@ export const LoggingCli = Layer.effect(
           const notes = new Map<string, string>();
           const statusNotes = new Map<string, string>();
           return {
+            setOutput: (value: unknown) =>
+              Effect.logInfo(inspect(value, { colors: false })),
             // Progress is an Effect log record, just like provider and build
             // diagnostics, so the append-only renderer gives every line the
             // same timestamp / level / fiber prefix.

--- a/packages/alchemy/test/Cli/LoggingCli.test.ts
+++ b/packages/alchemy/test/Cli/LoggingCli.test.ts
@@ -72,6 +72,26 @@ it.effect("emits plain progress through the Effect logger", () => {
   );
 });
 
+it.effect("prints dev stack outputs with the plain apply renderer", () => {
+  const messages: unknown[] = [];
+  return Effect.gen(function* () {
+    const cli = yield* Cli;
+    const session = yield* cli.startApplySession(planWith([]), { dev: true });
+    expect(session.setOutput).toBeDefined();
+    yield* session.setOutput!({ api: "http://localhost:1337/" });
+    expect(messages).toContainEqual(["{ api: 'http://localhost:1337/' }"]);
+  }).pipe(
+    Effect.provide(Layer.provide(LoggingCli, PlatformServices)),
+    Effect.provide(
+      Logger.layer([
+        Logger.make<unknown, void>((options) => {
+          messages.push(options.message);
+        }),
+      ]),
+    ),
+  );
+});
+
 it.effect("streams apply notes as they arrive", () => {
   const messages: string[] = [];
   const logger = Logger.make<unknown, void>((options) => {

--- a/packages/cloudflare-runtime/src/rolldown/plugins/options.ts
+++ b/packages/cloudflare-runtime/src/rolldown/plugins/options.ts
@@ -345,7 +345,7 @@ const getDefine = (
     "process.env.NODE_ENV": JSON.stringify(nodeEnv),
     "global.process.env.NODE_ENV": JSON.stringify(nodeEnv),
     "globalThis.process.env.NODE_ENV": JSON.stringify(nodeEnv),
-    ...(hasNodejsCompat(options.compatibilityFlags)
+    ...(hasNodejsCompat(options.compatibilityFlags, options.compatibilityDate)
       ? {}
       : {
           "process.env": "{}",

--- a/packages/cloudflare-runtime/src/rolldown/test/options.test.ts
+++ b/packages/cloudflare-runtime/src/rolldown/test/options.test.ts
@@ -120,10 +120,11 @@ describe("options plugin", () => {
     });
   });
 
-  it("does not stub process.env with nodejs_compat enabled", () => {
-    const plugin = optionsPlugin.rolldown({
-      compatibilityFlags: ["nodejs_compat"],
-    });
+  it.each([
+    { compatibilityFlags: ["nodejs_compat"] },
+    { compatibilityDate: "2026-08-31" },
+  ])("preserves runtime process.env with Node compatibility: %j", (options) => {
+    const plugin = optionsPlugin.rolldown(options);
     const input = {};
     assert(
       typeof plugin.options === "function",

--- a/packages/pr-package/src/PackageStore.ts
+++ b/packages/pr-package/src/PackageStore.ts
@@ -152,6 +152,10 @@ export default class PackageStore extends Cloudflare.DurableObject<PackageStore>
         recordDownload: (tag: string) =>
           Effect.gen(function* () {
             const current = yield* getState;
+            // KV can still point here after a tag is removed. The Durable
+            // Object owns tag membership, even while the tarball survives
+            // under another tag.
+            if (!current.tags.includes(tag)) return false;
             const downloads = { ...current.downloads };
             downloads[tag] = (downloads[tag] ?? 0) + 1;
             yield* setState({
@@ -159,6 +163,7 @@ export default class PackageStore extends Cloudflare.DurableObject<PackageStore>
               downloads,
               totalDownloads: current.totalDownloads + 1,
             });
+            return true;
           }),
 
         getStats: () =>

--- a/packages/pr-package/src/Worker.ts
+++ b/packages/pr-package/src/Worker.ts
@@ -326,7 +326,12 @@ export const handler = (options: HandlerOptions = {}) =>
           }
 
           const store = packages.getByName(id);
-          yield* store.recordDownload(tag).pipe(Effect.orDie);
+          if (!(yield* store.recordDownload(tag).pipe(Effect.orDie))) {
+            return yield* HttpServerResponse.json(
+              { error: "tag not found" },
+              { status: 404 },
+            );
+          }
 
           return HttpServerResponse.fromWeb(
             new Response(null, {

--- a/scripts/test-examples.ts
+++ b/scripts/test-examples.ts
@@ -182,6 +182,23 @@ const makeStatusRenderer = (states: readonly TaskState[]) => {
   };
 
   return {
+    failure(result: CommandResult) {
+      if (interactive && renderedRows > 0) {
+        process.stdout.write(`\x1b[${renderedRows}F\x1b[J`);
+        renderedRows = 0;
+      }
+      const output = [
+        `\nFailed: ${result.label} (exit ${result.exitCode ?? "signal"}): ${result.command.join(" ")}`,
+        `--- ${result.label} stdout ---`,
+        result.stdout.trimEnd() || "(empty)",
+        `--- ${result.label} stderr ---`,
+        result.stderr.trimEnd() || "(empty)",
+        "",
+      ].join("\n");
+      // Use the TUI's stream so its next repaint starts below the logs.
+      (interactive ? process.stdout : process.stderr).write(output);
+      this.render();
+    },
     render() {
       if (!interactive) {
         return;
@@ -261,7 +278,11 @@ const runParallel = async (
 
   try {
     return await Promise.all(
-      states.map((state) => run(state, () => renderer.render())),
+      states.map(async (state) => {
+        const result = await run(state, () => renderer.render());
+        if (result.exitCode !== 0) renderer.failure(result);
+        return result;
+      }),
     );
   } finally {
     clearInterval(interval);
@@ -291,21 +312,6 @@ if (failedTests.length > 0) {
     );
   }
 
-  for (const failure of failedTests) {
-    console.error(`\n--- ${failure.label} stdout ---`);
-    if (failure.stdout.length > 0) {
-      console.error(failure.stdout.trimEnd());
-    } else {
-      console.error("(empty)");
-    }
-
-    console.error(`\n--- ${failure.label} stderr ---`);
-    if (failure.stderr.length > 0) {
-      console.error(failure.stderr.trimEnd());
-    } else {
-      console.error("(empty)");
-    }
-  }
   process.exit(1);
 }
 
@@ -322,8 +328,6 @@ if (failedCliTests.length > 0) {
   for (const failure of failedCliTests) {
     const exit = failure.exitCode === null ? "signal" : failure.exitCode;
     console.error(`- ${failure.label} (exit ${exit})`);
-    if (failure.stdout.length > 0) console.error(failure.stdout.trimEnd());
-    if (failure.stderr.length > 0) console.error(failure.stderr.trimEnd());
   }
   process.exit(1);
 }


### PR DESCRIPTION
Fix failures in the example tests caused by missing dev outputs, stripped runtime environment variables, and stale package-tag lookups.

- Print stack outputs in plain dev sessions so clients can discover deployed URLs.
- Preserve runtime environment variables when Node compatibility is enabled by the Cloudflare compatibility date.
- Check Durable Object tag membership before serving a cached KV pointer, so deleted PR tags return 404 while other tags retain the package.
- Inherit CI from the caller so local runs can use auth profiles, and print each failed example's logs as soon as it finishes.
