### PR TITLE
fix(cloudflare): tolerate span snapshot replay from another event in the native tracer

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/CloudflareTracer.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/CloudflareTracer.ts
@@ -22,6 +22,30 @@ type CloudflareSpan = ReturnType<
   (typeof import("cloudflare:workers"))["tracing"]["startSpan"]
 >;
 
+/**
+ * workerd binds a snapshot to the event that took it, and rejects replaying
+ * it from another event. A fiber's steps can still land there: two events
+ * in one isolate (a Worker and its Durable Objects under `alchemy dev`,
+ * overlapping invocations of one isolate) resume each other's yielded fibers
+ * on their own ticks. Left alone that throw repeats on every step, and the
+ * run loop answers each one by re-entering itself with a die exit until the
+ * stack overflows (`RangeError: Maximum call stack size exceeded`, with
+ * `durableObjectReset` on a DO). Run such a step bare instead; the next
+ * step, back on its own event, nests under the Cloudflare span again.
+ */
+const isForeignEvent = (error: unknown): boolean =>
+  error instanceof Error &&
+  error.message.includes("outside of the request in which it was created");
+
+const replay = <A>(runInContext: RunInContext, fn: () => A): A => {
+  try {
+    return runInContext(fn);
+  } catch (error) {
+    if (isForeignEvent(error)) return fn();
+    throw error;
+  }
+};
+
 class Span extends Tracer.NativeSpan {
   constructor(
     options: SpanOptions,
@@ -96,7 +120,7 @@ export const layer: Layer.Layer<never> = Layer.effect(
           return new Span(options, parentContext);
         }
 
-        return parentContext(() =>
+        return replay(parentContext, () =>
           tracing.startActiveSpan(
             options.name,
             (span) => new Span(options, AsyncLocalStorage.snapshot(), span),
@@ -104,7 +128,7 @@ export const layer: Layer.Layer<never> = Layer.effect(
         );
       },
       context(primitive, fiber) {
-        return contextFor(fiber.currentSpan)(() =>
+        return replay(contextFor(fiber.currentSpan), () =>
           primitive["~effect/Effect/evaluate"](fiber),
         );
       },

--- a/packages/alchemy/test/Cloudflare/Workers/NativeTracing.local.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/NativeTracing.local.test.ts
@@ -53,6 +53,18 @@ test.provider(
         `${url}/rpc?id=local-rpc`,
         "native-did-rpc:do-ok",
       );
+      // A second call into the already-activated object, and a forwarded
+      // request: under local emulation the Worker and its Durable Objects
+      // share one isolate, so the DO's fiber steps can run on the Worker
+      // event's ticks, where its spans' snapshots belong to another event.
+      yield* expectUrlContains(
+        `${url}/rpc?id=local-rpc-again`,
+        "native-did-rpc:do-ok",
+      );
+      yield* expectUrlContains(
+        `${url}/do-fetch?id=local-do-fetch`,
+        "native-did-do-fetch",
+      );
       yield* expectUrlContains(`${url}/enqueue?id=local-queue`, "local-queue");
       yield* expectUrlContains(`${url}/sampled`, "native-did-sample");
 

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/native-tracing/worker.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/native-tracing/worker.ts
@@ -16,8 +16,8 @@ export const Store = Cloudflare.KV.Namespace("NativeTracingStore");
 export const TracingQueue = Cloudflare.Queues.Queue("NativeTracingQueue");
 
 /**
- * Durable Object whose RPC method opens Effect spans, so the
- * DurableObjectBridge's per-call telemetry build is covered.
+ * Durable Object whose RPC method and `fetch` open Effect spans, so the
+ * DurableObjectBridge's per-call telemetry build is covered on both paths.
  */
 export class TracingTarget extends Cloudflare.DurableObject<TracingTarget>()(
   "TracingTarget",
@@ -29,6 +29,16 @@ export class TracingTarget extends Cloudflare.DurableObject<TracingTarget>()(
           yield* Effect.log("do-work").pipe(Effect.withSpan("do.inner"));
           return "do-ok";
         }).pipe(Effect.withSpan("do.operation")),
+      // A forwarded request: the `http.server` span opens on the DO's own
+      // event, under the Worker event that is still awaiting the reply.
+      fetch: Effect.gen(function* () {
+        const request = yield* HttpServerRequest;
+        yield* Effect.log("do-fetch").pipe(Effect.withSpan("do.fetch.inner"));
+        return yield* HttpServerResponse.json({
+          marker: "native-did-do-fetch",
+          url: request.url,
+        });
+      }),
     }),
   ),
 ) {}
@@ -149,6 +159,10 @@ export const tracedWorkerImpl = Effect.gen(function* () {
           marker: `native-did-rpc:${result}`,
           id: requestId,
         });
+      }
+
+      if (url.pathname === "/do-fetch") {
+        return yield* targets.getByName("tracing").fetch(request);
       }
 
       if (url.pathname === "/enqueue") {


### PR DESCRIPTION
## Problem

`Cloudflare.Telemetry()`'s tracer replays each span's `AsyncLocalStorage.snapshot()` on every fiber step (`context`) and when opening a child span. workerd binds a snapshot to the event that took it and throws when it is replayed from another event:

```
Error: Cannot call this AsyncLocalStorage bound function outside of the request in which it was created.
```

A fiber's steps can land on another event's tick: under `alchemy dev` a Worker and its Durable Objects share one isolate, and Effect's scheduler resumes yielded fibers from whichever event's tick fires next. Overlapping invocations of a single isolate have the same shape.

Because the throw comes from the tracer hook, it repeats on every step. `FiberImpl.runLoop` answers a thrown step by re-entering itself with `exitDie`, which throws again, until:

```
RangeError: Maximum call stack size exceeded { durableObjectReset: true }
    at exitDie
    at FiberImpl.runLoop
    at FiberImpl.runLoop
    ...
```

Every call into the Durable Object fails and the object is reset. The DO's own `http.server` span (from a forwarded `fetch`) was the one being replayed in the case that surfaced this.

## Fix

`replay()` wraps both replay sites. On that specific error the step runs bare; any other exception still propagates. The next step, back on its own event, nests under the Cloudflare span again. Nothing changes on the normal same-event path.

## Tests

The fixture Durable Object gains a `fetch`, the Worker gains `/do-fetch` (forwarding through the typed stub), and the local suite calls `/rpc` a second time on the already-activated object plus `/do-fetch`.

## Verification

- The same guard is running in an app on `2.0.0-beta.74` with a hand-rolled tracer of the same design, where it turned every DO invocation from a stack overflow into a normal reply. That is where the mechanism above was traced.
- `NativeTracing.local.test.ts` could not be run from my machine yet: the fixture's local KV and Queue resources want Cloudflare OAuth scopes my profile does not have. Happy to add a run log once refreshed.
