### PR TITLE
fix(cli): virtualize the profile dashboard's provider list

### DIFF
--- a/packages/alchemy/package.json
+++ b/packages/alchemy/package.json
@@ -422,7 +422,7 @@
     "@alchemy.run/cloudflare-runtime": "workspace:*",
     "@alchemy.run/floci": "workspace:*",
     "@alchemy.run/node-utils": "workspace:*",
-    "@alchemy.run/sigil": "0.0.0-alpha.8",
+    "@alchemy.run/sigil": "0.0.0-alpha.9",
     "@aws-sdk/credential-providers": "catalog:aws",
     "@distilled.cloud/aws": "workspace:*",
     "@distilled.cloud/axiom": "workspace:*",

--- a/packages/alchemy/src/Cli/components/ui/Layout.tsx
+++ b/packages/alchemy/src/Cli/components/ui/Layout.tsx
@@ -12,6 +12,10 @@ import { theme } from "../../../Util/Theme.ts";
 import { useCliEnvironment, useGlyphs } from "./Environment.tsx";
 import { Text } from "./Typography.tsx";
 
+// Windowed list that clips to the rows its container leaves over; it draws no
+// colors of its own, so it needs no theme-aware wrapper.
+export { VirtualList } from "@alchemy.run/sigil";
+
 export type BoxProps = ComponentProps<typeof SigilBox>;
 
 /** Theme-aware Sigil container used by CliKit layouts. */

