### PR TITLE
chore: adopt corrected Cloudflare operation names (getIndexInfo, queryIndex, listRules)

### DIFF
--- a/packages/alchemy/src/AWS/AMP/Scraper.ts
+++ b/packages/alchemy/src/AWS/AMP/Scraper.ts
@@ -315,7 +315,7 @@ export const ScraperProvider = () =>
             scraper.scrapeConfiguration.configurationBlob,
           );
           const observedDestination =
-            scraper.destination.ampConfiguration.workspaceArn;
+            scraper.destination.ampConfiguration?.workspaceArn;
           const aliasDrifts =
             (news!.alias ?? undefined) !== (scraper.alias ?? undefined);
           const configDrifts = observedConfig !== desiredConfig;

--- a/packages/alchemy/src/Cloudflare/Snippets/SnippetRules.ts
+++ b/packages/alchemy/src/Cloudflare/Snippets/SnippetRules.ts
@@ -224,7 +224,7 @@ interface WireRule {
 }
 
 const listObservedRules = (zoneId: string) =>
-  snippets.getRule({ zoneId }).pipe(
+  snippets.listRules({ zoneId }).pipe(
     // A zone that has never had a snippet-rule list 404s — there is simply
     // no rule list, which is equivalent to an empty one.
     Effect.catchTag("SnippetRulesNotFound", () => Effect.succeed([])),

--- a/packages/alchemy/src/Cloudflare/Snippets/SnippetRules.ts
+++ b/packages/alchemy/src/Cloudflare/Snippets/SnippetRules.ts
@@ -224,7 +224,7 @@ interface WireRule {
 }
 
 const listObservedRules = (zoneId: string) =>
-  snippets.listRules({ zoneId }).pipe(
+  snippets.getRule({ zoneId }).pipe(
     // A zone that has never had a snippet-rule list 404s — there is simply
     // no rule list, which is equivalent to an empty one.
     Effect.catchTag("SnippetRulesNotFound", () => Effect.succeed([])),

--- a/packages/alchemy/src/Cloudflare/Vectorize/SearchIndexHttpClient.ts
+++ b/packages/alchemy/src/Cloudflare/Vectorize/SearchIndexHttpClient.ts
@@ -61,13 +61,13 @@ export const makeHttpSearchIndexClient = (
     describe: () =>
       local((name) =>
         vectorize
-          .listInfo({ accountId, indexName: name })
+          .getIndexInfo({ accountId, indexName: name })
           .pipe(Effect.map(toIndexInfo)),
       ),
     query: (vector, options) =>
       local((name) =>
         vectorize
-          .listQuery({
+          .queryIndex({
             accountId,
             indexName: name,
             vector: Array.from(vector),
@@ -161,7 +161,7 @@ const toMutation = (r: {
 }): runtime.VectorizeAsyncMutation => ({ mutationId: r.mutationId ?? "" });
 
 const toIndexInfo = (
-  r: vectorize.ListInfoResponse,
+  r: vectorize.GetIndexInfoResponse,
 ): runtime.VectorizeIndexInfo =>
   ({
     vectorCount: r.vectorCount ?? 0,
@@ -170,7 +170,7 @@ const toIndexInfo = (
     processedUpToMutation: r.processedUpToMutation ?? undefined,
   }) as unknown as runtime.VectorizeIndexInfo;
 
-const toMatches = (r: vectorize.ListQueryResponse): runtime.VectorizeMatches =>
+const toMatches = (r: vectorize.QueryIndexResponse): runtime.VectorizeMatches =>
   ({
     count: r.count ?? r.matches?.length ?? 0,
     matches: (r.matches ?? []).map((m) => ({

--- a/packages/alchemy/src/Cloudflare/Vectorize/SearchIndexHttpClient.ts
+++ b/packages/alchemy/src/Cloudflare/Vectorize/SearchIndexHttpClient.ts
@@ -61,13 +61,13 @@ export const makeHttpSearchIndexClient = (
     describe: () =>
       local((name) =>
         vectorize
-          .infoIndex({ accountId, indexName: name })
+          .listInfo({ accountId, indexName: name })
           .pipe(Effect.map(toIndexInfo)),
       ),
     query: (vector, options) =>
       local((name) =>
         vectorize
-          .queryIndex({
+          .listQuery({
             accountId,
             indexName: name,
             vector: Array.from(vector),
@@ -161,7 +161,7 @@ const toMutation = (r: {
 }): runtime.VectorizeAsyncMutation => ({ mutationId: r.mutationId ?? "" });
 
 const toIndexInfo = (
-  r: vectorize.InfoIndexResponse,
+  r: vectorize.ListInfoResponse,
 ): runtime.VectorizeIndexInfo =>
   ({
     vectorCount: r.vectorCount ?? 0,
@@ -170,7 +170,7 @@ const toIndexInfo = (
     processedUpToMutation: r.processedUpToMutation ?? undefined,
   }) as unknown as runtime.VectorizeIndexInfo;
 
-const toMatches = (r: vectorize.QueryIndexResponse): runtime.VectorizeMatches =>
+const toMatches = (r: vectorize.ListQueryResponse): runtime.VectorizeMatches =>
   ({
     count: r.count ?? r.matches?.length ?? 0,
     matches: (r.matches ?? []).map((m) => ({

--- a/packages/alchemy/src/Railway/AuthProvider.ts
+++ b/packages/alchemy/src/Railway/AuthProvider.ts
@@ -155,7 +155,7 @@ export const RailwayAuth = AuthProviderLayer<
         effect: Effect.Effect<A, E, railway.RailwayOpContext>,
       ) => provideAnonymousRailway(effect, apiBaseUrl);
 
-      const code = yield* withAnonymous(railway.loginSessionCreate({})).pipe(
+      const code = yield* withAnonymous(railway.createLoginSession({})).pipe(
         Effect.mapError(
           (e) =>
             new AuthError({
@@ -178,7 +178,7 @@ export const RailwayAuth = AuthProviderLayer<
         Effect.catch(() => Effect.succeed(true)),
       );
 
-      const cancel = withAnonymous(railway.loginSessionCancel({ code })).pipe(
+      const cancel = withAnonymous(railway.cancelLoginSession({ code })).pipe(
         Effect.catch(() => Effect.void),
       );
 

--- a/packages/alchemy/src/Railway/Bucket.ts
+++ b/packages/alchemy/src/Railway/Bucket.ts
@@ -1,7 +1,7 @@
 import type {
-  BucketCreateResponse,
+  CreateBucketResponse,
   BucketS3CredentialsResultItem,
-  BucketUpdateResponse,
+  UpdateBucketResponse,
   ProjectResponseBucketsEdgesItemNode,
 } from "@distilled.cloud/railway";
 import * as railway from "@distilled.cloud/railway";
@@ -294,8 +294,8 @@ class BucketDeployPending extends Data.TaggedError(
 
 type CloudBucket =
   | ProjectResponseBucketsEdgesItemNode
-  | BucketCreateResponse
-  | BucketUpdateResponse;
+  | CreateBucketResponse
+  | UpdateBucketResponse;
 
 type BucketInstanceConfig = {
   region?: string | null;
@@ -708,7 +708,7 @@ export const BucketProvider = () =>
 
       if (current === undefined) {
         const created = yield* railway
-          .bucketCreate({
+          .createBucket({
             input: {
               projectId,
               name,
@@ -735,7 +735,7 @@ export const BucketProvider = () =>
       }
 
       if (current.name !== name) {
-        current = yield* railway.bucketUpdate({
+        current = yield* railway.updateBucket({
           id: current.id,
           input: { name },
         });

--- a/packages/alchemy/src/Railway/CloudAgent.ts
+++ b/packages/alchemy/src/Railway/CloudAgent.ts
@@ -1,5 +1,5 @@
 import type {
-  CloudAgentCreateResponse,
+  CreateCloudAgentResponse,
   CloudAgentResponse,
   CloudAgentSleepResponse,
   CloudAgentStatus,
@@ -190,7 +190,7 @@ export class CloudAgentEnvironmentRequired extends Data.TaggedError(
 
 type CloudRow =
   | CloudAgentResponse
-  | CloudAgentCreateResponse
+  | CreateCloudAgentResponse
   | CloudAgentSleepResponse
   | CloudAgentWakeResponse
   | CloudAgentsResultItem;
@@ -425,7 +425,7 @@ export const CloudAgentProvider = () =>
 
       if (current === undefined || isGone(current)) {
         const created = yield* railway
-          .cloudAgentCreate({
+          .createCloudAgent({
             input: {
               environmentId,
               name,
@@ -456,7 +456,7 @@ export const CloudAgentProvider = () =>
       const cloudAgentId = output.cloudAgentId;
       if (cloudAgentId.length === 0) return;
       yield* railway
-        .cloudAgentDelete({ id: cloudAgentId })
+        .deleteCloudAgent({ id: cloudAgentId })
         .pipe(
           Effect.catchTag(["RailwayNotFound", "NotFound"], () => Effect.void),
         );

--- a/packages/alchemy/src/Railway/CustomDomain.ts
+++ b/packages/alchemy/src/Railway/CustomDomain.ts
@@ -1,5 +1,5 @@
 import type {
-  CustomDomainCreateResponse,
+  CreateCustomDomainResponse,
   CustomDomainResponse,
   DomainsResponseCustomDomainsItem,
 } from "@distilled.cloud/railway";
@@ -181,7 +181,7 @@ export class CustomDomainServiceMissing extends Data.TaggedError(
 
 type CloudDomain =
   | CustomDomainResponse
-  | CustomDomainCreateResponse
+  | CreateCustomDomainResponse
   | DomainsResponseCustomDomainsItem;
 
 const serviceIdOf = (value: unknown): string | undefined => {
@@ -462,7 +462,7 @@ export const CustomDomainProvider = () =>
 
       if (current === undefined) {
         const created = yield* railway
-          .customDomainCreate({
+          .createCustomDomain({
             input: {
               domain,
               environmentId,
@@ -498,7 +498,7 @@ export const CustomDomainProvider = () =>
       const observedPort = current.targetPort ?? undefined;
       const desiredPort = props.targetPort;
       if (desiredPort !== undefined && desiredPort !== observedPort) {
-        yield* railway.customDomainUpdate({
+        yield* railway.updateCustomDomain({
           environmentId: current.environmentId,
           id: current.id,
           targetPort: desiredPort,
@@ -516,7 +516,7 @@ export const CustomDomainProvider = () =>
       const projectId = output.projectId;
       if (customDomainId.length === 0) return;
       yield* railway
-        .customDomainDelete({ id: customDomainId })
+        .deleteCustomDomain({ id: customDomainId })
         .pipe(
           Effect.catchTag(["RailwayNotFound", "NotFound"], () => Effect.void),
         );

--- a/packages/alchemy/src/Railway/Function.ts
+++ b/packages/alchemy/src/Railway/Function.ts
@@ -1,11 +1,11 @@
 import { createHash } from "node:crypto";
 import type {
   ProjectResponseServicesEdgesItemNode,
-  ServiceCreateResponse,
+  CreateServiceResponse,
   ServiceInstanceResponse,
   ServiceInstanceUpdateInput,
   ServiceResponse,
-  ServiceUpdateResponse,
+  UpdateServiceResponse,
 } from "@distilled.cloud/railway";
 import * as railway from "@distilled.cloud/railway";
 import * as Data from "effect/Data";
@@ -554,8 +554,8 @@ class FunctionDeployPending extends Data.TaggedError(
 
 type CloudService =
   | ServiceResponse
-  | ServiceCreateResponse
-  | ServiceUpdateResponse
+  | CreateServiceResponse
+  | UpdateServiceResponse
   | ProjectResponseServicesEdgesItemNode;
 
 const projectIdOf = (value: unknown): string | undefined => {
@@ -795,7 +795,7 @@ const upsertVariable = (input: {
   name: string;
   value: string;
 }) =>
-  railway.variableUpsert({
+  railway.upsertVariable({
     input: {
       projectId: input.projectId,
       environmentId: input.environmentId,
@@ -857,7 +857,7 @@ const syncMounts = Effect.fn(function* (input: {
   for (const mount of input.mounts) {
     if (mount.volumeId.length === 0) continue;
     yield* railway
-      .volumeInstanceUpdate({
+      .updateVolumeInstance({
         volumeId: mount.volumeId,
         environmentId: input.environmentId,
         input: {
@@ -1179,7 +1179,7 @@ export const FunctionProvider = () =>
 
           if (current === undefined) {
             const created = yield* railway
-              .serviceCreate({
+              .createService({
                 input: {
                   projectId,
                   environmentId,
@@ -1203,7 +1203,7 @@ export const FunctionProvider = () =>
           }
 
           if (current.name !== name) {
-            current = yield* railway.serviceUpdate({
+            current = yield* railway.updateService({
               id: current.id,
               input: { name },
             });
@@ -1231,7 +1231,7 @@ export const FunctionProvider = () =>
             props,
           });
           if (instanceDelta !== undefined) {
-            yield* railway.serviceInstanceUpdate({
+            yield* railway.updateServiceInstance({
               environmentId,
               serviceId: current.id,
               input: instanceDelta,
@@ -1316,7 +1316,7 @@ export const FunctionProvider = () =>
           const serviceId = output.serviceId;
           if (serviceId.length === 0) return;
           yield* railway
-            .serviceDelete({
+            .deleteService({
               id: serviceId,
               ...(output.environmentId.length > 0
                 ? { environmentId: output.environmentId }

--- a/packages/alchemy/src/Railway/Group.ts
+++ b/packages/alchemy/src/Railway/Group.ts
@@ -581,7 +581,7 @@ const commitPatch = (input: {
 
 const previewCanvas = (environmentId: string) =>
   railway
-    .canvasViewMergePreview({
+    .previewCanvasViewMerge({
       sourceEnvironmentId: environmentId,
       targetEnvironmentId: environmentId,
     })
@@ -602,7 +602,7 @@ const mergeCanvas = (
   targetEnvironmentId: string,
 ) =>
   railway
-    .canvasViewMerge({
+    .mergeCanvasView({
       sourceEnvironmentId,
       targetEnvironmentId,
     })

--- a/packages/alchemy/src/Railway/LoginSession.ts
+++ b/packages/alchemy/src/Railway/LoginSession.ts
@@ -8,14 +8,14 @@ import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
 export const RAILWAY_CLI_LOGIN_HOST = "https://railway.com";
 
 /**
- * Build the Railway CLI pairing URL for a {@link railway.loginSessionCreate}
+ * Build the Railway CLI pairing URL for a {@link railway.createLoginSession}
  * code.
  *
  * Mirrors `railway login --browserless`: the payload is
  * `wordCode={code}&hostname={hostname}` (URL-safe base64) on
  * `https://railway.com/cli-login?d=…`. The user confirms the pairing code
  * in the browser; {@link railway.loginSessionAuth} is the dashboard-side
- * mutation that marks the session authorized. {@link railway.loginSessionVerify}
+ * mutation that marks the session authorized. {@link railway.verifyLoginSession}
  * is a liveness check (true while the pairing session exists). The CLI then
  * polls {@link railway.loginSessionConsume} until a token is returned.
  *
@@ -25,7 +25,7 @@ export const RAILWAY_CLI_LOGIN_HOST = "https://railway.com";
  * ### Pairing URL
  * **Example:** From a session code
  * ```typescript
- * const code = yield* railway.loginSessionCreate({});
+ * const code = yield* railway.createLoginSession({});
  * const url = loginSessionUrl(code, { hostname: "dev-box" });
  * ```
  */
@@ -69,7 +69,7 @@ export const provideAnonymousRailway = <A, E>(
 const LOGIN_POLL_TIMES = 300;
 
 /**
- * Poll {@link railway.loginSessionVerify} then
+ * Poll {@link railway.verifyLoginSession} then
  * {@link railway.loginSessionConsume} until a token is returned, or 5 minutes
  * elapse. Mirrors `railway login --browserless`: consume is the token source;
  * verify is a liveness check. Does not cancel the session — the caller should
@@ -87,7 +87,7 @@ export const pollLoginSessionToken = (
   railway.RailwayOpError,
   railway.RailwayOpContext
 > =>
-  railway.loginSessionVerify({ code }).pipe(
+  railway.verifyLoginSession({ code }).pipe(
     Effect.catchTag(missingSession, () => Effect.succeed(false)),
     Effect.flatMap(() =>
       railway

--- a/packages/alchemy/src/Railway/Mongo.ts
+++ b/packages/alchemy/src/Railway/Mongo.ts
@@ -2,12 +2,12 @@ import { randomBytes } from "node:crypto";
 import type {
   EnvironmentResponseVolumeInstancesEdgesItemNode,
   ProjectResponseServicesEdgesItemNode,
-  ServiceCreateResponse,
+  CreateServiceResponse,
   ServiceInstanceResponse,
   ServiceResponse,
-  ServiceUpdateResponse,
+  UpdateServiceResponse,
   TcpProxiesResultItem,
-  TcpProxyCreateResponse,
+  CreateTcpProxyResponse,
   VolumeInstanceResponse,
   VolumeState,
 } from "@distilled.cloud/railway";
@@ -346,15 +346,15 @@ class VolumePending extends Data.TaggedError("Railway.MongoVolumePending")<{
 
 type CloudService =
   | ServiceResponse
-  | ServiceCreateResponse
-  | ServiceUpdateResponse
+  | CreateServiceResponse
+  | UpdateServiceResponse
   | ProjectResponseServicesEdgesItemNode;
 
 type CloudInstance =
   | EnvironmentResponseVolumeInstancesEdgesItemNode
   | VolumeInstanceResponse;
 
-type CloudProxy = TcpProxiesResultItem | TcpProxyCreateResponse;
+type CloudProxy = TcpProxiesResultItem | CreateTcpProxyResponse;
 
 const projectIdOf = (value: unknown): string | undefined => {
   if (value === null || typeof value !== "object") return undefined;
@@ -622,7 +622,7 @@ const findProxy = (
  * operation is already in progress". Already-gone proxies are a no-op.
  */
 const deleteProxy = (id: string) =>
-  railway.tcpProxyDelete({ id }).pipe(
+  railway.deleteTcpProxy({ id }).pipe(
     Effect.retry({
       while: (e) =>
         e._tag === "RailwayInternalError" &&
@@ -673,7 +673,7 @@ const upsertVariable = (input: {
   name: string;
   value: string;
 }) =>
-  railway.variableUpsert({
+  railway.upsertVariable({
     input: {
       projectId: input.projectId,
       environmentId: input.environmentId,
@@ -793,7 +793,7 @@ const waitForVolume = (
 };
 
 const stampVolumeName = (volumeId: string, name: string) =>
-  railway.volumeUpdate({
+  railway.updateVolume({
     volumeId,
     input: { name },
   });
@@ -1032,7 +1032,7 @@ export const MongoProvider = () =>
 
       if (current === undefined) {
         const created = yield* railway
-          .serviceCreate({
+          .createService({
             input: {
               projectId,
               environmentId,
@@ -1057,7 +1057,7 @@ export const MongoProvider = () =>
       }
 
       if (current.name !== name) {
-        current = yield* railway.serviceUpdate({
+        current = yield* railway.updateService({
           id: current.id,
           input: { name },
         });
@@ -1077,7 +1077,7 @@ export const MongoProvider = () =>
         normalizeStart(instance?.startCommand) !==
         normalizeStart(MONGO_START_COMMAND);
       if (imageChanged || regionChanged || sleepOn || startChanged) {
-        yield* railway.serviceInstanceUpdate({
+        yield* railway.updateServiceInstance({
           environmentId,
           serviceId: current.id,
           input: {
@@ -1121,7 +1121,7 @@ export const MongoProvider = () =>
         );
       }
       if (volume === undefined) {
-        const created = yield* railway.volumeCreate({
+        const created = yield* railway.createVolume({
           input: {
             projectId,
             environmentId,
@@ -1163,7 +1163,7 @@ export const MongoProvider = () =>
       const mountChanged = observedMount !== MONGO_MOUNT_PATH;
       const attached = observedServiceId === current.id;
       if (mountChanged || !attached) {
-        yield* railway.volumeInstanceUpdate({
+        yield* railway.updateVolumeInstance({
           volumeId: volume.volumeId,
           environmentId,
           input: {
@@ -1180,7 +1180,7 @@ export const MongoProvider = () =>
       let proxy = yield* findProxy(environmentId, current.id, MONGO_PORT);
       if (wantPublic && proxy === undefined) {
         const created = yield* railway
-          .tcpProxyCreate({
+          .createTcpProxy({
             input: {
               applicationPort: MONGO_PORT,
               environmentId,
@@ -1221,7 +1221,7 @@ export const MongoProvider = () =>
       if (!deployFailed(finalStatus) && !deployReady(finalStatus)) {
         const wedged = instance?.latestDeployment?.id;
         if (wedged != null && wedged.length > 0) {
-          yield* railway.deploymentCancel({ id: wedged }).pipe(Effect.ignore);
+          yield* railway.cancelDeployment({ id: wedged }).pipe(Effect.ignore);
         }
         yield* railway
           .serviceInstanceDeployV2({ environmentId, serviceId: current.id })
@@ -1268,14 +1268,14 @@ export const MongoProvider = () =>
           !deployFailed(latest.status)
         ) {
           yield* railway
-            .deploymentCancel({ id: latest.id })
+            .cancelDeployment({ id: latest.id })
             .pipe(Effect.ignore);
         }
       }
       // Delete the SERVICE next — its teardown cascades onto the proxies.
       if (serviceId.length > 0) {
         yield* railway
-          .serviceDelete({
+          .deleteService({
             id: serviceId,
             ...(environmentId.length > 0 ? { environmentId } : {}),
           })
@@ -1313,7 +1313,7 @@ export const MongoProvider = () =>
       }
       if (output.volumeId.length > 0) {
         yield* railway
-          .volumeDelete({ volumeId: output.volumeId })
+          .deleteVolume({ volumeId: output.volumeId })
           .pipe(
             Effect.catchTag(["RailwayNotFound", "NotFound"], () => Effect.void),
           );

--- a/packages/alchemy/src/Railway/MySQL.ts
+++ b/packages/alchemy/src/Railway/MySQL.ts
@@ -2,12 +2,12 @@ import { randomBytes } from "node:crypto";
 import type {
   EnvironmentResponseVolumeInstancesEdgesItemNode,
   ProjectResponseServicesEdgesItemNode,
-  ServiceCreateResponse,
+  CreateServiceResponse,
   ServiceInstanceResponse,
   ServiceResponse,
-  ServiceUpdateResponse,
+  UpdateServiceResponse,
   TcpProxiesResultItem,
-  TcpProxyCreateResponse,
+  CreateTcpProxyResponse,
   VolumeInstanceResponse,
   VolumeState,
 } from "@distilled.cloud/railway";
@@ -336,15 +336,15 @@ class VolumePending extends Data.TaggedError("Railway.MySQLVolumePending")<{
 
 type CloudService =
   | ServiceResponse
-  | ServiceCreateResponse
-  | ServiceUpdateResponse
+  | CreateServiceResponse
+  | UpdateServiceResponse
   | ProjectResponseServicesEdgesItemNode;
 
 type CloudInstance =
   | EnvironmentResponseVolumeInstancesEdgesItemNode
   | VolumeInstanceResponse;
 
-type CloudProxy = TcpProxiesResultItem | TcpProxyCreateResponse;
+type CloudProxy = TcpProxiesResultItem | CreateTcpProxyResponse;
 
 const projectIdOf = (value: unknown): string | undefined => {
   if (value === null || typeof value !== "object") return undefined;
@@ -622,7 +622,7 @@ const findProxy = (
  * operation is already in progress". Already-gone proxies are a no-op.
  */
 const deleteProxy = (id: string) =>
-  railway.tcpProxyDelete({ id }).pipe(
+  railway.deleteTcpProxy({ id }).pipe(
     Effect.retry({
       while: (e) =>
         e._tag === "RailwayInternalError" &&
@@ -673,7 +673,7 @@ const upsertVariable = (input: {
   name: string;
   value: string;
 }) =>
-  railway.variableUpsert({
+  railway.upsertVariable({
     input: {
       projectId: input.projectId,
       environmentId: input.environmentId,
@@ -793,7 +793,7 @@ const waitForVolume = (
 };
 
 const stampVolumeName = (volumeId: string, name: string) =>
-  railway.volumeUpdate({
+  railway.updateVolume({
     volumeId,
     input: { name },
   });
@@ -1033,7 +1033,7 @@ export const MySQLProvider = () =>
 
       if (current === undefined) {
         const created = yield* railway
-          .serviceCreate({
+          .createService({
             input: {
               projectId,
               environmentId,
@@ -1058,7 +1058,7 @@ export const MySQLProvider = () =>
       }
 
       if (current.name !== name) {
-        current = yield* railway.serviceUpdate({
+        current = yield* railway.updateService({
           id: current.id,
           input: { name },
         });
@@ -1078,7 +1078,7 @@ export const MySQLProvider = () =>
       const startChanged =
         startCommand !== undefined && observedStart !== startCommand;
       if (imageChanged || regionChanged || sleepOn || startChanged) {
-        yield* railway.serviceInstanceUpdate({
+        yield* railway.updateServiceInstance({
           environmentId,
           serviceId: current.id,
           input: {
@@ -1122,7 +1122,7 @@ export const MySQLProvider = () =>
         );
       }
       if (volume === undefined) {
-        const created = yield* railway.volumeCreate({
+        const created = yield* railway.createVolume({
           input: {
             projectId,
             environmentId,
@@ -1164,7 +1164,7 @@ export const MySQLProvider = () =>
       const mountChanged = observedMount !== MYSQL_MOUNT_PATH;
       const attached = observedServiceId === current.id;
       if (mountChanged || !attached) {
-        yield* railway.volumeInstanceUpdate({
+        yield* railway.updateVolumeInstance({
           volumeId: volume.volumeId,
           environmentId,
           input: {
@@ -1181,7 +1181,7 @@ export const MySQLProvider = () =>
       let proxy = yield* findProxy(environmentId, current.id, MYSQL_PORT);
       if (wantPublic && proxy === undefined) {
         const created = yield* railway
-          .tcpProxyCreate({
+          .createTcpProxy({
             input: {
               applicationPort: MYSQL_PORT,
               environmentId,
@@ -1222,7 +1222,7 @@ export const MySQLProvider = () =>
       if (!deployFailed(finalStatus) && !deployReady(finalStatus)) {
         const wedged = instance?.latestDeployment?.id;
         if (wedged != null && wedged.length > 0) {
-          yield* railway.deploymentCancel({ id: wedged }).pipe(Effect.ignore);
+          yield* railway.cancelDeployment({ id: wedged }).pipe(Effect.ignore);
         }
         yield* railway
           .serviceInstanceDeployV2({ environmentId, serviceId: current.id })
@@ -1269,14 +1269,14 @@ export const MySQLProvider = () =>
           !deployFailed(latest.status)
         ) {
           yield* railway
-            .deploymentCancel({ id: latest.id })
+            .cancelDeployment({ id: latest.id })
             .pipe(Effect.ignore);
         }
       }
       // Delete the SERVICE next — its teardown cascades onto the proxies.
       if (serviceId.length > 0) {
         yield* railway
-          .serviceDelete({
+          .deleteService({
             id: serviceId,
             ...(environmentId.length > 0 ? { environmentId } : {}),
           })
@@ -1314,7 +1314,7 @@ export const MySQLProvider = () =>
       }
       if (output.volumeId.length > 0) {
         yield* railway
-          .volumeDelete({ volumeId: output.volumeId })
+          .deleteVolume({ volumeId: output.volumeId })
           .pipe(
             Effect.catchTag(["RailwayNotFound", "NotFound"], () => Effect.void),
           );

--- a/packages/alchemy/src/Railway/Postgres.ts
+++ b/packages/alchemy/src/Railway/Postgres.ts
@@ -2,12 +2,12 @@ import { randomBytes } from "node:crypto";
 import type {
   EnvironmentResponseVolumeInstancesEdgesItemNode,
   ProjectResponseServicesEdgesItemNode,
-  ServiceCreateResponse,
+  CreateServiceResponse,
   ServiceInstanceResponse,
   ServiceResponse,
-  ServiceUpdateResponse,
+  UpdateServiceResponse,
   TcpProxiesResultItem,
-  TcpProxyCreateResponse,
+  CreateTcpProxyResponse,
   VolumeInstanceResponse,
   VolumeState,
 } from "@distilled.cloud/railway";
@@ -333,15 +333,15 @@ class VolumePending extends Data.TaggedError("Railway.PostgresVolumePending")<{
 
 type CloudService =
   | ServiceResponse
-  | ServiceCreateResponse
-  | ServiceUpdateResponse
+  | CreateServiceResponse
+  | UpdateServiceResponse
   | ProjectResponseServicesEdgesItemNode;
 
 type CloudInstance =
   | EnvironmentResponseVolumeInstancesEdgesItemNode
   | VolumeInstanceResponse;
 
-type CloudProxy = TcpProxiesResultItem | TcpProxyCreateResponse;
+type CloudProxy = TcpProxiesResultItem | CreateTcpProxyResponse;
 
 const projectIdOf = (value: unknown): string | undefined => {
   if (value === null || typeof value !== "object") return undefined;
@@ -608,7 +608,7 @@ const findProxy = (
  * operation is already in progress". Already-gone proxies are a no-op.
  */
 const deleteProxy = (id: string) =>
-  railway.tcpProxyDelete({ id }).pipe(
+  railway.deleteTcpProxy({ id }).pipe(
     Effect.retry({
       while: (e) =>
         e._tag === "RailwayInternalError" &&
@@ -659,7 +659,7 @@ const upsertVariable = (input: {
   name: string;
   value: string;
 }) =>
-  railway.variableUpsert({
+  railway.upsertVariable({
     input: {
       projectId: input.projectId,
       environmentId: input.environmentId,
@@ -781,7 +781,7 @@ const waitForVolume = (
 };
 
 const stampVolumeName = (volumeId: string, name: string) =>
-  railway.volumeUpdate({
+  railway.updateVolume({
     volumeId,
     input: { name },
   });
@@ -988,7 +988,7 @@ export const PostgresProvider = () =>
 
       if (current === undefined) {
         const created = yield* railway
-          .serviceCreate({
+          .createService({
             input: {
               projectId,
               environmentId,
@@ -1013,7 +1013,7 @@ export const PostgresProvider = () =>
       }
 
       if (current.name !== name) {
-        current = yield* railway.serviceUpdate({
+        current = yield* railway.updateService({
           id: current.id,
           input: { name },
         });
@@ -1030,7 +1030,7 @@ export const PostgresProvider = () =>
         props.region !== undefined && props.region !== observedRegion;
       const sleepOn = instance?.sleepApplication !== false;
       if (imageChanged || regionChanged || sleepOn) {
-        yield* railway.serviceInstanceUpdate({
+        yield* railway.updateServiceInstance({
           environmentId,
           serviceId: current.id,
           input: {
@@ -1073,7 +1073,7 @@ export const PostgresProvider = () =>
         );
       }
       if (volume === undefined) {
-        const created = yield* railway.volumeCreate({
+        const created = yield* railway.createVolume({
           input: {
             projectId,
             environmentId,
@@ -1115,7 +1115,7 @@ export const PostgresProvider = () =>
       const mountChanged = observedMount !== POSTGRES_MOUNT_PATH;
       const attached = observedServiceId === current.id;
       if (mountChanged || !attached) {
-        yield* railway.volumeInstanceUpdate({
+        yield* railway.updateVolumeInstance({
           volumeId: volume.volumeId,
           environmentId,
           input: {
@@ -1132,7 +1132,7 @@ export const PostgresProvider = () =>
       let proxy = yield* findProxy(environmentId, current.id, POSTGRES_PORT);
       if (wantPublic && proxy === undefined) {
         const created = yield* railway
-          .tcpProxyCreate({
+          .createTcpProxy({
             input: {
               applicationPort: POSTGRES_PORT,
               environmentId,
@@ -1173,7 +1173,7 @@ export const PostgresProvider = () =>
       if (!deployFailed(finalStatus) && !deployReady(finalStatus)) {
         const wedged = instance?.latestDeployment?.id;
         if (wedged != null && wedged.length > 0) {
-          yield* railway.deploymentCancel({ id: wedged }).pipe(Effect.ignore);
+          yield* railway.cancelDeployment({ id: wedged }).pipe(Effect.ignore);
         }
         yield* railway
           .serviceInstanceDeployV2({ environmentId, serviceId: current.id })
@@ -1220,14 +1220,14 @@ export const PostgresProvider = () =>
           !deployFailed(latest.status)
         ) {
           yield* railway
-            .deploymentCancel({ id: latest.id })
+            .cancelDeployment({ id: latest.id })
             .pipe(Effect.ignore);
         }
       }
       // Delete the SERVICE next — its teardown cascades onto the proxies.
       if (serviceId.length > 0) {
         yield* railway
-          .serviceDelete({
+          .deleteService({
             id: serviceId,
             ...(environmentId.length > 0 ? { environmentId } : {}),
           })
@@ -1265,7 +1265,7 @@ export const PostgresProvider = () =>
       }
       if (output.volumeId.length > 0) {
         yield* railway
-          .volumeDelete({ volumeId: output.volumeId })
+          .deleteVolume({ volumeId: output.volumeId })
           .pipe(
             Effect.catchTag(["RailwayNotFound", "NotFound"], () => Effect.void),
           );

--- a/packages/alchemy/src/Railway/PrivateNetwork.ts
+++ b/packages/alchemy/src/Railway/PrivateNetwork.ts
@@ -943,7 +943,7 @@ export const PrivateNetworkEndpointProvider = () =>
           prefix: desiredPrefix,
         });
         if (available) {
-          yield* railway.privateNetworkEndpointRename({
+          yield* railway.renamePrivateNetworkEndpoint({
             dnsName: desiredPrefix,
             id: current.publicId,
             privateNetworkId,
@@ -970,7 +970,7 @@ export const PrivateNetworkEndpointProvider = () =>
       const id = output.publicId;
       if (id.length === 0) return;
       yield* railway
-        .privateNetworkEndpointDelete({ id })
+        .deletePrivateNetworkEndpoint({ id })
         .pipe(
           Effect.catchTag(["RailwayNotFound", "NotFound"], () => Effect.void),
         );

--- a/packages/alchemy/src/Railway/Project.ts
+++ b/packages/alchemy/src/Railway/Project.ts
@@ -1,7 +1,7 @@
 import type {
-  ProjectCreateResponse,
+  CreateProjectResponse,
   ProjectResponse,
-  ProjectUpdateResponse,
+  UpdateProjectResponse,
   ProjectsResponseEdgesItemNode,
 } from "@distilled.cloud/railway";
 import * as railway from "@distilled.cloud/railway";
@@ -157,8 +157,8 @@ export class ProjectNotCreated extends Data.TaggedError(
 
 type CloudProject =
   | ProjectResponse
-  | ProjectCreateResponse
-  | ProjectUpdateResponse
+  | CreateProjectResponse
+  | UpdateProjectResponse
   | ProjectsResponseEdgesItemNode;
 
 /** Workspace id from a get-by-id or list-node Project payload. */
@@ -244,7 +244,7 @@ export const createProject = (input: {
   defaultEnvironmentName?: string;
 }) =>
   waitOutCreateRateLimit(
-    railway.projectCreate({
+    railway.createProject({
       input: {
         name: input.name,
         workspaceId: input.workspaceId,
@@ -398,7 +398,7 @@ export const ProjectProvider = () =>
         props.description !== undefined &&
         props.description !== observedDescription;
       if (nameChanged || descriptionChanged) {
-        current = yield* railway.projectUpdate({
+        current = yield* railway.updateProject({
           id: current.id,
           input: {
             ...(nameChanged ? { name } : {}),
@@ -420,7 +420,7 @@ export const ProjectProvider = () =>
       const projectId = output.projectId;
       if (projectId.length === 0) return;
       yield* railway
-        .projectDelete({ id: projectId })
+        .deleteProject({ id: projectId })
         .pipe(
           Effect.catchTag(["RailwayNotFound", "NotFound"], () => Effect.void),
         );

--- a/packages/alchemy/src/Railway/ProjectEnvironment.ts
+++ b/packages/alchemy/src/Railway/ProjectEnvironment.ts
@@ -1,6 +1,6 @@
 import type {
-  EnvironmentCreateResponse,
-  EnvironmentRenameResponse,
+  CreateEnvironmentResponse,
+  RenameEnvironmentResponse,
   EnvironmentResponse,
   EnvironmentsResponseEdgesItemNode,
 } from "@distilled.cloud/railway";
@@ -169,8 +169,8 @@ export class EnvironmentProjectRequired extends Data.TaggedError(
 
 type CloudEnvironment =
   | EnvironmentResponse
-  | EnvironmentCreateResponse
-  | EnvironmentRenameResponse
+  | CreateEnvironmentResponse
+  | RenameEnvironmentResponse
   | EnvironmentsResponseEdgesItemNode;
 
 const toAttrs = (
@@ -323,7 +323,7 @@ export const EnvironmentProvider = () =>
 
       if (current === undefined) {
         const created = yield* waitOutCreateRateLimit(
-          railway.environmentCreate({
+          railway.createEnvironment({
             input: {
               name,
               projectId,
@@ -345,7 +345,7 @@ export const EnvironmentProvider = () =>
       }
 
       if (current.name !== name) {
-        current = yield* railway.environmentRename({
+        current = yield* railway.renameEnvironment({
           id: current.id,
           input: { name },
         });
@@ -358,7 +358,7 @@ export const EnvironmentProvider = () =>
       const environmentId = output.environmentId;
       if (environmentId.length === 0) return;
       yield* railway
-        .environmentDelete({ id: environmentId })
+        .deleteEnvironment({ id: environmentId })
         .pipe(
           Effect.catchTag(["RailwayNotFound", "NotFound"], () => Effect.void),
         );

--- a/packages/alchemy/src/Railway/Redis.ts
+++ b/packages/alchemy/src/Railway/Redis.ts
@@ -1,10 +1,10 @@
 import { randomBytes } from "node:crypto";
 import type {
   ProjectResponseServicesEdgesItemNode,
-  ServiceCreateResponse,
+  CreateServiceResponse,
   ServiceInstanceResponse,
   ServiceResponse,
-  ServiceUpdateResponse,
+  UpdateServiceResponse,
 } from "@distilled.cloud/railway";
 import * as railway from "@distilled.cloud/railway";
 import * as Data from "effect/Data";
@@ -289,8 +289,8 @@ class RedisDeployPending extends Data.TaggedError(
 
 type CloudService =
   | ServiceResponse
-  | ServiceCreateResponse
-  | ServiceUpdateResponse
+  | CreateServiceResponse
+  | UpdateServiceResponse
   | ProjectResponseServicesEdgesItemNode;
 
 const projectIdOf = (value: unknown): string | undefined => {
@@ -486,7 +486,7 @@ const upsertVariable = (input: {
   name: string;
   value: string;
 }) =>
-  railway.variableUpsert({
+  railway.upsertVariable({
     input: {
       projectId: input.projectId,
       environmentId: input.environmentId,
@@ -703,7 +703,7 @@ export const RedisProvider = () =>
 
       if (current === undefined) {
         const created = yield* railway
-          .serviceCreate({
+          .createService({
             input: {
               projectId,
               environmentId,
@@ -728,7 +728,7 @@ export const RedisProvider = () =>
       }
 
       if (current.name !== name) {
-        current = yield* railway.serviceUpdate({
+        current = yield* railway.updateService({
           id: current.id,
           input: { name },
         });
@@ -745,7 +745,7 @@ export const RedisProvider = () =>
       const observedStart = instance?.startCommand ?? undefined;
       const startChanged = (observedStart ?? undefined) !== startCommand;
       if (imageChanged || regionChanged || startChanged) {
-        yield* railway.serviceInstanceUpdate({
+        yield* railway.updateServiceInstance({
           environmentId,
           serviceId: current.id,
           input: {
@@ -791,7 +791,7 @@ export const RedisProvider = () =>
       const serviceId = output.serviceId;
       if (serviceId.length === 0) return;
       yield* railway
-        .serviceDelete({
+        .deleteService({
           id: serviceId,
           ...(output.environmentId.length > 0
             ? { environmentId: output.environmentId }

--- a/packages/alchemy/src/Railway/Sandbox.ts
+++ b/packages/alchemy/src/Railway/Sandbox.ts
@@ -1,8 +1,8 @@
 import type {
   SandboxCheckpointsResultItem,
-  SandboxCreateResponse,
+  CreateSandboxResponse,
   SandboxDestroyResponse,
-  SandboxExecResponse,
+  ExecSandboxResponse,
   SandboxHeartbeatResponse,
   SandboxNetworkIsolation,
   SandboxResponse,
@@ -289,7 +289,7 @@ class SandboxPending extends Data.TaggedError("Railway.SandboxPending")<{
 
 type CloudSandbox =
   | SandboxResponse
-  | SandboxCreateResponse
+  | CreateSandboxResponse
   | SandboxDestroyResponse
   | SandboxHeartbeatResponse
   | SandboxesResponseEdgesItemNode;
@@ -455,7 +455,7 @@ export const execSandbox = Effect.fn(function* (input: {
   command: string;
   timeoutSec?: number;
 }) {
-  return yield* railway.sandboxExec({
+  return yield* railway.execSandbox({
     command: input.command,
     environmentId: input.environmentId,
     id: input.sandboxId,
@@ -486,7 +486,7 @@ export const createSandboxCheckpoint = Effect.fn(function* (input: {
   environmentId: string;
   name: string;
 }) {
-  return yield* railway.sandboxCheckpointCreate({
+  return yield* railway.createSandboxCheckpoint({
     environmentId: input.environmentId,
     name: input.name,
     sandboxId: input.sandboxId,
@@ -527,7 +527,7 @@ export const renameSandboxCheckpoint = Effect.fn(function* (input: {
       name: input.name,
     });
   }
-  return yield* railway.sandboxCheckpointRename({
+  return yield* railway.renameSandboxCheckpoint({
     environmentId: input.environmentId,
     id: found.id,
     name: input.newName,
@@ -547,7 +547,7 @@ export const deleteSandboxCheckpoint = Effect.fn(function* (input: {
   const found = findCheckpoint(items, input.name);
   if (found === undefined) return;
   yield* railway
-    .sandboxCheckpointDelete({
+    .deleteSandboxCheckpoint({
       environmentId: input.environmentId,
       id: found.id,
     })
@@ -559,7 +559,7 @@ export type ExecRequest = {
   timeoutSec?: number;
 };
 
-export type ExecResult = SandboxExecResponse;
+export type ExecResult = ExecSandboxResponse;
 
 /**
  * Run a command inside a {@link Sandbox}. Control-plane GraphQL —
@@ -589,7 +589,7 @@ export const Exec = Binding.Service<Exec>("Railway.Sandbox.Exec");
 export interface ExecClient {
   (
     request: ExecRequest,
-  ): Effect.Effect<ExecResult, railway.SandboxExecError, RuntimeContext>;
+  ): Effect.Effect<ExecResult, railway.ExecSandboxError, RuntimeContext>;
 }
 
 /**
@@ -717,7 +717,7 @@ export const SandboxProvider = () =>
           : undefined;
 
       if (current === undefined) {
-        const created = yield* railway.sandboxCreate({
+        const created = yield* railway.createSandbox({
           input: {
             environmentId,
             ...(props.idleTimeoutMinutes !== undefined

--- a/packages/alchemy/src/Railway/ServiceDomain.ts
+++ b/packages/alchemy/src/Railway/ServiceDomain.ts
@@ -162,7 +162,7 @@ export const deleteOwnedServiceDomain = Effect.fn(function* (input: {
     if (row.syncStatus === "DELETING") continue;
     yield* withEnvironmentConfigLock(
       input.environmentId,
-      railway.serviceDomainDelete({ id: row.id }),
+      railway.deleteServiceDomain({ id: row.id }),
     ).pipe(
       Effect.catchTag(["RailwayNotFound", "NotFound"], () => Effect.void),
       Effect.asVoid,
@@ -353,7 +353,7 @@ const createViaMutation = (input: {
       ),
     );
   const create = railway
-    .serviceDomainCreate({
+    .createServiceDomain({
       input: {
         environmentId: input.environmentId,
         serviceId: input.serviceId,
@@ -439,7 +439,7 @@ const syncDomain = (input: {
   if (!rename && !retarget) return Effect.succeed(undefined);
   return withEnvironmentConfigLock(
     input.current.environmentId,
-    railway.serviceDomainUpdate({
+    railway.updateServiceDomain({
       input: {
         domain: domainName ?? input.current.domain,
         environmentId: input.current.environmentId,

--- a/packages/alchemy/src/Railway/ServiceProvider.ts
+++ b/packages/alchemy/src/Railway/ServiceProvider.ts
@@ -3,11 +3,11 @@ import type {
   DeploymentTriggersResponseEdgesItemNode,
   ProjectResponseServicesEdgesItemNode,
   RestartPolicyType,
-  ServiceCreateResponse,
+  CreateServiceResponse,
   ServiceInstanceResponse,
   ServiceInstanceUpdateInput,
   ServiceResponse,
-  ServiceUpdateResponse,
+  UpdateServiceResponse,
 } from "@distilled.cloud/railway";
 import * as railway from "@distilled.cloud/railway";
 import * as Data from "effect/Data";
@@ -106,8 +106,8 @@ class ServiceDeployPending extends Data.TaggedError(
 
 type CloudService =
   | ServiceResponse
-  | ServiceCreateResponse
-  | ServiceUpdateResponse
+  | CreateServiceResponse
+  | UpdateServiceResponse
   | ProjectResponseServicesEdgesItemNode;
 
 const projectIdOf = (value: unknown): string | undefined => {
@@ -634,7 +634,7 @@ const upsertVariable = (input: {
   name: string;
   value: string;
 }) =>
-  railway.variableUpsert({
+  railway.upsertVariable({
     input: {
       projectId: input.projectId,
       environmentId: input.environmentId,
@@ -713,7 +713,7 @@ const syncMounts = Effect.fn(function* (input: {
   for (const mount of input.mounts) {
     if (mount.volumeId.length === 0) continue;
     yield* railway
-      .volumeInstanceUpdate({
+      .updateVolumeInstance({
         volumeId: mount.volumeId,
         environmentId: input.environmentId,
         input: {
@@ -1055,7 +1055,7 @@ export const ServiceProvider = () =>
 
           if (current === undefined) {
             const created = yield* railway
-              .serviceCreate({
+              .createService({
                 input: {
                   projectId,
                   environmentId,
@@ -1088,7 +1088,7 @@ export const ServiceProvider = () =>
           }
 
           if (current.name !== name) {
-            current = yield* railway.serviceUpdate({
+            current = yield* railway.updateService({
               id: current.id,
               input: { name },
             });
@@ -1151,7 +1151,7 @@ export const ServiceProvider = () =>
             (instance?.source?.repo != null || instance?.source?.image != null);
 
           if (localSourceChanged) {
-            yield* railway.serviceDisconnect({ id: current.id });
+            yield* railway.disconnectService({ id: current.id });
             needsDeploy = true;
             instance =
               (yield* getInstance(environmentId, current.id)) ?? instance;
@@ -1189,7 +1189,7 @@ export const ServiceProvider = () =>
             },
           });
           if (instanceDelta !== undefined) {
-            yield* railway.serviceInstanceUpdate({
+            yield* railway.updateServiceInstance({
               environmentId,
               serviceId: current.id,
               input: instanceDelta,
@@ -1347,7 +1347,7 @@ export const ServiceProvider = () =>
           const serviceId = output.serviceId;
           if (serviceId.length === 0) return;
           yield* railway
-            .serviceDelete({
+            .deleteService({
               id: serviceId,
               ...(output.environmentId.length > 0
                 ? { environmentId: output.environmentId }

--- a/packages/alchemy/src/Railway/TcpProxy.ts
+++ b/packages/alchemy/src/Railway/TcpProxy.ts
@@ -1,6 +1,6 @@
 import type {
   TcpProxiesResultItem,
-  TcpProxyCreateResponse,
+  CreateTcpProxyResponse,
 } from "@distilled.cloud/railway";
 import * as railway from "@distilled.cloud/railway";
 import * as Data from "effect/Data";
@@ -187,7 +187,7 @@ export class TcpProxyTargetMissing extends Data.TaggedError(
   message: string;
 }> {}
 
-type CloudProxy = TcpProxiesResultItem | TcpProxyCreateResponse;
+type CloudProxy = TcpProxiesResultItem | CreateTcpProxyResponse;
 
 const isGone = (proxy: CloudProxy | undefined) =>
   proxy === undefined ||
@@ -386,7 +386,7 @@ export const TcpProxyProvider = () =>
 
       if (current === undefined) {
         const created = yield* railway
-          .tcpProxyCreate({
+          .createTcpProxy({
             input: {
               applicationPort,
               environmentId,
@@ -422,7 +422,7 @@ export const TcpProxyProvider = () =>
     delete: Effect.fn(function* ({ output }) {
       const id = output.id;
       if (id.length === 0) return;
-      yield* railway.tcpProxyDelete({ id }).pipe(
+      yield* railway.deleteTcpProxy({ id }).pipe(
         // Railway serializes proxy mutations per environment: a delete
         // racing an in-flight deploy fails with "Cannot delete TCP proxy:
         // an operation is already in progress".

--- a/packages/alchemy/src/Railway/Template.ts
+++ b/packages/alchemy/src/Railway/Template.ts
@@ -1,13 +1,13 @@
 import type {
-  ProjectCreateResponse,
+  CreateProjectResponse,
   ProjectResponse,
   ProjectResponseServicesEdgesItemNode,
-  ProjectUpdateResponse,
+  UpdateProjectResponse,
   ProjectsResponseEdgesItemNode,
   ServiceResponse,
-  TemplateCloneResponse,
-  TemplateGenerateResponse,
-  TemplatePublishResponse,
+  CloneTemplateResponse,
+  GenerateTemplateResponse,
+  PublishTemplateResponse,
   TemplateResponse,
   TemplatesResponseEdgesItemNode,
   TemplateSourceForProjectResponse,
@@ -273,16 +273,16 @@ class TemplatePending extends Data.TaggedError("Railway.TemplatePending")<{
 
 type CloudTemplate =
   | TemplateResponse
-  | TemplateCloneResponse
-  | TemplateGenerateResponse
-  | TemplatePublishResponse
+  | CloneTemplateResponse
+  | GenerateTemplateResponse
+  | PublishTemplateResponse
   | TemplateSourceForProjectResponse
   | TemplatesResponseEdgesItemNode;
 
 type CloudProject =
   | ProjectResponse
-  | ProjectCreateResponse
-  | ProjectUpdateResponse
+  | CreateProjectResponse
+  | UpdateProjectResponse
   | ProjectsResponseEdgesItemNode;
 
 type CloudService = ProjectResponseServicesEdgesItemNode | ServiceResponse;
@@ -868,7 +868,7 @@ export const TemplateProvider = () =>
       for (const serviceId of serviceIds) {
         if (serviceId.length === 0) continue;
         yield* railway
-          .serviceDelete({
+          .deleteService({
             id: serviceId,
             ...(output.environmentId.length > 0
               ? { environmentId: output.environmentId }
@@ -883,7 +883,7 @@ export const TemplateProvider = () =>
       const projectId = output.projectId;
       if (projectId.length === 0) return;
       yield* railway
-        .projectDelete({ id: projectId })
+        .deleteProject({ id: projectId })
         .pipe(
           Effect.catchTag(["RailwayNotFound", "NotFound"], () => Effect.void),
         );

--- a/packages/alchemy/src/Railway/Usage.ts
+++ b/packages/alchemy/src/Railway/Usage.ts
@@ -420,7 +420,7 @@ const setLimit = (input: {
   softLimitDollars: number;
   hardLimitDollars?: number | null;
 }) =>
-  railway.usageLimitSet({
+  railway.setUsageLimit({
     input: {
       customerId: input.customerId,
       softLimitDollars: input.softLimitDollars,
@@ -558,7 +558,7 @@ export const UsageLimitProvider = () =>
       const workspaceId = output.workspaceId;
       if (customerId.length === 0) return;
       yield* railway
-        .usageLimitRemove({ input: { customerId } })
+        .removeUsageLimit({ input: { customerId } })
         .pipe(
           Effect.catchTag(["RailwayNotFound", "NotFound"], () => Effect.void),
         );

--- a/packages/alchemy/src/Railway/Variable.ts
+++ b/packages/alchemy/src/Railway/Variable.ts
@@ -403,7 +403,7 @@ const upsertVariable = (input: {
   value: string;
   serviceId?: string;
 }) =>
-  railway.variableUpsert({
+  railway.upsertVariable({
     input: {
       projectId: input.projectId,
       environmentId: input.environmentId,
@@ -635,7 +635,7 @@ export const VariableProvider = () =>
         return;
       }
       yield* railway
-        .variableDelete({
+        .deleteVariable({
           input: {
             projectId: output.projectId,
             environmentId: output.environmentId,

--- a/packages/alchemy/src/Railway/Volume.ts
+++ b/packages/alchemy/src/Railway/Volume.ts
@@ -597,7 +597,7 @@ const waitUntilGone = (input: {
 };
 
 const stampName = (volumeId: string, name: string) =>
-  railway.volumeUpdate({
+  railway.updateVolume({
     volumeId,
     input: { name },
   });
@@ -762,7 +762,7 @@ export const VolumeProvider = () =>
 
           if (current === undefined) {
             const created = yield* railway
-              .volumeCreate({
+              .createVolume({
                 input: {
                   projectId,
                   environmentId,
@@ -830,7 +830,7 @@ export const VolumeProvider = () =>
             desiredServiceId !== undefined &&
             desiredServiceId !== observedServiceId;
           if (mountChanged || serviceChanged) {
-            yield* railway.volumeInstanceUpdate({
+            yield* railway.updateVolumeInstance({
               volumeId: current.volumeId,
               environmentId,
               input: {
@@ -860,7 +860,7 @@ export const VolumeProvider = () =>
       const volumeId = output.volumeId;
       if (volumeId.length === 0) return;
       yield* railway
-        .volumeDelete({ volumeId })
+        .deleteVolume({ volumeId })
         .pipe(
           Effect.catchTag(["RailwayNotFound", "NotFound"], () => Effect.void),
         );

--- a/packages/alchemy/src/Railway/VolumeBackup.ts
+++ b/packages/alchemy/src/Railway/VolumeBackup.ts
@@ -1,6 +1,6 @@
 import type {
   EnvironmentResponseVolumeInstancesEdgesItemNode,
-  VolumeInstanceBackupListResultItem,
+  ListVolumeInstanceBackupResultItem,
   VolumeInstanceBackupScheduleKind,
   VolumeInstanceResponse,
   VolumeState,
@@ -289,7 +289,7 @@ class VolumeBackupPending extends Data.TaggedError(
   state: string;
 }> {}
 
-type CloudBackup = VolumeInstanceBackupListResultItem;
+type CloudBackup = ListVolumeInstanceBackupResultItem;
 type CloudInstance =
   | EnvironmentResponseVolumeInstancesEdgesItemNode
   | VolumeInstanceResponse;
@@ -366,15 +366,15 @@ const resolveName = (id: string, existing?: string) =>
 
 const listBackups = (volumeInstanceId: string) =>
   railway
-    .volumeInstanceBackupList({ volumeInstanceId })
+    .listVolumeInstanceBackup({ volumeInstanceId })
     .pipe(
       Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-        Effect.succeed([] as VolumeInstanceBackupListResultItem[]),
+        Effect.succeed([] as ListVolumeInstanceBackupResultItem[]),
       ),
     );
 
 const listSchedules = (volumeInstanceId: string) =>
-  railway.volumeInstanceBackupScheduleList({ volumeInstanceId }).pipe(
+  railway.listVolumeInstanceBackupSchedule({ volumeInstanceId }).pipe(
     Effect.map((items) => uniqueKinds(items.map((item) => item.kind))),
     Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
       Effect.succeed([] as VolumeBackupScheduleKind[]),
@@ -625,7 +625,7 @@ export const restoreVolumeBackup = Effect.fn(function* (input: {
   volumeInstanceId: string;
   volumeInstanceBackupId: string;
 }) {
-  const result = yield* railway.volumeInstanceBackupRestore({
+  const result = yield* railway.restoreVolumeInstanceBackup({
     volumeInstanceBackupId: input.volumeInstanceBackupId,
     volumeInstanceId: input.volumeInstanceId,
   });
@@ -646,7 +646,7 @@ export const restoreVolumePITR = Effect.fn(function* (input: {
   newServiceName?: string;
   sourceRepoPath?: string;
 }) {
-  const result = yield* railway.volumeInstancePITRRestore({
+  const result = yield* railway.restoreVolumeInstancePITR({
     volumeInstanceId: input.volumeInstanceId,
     targetTimestamp: input.targetTimestamp,
     ...(input.newServiceName !== undefined
@@ -839,7 +839,7 @@ export const VolumeBackupProvider = () =>
           });
         }
         const previousIds = new Set(existing.map((backup) => backup.id));
-        const created = yield* railway.volumeInstanceBackupCreate({
+        const created = yield* railway.createVolumeInstanceBackup({
           volumeInstanceId,
           name,
         });
@@ -865,7 +865,7 @@ export const VolumeBackupProvider = () =>
       }
 
       if (props.lock === true && current.expiresAt != null) {
-        yield* railway.volumeInstanceBackupLock({
+        yield* railway.lockVolumeInstanceBackup({
           volumeInstanceBackupId: current.id,
           volumeInstanceId,
         });
@@ -881,7 +881,7 @@ export const VolumeBackupProvider = () =>
       if (props.schedules !== undefined) {
         const desired = uniqueKinds(props.schedules);
         if (kindsKey(desired) !== kindsKey(schedules)) {
-          yield* railway.volumeInstanceBackupScheduleUpdate({
+          yield* railway.updateVolumeInstanceBackupSchedule({
             volumeInstanceId,
             kinds: desired,
           });
@@ -908,7 +908,7 @@ export const VolumeBackupProvider = () =>
         return;
       }
       const deleted = yield* railway
-        .volumeInstanceBackupDelete({
+        .deleteVolumeInstanceBackup({
           volumeInstanceBackupId,
           volumeInstanceId,
         })

--- a/packages/alchemy/test/Cloudflare/Snippets/SnippetRules.test.ts
+++ b/packages/alchemy/test/Cloudflare/Snippets/SnippetRules.test.ts
@@ -67,7 +67,7 @@ const forbiddenRetryPolicy = {
 } as const;
 
 const listLiveRules = (zoneId: string) =>
-  snippets.getRule({ zoneId }).pipe(
+  snippets.listRules({ zoneId }).pipe(
     Effect.map((result) =>
       Array.isArray(result) ? (result as WireRule[]) : [],
     ),

--- a/packages/alchemy/test/Cloudflare/Snippets/SnippetRules.test.ts
+++ b/packages/alchemy/test/Cloudflare/Snippets/SnippetRules.test.ts
@@ -67,7 +67,7 @@ const forbiddenRetryPolicy = {
 } as const;
 
 const listLiveRules = (zoneId: string) =>
-  snippets.listRules({ zoneId }).pipe(
+  snippets.getRule({ zoneId }).pipe(
     Effect.map((result) =>
       Array.isArray(result) ? (result as WireRule[]) : [],
     ),

--- a/packages/alchemy/test/Railway/CloudAgent.test.ts
+++ b/packages/alchemy/test/Railway/CloudAgent.test.ts
@@ -48,7 +48,7 @@ const waitUntilAgentGone = (environmentId: string, cloudAgentId: string) =>
 
 const deleteAgent = (id: string) =>
   railway
-    .cloudAgentDelete({ id })
+    .deleteCloudAgent({ id })
     .pipe(Effect.catchTag(["RailwayNotFound", "NotFound"], () => Effect.void));
 
 test.provider(
@@ -65,7 +65,7 @@ test.provider(
       );
 
       const probe = yield* Effect.result(
-        railway.cloudAgentCreate({
+        railway.createCloudAgent({
           input: {
             environmentId: projectOnly.environment.environmentId,
             name: projectOnly.project.name,

--- a/packages/alchemy/test/Railway/CustomDomain.test.ts
+++ b/packages/alchemy/test/Railway/CustomDomain.test.ts
@@ -49,7 +49,7 @@ const waitUntilDomainGone = (customDomainId: string, projectId: string) =>
   );
 
 const createTargetService = (projectId: string, environmentId: string) =>
-  railway.serviceCreate({
+  railway.createService({
     input: {
       projectId,
       environmentId,
@@ -71,7 +71,7 @@ test.provider(
       );
 
       const rejected = yield* Effect.result(
-        railway.customDomainCreate({
+        railway.createCustomDomain({
           input: {
             domain: "not a hostname",
             environmentId: environment.environmentId,

--- a/packages/alchemy/test/Railway/LoginSession.test.ts
+++ b/packages/alchemy/test/Railway/LoginSession.test.ts
@@ -21,7 +21,7 @@ test.provider(
       yield* stack.destroy();
 
       const code = yield* Railway.provideAnonymousRailway(
-        railway.loginSessionCreate({}),
+        railway.createLoginSession({}),
       );
       expect(code).toEqual(expect.any(String));
       expect(code.length).toBeGreaterThan(0);
@@ -38,7 +38,7 @@ test.provider(
 
       const verified = yield* Railway.provideAnonymousRailway(
         railway
-          .loginSessionVerify({ code })
+          .verifyLoginSession({ code })
           .pipe(Effect.catchTag(missingSession, () => Effect.succeed(false))),
       );
       // Verify is a liveness check: true while the pairing session exists,
@@ -53,20 +53,20 @@ test.provider(
       expect(beforeAuth).toBeNull();
 
       const cancelled = yield* Railway.provideAnonymousRailway(
-        railway.loginSessionCancel({ code }),
+        railway.cancelLoginSession({ code }),
       );
       expect(cancelled).toBe(true);
 
       const cancelledAgain = yield* Railway.provideAnonymousRailway(
         railway
-          .loginSessionCancel({ code })
+          .cancelLoginSession({ code })
           .pipe(Effect.catchTag(missingSession, () => Effect.succeed(false))),
       );
       expect(typeof cancelledAgain).toBe("boolean");
 
       const verifiedAfter = yield* Railway.provideAnonymousRailway(
         railway
-          .loginSessionVerify({ code })
+          .verifyLoginSession({ code })
           .pipe(Effect.catchTag(missingSession, () => Effect.succeed(false))),
       );
       expect(verifiedAfter).toBe(false);

--- a/packages/alchemy/test/Railway/PrivateNetwork.test.ts
+++ b/packages/alchemy/test/Railway/PrivateNetwork.test.ts
@@ -125,7 +125,7 @@ test.provider.skip(
       expect(updated.network.dnsName).toEqual(created.network.dnsName);
       expect(updated.project.projectId).toEqual(created.project.projectId);
 
-      const service = yield* railway.serviceCreate({
+      const service = yield* railway.createService({
         input: {
           projectId: created.project.projectId,
           environmentId: created.environment.environmentId,

--- a/packages/alchemy/test/Railway/Sandbox.test.ts
+++ b/packages/alchemy/test/Railway/Sandbox.test.ts
@@ -54,7 +54,7 @@ test.provider(
       );
 
       const result = yield* Effect.result(
-        railway.sandboxCreate({
+        railway.createSandbox({
           input: {
             environmentId: created.environment.environmentId,
             idleTimeoutMinutes: 5,

--- a/packages/alchemy/test/Railway/TcpProxy.test.ts
+++ b/packages/alchemy/test/Railway/TcpProxy.test.ts
@@ -48,7 +48,7 @@ const waitUntilProxyGone = (
   );
 
 const createTargetService = (projectId: string, environmentId: string) =>
-  railway.serviceCreate({
+  railway.createService({
     input: {
       projectId,
       environmentId,

--- a/packages/alchemy/test/Railway/Usage.test.ts
+++ b/packages/alchemy/test/Railway/Usage.test.ts
@@ -76,7 +76,7 @@ test.provider(
       expect(customerId.length).toBeGreaterThan(0);
 
       const probe = yield* Effect.result(
-        railway.usageLimitSet({
+        railway.setUsageLimit({
           input: {
             customerId,
             softLimitDollars: SOFT_V1,
@@ -94,7 +94,7 @@ test.provider(
       }
 
       yield* railway
-        .usageLimitRemove({ input: { customerId } })
+        .removeUsageLimit({ input: { customerId } })
         .pipe(
           Effect.catchTag(["RailwayNotFound", "NotFound"], () => Effect.void),
         );

--- a/packages/alchemy/test/Railway/VolumeBackup.test.ts
+++ b/packages/alchemy/test/Railway/VolumeBackup.test.ts
@@ -40,7 +40,7 @@ const VolumeStack = Effect.gen(function* () {
 
 const listLive = (volumeInstanceId: string) =>
   railway
-    .volumeInstanceBackupList({ volumeInstanceId })
+    .listVolumeInstanceBackup({ volumeInstanceId })
     .pipe(
       Effect.catchTag(["RailwayNotFound", "NotFound", "RailwayForbidden"], () =>
         Effect.succeed([]),
@@ -98,7 +98,7 @@ test.provider(
       yield* waitUntilReady(created.volume.volumeInstanceId);
 
       const result = yield* Effect.result(
-        railway.volumeInstanceBackupCreate({
+        railway.createVolumeInstanceBackup({
           volumeInstanceId: created.volume.volumeInstanceId,
         }),
       );
@@ -119,7 +119,7 @@ test.provider(
         const extras = yield* listLive(created.volume.volumeInstanceId);
         for (const extra of extras) {
           yield* railway
-            .volumeInstanceBackupDelete({
+            .deleteVolumeInstanceBackup({
               volumeInstanceBackupId: extra.id,
               volumeInstanceId: created.volume.volumeInstanceId,
             })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5427,6 +5427,101 @@ importers:
         specifier: catalog:build
         version: 7.0.2
 
+  submodules/distilled/packages/adyen:
+    dependencies:
+      '@distilled.cloud/core':
+        specifier: workspace:*
+        version: link:../core
+      effect:
+        specifier: 4.0.0-rc.112
+        version: 4.0.0-rc.112
+    devDependencies:
+      '@effect/platform-bun':
+        specifier: catalog:effect
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+      '@types/bun':
+        specifier: catalog:tooling
+        version: 1.3.14
+      '@types/node':
+        specifier: catalog:tooling
+        version: 26.2.0
+
+  submodules/distilled/packages/apache-superset:
+    dependencies:
+      '@distilled.cloud/core':
+        specifier: workspace:*
+        version: link:../core
+      effect:
+        specifier: 4.0.0-rc.112
+        version: 4.0.0-rc.112
+    devDependencies:
+      '@effect/platform-bun':
+        specifier: catalog:effect
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+      '@types/bun':
+        specifier: catalog:tooling
+        version: 1.3.14
+      '@types/node':
+        specifier: catalog:tooling
+        version: 26.2.0
+
+  submodules/distilled/packages/archil:
+    dependencies:
+      '@distilled.cloud/core':
+        specifier: workspace:*
+        version: link:../core
+      effect:
+        specifier: 4.0.0-rc.112
+        version: 4.0.0-rc.112
+    devDependencies:
+      '@effect/platform-bun':
+        specifier: catalog:effect
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+      '@types/bun':
+        specifier: catalog:tooling
+        version: 1.3.14
+      '@types/node':
+        specifier: catalog:tooling
+        version: 26.2.0
+
+  submodules/distilled/packages/argocd:
+    dependencies:
+      '@distilled.cloud/core':
+        specifier: workspace:*
+        version: link:../core
+      effect:
+        specifier: 4.0.0-rc.112
+        version: 4.0.0-rc.112
+    devDependencies:
+      '@effect/platform-bun':
+        specifier: catalog:effect
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+      '@types/bun':
+        specifier: catalog:tooling
+        version: 1.3.14
+      '@types/node':
+        specifier: catalog:tooling
+        version: 26.2.0
+
+  submodules/distilled/packages/auth0:
+    dependencies:
+      '@distilled.cloud/core':
+        specifier: workspace:*
+        version: link:../core
+      effect:
+        specifier: 4.0.0-rc.112
+        version: 4.0.0-rc.112
+    devDependencies:
+      '@effect/platform-bun':
+        specifier: catalog:effect
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+      '@types/bun':
+        specifier: catalog:tooling
+        version: 1.3.14
+      '@types/node':
+        specifier: catalog:tooling
+        version: 26.2.0
+
   submodules/distilled/packages/aws:
     dependencies:
       '@aws-crypto/crc32':
@@ -5517,6 +5612,44 @@ importers:
         specifier: catalog:tooling
         version: 26.2.0
 
+  submodules/distilled/packages/chronosphere:
+    dependencies:
+      '@distilled.cloud/core':
+        specifier: workspace:*
+        version: link:../core
+      effect:
+        specifier: 4.0.0-rc.112
+        version: 4.0.0-rc.112
+    devDependencies:
+      '@effect/platform-bun':
+        specifier: catalog:effect
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+      '@types/bun':
+        specifier: catalog:tooling
+        version: 1.3.14
+      '@types/node':
+        specifier: catalog:tooling
+        version: 26.2.0
+
+  submodules/distilled/packages/clerk:
+    dependencies:
+      '@distilled.cloud/core':
+        specifier: workspace:*
+        version: link:../core
+      effect:
+        specifier: 4.0.0-rc.112
+        version: 4.0.0-rc.112
+    devDependencies:
+      '@effect/platform-bun':
+        specifier: catalog:effect
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+      '@types/bun':
+        specifier: catalog:tooling
+        version: 1.3.14
+      '@types/node':
+        specifier: catalog:tooling
+        version: 26.2.0
+
   submodules/distilled/packages/cloudflare:
     dependencies:
       '@distilled.cloud/core':
@@ -5555,6 +5688,25 @@ importers:
         specifier: catalog:tooling
         version: 26.2.0
 
+  submodules/distilled/packages/coolify:
+    dependencies:
+      '@distilled.cloud/core':
+        specifier: workspace:*
+        version: link:../core
+      effect:
+        specifier: 4.0.0-rc.112
+        version: 4.0.0-rc.112
+    devDependencies:
+      '@effect/platform-bun':
+        specifier: catalog:effect
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+      '@types/bun':
+        specifier: catalog:tooling
+        version: 1.3.14
+      '@types/node':
+        specifier: catalog:tooling
+        version: 26.2.0
+
   submodules/distilled/packages/core:
     devDependencies:
       '@effect/platform-bun':
@@ -5570,7 +5722,121 @@ importers:
         specifier: 4.0.0-rc.112
         version: 4.0.0-rc.112
 
+  submodules/distilled/packages/customerio:
+    dependencies:
+      '@distilled.cloud/core':
+        specifier: workspace:*
+        version: link:../core
+      effect:
+        specifier: 4.0.0-rc.112
+        version: 4.0.0-rc.112
+    devDependencies:
+      '@effect/platform-bun':
+        specifier: catalog:effect
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+      '@types/bun':
+        specifier: catalog:tooling
+        version: 1.3.14
+      '@types/node':
+        specifier: catalog:tooling
+        version: 26.2.0
+
+  submodules/distilled/packages/datadog:
+    dependencies:
+      '@distilled.cloud/core':
+        specifier: workspace:*
+        version: link:../core
+      effect:
+        specifier: 4.0.0-rc.112
+        version: 4.0.0-rc.112
+    devDependencies:
+      '@effect/platform-bun':
+        specifier: catalog:effect
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+      '@types/bun':
+        specifier: catalog:tooling
+        version: 1.3.14
+      '@types/node':
+        specifier: catalog:tooling
+        version: 26.2.0
+
+  submodules/distilled/packages/digitalocean:
+    dependencies:
+      '@distilled.cloud/core':
+        specifier: workspace:*
+        version: link:../core
+      effect:
+        specifier: 4.0.0-rc.112
+        version: 4.0.0-rc.112
+    devDependencies:
+      '@effect/platform-bun':
+        specifier: catalog:effect
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+      '@types/bun':
+        specifier: catalog:tooling
+        version: 1.3.14
+      '@types/node':
+        specifier: catalog:tooling
+        version: 26.2.0
+
   submodules/distilled/packages/discord:
+    dependencies:
+      '@distilled.cloud/core':
+        specifier: workspace:*
+        version: link:../core
+      effect:
+        specifier: 4.0.0-rc.112
+        version: 4.0.0-rc.112
+    devDependencies:
+      '@effect/platform-bun':
+        specifier: catalog:effect
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+      '@types/bun':
+        specifier: catalog:tooling
+        version: 1.3.14
+      '@types/node':
+        specifier: catalog:tooling
+        version: 26.2.0
+
+  submodules/distilled/packages/docker:
+    dependencies:
+      '@distilled.cloud/core':
+        specifier: workspace:*
+        version: link:../core
+      effect:
+        specifier: 4.0.0-rc.112
+        version: 4.0.0-rc.112
+    devDependencies:
+      '@effect/platform-bun':
+        specifier: catalog:effect
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+      '@types/bun':
+        specifier: catalog:tooling
+        version: 1.3.14
+      '@types/node':
+        specifier: catalog:tooling
+        version: 26.2.0
+
+  submodules/distilled/packages/doppler:
+    dependencies:
+      '@distilled.cloud/core':
+        specifier: workspace:*
+        version: link:../core
+      effect:
+        specifier: 4.0.0-rc.112
+        version: 4.0.0-rc.112
+    devDependencies:
+      '@effect/platform-bun':
+        specifier: catalog:effect
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+      '@types/bun':
+        specifier: catalog:tooling
+        version: 1.3.14
+      '@types/node':
+        specifier: catalog:tooling
+        version: 26.2.0
+
+  submodules/distilled/packages/elasticsearch:
     dependencies:
       '@distilled.cloud/core':
         specifier: workspace:*
@@ -5627,6 +5893,25 @@ importers:
         specifier: catalog:tooling
         version: 26.2.0
 
+  submodules/distilled/packages/forgejo:
+    dependencies:
+      '@distilled.cloud/core':
+        specifier: workspace:*
+        version: link:../core
+      effect:
+        specifier: 4.0.0-rc.112
+        version: 4.0.0-rc.112
+    devDependencies:
+      '@effect/platform-bun':
+        specifier: catalog:effect
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+      '@types/bun':
+        specifier: catalog:tooling
+        version: 1.3.14
+      '@types/node':
+        specifier: catalog:tooling
+        version: 26.2.0
+
   submodules/distilled/packages/gcp:
     dependencies:
       '@distilled.cloud/core':
@@ -5665,7 +5950,102 @@ importers:
         specifier: catalog:tooling
         version: 26.2.0
 
+  submodules/distilled/packages/google-workspace:
+    dependencies:
+      '@distilled.cloud/core':
+        specifier: workspace:*
+        version: link:../core
+      effect:
+        specifier: 4.0.0-rc.112
+        version: 4.0.0-rc.112
+    devDependencies:
+      '@effect/platform-bun':
+        specifier: catalog:effect
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+      '@types/bun':
+        specifier: catalog:tooling
+        version: 1.3.14
+      '@types/node':
+        specifier: catalog:tooling
+        version: 26.2.0
+
+  submodules/distilled/packages/grafana:
+    dependencies:
+      '@distilled.cloud/core':
+        specifier: workspace:*
+        version: link:../core
+      effect:
+        specifier: 4.0.0-rc.112
+        version: 4.0.0-rc.112
+    devDependencies:
+      '@effect/platform-bun':
+        specifier: catalog:effect
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+      '@types/bun':
+        specifier: catalog:tooling
+        version: 1.3.14
+      '@types/node':
+        specifier: catalog:tooling
+        version: 26.2.0
+
+  submodules/distilled/packages/growthbook:
+    dependencies:
+      '@distilled.cloud/core':
+        specifier: workspace:*
+        version: link:../core
+      effect:
+        specifier: 4.0.0-rc.112
+        version: 4.0.0-rc.112
+    devDependencies:
+      '@effect/platform-bun':
+        specifier: catalog:effect
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+      '@types/bun':
+        specifier: catalog:tooling
+        version: 1.3.14
+      '@types/node':
+        specifier: catalog:tooling
+        version: 26.2.0
+
+  submodules/distilled/packages/gusto:
+    dependencies:
+      '@distilled.cloud/core':
+        specifier: workspace:*
+        version: link:../core
+      effect:
+        specifier: 4.0.0-rc.112
+        version: 4.0.0-rc.112
+    devDependencies:
+      '@effect/platform-bun':
+        specifier: catalog:effect
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+      '@types/bun':
+        specifier: catalog:tooling
+        version: 1.3.14
+      '@types/node':
+        specifier: catalog:tooling
+        version: 26.2.0
+
   submodules/distilled/packages/hetzner:
+    dependencies:
+      '@distilled.cloud/core':
+        specifier: workspace:*
+        version: link:../core
+      effect:
+        specifier: 4.0.0-rc.112
+        version: 4.0.0-rc.112
+    devDependencies:
+      '@effect/platform-bun':
+        specifier: catalog:effect
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+      '@types/bun':
+        specifier: catalog:tooling
+        version: 1.3.14
+      '@types/node':
+        specifier: catalog:tooling
+        version: 26.2.0
+
+  submodules/distilled/packages/hostinger:
     dependencies:
       '@distilled.cloud/core':
         specifier: workspace:*
@@ -5703,7 +6083,178 @@ importers:
         specifier: catalog:tooling
         version: 26.2.0
 
+  submodules/distilled/packages/infisical:
+    dependencies:
+      '@distilled.cloud/core':
+        specifier: workspace:*
+        version: link:../core
+      effect:
+        specifier: 4.0.0-rc.112
+        version: 4.0.0-rc.112
+    devDependencies:
+      '@effect/platform-bun':
+        specifier: catalog:effect
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+      '@types/bun':
+        specifier: catalog:tooling
+        version: 1.3.14
+      '@types/node':
+        specifier: catalog:tooling
+        version: 26.2.0
+
+  submodules/distilled/packages/inngest:
+    dependencies:
+      '@distilled.cloud/core':
+        specifier: workspace:*
+        version: link:../core
+      effect:
+        specifier: 4.0.0-rc.112
+        version: 4.0.0-rc.112
+    devDependencies:
+      '@effect/platform-bun':
+        specifier: catalog:effect
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+      '@types/bun':
+        specifier: catalog:tooling
+        version: 1.3.14
+      '@types/node':
+        specifier: catalog:tooling
+        version: 26.2.0
+
+  submodules/distilled/packages/intercom:
+    dependencies:
+      '@distilled.cloud/core':
+        specifier: workspace:*
+        version: link:../core
+      effect:
+        specifier: 4.0.0-rc.112
+        version: 4.0.0-rc.112
+    devDependencies:
+      '@effect/platform-bun':
+        specifier: catalog:effect
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+      '@types/bun':
+        specifier: catalog:tooling
+        version: 1.3.14
+      '@types/node':
+        specifier: catalog:tooling
+        version: 26.2.0
+
   submodules/distilled/packages/kubernetes:
+    dependencies:
+      '@distilled.cloud/core':
+        specifier: workspace:*
+        version: link:../core
+      effect:
+        specifier: 4.0.0-rc.112
+        version: 4.0.0-rc.112
+    devDependencies:
+      '@effect/platform-bun':
+        specifier: catalog:effect
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+      '@types/bun':
+        specifier: catalog:tooling
+        version: 1.3.14
+      '@types/node':
+        specifier: catalog:tooling
+        version: 26.2.0
+
+  submodules/distilled/packages/launchdarkly:
+    dependencies:
+      '@distilled.cloud/core':
+        specifier: workspace:*
+        version: link:../core
+      effect:
+        specifier: 4.0.0-rc.112
+        version: 4.0.0-rc.112
+    devDependencies:
+      '@effect/platform-bun':
+        specifier: catalog:effect
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+      '@types/bun':
+        specifier: catalog:tooling
+        version: 1.3.14
+      '@types/node':
+        specifier: catalog:tooling
+        version: 26.2.0
+
+  submodules/distilled/packages/meilisearch:
+    dependencies:
+      '@distilled.cloud/core':
+        specifier: workspace:*
+        version: link:../core
+      effect:
+        specifier: 4.0.0-rc.112
+        version: 4.0.0-rc.112
+    devDependencies:
+      '@effect/platform-bun':
+        specifier: catalog:effect
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+      '@types/bun':
+        specifier: catalog:tooling
+        version: 1.3.14
+      '@types/node':
+        specifier: catalog:tooling
+        version: 26.2.0
+
+  submodules/distilled/packages/mercury:
+    dependencies:
+      '@distilled.cloud/core':
+        specifier: workspace:*
+        version: link:../core
+      effect:
+        specifier: 4.0.0-rc.112
+        version: 4.0.0-rc.112
+    devDependencies:
+      '@effect/platform-bun':
+        specifier: catalog:effect
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+      '@types/bun':
+        specifier: catalog:tooling
+        version: 1.3.14
+      '@types/node':
+        specifier: catalog:tooling
+        version: 26.2.0
+
+  submodules/distilled/packages/metabase:
+    dependencies:
+      '@distilled.cloud/core':
+        specifier: workspace:*
+        version: link:../core
+      effect:
+        specifier: 4.0.0-rc.112
+        version: 4.0.0-rc.112
+    devDependencies:
+      '@effect/platform-bun':
+        specifier: catalog:effect
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+      '@types/bun':
+        specifier: catalog:tooling
+        version: 1.3.14
+      '@types/node':
+        specifier: catalog:tooling
+        version: 26.2.0
+
+  submodules/distilled/packages/modal:
+    dependencies:
+      '@distilled.cloud/core':
+        specifier: workspace:*
+        version: link:../core
+      effect:
+        specifier: 4.0.0-rc.112
+        version: 4.0.0-rc.112
+    devDependencies:
+      '@effect/platform-bun':
+        specifier: catalog:effect
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+      '@types/bun':
+        specifier: catalog:tooling
+        version: 1.3.14
+      '@types/node':
+        specifier: catalog:tooling
+        version: 26.2.0
+
+  submodules/distilled/packages/modrinth:
     dependencies:
       '@distilled.cloud/core':
         specifier: workspace:*
@@ -5760,7 +6311,159 @@ importers:
         specifier: catalog:tooling
         version: 26.2.0
 
+  submodules/distilled/packages/okta:
+    dependencies:
+      '@distilled.cloud/core':
+        specifier: workspace:*
+        version: link:../core
+      effect:
+        specifier: 4.0.0-rc.112
+        version: 4.0.0-rc.112
+    devDependencies:
+      '@effect/platform-bun':
+        specifier: catalog:effect
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+      '@types/bun':
+        specifier: catalog:tooling
+        version: 1.3.14
+      '@types/node':
+        specifier: catalog:tooling
+        version: 26.2.0
+
+  submodules/distilled/packages/onepassword:
+    dependencies:
+      '@distilled.cloud/core':
+        specifier: workspace:*
+        version: link:../core
+      effect:
+        specifier: 4.0.0-rc.112
+        version: 4.0.0-rc.112
+    devDependencies:
+      '@effect/platform-bun':
+        specifier: catalog:effect
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+      '@types/bun':
+        specifier: catalog:tooling
+        version: 1.3.14
+      '@types/node':
+        specifier: catalog:tooling
+        version: 26.2.0
+
+  submodules/distilled/packages/opencode:
+    dependencies:
+      '@distilled.cloud/core':
+        specifier: workspace:*
+        version: link:../core
+      effect:
+        specifier: 4.0.0-rc.112
+        version: 4.0.0-rc.112
+    devDependencies:
+      '@effect/platform-bun':
+        specifier: catalog:effect
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+      '@types/bun':
+        specifier: catalog:tooling
+        version: 1.3.14
+      '@types/node':
+        specifier: catalog:tooling
+        version: 26.2.0
+
+  submodules/distilled/packages/ovh:
+    dependencies:
+      '@distilled.cloud/core':
+        specifier: workspace:*
+        version: link:../core
+      effect:
+        specifier: 4.0.0-rc.112
+        version: 4.0.0-rc.112
+    devDependencies:
+      '@effect/platform-bun':
+        specifier: catalog:effect
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+      '@types/bun':
+        specifier: catalog:tooling
+        version: 1.3.14
+      '@types/node':
+        specifier: catalog:tooling
+        version: 26.2.0
+
+  submodules/distilled/packages/paypal:
+    dependencies:
+      '@distilled.cloud/core':
+        specifier: workspace:*
+        version: link:../core
+      effect:
+        specifier: 4.0.0-rc.112
+        version: 4.0.0-rc.112
+    devDependencies:
+      '@effect/platform-bun':
+        specifier: catalog:effect
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+      '@types/bun':
+        specifier: catalog:tooling
+        version: 1.3.14
+      '@types/node':
+        specifier: catalog:tooling
+        version: 26.2.0
+
+  submodules/distilled/packages/plaid:
+    dependencies:
+      '@distilled.cloud/core':
+        specifier: workspace:*
+        version: link:../core
+      effect:
+        specifier: 4.0.0-rc.112
+        version: 4.0.0-rc.112
+    devDependencies:
+      '@effect/platform-bun':
+        specifier: catalog:effect
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+      '@types/bun':
+        specifier: catalog:tooling
+        version: 1.3.14
+      '@types/node':
+        specifier: catalog:tooling
+        version: 26.2.0
+
   submodules/distilled/packages/planetscale:
+    dependencies:
+      '@distilled.cloud/core':
+        specifier: workspace:*
+        version: link:../core
+      effect:
+        specifier: 4.0.0-rc.112
+        version: 4.0.0-rc.112
+    devDependencies:
+      '@effect/platform-bun':
+        specifier: catalog:effect
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+      '@types/bun':
+        specifier: catalog:tooling
+        version: 1.3.14
+      '@types/node':
+        specifier: catalog:tooling
+        version: 26.2.0
+
+  submodules/distilled/packages/polar:
+    dependencies:
+      '@distilled.cloud/core':
+        specifier: workspace:*
+        version: link:../core
+      effect:
+        specifier: 4.0.0-rc.112
+        version: 4.0.0-rc.112
+    devDependencies:
+      '@effect/platform-bun':
+        specifier: catalog:effect
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+      '@types/bun':
+        specifier: catalog:tooling
+        version: 1.3.14
+      '@types/node':
+        specifier: catalog:tooling
+        version: 26.2.0
+
+  submodules/distilled/packages/porkbun:
     dependencies:
       '@distilled.cloud/core':
         specifier: workspace:*
@@ -5836,6 +6539,158 @@ importers:
         specifier: catalog:tooling
         version: 26.2.0
 
+  submodules/distilled/packages/redis-cloud:
+    dependencies:
+      '@distilled.cloud/core':
+        specifier: workspace:*
+        version: link:../core
+      effect:
+        specifier: 4.0.0-rc.112
+        version: 4.0.0-rc.112
+    devDependencies:
+      '@effect/platform-bun':
+        specifier: catalog:effect
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+      '@types/bun':
+        specifier: catalog:tooling
+        version: 1.3.14
+      '@types/node':
+        specifier: catalog:tooling
+        version: 26.2.0
+
+  submodules/distilled/packages/remote:
+    dependencies:
+      '@distilled.cloud/core':
+        specifier: workspace:*
+        version: link:../core
+      effect:
+        specifier: 4.0.0-rc.112
+        version: 4.0.0-rc.112
+    devDependencies:
+      '@effect/platform-bun':
+        specifier: catalog:effect
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+      '@types/bun':
+        specifier: catalog:tooling
+        version: 1.3.14
+      '@types/node':
+        specifier: catalog:tooling
+        version: 26.2.0
+
+  submodules/distilled/packages/render:
+    dependencies:
+      '@distilled.cloud/core':
+        specifier: workspace:*
+        version: link:../core
+      effect:
+        specifier: 4.0.0-rc.112
+        version: 4.0.0-rc.112
+    devDependencies:
+      '@effect/platform-bun':
+        specifier: catalog:effect
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+      '@types/bun':
+        specifier: catalog:tooling
+        version: 1.3.14
+      '@types/node':
+        specifier: catalog:tooling
+        version: 26.2.0
+
+  submodules/distilled/packages/resend:
+    dependencies:
+      '@distilled.cloud/core':
+        specifier: workspace:*
+        version: link:../core
+      effect:
+        specifier: 4.0.0-rc.112
+        version: 4.0.0-rc.112
+    devDependencies:
+      '@effect/platform-bun':
+        specifier: catalog:effect
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+      '@types/bun':
+        specifier: catalog:tooling
+        version: 1.3.14
+      '@types/node':
+        specifier: catalog:tooling
+        version: 26.2.0
+
+  submodules/distilled/packages/sentry:
+    dependencies:
+      '@distilled.cloud/core':
+        specifier: workspace:*
+        version: link:../core
+      effect:
+        specifier: 4.0.0-rc.112
+        version: 4.0.0-rc.112
+    devDependencies:
+      '@effect/platform-bun':
+        specifier: catalog:effect
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+      '@types/bun':
+        specifier: catalog:tooling
+        version: 1.3.14
+      '@types/node':
+        specifier: catalog:tooling
+        version: 26.2.0
+
+  submodules/distilled/packages/slack:
+    dependencies:
+      '@distilled.cloud/core':
+        specifier: workspace:*
+        version: link:../core
+      effect:
+        specifier: 4.0.0-rc.112
+        version: 4.0.0-rc.112
+    devDependencies:
+      '@effect/platform-bun':
+        specifier: catalog:effect
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+      '@types/bun':
+        specifier: catalog:tooling
+        version: 1.3.14
+      '@types/node':
+        specifier: catalog:tooling
+        version: 26.2.0
+
+  submodules/distilled/packages/spacetimedb:
+    dependencies:
+      '@distilled.cloud/core':
+        specifier: workspace:*
+        version: link:../core
+      effect:
+        specifier: 4.0.0-rc.112
+        version: 4.0.0-rc.112
+    devDependencies:
+      '@effect/platform-bun':
+        specifier: catalog:effect
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+      '@types/bun':
+        specifier: catalog:tooling
+        version: 1.3.14
+      '@types/node':
+        specifier: catalog:tooling
+        version: 26.2.0
+
+  submodules/distilled/packages/squarespace:
+    dependencies:
+      '@distilled.cloud/core':
+        specifier: workspace:*
+        version: link:../core
+      effect:
+        specifier: 4.0.0-rc.112
+        version: 4.0.0-rc.112
+    devDependencies:
+      '@effect/platform-bun':
+        specifier: catalog:effect
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+      '@types/bun':
+        specifier: catalog:tooling
+        version: 1.3.14
+      '@types/node':
+        specifier: catalog:tooling
+        version: 26.2.0
+
   submodules/distilled/packages/stripe:
     dependencies:
       '@distilled.cloud/core':
@@ -5856,6 +6711,82 @@ importers:
         version: 26.2.0
 
   submodules/distilled/packages/supabase:
+    dependencies:
+      '@distilled.cloud/core':
+        specifier: workspace:*
+        version: link:../core
+      effect:
+        specifier: 4.0.0-rc.112
+        version: 4.0.0-rc.112
+    devDependencies:
+      '@effect/platform-bun':
+        specifier: catalog:effect
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+      '@types/bun':
+        specifier: catalog:tooling
+        version: 1.3.14
+      '@types/node':
+        specifier: catalog:tooling
+        version: 26.2.0
+
+  submodules/distilled/packages/surrealdb:
+    dependencies:
+      '@distilled.cloud/core':
+        specifier: workspace:*
+        version: link:../core
+      effect:
+        specifier: 4.0.0-rc.112
+        version: 4.0.0-rc.112
+    devDependencies:
+      '@effect/platform-bun':
+        specifier: catalog:effect
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+      '@types/bun':
+        specifier: catalog:tooling
+        version: 1.3.14
+      '@types/node':
+        specifier: catalog:tooling
+        version: 26.2.0
+
+  submodules/distilled/packages/temporal:
+    dependencies:
+      '@distilled.cloud/core':
+        specifier: workspace:*
+        version: link:../core
+      effect:
+        specifier: 4.0.0-rc.112
+        version: 4.0.0-rc.112
+    devDependencies:
+      '@effect/platform-bun':
+        specifier: catalog:effect
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+      '@types/bun':
+        specifier: catalog:tooling
+        version: 1.3.14
+      '@types/node':
+        specifier: catalog:tooling
+        version: 26.2.0
+
+  submodules/distilled/packages/trigger-dev:
+    dependencies:
+      '@distilled.cloud/core':
+        specifier: workspace:*
+        version: link:../core
+      effect:
+        specifier: 4.0.0-rc.112
+        version: 4.0.0-rc.112
+    devDependencies:
+      '@effect/platform-bun':
+        specifier: catalog:effect
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+      '@types/bun':
+        specifier: catalog:tooling
+        version: 1.3.14
+      '@types/node':
+        specifier: catalog:tooling
+        version: 26.2.0
+
+  submodules/distilled/packages/turbopuffer:
     dependencies:
       '@distilled.cloud/core':
         specifier: workspace:*
@@ -5912,6 +6843,44 @@ importers:
         specifier: catalog:tooling
         version: 26.2.0
 
+  submodules/distilled/packages/unkey:
+    dependencies:
+      '@distilled.cloud/core':
+        specifier: workspace:*
+        version: link:../core
+      effect:
+        specifier: 4.0.0-rc.112
+        version: 4.0.0-rc.112
+    devDependencies:
+      '@effect/platform-bun':
+        specifier: catalog:effect
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+      '@types/bun':
+        specifier: catalog:tooling
+        version: 1.3.14
+      '@types/node':
+        specifier: catalog:tooling
+        version: 26.2.0
+
+  submodules/distilled/packages/vanta:
+    dependencies:
+      '@distilled.cloud/core':
+        specifier: workspace:*
+        version: link:../core
+      effect:
+        specifier: 4.0.0-rc.112
+        version: 4.0.0-rc.112
+    devDependencies:
+      '@effect/platform-bun':
+        specifier: catalog:effect
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+      '@types/bun':
+        specifier: catalog:tooling
+        version: 1.3.14
+      '@types/node':
+        specifier: catalog:tooling
+        version: 26.2.0
+
   submodules/distilled/packages/vercel:
     dependencies:
       '@distilled.cloud/core':
@@ -5931,7 +6900,64 @@ importers:
         specifier: catalog:tooling
         version: 26.2.0
 
+  submodules/distilled/packages/whop:
+    dependencies:
+      '@distilled.cloud/core':
+        specifier: workspace:*
+        version: link:../core
+      effect:
+        specifier: 4.0.0-rc.112
+        version: 4.0.0-rc.112
+    devDependencies:
+      '@effect/platform-bun':
+        specifier: catalog:effect
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+      '@types/bun':
+        specifier: catalog:tooling
+        version: 1.3.14
+      '@types/node':
+        specifier: catalog:tooling
+        version: 26.2.0
+
   submodules/distilled/packages/workos:
+    dependencies:
+      '@distilled.cloud/core':
+        specifier: workspace:*
+        version: link:../core
+      effect:
+        specifier: 4.0.0-rc.112
+        version: 4.0.0-rc.112
+    devDependencies:
+      '@effect/platform-bun':
+        specifier: catalog:effect
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+      '@types/bun':
+        specifier: catalog:tooling
+        version: 1.3.14
+      '@types/node':
+        specifier: catalog:tooling
+        version: 26.2.0
+
+  submodules/distilled/packages/xata:
+    dependencies:
+      '@distilled.cloud/core':
+        specifier: workspace:*
+        version: link:../core
+      effect:
+        specifier: 4.0.0-rc.112
+        version: 4.0.0-rc.112
+    devDependencies:
+      '@effect/platform-bun':
+        specifier: catalog:effect
+        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+      '@types/bun':
+        specifier: catalog:tooling
+        version: 1.3.14
+      '@types/node':
+        specifier: catalog:tooling
+        version: 26.2.0
+
+  submodules/distilled/packages/zendesk:
     dependencies:
       '@distilled.cloud/core':
         specifier: workspace:*


### PR DESCRIPTION
Addresses the review on #1517 (stacked on that branch).

The two names @sam-goodwin flagged were the generator's fault, not the rename script's — fixed upstream in alchemy-run/distilled#563, and this PR moves the submodule to that branch and adopts the corrected names:

| Site | #1517 | This PR |
|---|---|---|
| `Vectorize/SearchIndexHttpClient.ts` | `vectorize.listInfo`, `vectorize.listQuery` | `vectorize.getIndexInfo`, `vectorize.queryIndex` |
| `Snippets/SnippetRules.ts` (+ test) | `snippets.getRule` | `snippets.listRules` |

**Why `listRules` got turned into `getRule` in #1517:** Cloudflare's docs publish `GET …/snippets/snippet_rules` twice (`RulesGet` and `RulesList`, identical shapes). The old distilled patch renamed `RulesGet` → `getRule` and aliased `listRules` to it; after the verbNoun change both twins survived and the alias stopped applying, so the typed `SnippetRulesNotFound`/`Forbidden` errors sat on `getRule` and `listRules` had none. distilled#563 drops the twin and names the survivor `listRules` with the errors attached, so this PR calls `listRules` and the `catchTag("SnippetRulesNotFound")` in `SnippetRules.ts` type-checks again.

**Why `infoIndex` became `listInfo`:** the Rails `index → list` alias fired on the trailing token of a camel id. distilled#563 restricts that alias to a bare `index` / `_index` segment; `index` inside a camel id is now the entity noun.

`bun tsc -b` is clean. distilled#563 is merged and the submodule is pinned to its merge commit (`9572af3`, distilled `main`).