### PR TITLE
fix(cli): honor --profile on cloudflare bootstrap

### DIFF
--- a/packages/alchemy/src/Alchemist/routes/cloudflare.ts
+++ b/packages/alchemy/src/Alchemist/routes/cloudflare.ts
@@ -54,6 +54,17 @@ const services = Effect.fn(function* (target: StateTarget) {
     CloudflareAuth,
     Layer.succeed(AuthProviders, {} satisfies AuthProviders["Service"]),
   );
+  // `provideMerge` (not `mergeAll`) so `fromProfile` / `fromAuthProvider`
+  // actually *see* `--profile`. Sibling-merging ConfigProvider left those
+  // layers requiring it from the outer CLI `fromEnv()` — which is how
+  // `alchemy provider cloudflare bootstrap --profile <name>` ignored the
+  // flag and resolved the default profile (#252).
+  const config = ConfigProvider.layer(
+    withProfileOverride(
+      yield* loadConfigProvider(Option.fromNullishOr(target.envFile)),
+      target.profile,
+    ),
+  );
   return Layer.mergeAll(
     Layer.provideMerge(
       Layer.mergeAll(
@@ -62,19 +73,18 @@ const services = Effect.fn(function* (target: StateTarget) {
         CloudflareAccess.AccessLive,
       ),
       auth,
-    ),
-    ConfigProvider.layer(
-      withProfileOverride(
-        yield* loadConfigProvider(Option.fromNullishOr(target.envFile)),
-        target.profile,
-      ),
-    ),
+    ).pipe(Layer.provideMerge(config)),
     Logger.layer([fileLogger("cloudflare.txt")], { mergeWithExisting: true }),
   );
 });
 
