### PR TITLE
fix(cli): restore nuke progress and bulk state cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "build:pr-packages": "turbo run build --filter=alchemy --filter=@alchemy.run/better-auth --filter=@alchemy.run/cloudflare-runtime --filter=@alchemy.run/frontend-frameworks --filter=@alchemy.run/pr-package --filter=@distilled.cloud/core --filter=@distilled.cloud/aws --filter=@distilled.cloud/axiom --filter=@distilled.cloud/cloudflare --filter=@distilled.cloud/hetzner --filter=@distilled.cloud/neon --filter=@distilled.cloud/planetscale",
     "clean": "git clean -fqdx -e .env",
     "clean:shallow": "rm -rf alchemy/*.tgz && bun tsc -b --clean",
-    "clear:state": "alchemy state delete Nuke --config ./stacks/nuke.ts --recursive",
+    "clear:state": "alchemy state unsafe nuke --config ./stacks/nuke.ts",
     "deploy:github": "doppler run -c prod --project alchemy-v2 -- bun alchemy deploy ./stacks/github.ts --profile admin",
     "deploy:otel": "doppler run -c dev --project alchemy-v2 -- bun alchemy deploy ./stacks/otel.ts",
     "deploy:otel:prod": "bun deploy:otel --profile prod --stage prod",