--- a/packages/alchemy/src/Cli/components/ui/index.ts
+++ b/packages/alchemy/src/Cli/components/ui/index.ts
@@ -19,6 +19,7 @@ export {
   SectionHeading,
   Stack,
   Viewport,
+  VirtualList,
   type BoxProps,
   type RowProps,
   type StackProps,

--- a/packages/alchemy/src/Cli/components/view/Profile.tsx
+++ b/packages/alchemy/src/Cli/components/view/Profile.tsx
@@ -8,6 +8,7 @@ import {
   useBorderStyle,
   useGlyphs,
 } from "../ui/index.ts";
+import { stringWidth } from "@alchemy.run/sigil/ansi";
 import type { JSX } from "react";
 import { theme } from "../../CliKit/index.ts";
 
@@ -163,19 +164,8 @@ function ProfileList({
   );
 }
 
-/**
- * Provider table body shared by `profile show` and the dashboard's detail
- * pane, so the two render identically. The dashboard passes `reauthHint` to
- * advertise its `r` keybinding on rows that need a re-login.
- */
-export function ProfileDetailsBody({
-  providers,
-  reauthHint,
-  refreshingProvider,
-  focusedProvider,
-  showFocusRail = false,
-}: {
-  readonly providers: ReadonlyArray<ProfileProviderDisplay>;
+/** Options every provider block shares; the dashboard threads them through. */
+export interface ProviderBlockOptions {
   /** Muted hint appended to rows with `status: "reauth"`. */
   readonly reauthHint?: string;
   /** Provider whose detail rows are temporarily replaced by refresh status. */
@@ -184,11 +174,150 @@ export function ProfileDetailsBody({
   readonly focusedProvider?: string;
   /** Reserve a stable focus rail column for an interactive parent view. */
   readonly showFocusRail?: boolean;
+}
+
+/** Column widths computed over every provider so windowed blocks stay aligned. */
+export const providerColumnWidths = (
+  providers: ReadonlyArray<ProfileProviderDisplay>,
+): { readonly nameWidth: number; readonly methodWidth: number } => ({
+  nameWidth: columnWidth(providers.map((provider) => provider.name)),
+  methodWidth: columnWidth(providers.map((provider) => provider.method)),
+});
+
+/**
+ * Rows a `ProviderBlock` occupies: separator and padding above every block
+ * but the first, the header row, then a blank row and the detail rows (the
+ * refresh spinner fits inside that same reserved height). The dashboard
+ * windows providers by this number, so keep it in step with the layout.
+ */
+export const providerBlockHeight = (
+  provider: ProfileProviderDisplay,
+  first: boolean,
+): number => (first ? 0 : 2) + 1 + Math.max(provider.lines.length, 1) + 1;
+
+/**
+ * Columns the widest provider block needs. A windowed pane only lays out the
+ * blocks on screen, so it sizes itself by this instead, keeping the separators
+ * the width of the whole table rather than of the terminal.
+ */
+export const providerPaneWidth = (
+  providers: ReadonlyArray<ProfileProviderDisplay>,
+  { showFocusRail = false, reauthHint }: ProviderBlockOptions = {},
+): number => {
+  const { nameWidth, methodWidth } = providerColumnWidths(providers);
+  const indent = (showFocusRail ? 1 : 0) + theme.space.indent;
+  return Math.max(
+    0,
+    ...providers.flatMap((provider) => {
+      const status = providerStatusStyle[provider.status];
+      const hint =
+        reauthHint !== undefined && provider.status === "reauth"
+          ? stringWidth(` — ${reauthHint}`)
+          : 0;
+      // glyph, space, label
+      const header =
+        indent + nameWidth + methodWidth + 2 + stringWidth(status.label) + hint;
+      return [
+        header,
+        ...provider.lines.map((line) => indent + 2 + stringWidth(line)),
+      ];
+    }),
+  );
+};
+
+/** One provider's header and detail rows; `first` drops the separator above. */
+export function ProviderBlock({
+  provider,
+  first,
+  nameWidth,
+  methodWidth,
+  reauthHint,
+  refreshingProvider,
+  focusedProvider,
+  showFocusRail = false,
+}: ProviderBlockOptions & {
+  readonly provider: ProfileProviderDisplay;
+  readonly first: boolean;
+  readonly nameWidth: number;
+  readonly methodWidth: number;
 }): JSX.Element {
   const glyphs = useGlyphs();
   const borderStyle = useBorderStyle();
-  const nameWidth = columnWidth(providers.map((provider) => provider.name));
-  const methodWidth = columnWidth(providers.map((provider) => provider.method));
+  const status = providerStatusStyle[provider.status];
+  const focused = showFocusRail && provider.name === focusedProvider;
+  return (
+    <Box
+      flexDirection="column"
+      paddingTop={first ? 0 : 1}
+      paddingLeft={showFocusRail ? (focused ? 0 : 1) : 0}
+      borderStyle={borderStyle}
+      borderTop={!first}
+      borderBottom={false}
+      borderLeft={focused}
+      borderRight={false}
+      borderColor={theme.color.muted}
+      borderLeftColor={theme.color.brand}
+      borderDimColor
+    >
+      <Gutter>
+        <Box flexDirection="row">
+          <Box width={nameWidth} flexShrink={0}>
+            <Text bold color={theme.color.accent}>
+              {provider.name}
+            </Text>
+          </Box>
+          <Box width={methodWidth} flexShrink={0}>
+            <Text tone="muted">{provider.method}</Text>
+          </Box>
+          <Text color={status.color}>
+            {glyphs[status.glyph]} {status.label}
+          </Text>
+          {reauthHint !== undefined &&
+          provider.status === "reauth" &&
+          (focusedProvider === undefined ||
+            provider.name === focusedProvider) ? (
+            <Text tone="muted"> — {reauthHint}</Text>
+          ) : null}
+        </Box>
+      </Gutter>
+      <Box
+        flexDirection="column"
+        minHeight={Math.max(provider.lines.length, 1) + 1}
+      >
+        {provider.name === refreshingProvider ? (
+          <Gutter>
+            <Box paddingLeft={2} marginTop={1}>
+              <Spinner
+                label={`refreshing ${provider.method.toLowerCase() === "oauth" ? "OAuth" : provider.method} credentials…`}
+              />
+            </Box>
+          </Gutter>
+        ) : (
+          provider.lines.map((line, lineIndex) => (
+            <Gutter key={`${provider.name}-${lineIndex}`}>
+              <Box paddingLeft={2} marginTop={lineIndex === 0 ? 1 : 0}>
+                <Text>{line}</Text>
+              </Box>
+            </Gutter>
+          ))
+        )}
+      </Box>
+    </Box>
+  );
+}
+
+/**
+ * Provider table body shared by `profile show` and the dashboard's detail
+ * pane, so the two render identically. The dashboard passes `reauthHint` to
+ * advertise its `r` keybinding on rows that need a re-login.
+ */
+export function ProfileDetailsBody({
+  providers,
+  ...options
+}: ProviderBlockOptions & {
+  readonly providers: ReadonlyArray<ProfileProviderDisplay>;
+}): JSX.Element {
+  const { nameWidth, methodWidth } = providerColumnWidths(providers);
   return (
     <Box flexDirection="column">
       {providers.length === 0 ? (
@@ -196,70 +325,16 @@ export function ProfileDetailsBody({
           <Text tone="muted">No providers configured.</Text>
         </Gutter>
       ) : (
-        providers.map((provider, providerIndex) => {
-          const status = providerStatusStyle[provider.status];
-          const focused = showFocusRail && provider.name === focusedProvider;
-          return (
-            <Box
-              key={provider.name}
-              flexDirection="column"
-              paddingTop={providerIndex === 0 ? 0 : 1}
-              paddingLeft={showFocusRail ? (focused ? 0 : 1) : 0}
-              borderStyle={borderStyle}
-              borderTop={providerIndex > 0}
-              borderBottom={false}
-              borderLeft={focused}
-              borderRight={false}
-              borderColor={theme.color.muted}
-              borderLeftColor={theme.color.brand}
-              borderDimColor
-            >
-              <Gutter>
-                <Box flexDirection="row">
-                  <Box width={nameWidth} flexShrink={0}>
-                    <Text bold color={theme.color.accent}>
-                      {provider.name}
-                    </Text>
-                  </Box>
-                  <Box width={methodWidth} flexShrink={0}>
-                    <Text tone="muted">{provider.method}</Text>
-                  </Box>
-                  <Text color={status.color}>
-                    {glyphs[status.glyph]} {status.label}
-                  </Text>
-                  {reauthHint !== undefined &&
-                  provider.status === "reauth" &&
-                  (focusedProvider === undefined ||
-                    provider.name === focusedProvider) ? (
-                    <Text tone="muted"> — {reauthHint}</Text>
-                  ) : null}
-                </Box>
-              </Gutter>
-              <Box
-                flexDirection="column"
-                minHeight={Math.max(provider.lines.length, 1) + 1}
-              >
-                {provider.name === refreshingProvider ? (
-                  <Gutter>
-                    <Box paddingLeft={2} marginTop={1}>
-                      <Spinner
-                        label={`refreshing ${provider.method.toLowerCase() === "oauth" ? "OAuth" : provider.method} credentials…`}
-                      />
-                    </Box>
-                  </Gutter>
-                ) : (
-                  provider.lines.map((line, lineIndex) => (
-                    <Gutter key={`${provider.name}-${lineIndex}`}>
-                      <Box paddingLeft={2} marginTop={lineIndex === 0 ? 1 : 0}>
-                        <Text>{line}</Text>
-                      </Box>
-                    </Gutter>
-                  ))
-                )}
-              </Box>
-            </Box>
-          );
-        })
+        providers.map((provider, index) => (
+          <ProviderBlock
+            key={provider.name}
+            provider={provider}
+            first={index === 0}
+            nameWidth={nameWidth}
+            methodWidth={methodWidth}
+            {...options}
+          />
+        ))
       )}
     </Box>
   );

--- a/packages/alchemy/src/Cli/components/view/ProfileDashboard.tsx
+++ b/packages/alchemy/src/Cli/components/view/ProfileDashboard.tsx
@@ -40,6 +40,8 @@ import {
   useKeyGlyphs,
   useLiveStore,
   useTerminalInput,
+  useTerminalSize,
+  VirtualList,
 } from "../ui/index.ts";
 import {
   CliKit,
@@ -49,7 +51,10 @@ import {
 import {
   type EditState,
   editStateStyle,
-  ProfileDetailsBody,
+  ProviderBlock,
+  providerBlockHeight,
+  providerColumnWidths,
+  providerPaneWidth,
   type ProfileProviderDisplay,
 } from "./Profile.tsx";
 
@@ -128,7 +133,7 @@ interface DashState {
  * the mounted dashboard. The resolver bridge and the notice auto-dismiss
  * timer live outside the snapshot — they carry no visual state.
  */
-class DashStore extends LiveStore<DashState> {
+export class DashStore extends LiveStore<DashState> {
   private resolver: ((action: PureAction | ExternalAction) => void) | null =
     null;
 
@@ -193,14 +198,16 @@ class DashStore extends LiveStore<DashState> {
 type DetailsPaneProps = {
   details: Details;
   refreshingProvider?: string;
-  focusedProvider?: string;
+  /** Index into `details.providers` the up/down cursor rests on. */
+  focusedIndex: number;
 };
 
 function DetailsPane({
   details,
   refreshingProvider,
-  focusedProvider,
+  focusedIndex,
 }: DetailsPaneProps): JSX.Element {
+  const { columns } = useTerminalSize();
   if (details.state === "loading") {
     return <Spinner label="resolving credentials…" />;
   }
@@ -212,16 +219,46 @@ function DetailsPane({
       <Text tone="muted">No accounts connected — press e to add one.</Text>
     );
   }
-  // Same body as `profile show`, so the dashboard's detail pane and the
-  // non-interactive command render identically.
+  const { providers } = details;
+  const { nameWidth, methodWidth } = providerColumnWidths(providers);
+  const focusedProvider = providers[focusedIndex]?.name;
+  const reauthHint = "press r to re-login";
+  // The same blocks `profile show` prints, windowed to the rows the terminal
+  // leaves the pane: the list shrinks to fit (see the root layout in
+  // `Dashboard`) and scrolls just enough to keep the focused provider in view.
+  // The profile-level slot (no focused provider) shows the list from the top.
+  // The pane is as wide as the whole table, so the separators keep the width
+  // they have in `profile show` instead of stretching across the terminal.
   return (
-    <ProfileDetailsBody
-      providers={details.providers}
-      reauthHint="press r to re-login"
-      refreshingProvider={refreshingProvider}
-      focusedProvider={focusedProvider}
-      showFocusRail
-    />
+    <Box
+      flexDirection="column"
+      minHeight={0}
+      width={Math.min(
+        columns,
+        providerPaneWidth(providers, { showFocusRail: true, reauthHint }),
+      )}
+    >
+      <VirtualList
+        items={providers}
+        getKey={(provider) => provider.name}
+        itemHeight={(provider, index) =>
+          providerBlockHeight(provider, index === 0)
+        }
+        focusedIndex={Math.max(0, focusedIndex)}
+        renderItem={(provider, index) => (
+          <ProviderBlock
+            provider={provider}
+            first={index === 0}
+            nameWidth={nameWidth}
+            methodWidth={methodWidth}
+            reauthHint={reauthHint}
+            refreshingProvider={refreshingProvider}
+            focusedProvider={focusedProvider}
+            showFocusRail
+          />
+        )}
+      />
+    </Box>
   );
 }
 
@@ -418,10 +455,14 @@ type DashboardProps = {
   initialSelected: number;
 };
 
-function Dashboard({ store, initialSelected }: DashboardProps): JSX.Element {
+export function Dashboard({
+  store,
+  initialSelected,
+}: DashboardProps): JSX.Element {
   const state = useLiveStore(store);
   const keyGlyphs = useKeyGlyphs();
   const borderStyle = useBorderStyle();
+  const { rows } = useTerminalSize();
   const [selected, setSelected] = useState(initialSelected);
   // -1 is the profile-level slot: no provider is focused and profile actions
   // are shown. Up/down cycles through this slot and every connected provider.
@@ -605,23 +646,30 @@ function Dashboard({ store, initialSelected }: DashboardProps): JSX.Element {
           ["q", "quit"],
         ];
 
+  // The frame never exceeds the terminal: the provider list is the only part
+  // allowed to shrink (a `VirtualList` windows it to whatever rows are left),
+  // so every other row of chrome opts out of shrinking. Short lists keep the
+  // compact layout because the cap is a maximum, not a fixed height.
   return (
-    <Stack>
-      <Tabs
-        tabs={entries.map((e) => ({
-          id: e.name,
-          label: e.name,
-          marked: e.isActive,
-        }))}
-        active={entry?.name ?? ""}
-      />
-      <Stack gap={1}>
+    <Stack maxHeight={rows}>
+      <Stack flexShrink={0}>
+        <Tabs
+          tabs={entries.map((e) => ({
+            id: e.name,
+            label: e.name,
+            marked: e.isActive,
+          }))}
+          active={entry?.name ?? ""}
+        />
+      </Stack>
+      <Stack gap={1} minHeight={0}>
         {entry === undefined ? (
           <Text tone="muted">No profiles yet — press n to create one.</Text>
         ) : (
           <>
             <Box
               flexDirection="row"
+              flexShrink={0}
               paddingLeft={provider === undefined ? 0 : 1}
               borderStyle={borderStyle}
               borderLeft={provider === undefined}
@@ -637,10 +685,10 @@ function Dashboard({ store, initialSelected }: DashboardProps): JSX.Element {
                 <Text tone="muted"> · {annotation}</Text>
               )}
             </Box>
-            <Box>
+            <Box flexDirection="column" minHeight={0}>
               <DetailsPane
                 details={details ?? { state: "loading" }}
-                focusedProvider={provider?.name}
+                focusedIndex={focusedProvider}
                 refreshingProvider={
                   flow?.kind === "refresh" ? flow.provider : undefined
                 }
@@ -650,14 +698,14 @@ function Dashboard({ store, initialSelected }: DashboardProps): JSX.Element {
         )}
       </Stack>
       {/* Keep one stable status row so notices do not push the controls around. */}
-      <Box minHeight={1}>
+      <Box minHeight={1} flexShrink={0}>
         {busy && flow === undefined ? (
           <Spinner label="working…" />
         ) : notice !== undefined ? (
           <Toast variant={notice.ok ? "info" : "error"}>{notice.message}</Toast>
         ) : null}
       </Box>
-      <Stack>
+      <Stack flexShrink={0}>
         <DashboardControls
           mode={mode}
           busy={busy}

--- a/packages/alchemy/test/Cli/CliKit.test.tsx
+++ b/packages/alchemy/test/Cli/CliKit.test.tsx
@@ -12,6 +12,7 @@ import {
 import {
   AnsweredPrompt,
   Alert,
+  Box,
   ChoiceGroup,
   DescriptionList,
   Heading,
@@ -51,7 +52,17 @@ import {
 import { stackOutputsView } from "@/Cli/components/view/StackOutputs.tsx";
 import { Plan, PlanTree } from "@/Cli/components/view/PlanView.tsx";
 import { ApprovePlan } from "@/Cli/components/view/ApprovePlan.tsx";
-import { ProfileDetailsBody } from "@/Cli/components/view/Profile.tsx";
+import {
+  ProfileDetailsBody,
+  providerBlockHeight,
+  providerPaneWidth,
+  type ProfileProviderDisplay,
+} from "@/Cli/components/view/Profile.tsx";
+import {
+  Dashboard,
+  DashStore,
+  runProfileDashboardSession,
+} from "@/Cli/components/view/ProfileDashboard.tsx";
 import {
   buildStageNodes,
   stateExplorerScreen,
@@ -720,6 +731,178 @@ it("replaces provider details with refresh progress in place", () => {
   expect(output).toContain("GitHub");
   expect(output).toContain("token: gho_cZ****");
 });
+
+// Eight providers of varying height: 49 rows in total, twice a 24-row terminal.
+const dashboardProviders: ReadonlyArray<ProfileProviderDisplay> = [
+  {
+    name: "AWS",
+    method: "sso",
+    status: "ready",
+    lines: [
+      "accessKeyId: ASIA****",
+      "secretAccessKey: I7hs****",
+      "sessionToken: IQoJ****",
+      "region: us-east-2",
+      "source: sso - default",
+    ],
+  },
+  {
+    name: "Cloudflare",
+    method: "stored",
+    status: "configured",
+    lines: [
+      "apiKey: cfk_****",
+      "email: blan****",
+      "accountId: 2b29****",
+      "source: stored",
+    ],
+  },
+  {
+    name: "Fly",
+    method: "stored",
+    status: "configured",
+    lines: ["apiKey: FlyV****"],
+  },
+  {
+    name: "GitHub",
+    method: "gh-cli",
+    status: "configured",
+    lines: ["token: gho_cZ****", "source: gh-cli"],
+  },
+  {
+    name: "Hetzner",
+    method: "stored",
+    status: "configured",
+    lines: ["token: 50Kt****"],
+  },
+  {
+    name: "Prisma",
+    method: "stored",
+    status: "configured",
+    lines: ["serviceToken: eyJr****"],
+  },
+  {
+    name: "Railway",
+    method: "oauth",
+    status: "configured",
+    lines: [
+      "token: rw_Fe2****",
+      "tokenKind: account",
+      "apiBaseUrl: https://backboard.railway.com",
+      "source: oauth",
+    ],
+  },
+  {
+    name: "Vercel",
+    method: "stored",
+    status: "reauth",
+    lines: ["token: vc_****"],
+  },
+];
+
+const dashboardEntries = [{ name: "default", isActive: true, isDefault: true }];
+
+// The dashboard windows providers by `providerBlockHeight`, so the number must
+// match what a block actually renders.
+it("sizes provider blocks by providerBlockHeight", () => {
+  const { service } = makeStatic();
+  const output = service.output.format(
+    <ProfileDetailsBody providers={dashboardProviders} showFocusRail />,
+    { columns: 80 },
+  );
+  const expected = dashboardProviders.reduce(
+    (rows, provider, index) =>
+      rows + providerBlockHeight(provider, index === 0),
+    0,
+  );
+  expect(output.split("\n").length).toBe(expected);
+});
+
+const separatorWidth = (output: string) =>
+  Math.max(
+    0,
+    ...output
+      .split("\n")
+      .filter((line) => /^─+$/.test(line))
+      .map((line) => line.length),
+  );
+
+// `profile show` sizes the table to its content: a row box shrink-wraps the
+// column of blocks. The dashboard's windowed pane cannot lay out every block,
+// so it sizes itself by `providerPaneWidth`, which must match that width.
+it("providerPaneWidth matches the intrinsic width of the provider table", () => {
+  const { service } = makeStatic();
+  const options = { showFocusRail: true, reauthHint: "press r to re-login" };
+  const output = service.output.format(
+    <Box>
+      <ProfileDetailsBody providers={dashboardProviders} {...options} />
+    </Box>,
+    { columns: 120 },
+  );
+  const width = providerPaneWidth(dashboardProviders, options);
+  expect(width).toBeLessThan(120);
+  expect(separatorWidth(output)).toBe(width);
+});
+
+it("windows the profile dashboard's providers to the terminal height", () => {
+  const { service, stdout } = makeStatic();
+  const store = new DashStore(dashboardEntries);
+  store.setDetails("default", {
+    state: "ready",
+    providers: dashboardProviders,
+    available: [],
+  });
+  const output = service.output.format(
+    <Dashboard store={store} initialSelected={0} />,
+    { columns: 80 },
+  );
+
+  expect(output.split("\n").length).toBeLessThanOrEqual(stdout.rows);
+  expect(output).toContain("AWS");
+  expect(output).toContain("Cloudflare");
+  expect(output).toContain("switch profile");
+  expect(output).not.toContain("Vercel");
+  // Separators span the table, not the terminal.
+  expect(separatorWidth(output)).toBe(
+    providerPaneWidth(dashboardProviders, {
+      showFocusRail: true,
+      reauthHint: "press r to re-login",
+    }),
+  );
+});
+
+// The session sleeps on a real clock (loader delay, notice auto-dismiss).
+it.live("scrolls the profile dashboard to the focused provider", () =>
+  Effect.gen(function* () {
+    const stdin = new InputStream();
+    const { service, stdout } = yield* makeLive({ stdin });
+    const session = yield* runProfileDashboardSession({
+      entries: dashboardEntries,
+      selected: "default",
+      loadDetails: () =>
+        Effect.succeed({ providers: dashboardProviders, available: [] }),
+      execute: () =>
+        Effect.succeed({ ok: true, message: "", entries: dashboardEntries }),
+      runFlow: () => Effect.succeed({ ok: true, message: "" }),
+      reloadEntries: Effect.succeed(dashboardEntries),
+    }).pipe(Effect.provideService(CliKit, service), Effect.forkChild);
+
+    // "focus provider" joins the key bar once the providers have resolved;
+    // arrow keys are ignored while the pane still shows the loading spinner.
+    yield* Effect.promise(() => stdout.waitFor("focus provider"));
+    yield* Effect.promise(() => stdin.ready);
+    expect(stdout.output).not.toContain("Vercel");
+
+    // Walk the focus cursor down to the last provider; the list follows it.
+    for (const _ of dashboardProviders) {
+      yield* Effect.sync(() => stdin.write("\x1b[B"));
+    }
+    yield* Effect.promise(() => stdout.waitFor("Vercel"));
+
+    yield* Effect.sync(() => stdin.write("q"));
+    yield* Fiber.join(session);
+  }),
+);
 
 it("renders input frames inline by default and keeps a stacked variant", () => {
   const { service } = makeStatic();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4793,8 +4793,8 @@ importers:
         specifier: workspace:*
         version: link:../node-utils
       '@alchemy.run/sigil':
-        specifier: 0.0.0-alpha.8
-        version: 0.0.0-alpha.8(@types/react@19.2.18)(react-devtools-core@7.0.1)(react@19.2.8)
+        specifier: 0.0.0-alpha.9
+        version: 0.0.0-alpha.9(@types/react@19.2.18)(react-devtools-core@7.0.1)(react@19.2.8)
       '@aws-sdk/credential-providers':
         specifier: catalog:aws
         version: 3.1095.0
@@ -6040,8 +6040,8 @@ importers:
 
 packages:
 
-  '@alchemy.run/sigil@0.0.0-alpha.8':
-    resolution: {integrity: sha512-RFMxcEjgHk9QkUpPhsZTBuV2PnD5vZtVnjHaTiSh4heg/ULSaPx6Lxw4qA/55p4XralAZ3ecXPIzVURcGFPhcw==}
+  '@alchemy.run/sigil@0.0.0-alpha.9':
+    resolution: {integrity: sha512-ws3yQ1WfNxp26S+Dxu/HfZ437gDIO+9aZ8mKhNTyrELIakOL45wfx2swZLnLKNsXqrjk7TNHjNyejIarbjrlNw==}
     engines: {node: '>=22'}
     peerDependencies:
       '@types/react': '>=19.2.0'
@@ -18743,7 +18743,7 @@ packages:
 
 snapshots:
 
-  '@alchemy.run/sigil@0.0.0-alpha.8(@types/react@19.2.18)(react-devtools-core@7.0.1)(react@19.2.8)':
+  '@alchemy.run/sigil@0.0.0-alpha.9(@types/react@19.2.18)(react-devtools-core@7.0.1)(react@19.2.8)':
     dependencies:
       react: 19.2.8
       react-reconciler: 0.33.0(react@19.2.8)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -181,7 +181,7 @@ patchedDependencies:
   "@astrojs/starlight@0.42.0": patches/@astrojs%2Fstarlight@0.42.0.patch
   starlight-blog@0.29.0: patches/starlight-blog@0.29.0.patch
 minimumReleaseAgeExclude:
-  - "@alchemy.run/sigil@0.0.0-alpha.8"
+  - "@alchemy.run/sigil@0.0.0-alpha.9"
   - "@effect/atom-react@4.0.0-rc.112"
   - "@effect/platform-bun@4.0.0-rc.112"
   - "@effect/platform-node-shared@4.0.0-rc.112"


### PR DESCRIPTION
The bare `alchemy profile` dashboard rendered every provider block, so with more than a screenful Sigil clamped the frame and the tabs and profile header scrolled off the top.

The provider pane is now a `VirtualList` (new in `@alchemy.run/sigil@0.0.0-alpha.9`): it shrinks to the rows the terminal leaves over and scrolls just enough to keep the focused provider in view. No new keybinds; the look is unchanged.

```tsx
<Stack maxHeight={rows}>
  {/* tabs, header, status row, key bar: flexShrink={0} */}
  <VirtualList
    items={providers}
    itemHeight={(provider, index) => providerBlockHeight(provider, index === 0)}
    focusedIndex={Math.max(0, focusedProvider)}
    renderItem={(provider, index) => <ProviderBlock ... />}
  />
</Stack>
```

- `ProfileDetailsBody` is split into `ProviderBlock` plus `providerBlockHeight` / `providerPaneWidth`, so `profile show` and the dashboard keep rendering the same blocks
- The pane is sized by the whole table's width, so separators keep their `profile show` width instead of stretching across the terminal
- Bumps sigil to alpha.9 and uses its vendored `stringWidth`