-/** Resolve the account + worker name every state-store route is scoped to. */
-const scope = Effect.fn(function* (target: StateTarget) {
+/**
+ * Resolve the profile, Cloudflare account, and provider layer every
+ * state-store route (`bootstrap`, `teardown`, logs) is scoped to.
+ */
+export const resolveStateStoreScope = Effect.fn(function* (
+  target: StateTarget,
+) {
   const profile = yield* resolveProfileName(
     Option.fromNullishOr(target.envFile),
     target.profile,
@@ -95,7 +105,8 @@ const scope = Effect.fn(function* (target: StateTarget) {
 /** Provision (or adopt) the Cloudflare-hosted state-store worker. */
 export const bootstrap = Effect.fn("Alchemist.provider.cloudflare.bootstrap")(
   function* (input: BootstrapInput) {
-    const { layer, accountId, workerName, profile } = yield* scope(input);
+    const { layer, accountId, workerName, profile } =
+      yield* resolveStateStoreScope(input);
     return yield* Effect.gen(function* () {
       const existed = yield* workers
         .getScriptSetting({ accountId, scriptName: workerName })
@@ -129,7 +140,8 @@ export const bootstrap = Effect.fn("Alchemist.provider.cloudflare.bootstrap")(
 /** Tear down the Cloudflare-hosted state store. */
 export const teardown = Effect.fn("Alchemist.provider.cloudflare.teardown")(
   function* (input: StateTarget) {
-    const { layer, accountId, workerName, profile } = yield* scope(input);
+    const { layer, accountId, workerName, profile } =
+      yield* resolveStateStoreScope(input);
     yield* Effect.provide(teardownStateStore({ workerName, profile }), layer);
     return { accountId, workerName, deleted: [workerName] };
   },
@@ -138,7 +150,8 @@ export const teardown = Effect.fn("Alchemist.provider.cloudflare.teardown")(
 /** Query past log entries from the state-store worker, oldest first. */
 export const stateLogs = Effect.fn("Alchemist.provider.cloudflare.stateLogs")(
   function* (input: StateLogsInput) {
-    const { layer, accountId, workerName } = yield* scope(input);
+    const { layer, accountId, workerName } =
+      yield* resolveStateStoreScope(input);
     const lines = yield* Effect.gen(function* () {
       const telemetry = yield* CloudflareLogs;
       return yield* telemetry.queryLogs({
@@ -164,7 +177,8 @@ export const stateLogs = Effect.fn("Alchemist.provider.cloudflare.stateLogs")(
 export const tailStateLogs = (input: StateTarget) =>
   Stream.unwrap(
     Effect.gen(function* () {
-      const { layer, accountId, workerName } = yield* scope(input);
+      const { layer, accountId, workerName } =
+        yield* resolveStateStoreScope(input);
       const telemetry = yield* Effect.provide(CloudflareLogs, layer);
       return telemetry.tailScript({ accountId, scriptName: workerName }).pipe(
         Stream.provide(layer),

--- a/packages/alchemy/test/Alchemist/CloudflareBootstrapProfile.test.ts
+++ b/packages/alchemy/test/Alchemist/CloudflareBootstrapProfile.test.ts
@@ -10,6 +10,7 @@ import * as ConfigProvider from "effect/ConfigProvider";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
+import * as Path from "effect/Path";
 
 const STAGING_ACCOUNT = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 const DEFAULT_ACCOUNT = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
@@ -29,13 +30,21 @@ const CLOUDFLARE_ENV_KEYS = [
  * `resolveProviderConfig` actually reads the profile store. The alchemy-test
  * runner sets `CI=true` and `--profile testing` exports `ALCHEMY_PROFILE`,
  * both of which would otherwise skip the named-profile path under test.
+ *
+ * An empty `--env-file` in the temp home is passed through so
+ * `loadConfigProvider` never falls back to the checkout's cwd `.env`.
  */
-const withIsolatedHome = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+const withIsolatedHome = <A, E, R>(
+  effect: (envFile: string) => Effect.Effect<A, E, R>,
+) =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
     const dir = yield* fs.makeTempDirectoryScoped({
       prefix: "alchemy-cf-bootstrap-profile-",
     });
+    const envFile = path.join(dir, "empty.env");
+    yield* fs.writeFileString(envFile, "");
     const previous: Record<string, string | undefined> = {
       ALCHEMY_HOME: process.env.ALCHEMY_HOME,
     };
@@ -57,7 +66,7 @@ const withIsolatedHome = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
           }
         }),
     );
-    return yield* effect.pipe(
+    return yield* effect(envFile).pipe(
       Effect.provide(
         Layer.mergeAll(
           Layer.provide(ProfileStoreLive, PlatformServices),
@@ -84,7 +93,7 @@ const storedToken = (accountId: string, apiToken: string) => ({
 it.live(
   "cloudflare bootstrap --profile resolves that profile's credentials, not default (#252)",
   () =>
-    withIsolatedHome(
+    withIsolatedHome((envFile) =>
       Effect.gen(function* () {
         const profiles = yield* ProfileStore;
         yield* profiles.createProfile("staging");
@@ -99,7 +108,10 @@ it.live(
           storedToken(DEFAULT_ACCOUNT, "default-token"),
         );
 
-        const scoped = yield* resolveStateStoreScope({ profile: "staging" });
+        const scoped = yield* resolveStateStoreScope({
+          profile: "staging",
+          envFile,
+        });
         expect(scoped.profile).toBe("staging");
         expect(scoped.accountId).toBe(STAGING_ACCOUNT);
       }),
@@ -110,7 +122,7 @@ it.live(
 it.live(
   "cloudflare bootstrap without --profile uses the default profile",
   () =>
-    withIsolatedHome(
+    withIsolatedHome((envFile) =>
       Effect.gen(function* () {
         const profiles = yield* ProfileStore;
         yield* profiles.setProviderConfig(
@@ -119,7 +131,7 @@ it.live(
           storedToken(DEFAULT_ACCOUNT, "default-token"),
         );
 
-        const scoped = yield* resolveStateStoreScope({});
+        const scoped = yield* resolveStateStoreScope({ envFile });
         expect(scoped.profile).toBe("default");
         expect(scoped.accountId).toBe(DEFAULT_ACCOUNT);
       }),
@@ -130,7 +142,7 @@ it.live(
 it.live(
   "cloudflare bootstrap --profile does not fall back to an unconfigured default",
   () =>
-    withIsolatedHome(
+    withIsolatedHome((envFile) =>
       Effect.gen(function* () {
         const profiles = yield* ProfileStore;
         yield* profiles.createProfile("staging");
@@ -140,10 +152,15 @@ it.live(
           storedToken(STAGING_ACCOUNT, "staging-token"),
         );
 
-        const scoped = yield* resolveStateStoreScope({ profile: "staging" });
+        const scoped = yield* resolveStateStoreScope({
+          profile: "staging",
+          envFile,
+        });
         expect(scoped.accountId).toBe(STAGING_ACCOUNT);
 
-        const missing = yield* resolveStateStoreScope({}).pipe(Effect.flip);
+        const missing = yield* resolveStateStoreScope({ envFile }).pipe(
+          Effect.flip,
+        );
         expect(missing).toBeInstanceOf(AuthError);
         expect((missing as AuthError).message).toContain("profile 'default'");
       }),

--- a/packages/alchemy/test/Alchemist/cloudflare-bootstrap-profile.test.ts
+++ b/packages/alchemy/test/Alchemist/cloudflare-bootstrap-profile.test.ts
@@ -1,0 +1,152 @@
+import { AlchemyContext } from "@/AlchemyContext.ts";
+import { resolveStateStoreScope } from "@/Alchemist/routes/cloudflare.ts";
+import { AuthError } from "@/Auth/AuthProvider.ts";
+import { CredentialsStoreLive } from "@/Auth/Credentials.ts";
+import { ProfileStore, ProfileStoreLive } from "@/Auth/Profile.ts";
+import * as Interaction from "@/Interaction.ts";
+import { PlatformServices } from "@/Util/PlatformServices.ts";
+import { expect, it } from "alchemy-test";
+import * as ConfigProvider from "effect/ConfigProvider";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+
+const STAGING_ACCOUNT = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const DEFAULT_ACCOUNT = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+const CLOUDFLARE_ENV_KEYS = [
+  "CI",
+  "ALCHEMY_PROFILE",
+  "CLOUDFLARE_ACCOUNT_ID",
+  "CLOUDFLARE_API_TOKEN",
+  "CLOUDFLARE_API_KEY",
+  "CLOUDFLARE_EMAIL",
+  "CLOUDFLARE_ACCOUNT_EMAIL",
+] as const;
+
+/**
+ * Isolate `ALCHEMY_HOME` and strip env credentials / `CI` so
+ * `resolveProviderConfig` actually reads the profile store. The alchemy-test
+ * runner sets `CI=true` and `--profile testing` exports `ALCHEMY_PROFILE`,
+ * both of which would otherwise skip the named-profile path under test.
+ */
+const withIsolatedHome = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const dir = yield* fs.makeTempDirectoryScoped({
+      prefix: "alchemy-cf-bootstrap-profile-",
+    });
+    const previous: Record<string, string | undefined> = {
+      ALCHEMY_HOME: process.env.ALCHEMY_HOME,
+    };
+    for (const key of CLOUDFLARE_ENV_KEYS) {
+      previous[key] = process.env[key];
+    }
+    yield* Effect.acquireRelease(
+      Effect.sync(() => {
+        process.env.ALCHEMY_HOME = dir;
+        for (const key of CLOUDFLARE_ENV_KEYS) {
+          delete process.env[key];
+        }
+      }),
+      () =>
+        Effect.sync(() => {
+          for (const [key, value] of Object.entries(previous)) {
+            if (value === undefined) delete process.env[key];
+            else process.env[key] = value;
+          }
+        }),
+    );
+    return yield* effect.pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          Layer.provide(ProfileStoreLive, PlatformServices),
+          Layer.provide(CredentialsStoreLive, PlatformServices),
+          Layer.succeed(AlchemyContext, {
+            dotAlchemy: dir,
+            dev: false,
+            adopt: false,
+          }),
+          Interaction.layerNonInteractive(),
+          ConfigProvider.layer(ConfigProvider.fromUnknown({})),
+        ),
+      ),
+    );
+  }).pipe(Effect.scoped, Effect.provide(PlatformServices));
+
+const storedToken = (accountId: string, apiToken: string) => ({
+  method: "stored" as const,
+  credentialType: "apiToken" as const,
+  apiToken,
+  accountId,
+});
+
+it.live(
+  "cloudflare bootstrap --profile resolves that profile's credentials, not default (#252)",
+  () =>
+    withIsolatedHome(
+      Effect.gen(function* () {
+        const profiles = yield* ProfileStore;
+        yield* profiles.createProfile("staging");
+        yield* profiles.setProviderConfig(
+          "staging",
+          "Cloudflare",
+          storedToken(STAGING_ACCOUNT, "staging-token"),
+        );
+        yield* profiles.setProviderConfig(
+          "default",
+          "Cloudflare",
+          storedToken(DEFAULT_ACCOUNT, "default-token"),
+        );
+
+        const scoped = yield* resolveStateStoreScope({ profile: "staging" });
+        expect(scoped.profile).toBe("staging");
+        expect(scoped.accountId).toBe(STAGING_ACCOUNT);
+      }),
+    ),
+  { exclusive: true },
+);
+
+it.live(
+  "cloudflare bootstrap without --profile uses the default profile",
+  () =>
+    withIsolatedHome(
+      Effect.gen(function* () {
+        const profiles = yield* ProfileStore;
+        yield* profiles.setProviderConfig(
+          "default",
+          "Cloudflare",
+          storedToken(DEFAULT_ACCOUNT, "default-token"),
+        );
+
+        const scoped = yield* resolveStateStoreScope({});
+        expect(scoped.profile).toBe("default");
+        expect(scoped.accountId).toBe(DEFAULT_ACCOUNT);
+      }),
+    ),
+  { exclusive: true },
+);
+
+it.live(
+  "cloudflare bootstrap --profile does not fall back to an unconfigured default",
+  () =>
+    withIsolatedHome(
+      Effect.gen(function* () {
+        const profiles = yield* ProfileStore;
+        yield* profiles.createProfile("staging");
+        yield* profiles.setProviderConfig(
+          "staging",
+          "Cloudflare",
+          storedToken(STAGING_ACCOUNT, "staging-token"),
+        );
+
+        const scoped = yield* resolveStateStoreScope({ profile: "staging" });
+        expect(scoped.accountId).toBe(STAGING_ACCOUNT);
+
+        const missing = yield* resolveStateStoreScope({}).pipe(Effect.flip);
+        expect(missing).toBeInstanceOf(AuthError);
+        expect((missing as AuthError).message).toContain("profile 'default'");
+      }),
+    ),
+  { exclusive: true },
+);


### PR DESCRIPTION
`alchemy provider cloudflare bootstrap --profile <name>` resolved Cloudflare credentials from the default profile, so a named profile that already worked for deploy/destroy still prompted for login. `--force` only redeploys the state-store worker; it was never supposed to re-authenticate.

`fromProfile` / `fromAuthProvider` require `ConfigProvider`, but bootstrap sibling-merged the `--profile` override instead of providing it into those layers. They kept the CLI's ambient `fromEnv()` and landed on `default`.

The intended composition (not a verbatim excerpt):

```ts
// feed --profile into fromProfile / fromAuthProvider
Layer.provideMerge(cloudflareLayers, config)
```

Closes #252