--- a/packages/alchemy/src/Alchemist/Progress.ts
+++ b/packages/alchemy/src/Alchemist/Progress.ts
@@ -12,6 +12,9 @@ export {
   type ActionPlanned,
   type ApplyEvent,
   type NukeEvent,
+  type NukeScanStarted,
+  type NukeProviderScanStarted,
+  type NukePassStarted,
   type NukeProviderScanned,
   type NukeResourceDeleted,
   type NukeResourceFailed,
@@ -88,12 +91,30 @@ const spanEventOf = (
         name: `alchemy.${event._tag}`,
         attributes: { "alchemy.state_store.name": event.store },
       };
+    case "nuke.scan.started":
+      return {
+        name: "alchemy.nuke.scan.started",
+        attributes: { "alchemy.nuke.providers": event.total },
+      };
+    case "nuke.pass.started":
+      return {
+        name: "alchemy.nuke.pass.started",
+        attributes: { "alchemy.nuke.pass": event.pass },
+      };
+    case "nuke.scan.provider.started":
+      return {
+        name: "alchemy.nuke.scan.provider.started",
+        attributes: { "alchemy.provider": event.provider },
+      };
     case "nuke.scan.provider.completed":
       return {
         name: "alchemy.nuke.scan.provider.completed",
         attributes: {
           "alchemy.provider": event.provider,
           "alchemy.nuke.resources": event.resources,
+          ...(event.error === undefined
+            ? {}
+            : { "alchemy.nuke.message": event.error }),
         },
       };
     case "nuke.resource.deleted":

--- a/packages/alchemy/src/Alchemist/routes/nuke.ts
+++ b/packages/alchemy/src/Alchemist/routes/nuke.ts
@@ -7,6 +7,7 @@ import * as Option from "effect/Option";
 import { MinimumLogLevel } from "effect/References";
 import * as Nuke from "../../Nuke.ts";
 import type { ProviderMode } from "../../ProviderMode.ts";
+import type { ApplyStatus } from "../../Report.ts";
 import { Progress, withSpanEvents } from "../Progress.ts";
 import {
   buildStackProviders,
@@ -72,11 +73,15 @@ export const scan = Effect.fn("Alchemist.nuke.scan")(function* (
     exclude: input.exclude,
     concurrency: input.concurrency,
     timeoutSeconds: input.providerTimeoutSeconds,
-    onProvider: (provider, count) =>
+    onScan: (total) => report({ _tag: "nuke.scan.started", total }),
+    onProviderStarted: (provider) =>
+      report({ _tag: "nuke.scan.provider.started", provider }),
+    onProvider: (provider, count, error) =>
       report({
         _tag: "nuke.scan.provider.completed",
         provider,
         resources: count,
+        error,
       }),
   });
   return { mode: input.mode, resources, failures, context } satisfies NukeScan;
@@ -90,19 +95,52 @@ export const execute = Effect.fn("Alchemist.nuke.execute")(function* (
   input: ExecuteInput,
 ) {
   const report = withSpanEvents(yield* Progress);
+  const keys = new Map(
+    input.resources.map((resource, index) => [resource, `nuke/${index}`]),
+  );
+  const status = (
+    resource: Nuke.Target,
+    status: ApplyStatus,
+    message?: string,
+  ) =>
+    report({
+      _tag: "apply.resource.status",
+      fqn: keys.get(resource)!,
+      id: resource.providerId,
+      type: resource.providerId,
+      status,
+      message,
+    });
   return yield* Nuke.destroy({
     targets: input.resources,
     context: input.scan.context,
     strategy: input.strategy,
     concurrency: input.concurrency,
     timeoutSeconds: input.providerTimeoutSeconds,
+    onPass: (pass) => report({ _tag: "nuke.pass.started", pass }),
+    onDeleting: (resource) => status(resource, "deleting"),
+    onHeld: (resource, blockedBy) =>
+      status(resource, "skipped", `Held back by ${blockedBy.join(", ")}`),
     onDeleted: (resource) =>
-      report({ _tag: "nuke.resource.deleted", resource: resource.displayName }),
+      status(resource, "deleted").pipe(
+        Effect.andThen(
+          report({
+            _tag: "nuke.resource.deleted",
+            provider: resource.providerId,
+            resource: resource.displayName,
+          }),
+        ),
+      ),
     onFailed: (resource, message) =>
-      report({
-        _tag: "nuke.resource.failed",
-        resource: resource.displayName,
-        message,
-      }),
+      status(resource, "fail", message).pipe(
+        Effect.andThen(
+          report({
+            _tag: "nuke.resource.failed",
+            provider: resource.providerId,
+            resource: resource.displayName,
+            message,
+          }),
+        ),
+      ),
   });
 });

--- a/packages/alchemy/src/Cli/commands/nuke.ts
+++ b/packages/alchemy/src/Cli/commands/nuke.ts
@@ -4,13 +4,23 @@ import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 import { Command, Flag } from "effect/unstable/cli";
-import { Progress } from "../../Alchemist/Progress.ts";
 import * as Nuke from "../../Alchemist/routes/nuke.ts";
 import * as CliKit from "../../Cli/CliKit/index.ts";
 import { formatElapsed } from "../Format.ts";
-import { confirmOrDecline } from "./confirm.ts";
-import { UserInputError } from "./errors.ts";
-import { config, envFile, profile, yes } from "./flags.ts";
+import {
+  renderNukeScan,
+  renderNukeDelete,
+  reviewNuke,
+} from "../components/view/Nuke.tsx";
+import { exitDeclined, UserInputError } from "./errors.ts";
+import {
+  configPath,
+  envFile,
+  optionalConfig,
+  profile,
+  resolveConfig,
+  yes,
+} from "./flags.ts";
 import { instrumentCommand } from "./instrument.ts";
 
 const includeFlag = Flag.string("include").pipe(
@@ -26,10 +36,6 @@ const filterFlag = Flag.string("filter").pipe(
     "JavaScript expression evaluated with resource in scope; matching resources are excluded from deletion (repeatable)",
   ),
   Flag.atLeast(0),
-);
-const verboseFlag = Flag.boolean("verbose").pipe(
-  Flag.withDescription("List every individual resource"),
-  Flag.withDefault(false),
 );
 const concurrencyFlag = Flag.integer("concurrency").pipe(
   Flag.withDescription(
@@ -89,12 +95,12 @@ const compileFilter = (expression: string) =>
 const nukeCommand = Command.make(
   "nuke",
   {
-    main: config,
+    config: optionalConfig,
+    configPath,
     envFile,
     profile,
     yes,
     dryRun: dryRunFlag,
-    verbose: verboseFlag,
     concurrency: concurrencyFlag,
     timeout: timeoutFlag,
     independent: independentFlag,
@@ -104,121 +110,88 @@ const nukeCommand = Command.make(
     filter: filterFlag,
     local: localFlag,
   },
-  instrumentCommand(
-    "unsafe.nuke",
-    (args: { profile: string | undefined; main: string }) => ({
-      "alchemy.profile": args.profile ?? "",
-      "alchemy.main": args.main,
-    }),
-  )(
-    Effect.fn(function* (args) {
-      const scan = yield* Nuke.scan({
-        entrypoint: args.main,
-        profile: args.profile,
-        envFile: Option.getOrUndefined(args.envFile),
-        mode: args.local ? "local" : "live",
-        include: args.include,
-        exclude: args.exclude,
-        concurrency: args.concurrency,
-        providerTimeoutSeconds: Duration.toSeconds(args.timeout),
-      }).pipe(
-        // One line per provider as its listing settles — the scan fans out
-        // across every provider and is often the slowest part of a nuke.
-        Effect.provideService(Progress, (event) =>
-          event._tag === "nuke.scan.provider.completed"
-            ? Console.log(`scanned ${event.provider} (${event.resources})`)
-            : Effect.void,
-        ),
-      );
-      for (const item of scan.failures) {
-        yield* CliKit.accessors.output.warning(
-          `${item.provider}: ${item.message}`,
-        );
-      }
-
-      const predicates = yield* Effect.forEach(args.filter, compileFilter);
-      const targets: Array<(typeof scan.resources)[number]> = [];
-      for (const resource of scan.resources) {
-        const matches = yield* Effect.forEach(predicates, (predicate) =>
-          predicate({
-            ...resource.attributes,
-            Type: resource.providerId,
-            LogicalId: resource.displayName,
+  (args) =>
+    resolveConfig(args).pipe(
+      Effect.flatMap(
+        instrumentCommand(
+          "unsafe.nuke",
+          (args: { profile: string | undefined; main: string }) => ({
+            "alchemy.profile": args.profile ?? "",
+            "alchemy.main": args.main,
           }),
-        );
-        if (!matches.some(Boolean)) targets.push(resource);
-      }
-      const byProvider = new Map<string, typeof targets>();
-      for (const target of targets) {
-        byProvider.set(target.providerId, [
-          ...(byProvider.get(target.providerId) ?? []),
-          target,
-        ]);
-      }
-      yield* Console.log("");
-      for (const [providerId, resources] of [...byProvider.entries()].sort(
-        ([a], [b]) => a.localeCompare(b),
-      )) {
-        yield* Console.log(`${providerId}  ${resources.length} to delete`);
-        if (args.verbose) {
-          for (const resource of resources) {
-            yield* Console.log(`  - ${resource.displayName}`);
-          }
-        }
-      }
-      yield* Console.log("");
-      yield* Console.log(`${targets.length} resource(s) to delete.`);
-      if (targets.length === 0) {
-        yield* CliKit.accessors.output.info("Nothing to delete.");
-        return;
-      }
-      if (args.dryRun) {
-        yield* Console.log("Dry run complete: nothing was deleted.");
-        return;
-      }
-      yield* confirmOrDecline({
-        yes: args.yes,
-        message: `Permanently DELETE ${targets.length} ${args.local ? "locally emulated " : ""}resource(s)? This cannot be undone.`,
-        confirmLabel: "Delete",
-        cancelLabel: "Cancel",
-      });
-
-      const deleteStartedAt = yield* Clock.currentTimeMillis;
-      const result = yield* Nuke.execute({
-        scan,
-        resources: targets,
-        strategy: args.independent
-          ? { _tag: "independent", retries: args.retries }
-          : { _tag: "coordinated" },
-        concurrency: args.concurrency,
-        providerTimeoutSeconds: Duration.toSeconds(args.timeout),
-      }).pipe(
-        // One line per confirmed deletion — a long nuke was previously
-        // silent until the final summary in both renderers.
-        Effect.provideService(Progress, (event) =>
-          event._tag === "nuke.resource.deleted"
-            ? Console.log(`deleted ${event.resource}`)
-            : event._tag === "nuke.resource.failed"
-              ? Console.log(`failed ${event.resource}: ${event.message}`)
-              : Effect.void,
+        )(
+          Effect.fn(function* (args) {
+            const scan = yield* Nuke.scan({
+              entrypoint: args.main,
+              profile: args.profile,
+              envFile: Option.getOrUndefined(args.envFile),
+              mode: args.local ? "local" : "live",
+              include: args.include,
+              exclude: args.exclude,
+              concurrency: args.concurrency,
+              providerTimeoutSeconds: Duration.toSeconds(args.timeout),
+            }).pipe(renderNukeScan());
+            const predicates = yield* Effect.forEach(
+              args.filter,
+              compileFilter,
+            );
+            const targets: Array<(typeof scan.resources)[number]> = [];
+            for (const resource of scan.resources) {
+              const matches = yield* Effect.forEach(predicates, (predicate) =>
+                predicate({
+                  ...resource.attributes,
+                  Type: resource.providerId,
+                  LogicalId: resource.displayName,
+                }),
+              );
+              if (!matches.some(Boolean)) targets.push(resource);
+            }
+            if (targets.length === 0) {
+              yield* CliKit.accessors.output.info("Nothing to delete.");
+              return;
+            }
+            const approved = yield* reviewNuke(targets, {
+              mode: scan.mode,
+              yes: args.yes,
+              dryRun: args.dryRun,
+            });
+            if (!approved) {
+              yield* CliKit.accessors.output.info("Aborted.");
+              return yield* exitDeclined;
+            }
+            if (args.dryRun) {
+              yield* Console.log("Dry run complete: nothing was deleted.");
+              return;
+            }
+            const deleteStartedAt = yield* Clock.currentTimeMillis;
+            const result = yield* Nuke.execute({
+              scan,
+              resources: targets,
+              strategy: args.independent
+                ? { _tag: "independent", retries: args.retries }
+                : { _tag: "coordinated" },
+              concurrency: args.concurrency,
+              providerTimeoutSeconds: Duration.toSeconds(args.timeout),
+            }).pipe(renderNukeDelete(targets, scan.mode));
+            const deleteElapsed =
+              (yield* Clock.currentTimeMillis) - deleteStartedAt;
+            yield* CliKit.accessors.output.success(
+              `Deleted ${result.deleted.length} resource(s) over ${result.passes} pass(es) (${formatElapsed(deleteElapsed)}).`,
+            );
+            if (result.held.length > 0) {
+              yield* CliKit.accessors.output.warning(
+                `${result.held.length} resource(s) were held back.`,
+              );
+            }
+            if (result.failed.length > 0) {
+              yield* CliKit.accessors.output.error(
+                `${result.failed.length} resource(s) could not be deleted.`,
+              );
+            }
+          }),
         ),
-      );
-      const deleteElapsed = (yield* Clock.currentTimeMillis) - deleteStartedAt;
-      yield* CliKit.accessors.output.success(
-        `Deleted ${result.deleted.length} resource(s) over ${result.passes} pass(es) (${formatElapsed(deleteElapsed)}).`,
-      );
-      if (result.held.length > 0) {
-        yield* CliKit.accessors.output.warning(
-          `${result.held.length} resource(s) were held back.`,
-        );
-      }
-      if (result.failed.length > 0) {
-        yield* CliKit.accessors.output.error(
-          `${result.failed.length} resource(s) could not be deleted.`,
-        );
-      }
-    }),
-  ),
+      ),
+    ),
 ).pipe(
   Command.withDescription(
     "Enumerate resources across the stack providers and delete them",

--- a/packages/alchemy/src/Cli/commands/state.ts
+++ b/packages/alchemy/src/Cli/commands/state.ts
@@ -12,7 +12,8 @@ import {
   type StateExplorerSource,
 } from "../components/view/StateExplorer.tsx";
 import { failWithHelp, UserInputError } from "./errors.ts";
-import { envFile, profile } from "./flags.ts";
+import { envFile, profile, yes } from "./flags.ts";
+import { confirmOrDecline } from "./confirm.ts";
 import { instrumentCommand } from "./instrument.ts";
 
 const backend = Flag.choice("backend", [
@@ -241,6 +242,49 @@ const stateExplorer = (args: StateArgs) =>
       .pipe(Effect.catchTag("TerminalCancelled", () => Effect.void));
   });
 
+const nukeCommand = Command.make(
+  "nuke",
+  { main: config, envFile, profile, backend, yes },
+  instrumentCommand("state.unsafe.nuke")(
+    Effect.fn(function* ({ yes, ...args }) {
+      const store = yield* AlchemistState.store(source(args));
+      const stacks = [...(yield* store.listStacks())].sort();
+      if (stacks.length === 0) {
+        yield* CliKit.accessors.output.info("Nothing to clear.");
+        return;
+      }
+      yield* Console.log(stacks.map((stack) => `• ${stack}`).join("\n"));
+      yield* confirmOrDecline({
+        yes,
+        message: `Permanently delete ALL ${stacks.length} stacks from the state store? This cannot be undone. Cloud resources will remain.`,
+      });
+      yield* Effect.forEach(
+        stacks,
+        (stack) =>
+          store
+            .deleteStack({ stack })
+            .pipe(
+              Effect.andThen(
+                CliKit.accessors.output.success(`Cleared ${stack}`),
+              ),
+            ),
+        { concurrency: 32, discard: true },
+      );
+    }),
+  ),
+).pipe(
+  Command.withDescription(
+    "Delete all stacks, stages, and outputs from the state store",
+  ),
+  Command.unlisted,
+);
+
+const unsafeCommand = Command.make("unsafe", {}).pipe(
+  Command.withDescription("Destructive state operations"),
+  Command.withSubcommands([nukeCommand]),
+  Command.unlisted,
+);
+
 export const stateCommand = Command.make(
   "state",
   { main: config, envFile, profile, backend },
@@ -254,5 +298,10 @@ export const stateCommand = Command.make(
   ),
 ).pipe(
   Command.withDescription("Inspect and manage deployment state"),
-  Command.withSubcommands([listCommand, readCommand, deleteCommand]),
+  Command.withSubcommands([
+    listCommand,
+    readCommand,
+    deleteCommand,
+    unsafeCommand,
+  ]),
 );

--- a/packages/alchemy/src/Cli/components/ui/Feedback.tsx
+++ b/packages/alchemy/src/Cli/components/ui/Feedback.tsx
@@ -202,50 +202,6 @@ export function Spinner({ label, detail }: SpinnerProps) {
   );
 }
 
-type ProgressBarProps = {
-  /** Completion ratio. Values outside 0..1 are clamped. */
-  readonly value: number;
-  readonly width?: number;
-  readonly showPercent?: boolean;
-  readonly label?: ReactNode;
-  readonly detail?: ReactNode;
-  readonly variant?: StatusVariant;
-};
-
-export function ProgressBar({
-  value,
-  width = 24,
-  showPercent = true,
-  label,
-  detail,
-  variant = "success",
-}: ProgressBarProps) {
-  const { unicode } = useCliEnvironment();
-  const ratio = Math.max(0, Math.min(1, value));
-  const cells = Math.max(1, Math.floor(width));
-  const filled = Math.round(cells * ratio);
-  return (
-    <Box
-      gap={1}
-      aria-role="progressbar"
-      aria-label={`${Math.round(ratio * 100)}%`}
-      aria-state={{ busy: ratio < 1 }}
-    >
-      <Text>
-        <Text color={statusPaint(variant)}>
-          {(unicode ? "█" : "#").repeat(filled)}
-        </Text>
-        <Text tone="muted">{(unicode ? "░" : ".").repeat(cells - filled)}</Text>
-      </Text>
-      {showPercent ? (
-        <Text tone="muted">{`${Math.round(ratio * 100)}%`.padStart(4)}</Text>
-      ) : null}
-      {label === undefined ? null : <Text>{label}</Text>}
-      {detail === undefined ? null : <Text tone="muted">{detail}</Text>}
-    </Box>
-  );
-}
-
 type TabsProps = {
   readonly tabs: ReadonlyArray<{
     readonly id: string;

--- a/packages/alchemy/src/Cli/components/ui/Live.tsx
+++ b/packages/alchemy/src/Cli/components/ui/Live.tsx
@@ -2,7 +2,8 @@
 import type { ReactNode } from "react";
 import { useSyncExternalStore } from "react";
 import { useGlyphs } from "./Environment.tsx";
-import { ProgressBar, SpinnerGlyph } from "./Feedback.tsx";
+import { SpinnerGlyph } from "./Feedback.tsx";
+import { ProgressBar } from "./ProgressBar.tsx";
 import { Box, Row, Stack } from "./Layout.tsx";
 import { Text } from "./Typography.tsx";
 import { theme } from "../../../Util/Theme.ts";

--- a/packages/alchemy/src/Cli/components/ui/ProgressBar.tsx
+++ b/packages/alchemy/src/Cli/components/ui/ProgressBar.tsx
@@ -1,0 +1,57 @@
+/** @jsxImportSource react */
+import type { ReactNode } from "react";
+import { statusPaint, type StatusVariant } from "../../../Util/Theme.ts";
+import { useCliEnvironment } from "./Environment.tsx";
+import { Box } from "./Layout.tsx";
+import { Text } from "./Typography.tsx";
+
+export interface ProgressBarProps {
+  /** Completion ratio. Values outside 0..1 are clamped. */
+  readonly value: number;
+  /** Width in terminal cells (default: 24). */
+  readonly width?: number;
+  readonly showPercent?: boolean;
+  readonly label?: ReactNode;
+  readonly detail?: ReactNode;
+  readonly variant?: StatusVariant;
+}
+
+/** Left-to-right progress using half/full Braille cells and an ASCII fallback. */
+export function ProgressBar({
+  value,
+  width = 24,
+  showPercent = true,
+  label,
+  detail,
+  variant = "success",
+}: ProgressBarProps) {
+  const { unicode } = useCliEnvironment();
+  const ratio = Math.max(0, Math.min(1, value));
+  const cells = Math.max(1, Math.floor(width));
+  const steps = Math.floor(cells * ratio * (unicode ? 2 : 1));
+  const filled = unicode ? Math.floor(steps / 2) : steps;
+  const partial = unicode && steps % 2 !== 0 ? "⡇" : "";
+  const remaining = cells - filled - (partial === "" ? 0 : 1);
+  return (
+    <Box
+      gap={1}
+      aria-role="progressbar"
+      aria-label={`${Math.round(ratio * 100)}%`}
+      aria-state={{ busy: ratio < 1 }}
+    >
+      <Text>
+        <Text tone="muted">[</Text>
+        <Text color={statusPaint(variant)}>
+          {(unicode ? "⣿" : "#").repeat(filled)}
+          {partial}
+        </Text>
+        <Text tone="muted">{(unicode ? " " : ".").repeat(remaining)}]</Text>
+      </Text>
+      {showPercent ? (
+        <Text tone="muted">{`${Math.round(ratio * 100)}%`.padStart(4)}</Text>
+      ) : null}
+      {label === undefined ? null : <Text>{label}</Text>}
+      {detail === undefined ? null : <Text tone="muted">{detail}</Text>}
+    </Box>
+  );
+}

--- a/packages/alchemy/src/Cli/components/ui/index.ts
+++ b/packages/alchemy/src/Cli/components/ui/index.ts
@@ -27,7 +27,6 @@ export { Link, Text, type TextProps, type TextTone } from "./Typography.tsx";
 export {
   Alert,
   KeyBar,
-  ProgressBar,
   Spinner,
   SpinnerGlyph,
   Status,
@@ -63,3 +62,5 @@ export {
   type ProgressGroupRow,
   type TaskRowProps,
 } from "./Live.tsx";
+
+export { ProgressBar, type ProgressBarProps } from "./ProgressBar.tsx";

--- a/packages/alchemy/src/Cli/components/view/Nuke.tsx
+++ b/packages/alchemy/src/Cli/components/view/Nuke.tsx
@@ -1,0 +1,258 @@
+/** @jsxImportSource react */
+import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import type { Result as NukeResult, Target } from "../../../Nuke.ts";
+import type { ProviderMode } from "../../../ProviderMode.ts";
+import { Plan, PlanTree } from "./PlanView.tsx";
+import type { PlanTreeData } from "./PlanTree.ts";
+import { planDecisionScreen } from "./PlanDecision.tsx";
+import { Progress, type ProgressEvent } from "../../../Report.ts";
+import { CliKit } from "../../CliKit/index.ts";
+import {
+  LiveStore,
+  ProgressBar,
+  Row,
+  SpinnerGlyph,
+  Stack,
+  Text,
+  useLiveStore,
+} from "../ui/index.ts";
+
+interface NukeProgressState {
+  readonly total: number;
+  readonly completed: number;
+  readonly resources: number;
+  readonly inFlight: ReadonlyArray<string>;
+}
+
+export class NukeProgressStore extends LiveStore<NukeProgressState> {
+  constructor() {
+    super({ total: 0, completed: 0, resources: 0, inFlight: [] });
+  }
+
+  emit(event: ProgressEvent) {
+    this.update((state) => {
+      switch (event._tag) {
+        case "nuke.scan.started":
+          return { ...state, total: event.total };
+        case "nuke.scan.provider.started":
+          return { ...state, inFlight: [...state.inFlight, event.provider] };
+        case "nuke.scan.provider.completed":
+          return {
+            ...state,
+            completed: state.completed + 1,
+            resources: state.resources + event.resources,
+            inFlight: state.inFlight.filter((id) => id !== event.provider),
+          };
+        default:
+          return state;
+      }
+    });
+  }
+}
+
+export function NukeProgress({ store }: { store: NukeProgressStore }) {
+  const state = useLiveStore(store);
+  return (
+    <Stack paddingX={2} paddingY={1} gap={1}>
+      <Row gap={2}>
+        <ProgressBar
+          value={state.total === 0 ? 0 : state.completed / state.total}
+          width={32}
+          showPercent={false}
+          variant="info"
+        />
+        <Text bold>
+          [{state.completed}/{state.total}]
+        </Text>
+      </Row>
+      <Stack>
+        <Text tone="muted">
+          Scanning providers · {state.resources} resource
+          {state.resources === 1 ? "" : "s"} found
+        </Text>
+        {state.inFlight.slice(0, 10).map((id) => (
+          <Row key={id} gap={1}>
+            <SpinnerGlyph />
+            <Text>Scanning {id}</Text>
+          </Row>
+        ))}
+        {state.inFlight.length > 10 ? (
+          <Text tone="muted">…and {state.inFlight.length - 10} more</Text>
+        ) : null}
+        {state.total === 0 ? (
+          <Row gap={1}>
+            <SpinnerGlyph />
+            <Text>Discovering providers</Text>
+          </Row>
+        ) : null}
+      </Stack>
+    </Stack>
+  );
+}
+
+const logNukeEvent = (event: ProgressEvent, interactive: boolean) => {
+  if (event._tag === "nuke.scan.provider.completed") {
+    if (event.error !== undefined)
+      return Effect.logWarning(`${event.provider}: ${event.error}`);
+    if (!interactive)
+      return Effect.logInfo(`scanned ${event.provider} (${event.resources})`);
+  } else if (event._tag === "nuke.resource.failed") {
+    return Effect.logWarning(
+      `${event.provider} ${event.resource}: ${event.message}`,
+    );
+  } else if (!interactive && event._tag === "nuke.resource.deleted") {
+    return Effect.logInfo(`deleted ${event.provider} ${event.resource}`);
+  }
+  return Effect.void;
+};
+
+/** Scan progress stays separate until the inventory is ready to review. */
+export const renderNukeScan =
+  () =>
+  <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+    Effect.gen(function* () {
+      const cli = yield* CliKit;
+      const store = new NukeProgressStore();
+      const live =
+        cli.terminal.input && !process.env.DEBUG
+          ? yield* cli.live.open(<NukeProgress store={store} />)
+          : undefined;
+      return yield* effect.pipe(
+        Effect.provideService(Progress, (event) =>
+          Effect.gen(function* () {
+            if (live) store.emit(event);
+            yield* logNukeEvent(event, live !== undefined);
+          }),
+        ),
+        Effect.ensuring(live?.close ?? Effect.void),
+      );
+    });
+
+/** Drive the same resource rows used by the preview through their deletion lifecycle. */
+export const renderNukeDelete =
+  (
+    targets: ReadonlyArray<Pick<Target, "providerId" | "displayName">>,
+    mode: ProviderMode,
+  ) =>
+  <A extends NukeResult, E, R>(effect: Effect.Effect<A, E, R>) =>
+    Effect.gen(function* () {
+      const cli = yield* CliKit;
+      const tree = new PlanTree(nukePlan(targets, { mode }), {
+        mode: "apply",
+        label: "Deleting resources",
+        busy: true,
+      });
+      const live =
+        cli.terminal.input && !process.env.DEBUG
+          ? yield* cli.live.open(<Plan tree={tree} />, { persistOnClose: true })
+          : undefined;
+      return yield* effect.pipe(
+        Effect.provideService(Progress, (event) =>
+          Effect.gen(function* () {
+            if (
+              event._tag === "apply.resource.status" ||
+              event._tag === "apply.resource.note"
+            )
+              tree.emit(event);
+            else if (event._tag === "nuke.pass.started")
+              tree.setLabel(`Deleting resources · pass ${event.pass}`);
+            yield* logNukeEvent(event, live !== undefined);
+          }),
+        ),
+        Effect.onExit((exit) =>
+          Effect.sync(() => {
+            const success =
+              Exit.isSuccess(exit) &&
+              exit.value.failed.length === 0 &&
+              exit.value.held.length === 0;
+            tree.finish(
+              success ? "success" : "failure",
+              success ? "Nuke complete" : "Nuke incomplete",
+            );
+            tree.setViewport("full");
+          }),
+        ),
+        Effect.ensuring(live?.close ?? Effect.void),
+      );
+    });
+
+/** Cloud inventory rows carry display identity only, never fabricated stack state. */
+export const nukePlan = (
+  targets: ReadonlyArray<Pick<Target, "providerId" | "displayName">>,
+  options: { mode: ProviderMode },
+): PlanTreeData => {
+  return {
+    defaultMode: options.mode,
+    rows: targets
+      .map((target, index) => ({
+        key: `nuke/${index}`,
+        type: "resource" as const,
+        id: target.providerId,
+        resourceType: target.providerId,
+        detail:
+          target.displayName && target.displayName !== "unknown"
+            ? target.displayName
+            : undefined,
+        depth: 0,
+        action: "delete" as const,
+        providerMode: options.mode,
+      }))
+      .sort(
+        (a, b) =>
+          a.id.localeCompare(b.id) ||
+          (a.detail ?? "").localeCompare(b.detail ?? ""),
+      ),
+    summary: {
+      counts: {
+        create: 0,
+        update: 0,
+        adopted: 0,
+        delete: targets.length,
+        orphaned: 0,
+        replace: 0,
+        noop: 0,
+      },
+      taskCounts: { run: 0, delete: 0, noop: 0 },
+      bindingChanges: 0,
+    },
+  };
+};
+
+export const reviewNuke = Effect.fn(function* (
+  targets: ReadonlyArray<Pick<Target, "providerId" | "displayName">>,
+  options: {
+    mode: ProviderMode;
+    yes: boolean;
+    dryRun: boolean;
+  },
+) {
+  const cli = yield* CliKit;
+  const plan = nukePlan(targets, options);
+  if (options.yes || options.dryRun) {
+    yield* cli.output.print(
+      <Plan
+        tree={
+          new PlanTree(plan, {
+            mode: "review",
+            label: "Nuke",
+            viewport: "full",
+          })
+        }
+      />,
+    );
+    return true;
+  }
+  return yield* cli.prompt.custom(
+    planDecisionScreen({
+      plan,
+      label: "Nuke",
+      message: `Permanently DELETE ${targets.length} ${options.mode === "local" ? "locally emulated " : ""}resource(s)? This cannot be undone.`,
+      choices: [
+        { value: true, label: "Delete" },
+        { value: false, label: "Cancel" },
+      ],
+      initialValue: false,
+    }),
+  );
+});

--- a/packages/alchemy/src/Cli/components/view/PlanDecision.tsx
+++ b/packages/alchemy/src/Cli/components/view/PlanDecision.tsx
@@ -9,6 +9,7 @@ import {
 } from "../ui/index.ts";
 import { Screen, type ScreenController } from "../../CliKit/index.ts";
 import { Plan as PlanComponent, PlanTree } from "./PlanView.tsx";
+import type { PlanTreeData } from "./PlanTree.ts";
 
 export interface PlanDecisionChoice<Value> {
   readonly value: Value;
@@ -16,7 +17,7 @@ export interface PlanDecisionChoice<Value> {
 }
 
 function PlanDecision<Value>(props: {
-  readonly plan: Plan;
+  readonly plan: Plan | PlanTreeData;
   readonly label?: string;
   readonly message: string;
   readonly choices: ReadonlyArray<PlanDecisionChoice<Value>>;
@@ -68,7 +69,7 @@ function PlanDecision<Value>(props: {
 }
 
 export const planDecisionScreen = <Value,>(options: {
-  readonly plan: Plan;
+  readonly plan: Plan | PlanTreeData;
   readonly label?: string;
   readonly message: string;
   readonly choices: ReadonlyArray<PlanDecisionChoice<Value>>;

--- a/packages/alchemy/src/Cli/components/view/PlanTree.ts
+++ b/packages/alchemy/src/Cli/components/view/PlanTree.ts
@@ -29,6 +29,8 @@ export type PlanRow =
       type: "resource";
       id: string;
       resourceType: string;
+      /** Secondary identity for inventories without logical resource names. */
+      detail?: string;
       depth: number;
       action: CRUD["action"];
       persistedApplyStatus?: "created" | "updated";
@@ -110,6 +112,13 @@ export interface PlanTreeOptions {
    * @default true
    */
   readonly expanded?: boolean;
+}
+
+/** Display-only plans, such as cloud inventories, need no engine state or providers. */
+export interface PlanTreeData {
+  readonly rows: readonly PlanRow[];
+  readonly summary: PlanSummaryCounts;
+  readonly defaultMode?: ProviderMode;
 }
 
 const getRowKey = (item: FlattenedItem) => item.path.join("/");
@@ -219,19 +228,18 @@ export class PlanTree {
   readonly mode: "review" | "apply";
   readonly detailed: boolean;
   readonly titleDetail?: string;
+  readonly defaultMode?: ProviderMode;
   private state: PlanTreeState;
   private readonly listeners = new Set<() => void>();
 
-  constructor(
-    readonly plan: Plan,
-    options: PlanTreeOptions = {},
-  ) {
+  constructor(plan: Plan | PlanTreeData, options: PlanTreeOptions = {}) {
     this.detailed = options.detailed ?? false;
     this.mode = options.mode ?? "review";
     this.titleDetail = options.titleDetail;
-    this.rows = buildRows(plan, this.detailed);
+    this.defaultMode = plan.defaultMode;
+    this.rows = "rows" in plan ? plan.rows : buildRows(plan, this.detailed);
     this.progressRows = this.rows.filter(isProgressRow);
-    this.summary = buildPlanSummary(plan);
+    this.summary = "rows" in plan ? plan.summary : buildPlanSummary(plan);
     this.state = {
       tasks: buildInitialTasks(this.rows),
       label: options.label ?? "Plan",
@@ -270,6 +278,10 @@ export class PlanTree {
 
   setExpanded(expanded: boolean) {
     this.update({ expanded });
+  }
+
+  setLabel(label: string) {
+    this.update({ label });
   }
 
   setViewport(viewport: PlanViewport) {

--- a/packages/alchemy/src/Cli/components/view/PlanView.tsx
+++ b/packages/alchemy/src/Cli/components/view/PlanView.tsx
@@ -298,7 +298,7 @@ function PlanContent(props: {
             state={state.tasks.get(
               row.type === "binding" ? row.hostKey : row.key,
             )}
-            defaultMode={tree.plan.defaultMode}
+            defaultMode={tree.defaultMode}
           />
         ))
       ) : (
@@ -313,7 +313,7 @@ function PlanContent(props: {
               state={state.tasks.get(
                 line.row.type === "binding" ? line.row.hostKey : line.row.key,
               )}
-              defaultMode={tree.plan.defaultMode}
+              defaultMode={tree.defaultMode}
             />
           ) : line.kind === "yaml" ? (
             <YamlLine
@@ -500,9 +500,12 @@ function PlanRowView(props: {
             </Text>
           }
           depth={row.depth}
+          detail={row.detail}
         >
           {modeNote && <Text tone="muted">({modeNote})</Text>}
-          <Text tone="muted">({row.resourceType})</Text>
+          {row.id !== row.resourceType ? (
+            <Text tone="muted">({row.resourceType})</Text>
+          ) : null}
         </TaskRow>
         {yaml}
       </Box>
@@ -534,8 +537,11 @@ function PlanRowView(props: {
               <Text tone="muted">{row.id}</Text>
             ) : (
               row.id
-            )}{" "}
-            <Text tone="muted">({row.resourceType})</Text>
+            )}
+            {row.id !== row.resourceType ? (
+              <Text tone="muted"> ({row.resourceType})</Text>
+            ) : null}
+            {row.detail ? <Text tone="muted"> · {row.detail}</Text> : null}
           </>
         }
         detail={rowDetail(rowState.status, rowState.message)}

--- a/packages/alchemy/src/Nuke.ts
+++ b/packages/alchemy/src/Nuke.ts
@@ -1,6 +1,7 @@
 import * as Context from "effect/Context";
 import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
+import * as Formatter from "effect/Formatter";
 import * as Schedule from "effect/Schedule";
 import picomatch from "picomatch";
 import {
@@ -44,6 +45,10 @@ export interface ListOptions extends DiscoverOptions {
   readonly context: Context.Context<never>;
   readonly concurrency?: number | "unbounded";
   readonly timeoutSeconds?: number;
+  /** Called once with the selected provider count before enumeration starts. */
+  readonly onScan?: (total: number) => Effect.Effect<void>;
+  /** Called when a provider starts resolving/listing, to identify slow scans. */
+  readonly onProviderStarted?: (provider: string) => Effect.Effect<void>;
   /**
    * Called as each provider's listing settles (0 resources when it failed),
    * for progress reporting — scans across many providers are the slowest
@@ -52,6 +57,7 @@ export interface ListOptions extends DiscoverOptions {
   readonly onProvider?: (
     provider: string,
     resources: number,
+    error?: string,
   ) => Effect.Effect<void>;
 }
 
@@ -67,6 +73,15 @@ export interface DestroyOptions {
   readonly strategy: Strategy;
   readonly concurrency?: number | "unbounded";
   readonly timeoutSeconds?: number;
+  /** Called before each coordinated pass, or once for independent deletion. */
+  readonly onPass?: (pass: number) => Effect.Effect<void>;
+  /** Called before each deletion attempt. */
+  readonly onDeleting?: (resource: Target) => Effect.Effect<void>;
+  /** Called when dependency failures prevent a resource from being attempted. */
+  readonly onHeld?: (
+    resource: Target,
+    blockedBy: ReadonlyArray<string>,
+  ) => Effect.Effect<void>;
   /** Called as each object is confirmed gone, for progress reporting. */
   readonly onDeleted?: (resource: Target) => Effect.Effect<void>;
   /** Called as a deletion attempt fails permanently (the run keeps going). */
@@ -100,7 +115,11 @@ const failure = (
   provider: string,
   operation: ProviderFailure["operation"],
   cause: unknown,
-): ProviderFailure => ({ provider, operation, message: String(cause) });
+): ProviderFailure => ({
+  provider,
+  operation,
+  message: typeof cause === "string" ? cause : Formatter.format(cause),
+});
 
 /** Deletions here run out-of-band, so nothing reports through an apply session. */
 const silent = {
@@ -198,10 +217,13 @@ export const list = (
   Effect.gen(function* () {
     const failures: ProviderFailure[] = [];
     const resources: Target[] = [];
+    const providers = discover(options.context, options);
+    yield* options.onScan?.(providers.length) ?? Effect.void;
     yield* Effect.forEach(
-      discover(options.context, options),
+      providers,
       ({ id, resolve }) =>
         Effect.gen(function* () {
+          yield* options.onProviderStarted?.(id) ?? Effect.void;
           const result = yield* Effect.result(
             Effect.gen(function* () {
               const provider = yield* resolve;
@@ -216,8 +238,9 @@ export const list = (
             }).pipe(Effect.provide(options.context)),
           );
           if (result._tag === "Failure") {
-            failures.push(failure(id, "list", result.failure));
-            yield* options.onProvider?.(id, 0) ?? Effect.void;
+            const error = failure(id, "list", result.failure);
+            failures.push(error);
+            yield* options.onProvider?.(id, 0, error.message) ?? Effect.void;
             return;
           }
           for (const raw of result.success.listed) {
@@ -248,6 +271,9 @@ export const destroy = ({
   timeoutSeconds = 120,
   onDeleted = () => Effect.void,
   onFailed = () => Effect.void,
+  onPass = () => Effect.void,
+  onDeleting = () => Effect.void,
+  onHeld = () => Effect.void,
 }: DestroyOptions): Effect.Effect<Result> =>
   Effect.gen(function* () {
     const deleted: Target[] = [];
@@ -257,24 +283,28 @@ export const destroy = ({
     // Account-wide scans have no state rows: delete must derive identity from
     // `output` alone — `olds` just mirrors it and `instanceId` is unavailable.
     const attempt = (resource: Target) =>
-      resource.provider
-        .delete({
-          id: resource.displayName,
-          fqn: resource.displayName,
-          instanceId: "",
-          olds: resource.attributes as never,
-          output: resource.attributes as never,
-          session: silent,
-          bindings: [],
-          force: true,
-        })
-        .pipe(
-          Effect.timeout(Duration.seconds(timeoutSeconds)),
-          Effect.provide(context),
-        );
+      Effect.gen(function* () {
+        yield* onDeleting(resource);
+        return yield* resource.provider
+          .delete({
+            id: resource.displayName,
+            fqn: resource.displayName,
+            instanceId: "",
+            olds: resource.attributes as never,
+            output: resource.attributes as never,
+            session: silent,
+            bindings: [],
+            force: true,
+          })
+          .pipe(
+            Effect.timeout(Duration.seconds(timeoutSeconds)),
+            Effect.provide(context),
+          );
+      });
 
     if (strategy._tag === "independent") {
       passes = 1;
+      yield* onPass(passes);
       yield* Effect.forEach(
         targets,
         (resource) =>
@@ -364,6 +394,9 @@ export const destroy = ({
           );
           if (blockers.length > 0) {
             heldTypes.add(typeId);
+            yield* Effect.forEach(resources, (resource) =>
+              onHeld(resource, blockers),
+            );
             held.push(
               ...resources.map((resource) => ({
                 resource,
@@ -375,27 +408,31 @@ export const destroy = ({
         let remaining = runnable;
         while (remaining.length > 0) {
           passes += 1;
+          yield* onPass(passes);
           const results = yield* Effect.forEach(
             remaining,
             (resource) =>
-              Effect.result(attempt(resource)).pipe(
-                Effect.map((result) => ({ resource, result })),
-              ),
+              Effect.gen(function* () {
+                const result = yield* Effect.result(attempt(resource));
+                if (result._tag === "Success") {
+                  deleted.push(resource);
+                  yield* onDeleted(resource);
+                }
+                return { resource, result };
+              }),
             { concurrency: concurrency },
           );
           const next: Target[] = [];
           for (const { resource, result } of results) {
-            if (result._tag === "Success") {
-              deleted.push(resource);
-              yield* onDeleted(resource);
-            } else next.push(resource);
+            if (result._tag === "Failure") next.push(resource);
           }
           if (next.length === remaining.length) {
-            for (const resource of next) {
+            for (const { resource, result } of results) {
+              if (result._tag !== "Failure") continue;
               const why = failure(
                 resource.providerId,
                 "delete",
-                "no progress after coordinated pass",
+                result.failure,
               );
               failed.push({ resource, failure: why });
               yield* onFailed(resource, why.message);

--- a/packages/alchemy/src/Report.ts
+++ b/packages/alchemy/src/Report.ts
@@ -189,16 +189,34 @@ export interface StateBootstrapCompleted {
 
 export type StateEvent = StateBootstrapStarted | StateBootstrapCompleted;
 
+export interface NukeScanStarted {
+  readonly _tag: "nuke.scan.started";
+  readonly total: number;
+}
+
+export interface NukeProviderScanStarted {
+  readonly _tag: "nuke.scan.provider.started";
+  readonly provider: string;
+}
+
+export interface NukePassStarted {
+  readonly _tag: "nuke.pass.started";
+  readonly pass: number;
+}
+
 /** Emitted as a nuke scan finishes enumerating one provider's resources. */
 export interface NukeProviderScanned {
   readonly _tag: "nuke.scan.provider.completed";
   readonly provider: string;
   /** Resources found for this provider (0 when the listing failed). */
   readonly resources: number;
+  /** Listing failure, reported immediately when this provider settles. */
+  readonly error?: string;
 }
 
 export interface NukeResourceDeleted {
   readonly _tag: "nuke.resource.deleted";
+  readonly provider: string;
   /** Display name of the deleted resource. */
   readonly resource: string;
 }
@@ -206,11 +224,15 @@ export interface NukeResourceDeleted {
 /** Emitted when a nuke deletion attempt fails (the run keeps going). */
 export interface NukeResourceFailed {
   readonly _tag: "nuke.resource.failed";
+  readonly provider: string;
   readonly resource: string;
   readonly message: string;
 }
 
 export type NukeEvent =
+  | NukeScanStarted
+  | NukeProviderScanStarted
+  | NukePassStarted
   | NukeProviderScanned
   | NukeResourceDeleted
   | NukeResourceFailed;

--- a/packages/alchemy/test/Cli/CliKit.test.tsx
+++ b/packages/alchemy/test/Cli/CliKit.test.tsx
@@ -104,8 +104,19 @@ class InputStream extends PassThrough {
 
   setRawMode(mode: boolean) {
     this.isRaw = mode;
-    if (mode) this.resolveReady?.();
     return this;
+  }
+
+  connect(stdout: CaptureStream) {
+    stdout.on("data", (chunk) => {
+      if (!chunk.toString().includes("\x1b[c")) return;
+      // Raw mode starts before Sigil finishes querying the terminal. Answer
+      // its device query, then allow input handlers to attach before typing.
+      setImmediate(() => {
+        this.write("\x1b[?1;2c");
+        setImmediate(() => this.resolveReady?.());
+      });
+    });
   }
 
   ref() {
@@ -765,6 +776,7 @@ const makeLive = (
       // process.stdin pipe Sigil's useInput throws during commit, which now
       // surfaces as a renderer error instead of being silently swallowed.
       const stdin = overrides.stdin ?? (input ? new InputStream() : undefined);
+      stdin?.connect(stdout);
       const runtime = makeRuntime(
         {
           input,
@@ -2348,11 +2360,7 @@ it.live("defaults nuke plan approval to Cancel", () =>
         Effect.flatMap(() => Effect.die("review ended before prompt")),
       ),
     );
-    // Answer Sigil's startup device query before sending the confirmation key.
-    yield* Effect.promise(() => stdout.waitFor("\x1b[c"));
-    yield* Effect.sync(() => stdin.write("\x1b[?1;2c"));
-    yield* Effect.promise(flushEffects);
-    yield* settleInput;
+    yield* Effect.promise(() => stdin.ready);
     expect(stdout.output).toContain("1 to delete");
     expect(stdout.output).toContain("locally emulated");
     yield* Effect.sync(() => stdin.write("\r"));

--- a/packages/alchemy/test/Cli/CliKit.test.tsx
+++ b/packages/alchemy/test/Cli/CliKit.test.tsx
@@ -19,6 +19,7 @@ import {
   LiveStore,
   PromptFrame,
   ProgressGroup,
+  ProgressBar,
   SectionHeading,
   Status,
   Toast,
@@ -31,7 +32,15 @@ import {
 import { tabsWindow } from "@/Cli/components/ui/Layout.tsx";
 import { makeRuntime } from "@/Cli/components/view/Runtime.tsx";
 import { sigilCli } from "@/Cli/components/view/SigilCli.tsx";
-import { Cli } from "@/Report.ts";
+import { Cli, Progress } from "@/Report.ts";
+import {
+  NukeProgress,
+  NukeProgressStore,
+  nukePlan,
+  reviewNuke,
+  renderNukeDelete,
+  renderNukeScan,
+} from "@/Cli/components/view/Nuke.tsx";
 import { renderApply } from "@/Cli/commands/render.ts";
 import { isInProgress } from "@/Cli/components/view/statusStyle.ts";
 import { spinnerFramesFor } from "@/Util/Theme.ts";
@@ -50,6 +59,9 @@ import {
   type StateExplorerSource,
 } from "@/Cli/components/view/StateExplorer.tsx";
 import * as Effect from "effect/Effect";
+import * as Context from "effect/Context";
+import * as NukeRoute from "@/Alchemist/routes/nuke.ts";
+import type { ProviderService } from "@/Provider.ts";
 import * as Exit from "effect/Exit";
 import * as Fiber from "effect/Fiber";
 import * as Layer from "effect/Layer";
@@ -2068,5 +2080,368 @@ it.live(
       expect(after).toContain("app/prod/Api/Worker");
       yield* press("q");
       yield* Fiber.join(fiber);
+    }),
+);
+
+it.effect("renders nuke scan counts and outstanding providers", () =>
+  Effect.gen(function* () {
+    const { service } = makeStatic();
+    const store = new NukeProgressStore();
+    store.emit({ _tag: "nuke.scan.started", total: 2 });
+    store.emit({ _tag: "nuke.scan.provider.started", provider: "Test.Fast" });
+    store.emit({ _tag: "nuke.scan.provider.started", provider: "Test.Slow" });
+    store.emit({
+      _tag: "nuke.scan.provider.completed",
+      provider: "Test.Fast",
+      resources: 3,
+    });
+    const output = yield* service.output.render(<NukeProgress store={store} />);
+    expect(output).toContain("1/2");
+    expect(output).toContain("3 resources found");
+    expect(output).toContain("Scanning Test.Slow");
+    const lines = output.split("\n");
+    const header = lines.findIndex((line) => line.includes("1/2"));
+    expect(lines[header]).toMatch(/^  \[[⣿⡇ ]+\] {2}\[1\/2\]\s*$/);
+    expect(lines[header + 1]?.trim()).toBe("");
+    expect(lines[header + 2]).toContain("Scanning providers");
+    expect(output).not.toContain("Scanning Test.Fast");
+  }),
+);
+
+it.effect("updates individual nuke plan rows during deletion", () =>
+  Effect.gen(function* () {
+    const { service } = makeStatic();
+    const tree = new PlanTree(
+      nukePlan(
+        [
+          { providerId: "Test.B", displayName: "same-name" },
+          { providerId: "Test.A", displayName: "same-name" },
+          { providerId: "Test.A", displayName: "same-name" },
+        ],
+        { mode: "live" },
+      ),
+      { mode: "apply", viewport: "full", busy: true },
+    );
+    tree.setLabel("Deleting resources · pass 2");
+    tree.emit({
+      _tag: "apply.resource.status",
+      fqn: "nuke/2",
+      id: "Test.A",
+      type: "Test.A",
+      status: "deleted",
+    });
+    tree.emit({
+      _tag: "apply.resource.status",
+      fqn: "nuke/1",
+      id: "Test.A",
+      type: "Test.A",
+      status: "fail",
+      message: "blocked",
+    });
+    tree.emit({
+      _tag: "apply.resource.status",
+      fqn: "nuke/0",
+      id: "Test.B",
+      type: "Test.B",
+      status: "deleting",
+    });
+    expect(tree.snapshot().tasks.get("nuke/2")?.status).toBe("deleted");
+    expect(tree.snapshot().tasks.get("nuke/1")?.status).toBe("fail");
+    expect(tree.progress()).toEqual({ completed: 2, total: 3, failures: 1 });
+    const output = yield* service.output.render(<Plan tree={tree} />);
+    expect(output).toContain("pass 2");
+    expect(output).toContain("blocked");
+    expect(output.match(/same-name/g)).toHaveLength(3);
+    expect(output).not.toContain("(Test.A)");
+  }),
+);
+
+it.effect("renders nuke execution outcomes in the shared plan", () =>
+  Effect.gen(function* () {
+    const { service, stdout } = yield* makeLive();
+    const provider: ProviderService = {
+      nuke: { dependsOn: ["Test.Parent"] },
+      list: () => Effect.succeed([]),
+      reconcile: () => Effect.succeed({}),
+      delete: () => Effect.void,
+    };
+    const resources = [
+      {
+        providerId: "Test.Parent",
+        displayName: "parent",
+        attributes: {},
+        provider: { ...provider, nuke: undefined },
+      },
+      {
+        providerId: "Test.Child",
+        displayName: "same-name",
+        attributes: {},
+        provider: {
+          ...provider,
+          delete: () => Effect.fail("cannot delete child"),
+        },
+      },
+      {
+        providerId: "Test.Child",
+        displayName: "same-name",
+        attributes: {},
+        provider,
+      },
+    ];
+    const result = yield* NukeRoute.execute({
+      scan: { resources, mode: "live", context: Context.empty(), failures: [] },
+      resources,
+      strategy: { _tag: "coordinated" },
+    }).pipe(
+      renderNukeDelete(resources, "live"),
+      Effect.provideService(CliKit, service),
+    );
+    expect(result.deleted).toHaveLength(1);
+    expect(result.failed).toHaveLength(1);
+    expect(result.held).toHaveLength(1);
+    expect(stdout.output).toContain("Nuke incomplete");
+    expect(stdout.output).toContain("Held back by Test.Child");
+    expect(stdout.output).toContain("cannot delete child");
+    expect(stdout.output).toContain("same-name");
+    expect(stdout.output).not.toContain("Test.Child 1/2");
+  }),
+);
+
+it.effect("closes nuke live progress when the operation fails", () =>
+  Effect.gen(function* () {
+    const { service, stdout } = yield* makeLive();
+    yield* Effect.gen(function* () {
+      const report = yield* Progress;
+      yield* report({ _tag: "nuke.scan.started", total: 2 });
+      yield* Effect.fail("scan failed");
+    }).pipe(
+      renderNukeScan(),
+      Effect.provideService(CliKit, service),
+      Effect.result,
+    );
+    expect(stdout.output).toContain("\u001B[?25h");
+    yield* service.output.info("After nuke");
+    expect(stdout.output).toContain("After nuke");
+  }),
+);
+
+it.effect("renders fixed-width Braille progress bars with partial cells", () =>
+  Effect.gen(function* () {
+    const { service } = makeStatic();
+    for (const [value, expected] of [
+      [-1, "[  ]"],
+      [0, "[  ]"],
+      [0.0625, "[  ]"],
+      [0.25, "[⡇ ]"],
+      [0.5, "[⣿ ]"],
+      [0.75, "[⣿⡇]"],
+      [1, "[⣿⣿]"],
+      [2, "[⣿⣿]"],
+    ] as const) {
+      const output = yield* service.output.render(
+        <ProgressBar value={value} width={2} showPercent={false} />,
+      );
+      expect(output.trim()).toBe(expected);
+    }
+    const labeled = yield* service.output.render(
+      <ProgressBar
+        value={0.5}
+        width={2}
+        label="Uploading"
+        detail="2 of 4 files"
+      />,
+    );
+    expect(labeled).toContain("[⣿ ]");
+    expect(labeled).toContain("50%");
+    expect(labeled).toContain("Uploading");
+    expect(labeled).toContain("2 of 4 files");
+  }),
+);
+
+it.effect("falls back to ASCII for progress bars without Unicode", () =>
+  Effect.gen(function* () {
+    const { service } = yield* makeLive({ input: false, unicode: false });
+    const output = yield* service.output.render(
+      <ProgressBar value={0.5} width={4} showPercent={false} />,
+    );
+    expect(output.trim()).toBe("[##..]");
+  }),
+);
+
+it.effect(
+  "renders nuke inventory with resource types as names and distinct row keys",
+  () =>
+    Effect.gen(function* () {
+      const { service } = makeStatic();
+      const targets = [
+        { providerId: "Cloudflare.R2.Bucket", displayName: "same/name" },
+        { providerId: "Cloudflare.R2.Bucket", displayName: "same/name" },
+        { providerId: "AWS.S3.Bucket", displayName: "" },
+      ];
+      const plan = nukePlan(targets, { mode: "live" });
+      const tree = new PlanTree(plan, { viewport: "full" });
+      expect(tree.progressRows).toHaveLength(3);
+      expect(new Set(tree.rows.map((row) => row.key)).size).toBe(3);
+      expect(tree.rows.map((row) => row.id)).toEqual([
+        "AWS.S3.Bucket",
+        "Cloudflare.R2.Bucket",
+        "Cloudflare.R2.Bucket",
+      ]);
+      expect(
+        tree.rows.every((row) => row.type === "resource" && row.depth === 0),
+      ).toBe(true);
+      const output = yield* service.output.render(<Plan tree={tree} />);
+      expect(output).toContain("3 to delete");
+      expect(output.match(/Cloudflare.R2.Bucket/g)).toHaveLength(2);
+      expect(output).not.toContain("(Cloudflare.R2.Bucket)");
+      expect(output.match(/same\/name/g)).toHaveLength(2);
+
+      const compact = yield* service.output.render(
+        <Plan
+          tree={
+            new PlanTree(nukePlan(targets, { mode: "live" }), {
+              viewport: "full",
+            })
+          }
+        />,
+      );
+      expect(compact).toContain("3 to delete");
+      expect(compact.match(/same\/name/g)).toHaveLength(2);
+      expect(compact.match(/Cloudflare.R2.Bucket/g)).toHaveLength(2);
+      expect(compact).not.toContain("(x2)");
+    }),
+);
+
+it.effect(
+  "prints the shared nuke plan for dry-run and yes without prompting",
+  () =>
+    Effect.gen(function* () {
+      for (const options of [
+        { yes: false, dryRun: true },
+        { yes: true, dryRun: false },
+      ]) {
+        const { service, stdout } = makeStatic();
+        const result = yield* reviewNuke(
+          [{ providerId: "AWS.S3.Bucket", displayName: "bucket" }],
+          { ...options, mode: "local" },
+        ).pipe(Effect.provideService(CliKit, service));
+        expect(result).toBe(true);
+        expect(stdout.output).toContain("1 to delete");
+        expect(stdout.output).toContain("AWS.S3.Bucket");
+        expect(stdout.output).toContain("bucket");
+      }
+    }),
+);
+
+it.live("defaults nuke plan approval to Cancel", () =>
+  Effect.gen(function* () {
+    const stdin = new InputStream();
+    const { service, stdout } = yield* makeLive({ stdin });
+    const review = yield* reviewNuke(
+      [{ providerId: "AWS.S3.Bucket", displayName: "bucket" }],
+      { mode: "local", yes: false, dryRun: false },
+    ).pipe(Effect.provideService(CliKit, service), Effect.forkChild);
+    yield* Effect.promise(flushEffects);
+    yield* Effect.raceFirst(
+      Effect.promise(() => stdout.waitFor("Cancel")),
+      Fiber.join(review).pipe(
+        Effect.flatMap(() => Effect.die("review ended before prompt")),
+      ),
+    );
+    // Answer Sigil's startup device query before sending the confirmation key.
+    yield* Effect.promise(() => stdout.waitFor("\x1b[c"));
+    yield* Effect.sync(() => stdin.write("\x1b[?1;2c"));
+    yield* Effect.promise(flushEffects);
+    yield* settleInput;
+    expect(stdout.output).toContain("1 to delete");
+    expect(stdout.output).toContain("locally emulated");
+    yield* Effect.sync(() => stdin.write("\r"));
+    yield* Effect.promise(flushEffects);
+    expect(yield* Fiber.join(review)).toBe(false);
+  }),
+);
+
+it.effect("keeps unnamed and duplicate nuke targets as individual rows", () =>
+  Effect.gen(function* () {
+    const { service } = makeStatic();
+    const targets = [
+      { providerId: "AWS.ApiGateway.GatewayResponse", displayName: "api-123" },
+      { providerId: "AWS.ApiGateway.GatewayResponse", displayName: "api-123" },
+      { providerId: "AWS.S3.Bucket", displayName: "photos" },
+      { providerId: "AWS.S3.Bucket", displayName: "backups" },
+      { providerId: "Test.Unknown", displayName: "unknown" },
+      { providerId: "Test.Unknown", displayName: "" },
+    ];
+    const plan = nukePlan(targets, { mode: "live" });
+    expect(plan.rows).toHaveLength(6);
+    const output = yield* service.output.render(
+      <Plan tree={new PlanTree(plan, { viewport: "full" })} />,
+    );
+    expect(output).toContain("6 to delete");
+    expect(output.match(/api-123/g)).toHaveLength(2);
+    expect(output.match(/Test.Unknown/g)).toHaveLength(2);
+    expect(output).not.toContain("(x2)");
+    expect(output).toContain("photos");
+    expect(output).toContain("backups");
+    expect(output).not.toContain("· unknown");
+  }),
+);
+
+it.effect(
+  "logs nuke errors immediately through the configured Effect logger",
+  () =>
+    Effect.gen(function* () {
+      for (const input of [true, false]) {
+        const { service } = yield* makeLive({ input });
+        const entries: Array<{ level: string; message: unknown }> = [];
+        const logger = Logger.make<unknown, void>(({ logLevel, message }) => {
+          entries.push({ level: logLevel, message });
+        });
+        yield* Effect.gen(function* () {
+          const report = yield* Progress;
+          yield* report({ _tag: "nuke.scan.started", total: 2 });
+          yield* report({
+            _tag: "nuke.scan.provider.completed",
+            provider: "Test.Failed",
+            resources: 0,
+            error: "denied during scan",
+          });
+          // Check before the operation returns: errors must not wait for completion.
+          expect(entries).toEqual([
+            { level: "Warn", message: ["Test.Failed: denied during scan"] },
+          ]);
+          yield* report({
+            _tag: "nuke.resource.failed",
+            provider: "Test.Resource",
+            resource: "example",
+            message: "denied during delete",
+          });
+          expect(entries[1]).toEqual({
+            level: "Warn",
+            message: ["Test.Resource example: denied during delete"],
+          });
+          yield* report({
+            _tag: "nuke.scan.provider.completed",
+            provider: "Test.Ready",
+            resources: 1,
+          });
+          yield* report({
+            _tag: "nuke.resource.deleted",
+            provider: "Test.Ready",
+            resource: "gone",
+          });
+        }).pipe(
+          renderNukeScan(),
+          Effect.provideService(CliKit, service),
+          Effect.provide(Logger.layer([logger])),
+        );
+        expect(entries).toHaveLength(input ? 2 : 4);
+        if (!input) {
+          expect(entries.slice(2)).toEqual([
+            { level: "Info", message: ["scanned Test.Ready (1)"] },
+            { level: "Info", message: ["deleted Test.Ready gone"] },
+          ]);
+        }
+      }
     }),
 );

--- a/packages/alchemy/test/Cli/Nuke.test.ts
+++ b/packages/alchemy/test/Cli/Nuke.test.ts
@@ -1,0 +1,165 @@
+import * as Nuke from "@/Nuke.ts";
+import type { ProviderService } from "@/Provider.ts";
+import * as Context from "effect/Context";
+import * as Deferred from "effect/Deferred";
+import * as Effect from "effect/Effect";
+import { expect, it } from "alchemy-test";
+
+it.effect("reports each deletion before a slow coordinated pass finishes", () =>
+  Effect.gen(function* () {
+    const fastDeleted = yield* Deferred.make<void>();
+    const events: string[] = [];
+    const provider: ProviderService = {
+      list: () => Effect.succeed([]),
+      reconcile: () => Effect.succeed({}),
+      delete: ({ id }) =>
+        id === "slow" ? Deferred.await(fastDeleted) : Effect.void,
+    };
+    const result = yield* Nuke.destroy({
+      targets: ["fast", "slow"].map((displayName) => ({
+        providerId: "Test.Resource",
+        displayName,
+        attributes: {},
+        provider,
+      })),
+      context: Context.empty(),
+      strategy: { _tag: "coordinated" },
+      onPass: (pass) =>
+        Effect.sync(() => {
+          events.push(`pass ${pass}`);
+        }),
+      onDeleted: (resource) =>
+        Effect.gen(function* () {
+          events.push(resource.displayName);
+          if (resource.displayName === "fast")
+            yield* Deferred.succeed(fastDeleted, undefined);
+        }),
+    }).pipe(Effect.timeout("2 seconds"));
+    expect(result.deleted).toHaveLength(2);
+    expect(events).toEqual(["pass 1", "fast", "slow"]);
+  }),
+);
+
+it.effect("reports scan totals and settles failed providers", () =>
+  Effect.gen(function* () {
+    const events: string[] = [];
+    const provider: ProviderService = {
+      list: () => Effect.fail(new Error("unavailable")),
+      reconcile: () => Effect.succeed({}),
+      delete: () => Effect.void,
+    };
+    const tag = Context.Service<ProviderService>("Test.Resource");
+    const result = yield* Nuke.list({
+      context: Context.make(tag, provider),
+      mode: "live",
+      onScan: (total) =>
+        Effect.sync(() => {
+          events.push(`total ${total}`);
+        }),
+      onProviderStarted: (id) =>
+        Effect.sync(() => {
+          events.push(`start ${id}`);
+        }),
+      onProvider: (id, count) =>
+        Effect.sync(() => {
+          events.push(`done ${id} ${count}`);
+        }),
+    });
+    expect(result.failures).toHaveLength(1);
+    expect(events).toEqual([
+      "total 1",
+      "start Test.Resource",
+      "done Test.Resource 0",
+    ]);
+  }),
+);
+
+it.effect(
+  "preserves structured provider errors in scan and deletion reports",
+  () =>
+    Effect.gen(function* () {
+      const error = {
+        _tag: "AccessDeniedException",
+        message: "This service is unavailable for this account",
+        details: { code: 403 },
+      };
+      const provider: ProviderService = {
+        list: () => Effect.fail(error),
+        reconcile: () => Effect.succeed({}),
+        delete: () => Effect.fail(error),
+      };
+      const context = Context.make(
+        Context.Service<ProviderService>("Test.Resource"),
+        provider,
+      );
+      const scan = yield* Nuke.list({ context, mode: "live" });
+      const messages = scan.failures.map((failure) => failure.message);
+      for (const strategy of [
+        { _tag: "coordinated" },
+        { _tag: "independent", retries: 0 },
+      ] as const) {
+        const result = yield* Nuke.destroy({
+          targets: [
+            {
+              providerId: "Test.Resource",
+              displayName: "example",
+              attributes: {},
+              provider,
+            },
+          ],
+          context,
+          strategy,
+          onFailed: (_resource, message) =>
+            Effect.sync(() => {
+              messages.push(message);
+            }),
+        });
+        expect(result.failed).toHaveLength(1);
+        messages.push(result.failed[0]!.failure.message);
+      }
+      expect(messages).toHaveLength(5);
+      for (const message of messages) {
+        expect(message).toContain("AccessDeniedException");
+        expect(message).toContain(error.message);
+        expect(message).toContain("403");
+        expect(message).not.toContain("[object Object]");
+        expect(message).not.toContain("no progress");
+      }
+    }),
+);
+
+it.effect("reports scan failures before other providers finish listing", () =>
+  Effect.gen(function* () {
+    const reported = yield* Deferred.make<void>();
+    const failed: ProviderService = {
+      list: () =>
+        Effect.fail({ _tag: "AccessDenied", message: "denied during scan" }),
+      reconcile: () => Effect.succeed({}),
+      delete: () => Effect.void,
+    };
+    const slow: ProviderService = {
+      ...failed,
+      list: () => Deferred.await(reported).pipe(Effect.as([])),
+    };
+    const context = Context.make(
+      Context.Service<ProviderService>("Test.Failed"),
+      failed,
+    ).pipe(Context.add(Context.Service<ProviderService>("Test.Slow"), slow));
+    const errors: string[] = [];
+    const result = yield* Nuke.list({
+      context,
+      mode: "live",
+      onProvider: (provider, count, error) =>
+        Effect.gen(function* () {
+          if (error === undefined) return;
+          expect(provider).toBe("Test.Failed");
+          expect(count).toBe(0);
+          errors.push(error);
+          yield* Deferred.succeed(reported, undefined);
+        }),
+    }).pipe(Effect.timeout("2 seconds"));
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toContain("denied during scan");
+    expect(result.failures[0]?.message).toBe(errors[0]);
+  }),
+);

--- a/packages/alchemy/test/Cli/StateNuke.test.ts
+++ b/packages/alchemy/test/Cli/StateNuke.test.ts
@@ -1,0 +1,52 @@
+import { spawnSync } from "node:child_process";
+import {
+  mkdtempSync,
+  mkdirSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { expect, it } from "alchemy-test";
+
+const cli = fileURLToPath(new URL("../../bin/cli.js", import.meta.url));
+
+it("state unsafe nuke requires approval and clears every stack with --yes", () => {
+  const cwd = mkdtempSync(join(tmpdir(), "alchemy-state-nuke-"));
+  const state = join(cwd, ".alchemy", "state");
+  try {
+    for (const stack of ["First", "Second"]) {
+      for (const stage of ["dev", "prod"]) {
+        const directory = join(state, stack, stage);
+        mkdirSync(directory, { recursive: true });
+        writeFileSync(join(directory, "output.json"), "{}");
+      }
+    }
+    const run = (args: string[]) =>
+      spawnSync("bun", [cli, ...args], {
+        cwd,
+        env: { ...process.env, ALCHEMY_HOME: join(cwd, "home") },
+        encoding: "utf8",
+        timeout: 10000,
+      });
+    const args = ["state", "unsafe", "nuke", "--backend", "local"];
+    expect(run(args).status).toBe(1);
+    expect(readdirSync(state).sort()).toEqual(["First", "Second"]);
+    const cleared = run([...args, "--yes"]);
+    expect(cleared.status).toBe(0);
+    expect(cleared.stdout).toContain("• First\n• Second");
+    expect(cleared.stdout).toContain("Cleared First");
+    expect(cleared.stdout).toContain("Cleared Second");
+    expect(readdirSync(state)).toEqual([]);
+    const empty = run(args);
+    expect(empty.status).toBe(0);
+    expect(empty.stdout).toContain("Nothing to clear");
+    expect(
+      run(["state", "delete", "/", "--recursive", "--backend", "local"]).status,
+    ).toBe(1);
+  } finally {
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});

--- a/packages/alchemy/test/Cli/registerDevMode.test.ts
+++ b/packages/alchemy/test/Cli/registerDevMode.test.ts
@@ -52,7 +52,13 @@ it.live.skipIf(!nodeSupportsDevMode)(
         ],
         {
           cwd: exampleDir,
-          env: { NO_COLOR: "1" },
+          env: {
+            NO_COLOR: "1",
+            // The Bun test runner's markers must not select Bun for this
+            // explicitly Node/pnpm invocation.
+            npm_execpath: "",
+            npm_config_user_agent: "",
+          },
           extendEnv: true,
           stdin: "ignore",
           stdout: "pipe",
@@ -87,7 +93,13 @@ it.live.skipIf(!nodeSupportsDevMode)(
       expect(pnpm).not.toBeNull();
       const cli = yield* ChildProcess.make(pnpm!, ["alchemy", "--version"], {
         cwd: repoDir,
-        env: { NO_COLOR: "1" },
+        env: {
+          NO_COLOR: "1",
+          // The Bun test runner's markers must not select Bun for this
+          // explicitly Node/pnpm invocation.
+          npm_execpath: "",
+          npm_config_user_agent: "",
+        },
         extendEnv: true,
         stdin: "ignore",
         stdout: "pipe",

--- a/website/src/content/docs/cli/nuke.mdx
+++ b/website/src/content/docs/cli/nuke.mdx
@@ -4,10 +4,17 @@ description: Enumerate and delete every live resource across the stack's provide
 ---
 
 ```sh
-bun alchemy unsafe nuke [options]
+bun alchemy unsafe nuke [config] [options]
 ```
 
 `nuke` enumerates and deletes every live resource across the stack's providers. The command nests under `unsafe` and is deliberately hidden from `--help` — it's dangerous and we don't want agents to discover and use it. This page is its only discovery surface.
+
+Pass the stack file positionally or with `--config` / `-c`, but not both. If omitted, it defaults to `alchemy.run.ts`.
+
+```sh
+bun alchemy unsafe nuke ./stacks/nuke.ts --dry-run
+bun alchemy unsafe nuke --config ./stacks/nuke.ts --dry-run
+```
 
 :::caution
 `nuke` is **not** scoped to a stack, a stage, or the state store. The stack file is imported only to learn which providers are registered; each provider's `list()` then enumerates **every** resource of that type in the ambient account/region/zone — including resources alchemy never created — and deletes them all. This cannot be undone. What you usually want is [`alchemy destroy`](/cli/destroy), which is stack-scoped and state-driven.
@@ -48,7 +55,7 @@ Each selected provider's local variant is built lazily, as it is scanned, so `--
 `--include` and `--exclude` take provider-ID globs (picomatch, e.g. `'Cloudflare.*'`), are repeatable, and `--exclude` is applied after `--include`.
 
 ```sh
-bun alchemy unsafe nuke --include 'Cloudflare.Worker' --dry-run --verbose
+bun alchemy unsafe nuke --include 'Cloudflare.Worker' --dry-run
 ```
 
 `--filter` is a JavaScript expression evaluated with `resource` in scope (plus synthesized `Type` and `LogicalId` fields); a **truthy** expression **spares** the resource, and a throwing or non-boolean expression is treated as false. Repeatable.
@@ -60,9 +67,7 @@ bun alchemy unsafe nuke --filter 'resource.workerName.startsWith("prod-")'
 
 ## Dry run and confirmation
 
-Every run starts with a per-provider report of to-delete and filtered-out counts; `--verbose`/`-v` also enumerates each resource by a best-effort display name.
-
-`--dry-run` exits after the report. Otherwise a confirm prompt — `Permanently DELETE N resource(s)? This cannot be undone.` — defaults to **No** and is skipped by `--yes`. In non-interactive shells, run `--dry-run` first, then re-run with `--yes`.
+`--dry-run` exits after the report. Otherwise a confirm prompt — `Permanently DELETE N resource(s)? This cannot be undone.` — defaults to **Cancel** and is skipped by `--yes`. In non-interactive shells, run `--dry-run` first, then re-run with `--yes`.
 
 ## Multi-pass deletion
 
@@ -81,7 +86,6 @@ Deletion runs in passes: each pass attempts every remaining resource, failures a
 | `--env-file <path>`   | Load environment variables from a file                                                                                                                                 |
 | `--yes`               | Skip the confirmation prompt                                                                                                                                           |
 | `--dry-run`           | Report what would be deleted, then exit without deleting                                                                                                               |
-| `--verbose`           | List each resource instead of showing provider totals                                                                                                                  |
 | `--concurrency <n>`   | Max number of providers scanned/deleted in parallel (resources within a provider are always deleted concurrently). Use 0 for unbounded. Default: 16 — unbounded tends to be slower because it triggers provider-side rate limiting and retry backoff. |
 | `--timeout <s>`       | Per-provider timeout (seconds) for each list/delete call, so one slow or hanging provider can't stall the whole run. Default: 120.                                     |
 | `--include <glob>`    | Glob of provider IDs to include (e.g. `'Cloudflare.*'` or `'Cloudflare.Worker'`). Repeatable; when omitted, every provider is included.                                |
@@ -93,7 +97,7 @@ Deletion runs in passes: each pass attempts every remaining resource, failures a
 
 ## Debugging
 
-`DEBUG=1` routes provider logs to the console at Debug level and disables the TUI so the log stream isn't clobbered by the progress renderer; interactive runs otherwise show a scan progress bar followed by per-pass delete progress bars.
+`DEBUG=1` routes provider logs to the console at Debug level and disables the TUI so the log stream isn't clobbered by the progress renderer.
 
 ## Where next
 


### PR DESCRIPTION
Restore nuke scan progress and show individual resource identities and deletion status in the shared Plan view. Provider errors flow through the Effect logger as scans finish.

- Accept positional config paths consistently with deploy and destroy.
- Add a reusable half/full Braille progress bar with an ASCII fallback.
- Restore bulk state cleanup through `alchemy state unsafe nuke`, with a stack bullet list and confirmation, and update `clear:state` to use it.
- Remove the redundant `--verbose` option now that every resource is shown.
