### PR TITLE
fix(cloudflare/email): refuse catch-all Email.Rule and adopt matching rules

### DIFF
--- a/packages/alchemy/src/Cloudflare/Email/Rule.ts
+++ b/packages/alchemy/src/Cloudflare/Email/Rule.ts
@@ -224,9 +224,13 @@ export const RuleProvider = () =>
         : undefined;
 
       // 2. Fall back to scanning the zone for the same matchers.
-      //    Ownership has already been verified upstream — `read` reports
-      //    existing rules as `Unowned` and the engine gates takeover
-      //    behind the adopt policy before reconcile ever runs.
+      //    `read` brands an existing match `Unowned` so the engine can
+      //    gate takeover behind adopt — but plan skips that probe when
+      //    props are still unresolved (e.g. `zone: routing.zoneId` from
+      //    a sibling created in the same deploy). In that case this scan
+      //    is the AlreadyExists race: Cloudflare rejects a second rule
+      //    with the same literal matchers, so converging on the match is
+      //    the same as catching Conflict and re-listing.
       if (!observed) {
         observed = yield* findByMatchers(zoneId, desired.matchers);
       }
@@ -296,6 +300,8 @@ const isCatchAllRule = (rule: {
 const isCatchAllMatchers = (matchers: Matcher[]): boolean =>
   matchers.length === 1 && matchers[0]?.type === "all";
 
+// `olds.matchers` may still be unresolved Inputs after stripUnresolved;
+// only treat a concrete array as matcher identity for the adoption scan.
 const asMatchers = (value: unknown): Matcher[] | undefined =>
   Array.isArray(value) ? (value as Matcher[]) : undefined;
 

--- a/packages/alchemy/src/Cloudflare/Email/Rule.ts
+++ b/packages/alchemy/src/Cloudflare/Email/Rule.ts
@@ -1,6 +1,9 @@
 import * as emailRouting from "@distilled.cloud/cloudflare/email-routing";
+import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
 import * as Stream from "effect/Stream";
+import { Unowned } from "../../AdoptPolicy.ts";
 import { isResolved } from "../../Diff.ts";
 import * as Provider from "../../Provider.ts";
 import { Resource } from "../../Resource.ts";
@@ -43,6 +46,10 @@ export type RuleProps = {
   priority?: number;
   /**
    * Matchers that define which inbound emails trigger this rule.
+   *
+   * A sole `{ type: "all" }` matcher is the zone catch-all, which is a
+   * per-zone singleton owned by `Cloudflare.Email.CatchAll` — declaring
+   * it here fails with `CatchAllRuleNotSupported`.
    */
   matchers: Matcher[];
   /**
@@ -68,10 +75,30 @@ export type Rule = Resource<
 >;
 
 /**
+ * Raised when `Cloudflare.Email.Rule` is declared with a sole
+ * `{ type: "all" }` matcher. Cloudflare models the zone catch-all as a
+ * singleton behind `PUT /zones/{zone_id}/email/routing/rules/catch_all`
+ * and rejects creating a second one through the ordinary rule endpoint
+ * (`Conflict: Invalid rule operation`). Use `Cloudflare.Email.CatchAll`.
+ */
+export class CatchAllRuleNotSupported extends Data.TaggedError(
+  "CatchAllRuleNotSupported",
+)<{
+  message: string;
+}> {}
+
+/**
  * A Cloudflare Email Routing rule.
  *
  * Rules forward inbound mail matching `matchers` to the listed actions
  * (forward to a verified destination, drop, or hand off to a Worker).
+ *
+ * Safety: routing rules carry no ownership markers. When there is no
+ * prior state, `read` scans the zone for an existing non-catch-all rule
+ * with the same matchers and reports it as `Unowned`, so the engine
+ * refuses to take it over unless `--adopt` (or `adopt(true)`) is set.
+ * The zone catch-all is excluded from that scan — it is owned by
+ * `Email.CatchAll`.
  * ### Forwarding Mail
  * **Example:** Forward `info@` to a verified destination
  * ```typescript
@@ -79,6 +106,21 @@ export type Rule = Resource<
  *   zone: "example.com",
  *   matchers: [{ type: "literal", field: "to", value: "info@example.com" }],
  *   actions: [{ type: "forward", value: ["ops@example.com"] }],
+ * });
+ * ```
+ *
+ * ### Catch-all mail
+ * The zone catch-all is a per-zone singleton managed by
+ * `Cloudflare.Email.CatchAll` (PUT `/rules/catch_all`). Declaring
+ * `matchers: [{ type: "all" }]` on a Rule fails with
+ * `CatchAllRuleNotSupported` — Cloudflare rejects creating a second
+ * catch-all through the ordinary rule endpoint.
+ *
+ * **Example:** Use CatchAll for unmatched mail
+ * ```typescript
+ * yield* Cloudflare.Email.CatchAll("CatchAll", {
+ *   zone: "example.com",
+ *   actions: [{ type: "drop" }],
  * });
  * ```
  *
@@ -133,65 +175,101 @@ export const RuleProvider = () =>
       }
       return undefined;
     }),
-    read: Effect.fn(function* ({ output }) {
-      if (!output?.ruleId || !output?.zoneId) return undefined;
-      return yield* emailRouting
-        .getRule({
-          zoneId: output.zoneId,
-          ruleIdentifier: output.ruleId,
-        })
-        .pipe(
-          Effect.map((r) => normalize(r, output.zoneId)),
-          Effect.catch(() => Effect.succeed(undefined)),
-        );
+    read: Effect.fn(function* ({ output, olds }) {
+      const zoneId =
+        output?.zoneId ??
+        (olds?.zone !== undefined ? yield* resolve(olds.zone) : undefined);
+      if (!zoneId) return undefined;
+
+      // Owned path: refresh by our persisted rule id. A catch-all id is
+      // treated as missing — that singleton is owned by `CatchAll`.
+      if (output?.ruleId) {
+        const observed = yield* observeById(zoneId, output.ruleId);
+        if (observed) return observed;
+      }
+
+      // Adoption path: Cloudflare uniqueness is by matcher shape, and
+      // rules carry no ownership markers, so brand a match `Unowned`.
+      // Never adopt the zone catch-all this way.
+      const matchers = output?.matchers ?? asMatchers(olds?.matchers);
+      if (matchers && !isCatchAllMatchers(matchers)) {
+        const observed = yield* findByMatchers(zoneId, matchers);
+        if (observed) return Unowned(observed);
+      }
+      return undefined;
     }),
     reconcile: Effect.fn(function* ({ news, output }) {
       const zoneId = output?.zoneId ?? (yield* resolve(news.zone));
-      const body = {
-        actions: news.actions.map((a) =>
-          a.type === "drop"
-            ? { type: a.type }
-            : { type: a.type, value: a.value },
-        ),
-        matchers: news.matchers.map((m) =>
-          m.type === "all"
-            ? { type: "all" as const }
-            : {
-                type: "literal" as const,
-                field: "to" as const,
-                value: m.value,
-              },
-        ),
-        enabled: news.enabled ?? true,
-        name: news.name ?? "",
-        priority: news.priority ?? 0,
-      };
+      const desired = toDesired(news);
 
-      if (output?.ruleId) {
-        const result = yield* emailRouting
-          .updateRule({
-            zoneId,
-            ruleIdentifier: output.ruleId,
-            ...body,
-          })
-          .pipe(
-            retryWorkerScriptNotFound,
-            Effect.catch(() =>
-              emailRouting
-                .createRule({ zoneId, ...body })
-                .pipe(retryWorkerScriptNotFound),
-            ),
-          );
-        return normalize(result, zoneId);
+      // The zone catch-all is a singleton behind `/rules/catch_all`.
+      // Creating it as an ordinary rule 409s ("Invalid rule operation")
+      // and deleting it through the rule endpoint does the same — refuse
+      // before any write and point at `Email.CatchAll`.
+      if (isCatchAllMatchers(desired.matchers)) {
+        return yield* Effect.fail(
+          new CatchAllRuleNotSupported({
+            message:
+              'Cloudflare.Email.Rule cannot manage the zone catch-all (matchers: [{ type: "all" }]). ' +
+              "Cloudflare models that as a per-zone singleton behind PUT /zones/{zone_id}/email/routing/rules/catch_all. " +
+              "Use Cloudflare.Email.CatchAll instead.",
+          }),
+        );
       }
 
-      const result = yield* emailRouting
-        .createRule({ zoneId, ...body })
-        .pipe(retryWorkerScriptNotFound);
-      return normalize(result, zoneId);
+      // 1. Observe — cached id is a hint, not a guarantee the rule still
+      //    exists. A missing id falls through to the matcher scan.
+      let observed = output?.ruleId
+        ? yield* observeById(zoneId, output.ruleId)
+        : undefined;
+
+      // 2. Fall back to scanning the zone for the same matchers.
+      //    Ownership has already been verified upstream — `read` reports
+      //    existing rules as `Unowned` and the engine gates takeover
+      //    behind the adopt policy before reconcile ever runs.
+      if (!observed) {
+        observed = yield* findByMatchers(zoneId, desired.matchers);
+      }
+
+      // 3. Ensure — create when missing. The rejected call creates
+      //    nothing, so a Worker-script retry cannot duplicate the rule.
+      if (!observed) {
+        const created = yield* emailRouting
+          .createRule({
+            zoneId,
+            actions: desired.actions.map(toActionBody),
+            matchers: desired.matchers.map(toMatcherBody),
+            enabled: desired.enabled,
+            name: desired.name,
+            priority: desired.priority,
+          })
+          .pipe(retryWorkerScriptNotFound);
+        observed = normalize(created, zoneId);
+      }
+
+      // 4. Sync — PUT the full desired body when observed state drifts.
+      if (!sameRule(observed, desired)) {
+        const updated = yield* emailRouting
+          .updateRule({
+            zoneId,
+            ruleIdentifier: observed.ruleId,
+            actions: desired.actions.map(toActionBody),
+            matchers: desired.matchers.map(toMatcherBody),
+            enabled: desired.enabled,
+            name: desired.name,
+            priority: desired.priority,
+          })
+          .pipe(retryWorkerScriptNotFound);
+        observed = normalize(updated, zoneId);
+      }
+
+      return observed;
     }),
     delete: Effect.fn(function* ({ output }) {
       if (!output?.ruleId) return;
+      // Never attempt to delete the zone catch-all through this endpoint
+      // — Cloudflare rejects it with "Invalid rule operation".
+      if (isCatchAllMatchers(output.matchers)) return;
       // Idempotent: a rule that's already gone is success. Any other error
       // (e.g. a 409 because email routing is disabled) must surface so the
       // engine reports the failure instead of falsely claiming deletion.
@@ -215,6 +293,79 @@ const isCatchAllRule = (rule: {
 }): boolean =>
   (rule.matchers ?? []).length === 1 && rule.matchers?.[0]?.type === "all";
 
+const isCatchAllMatchers = (matchers: Matcher[]): boolean =>
+  matchers.length === 1 && matchers[0]?.type === "all";
+
+const asMatchers = (value: unknown): Matcher[] | undefined =>
+  Array.isArray(value) ? (value as Matcher[]) : undefined;
+
+type RuleAttributes = {
+  ruleId: string;
+  zoneId: string;
+  name: string;
+  enabled: boolean;
+  priority: number;
+  matchers: Matcher[];
+  actions: Action[];
+};
+
+const toDesired = (
+  news: RuleProps,
+): Omit<RuleAttributes, "ruleId" | "zoneId"> => ({
+  name: news.name ?? "",
+  enabled: news.enabled ?? true,
+  priority: news.priority ?? 0,
+  matchers: news.matchers.map((m): Matcher =>
+    m.type === "all"
+      ? { type: "all" }
+      : { type: "literal", field: "to", value: m.value },
+  ),
+  actions: news.actions.map((a): Action =>
+    a.type === "drop"
+      ? { type: "drop" }
+      : a.type === "forward"
+        ? { type: "forward", value: a.value }
+        : { type: "worker", value: a.value },
+  ),
+});
+
+const toMatcherBody = (m: Matcher) =>
+  m.type === "all"
+    ? { type: "all" as const }
+    : { type: "literal" as const, field: "to" as const, value: m.value };
+
+const toActionBody = (a: Action) =>
+  a.type === "drop" ? { type: a.type } : { type: a.type, value: a.value };
+
+const matchersEqual = (a: Matcher[], b: Matcher[]): boolean =>
+  a.length === b.length &&
+  a.every((x, i) => {
+    const y = b[i]!;
+    if (x.type !== y.type) return false;
+    if (x.type === "all") return true;
+    return y.type === "literal" && x.field === y.field && x.value === y.value;
+  });
+
+const actionsEqual = (a: Action[], b: Action[]): boolean =>
+  a.length === b.length &&
+  a.every((x, i) => {
+    const y = b[i]!;
+    if (x.type !== y.type) return false;
+    const xv = x.type === "drop" ? [] : x.value;
+    const yv = y.type === "drop" ? [] : y.value;
+    return xv.length === yv.length && xv.every((v, j) => v === yv[j]);
+  });
+
+const sameRule = (
+  observed: RuleAttributes,
+  desired: Omit<RuleAttributes, "ruleId" | "zoneId">,
+): boolean =>
+  observed.enabled === desired.enabled &&
+  observed.name === desired.name &&
+  observed.priority === desired.priority &&
+  matchersEqual(observed.matchers, desired.matchers) &&
+  actionsEqual(observed.actions, desired.actions);
+
 const normalize = (
   rule: {
     id?: string | null;
@@ -233,7 +384,7 @@ const normalize = (
     actions?: { type: string; value?: string[] | null }[] | null;
   },
   zoneId: string,
-) => ({
+): RuleAttributes => ({
   ruleId: rule.id ?? "",
   zoneId,
   name: rule.name ?? "",
@@ -252,6 +403,34 @@ const normalize = (
         : { type: "worker", value: a.value ?? [] },
   ),
 });
+
+const observeById = (zoneId: string, ruleId: string) =>
+  emailRouting.getRule({ zoneId, ruleIdentifier: ruleId }).pipe(
+    Effect.map((rule) =>
+      isCatchAllRule(rule) ? undefined : normalize(rule, zoneId),
+    ),
+    Effect.catchTag(["EmailRoutingRuleNotFound", "Forbidden"], () =>
+      Effect.succeed(undefined),
+    ),
+  );
+
+/**
+ * Locate an existing non-catch-all rule by matcher identity. Cloudflare
+ * rejects a second catch-all and treats matcher shape as the rule's
+ * identity, so a match is the same logical rule.
+ */
+const findByMatchers = (zoneId: string, matchers: Matcher[]) =>
+  emailRouting.listRules.items({ zoneId }).pipe(
+    Stream.filter(
+      (rule) =>
+        !isCatchAllRule(rule) &&
+        matchersEqual(normalize(rule, zoneId).matchers, matchers),
+    ),
+    Stream.runHead,
+    Effect.map(Option.getOrUndefined),
+    Effect.map((rule) => (rule ? normalize(rule, zoneId) : undefined)),
+    Effect.catchTag("InvalidRoute", () => Effect.succeed(undefined)),
+  );
 
 const resolve = Effect.fn(function* (zone: Reference) {
   const { accountId } = yield* yield* CloudflareEnvironment;

--- a/packages/alchemy/test/Cloudflare/Email/EmailRule.test.ts
+++ b/packages/alchemy/test/Cloudflare/Email/EmailRule.test.ts
@@ -1,13 +1,18 @@
+import { adopt, OwnedBySomeoneElse } from "@/AdoptPolicy";
 import * as Cloudflare from "@/Cloudflare";
 import { CloudflareEnvironment } from "@/Cloudflare/CloudflareEnvironment";
+import { CatchAllRuleNotSupported } from "@/Cloudflare/Email/Rule.ts";
 import { findZoneByName } from "@/Cloudflare/Zone/lookup";
 import * as Provider from "@/Provider";
 import * as Test from "@/Test/Alchemy";
 import * as emailRouting from "@distilled.cloud/cloudflare/email-routing";
 import { describe, expect } from "alchemy-test";
+import * as Cause from "effect/Cause";
 import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
 import { MinimumLogLevel } from "effect/References";
 import * as Schedule from "effect/Schedule";
+import * as Stream from "effect/Stream";
 import { emailRoutingScoped } from "./scope.ts";
 const { test } = Test.make({ providers: Cloudflare.providers() });
 
@@ -37,16 +42,91 @@ const resolveZoneId = Effect.gen(function* () {
 // the email-routing enable operation's error union via distilled patches).
 const forbiddenRetrySchedule = Schedule.exponential("500 millis");
 
-// Email Routing must be enabled on the zone for rules to be created and
-// visible to `list()`.
-const enableRouting = (zoneId: string) =>
-  emailRouting.enableEmailRouting({ zoneId }).pipe(
+const rideOutAuth = <A, E extends { _tag: string }, R>(
+  effect: Effect.Effect<A, E, R>,
+) =>
+  effect.pipe(
     Effect.retry({
-      while: (e) => e._tag === "Forbidden",
+      while: (e) => e._tag === "Forbidden" || e._tag === "Unauthorized",
       schedule: forbiddenRetrySchedule,
       times: 8,
     }),
   );
+
+// Email Routing must be enabled on the zone for rules to be created and
+// visible to `list()`.
+const enableRouting = (zoneId: string) =>
+  rideOutAuth(emailRouting.enableEmailRouting({ zoneId }));
+
+const getCatchAll = (zoneId: string) =>
+  rideOutAuth(emailRouting.getRuleCatchAll({ zoneId }));
+
+const restoreCatchAll = (
+  zoneId: string,
+  snapshot: emailRouting.GetRuleCatchAllResponse,
+) =>
+  rideOutAuth(
+    emailRouting.putRuleCatchAll({
+      zoneId,
+      matchers: [{ type: "all" }],
+      actions: (snapshot.actions ?? [{ type: "drop" }]).map((a) =>
+        a.type === "drop"
+          ? { type: "drop" as const }
+          : a.type === "forward"
+            ? { type: "forward" as const, value: [...(a.value ?? [])] }
+            : { type: "worker" as const, value: [...(a.value ?? [])] },
+      ),
+      enabled: snapshot.enabled ?? false,
+      name: snapshot.name ?? "",
+    }),
+  );
+
+const ADOPT_TO = `adopt-413@${zoneName}`;
+
+const findRuleByTo = (zoneId: string, to: string) =>
+  rideOutAuth(
+    emailRouting.listRules.items({ zoneId }).pipe(
+      Stream.filter(
+        (rule) =>
+          (rule.matchers ?? []).length === 1 &&
+          rule.matchers?.[0]?.type === "literal" &&
+          rule.matchers?.[0]?.value === to,
+      ),
+      Stream.runHead,
+      Effect.map(Option.getOrUndefined),
+    ),
+  );
+
+const purgeRuleByTo = (zoneId: string, to: string) =>
+  Effect.gen(function* () {
+    const existing = yield* findRuleByTo(zoneId, to);
+    if (!existing?.id) return;
+    yield* rideOutAuth(
+      emailRouting
+        .deleteRule({ zoneId, ruleIdentifier: existing.id })
+        .pipe(Effect.catchTag("EmailRoutingRuleNotFound", () => Effect.void)),
+    );
+  });
+
+/**
+ * Pull the {@link OwnedBySomeoneElse} value out of a Cause regardless of
+ * whether the engine raised it as a typed failure or a defect.
+ */
+const findOwnedError = (
+  cause: Cause.Cause<unknown>,
+): OwnedBySomeoneElse | undefined =>
+  cause.reasons
+    .map((reason) =>
+      Cause.isFailReason(reason)
+        ? reason.error
+        : Cause.isDieReason(reason)
+          ? reason.defect
+          : undefined,
+    )
+    .find(
+      (value): value is OwnedBySomeoneElse =>
+        value instanceof OwnedBySomeoneElse,
+    );
 
 describe.sequential.skipIf(!emailRoutingScoped)("EmailRule", () => {
   // Canonical `list()` test (zone-scoped collection): email routing rules live
@@ -109,5 +189,119 @@ describe.sequential.skipIf(!emailRoutingScoped)("EmailRule", () => {
 
         yield* stack.destroy();
       }).pipe(logLevel),
+  );
+
+  // #413: a sole `{ type: "all" }` matcher is the zone catch-all, which
+  // already exists once Email Routing is enabled. Creating it as an
+  // Email.Rule 409s ("Invalid rule operation"). Fail fast with a typed
+  // error pointing at Email.CatchAll, and leave the singleton untouched.
+  test.provider(
+    "refuses a sole { type: 'all' } matcher and leaves the catch-all untouched (#413)",
+    (stack) =>
+      Effect.gen(function* () {
+        const zoneId = yield* resolveZoneId;
+
+        yield* stack.destroy();
+        yield* enableRouting(zoneId);
+
+        const before = yield* getCatchAll(zoneId);
+        yield* Effect.addFinalizer(() =>
+          restoreCatchAll(zoneId, before).pipe(Effect.ignore),
+        );
+
+        const error = yield* stack
+          .deploy(
+            Cloudflare.Email.Rule("CatchAll", {
+              zone: zoneName,
+              matchers: [{ type: "all" }],
+              actions: [{ type: "drop" }],
+            }),
+          )
+          .pipe(Effect.flip);
+
+        expect(error).toBeInstanceOf(CatchAllRuleNotSupported);
+        expect(String(error)).toContain("Cloudflare.Email.CatchAll");
+
+        const after = yield* getCatchAll(zoneId);
+        expect(after.id).toEqual(before.id);
+        expect(after.enabled).toEqual(before.enabled);
+        expect(after.name ?? "").toEqual(before.name ?? "");
+        expect(after.actions).toEqual(before.actions);
+
+        yield* stack.destroy();
+      }).pipe(logLevel),
+  );
+
+  // A pre-existing non-catch-all rule with identical matchers must be
+  // adopted (same physical id) rather than duplicated on first deploy.
+  test.provider(
+    "adopts a pre-existing non-catch-all rule with identical matchers",
+    (stack) =>
+      Effect.gen(function* () {
+        const zoneId = yield* resolveZoneId;
+
+        yield* stack.destroy();
+        yield* enableRouting(zoneId);
+        yield* purgeRuleByTo(zoneId, ADOPT_TO);
+        yield* Effect.addFinalizer(() =>
+          purgeRuleByTo(zoneId, ADOPT_TO).pipe(Effect.ignore),
+        );
+
+        const pre = yield* rideOutAuth(
+          emailRouting.createRule({
+            zoneId,
+            name: "alchemy adopt 413",
+            matchers: [{ type: "literal", field: "to", value: ADOPT_TO }],
+            actions: [{ type: "drop" }],
+            enabled: true,
+            priority: 0,
+          }),
+        );
+        expect(pre.id).toBeTruthy();
+
+        const error = yield* stack
+          .deploy(
+            Cloudflare.Email.Rule("AdoptRule", {
+              zone: zoneName,
+              name: "alchemy adopt 413",
+              matchers: [{ type: "literal", field: "to", value: ADOPT_TO }],
+              actions: [{ type: "drop" }],
+            }),
+          )
+          .pipe(
+            Effect.as(undefined),
+            Effect.catchCause((cause) => Effect.succeed(findOwnedError(cause))),
+          );
+        expect(error).toBeInstanceOf(OwnedBySomeoneElse);
+
+        const adopted = yield* stack.deploy(
+          Cloudflare.Email.Rule("AdoptRule", {
+            zone: zoneName,
+            name: "alchemy adopt 413 v2",
+            matchers: [{ type: "literal", field: "to", value: ADOPT_TO }],
+            actions: [{ type: "drop" }],
+          }).pipe(adopt(true)),
+        );
+        expect(adopted.ruleId).toEqual(pre.id);
+        expect(adopted.name).toEqual("alchemy adopt 413 v2");
+        expect(adopted.matchers).toEqual([
+          { type: "literal", field: "to", value: ADOPT_TO },
+        ]);
+
+        const live = yield* rideOutAuth(
+          emailRouting.getRule({
+            zoneId,
+            ruleIdentifier: adopted.ruleId,
+          }),
+        );
+        expect(live.id).toEqual(pre.id);
+        expect(live.name).toEqual("alchemy adopt 413 v2");
+
+        yield* stack.destroy();
+
+        const gone = yield* findRuleByTo(zoneId, ADOPT_TO);
+        expect(gone).toBeUndefined();
+      }).pipe(logLevel),
+    { timeout: 180_000 },
   );
 });

--- a/packages/alchemy/test/Cloudflare/Email/EmailRule.test.ts
+++ b/packages/alchemy/test/Cloudflare/Email/EmailRule.test.ts
@@ -61,26 +61,6 @@ const enableRouting = (zoneId: string) =>
 const getCatchAll = (zoneId: string) =>
   rideOutAuth(emailRouting.getRuleCatchAll({ zoneId }));
 
-const restoreCatchAll = (
-  zoneId: string,
-  snapshot: emailRouting.GetRuleCatchAllResponse,
-) =>
-  rideOutAuth(
-    emailRouting.putRuleCatchAll({
-      zoneId,
-      matchers: [{ type: "all" }],
-      actions: (snapshot.actions ?? [{ type: "drop" }]).map((a) =>
-        a.type === "drop"
-          ? { type: "drop" as const }
-          : a.type === "forward"
-            ? { type: "forward" as const, value: [...(a.value ?? [])] }
-            : { type: "worker" as const, value: [...(a.value ?? [])] },
-      ),
-      enabled: snapshot.enabled ?? false,
-      name: snapshot.name ?? "",
-    }),
-  );
-
 const ADOPT_TO = `adopt-413@${zoneName}`;
 
 const findRuleByTo = (zoneId: string, to: string) =>
@@ -200,7 +180,11 @@ describe.sequential.skipIf(!emailRoutingScoped)("EmailRule", () => {
   // #413: a sole `{ type: "all" }` matcher is the zone catch-all, which
   // already exists once Email Routing is enabled. Creating it as an
   // Email.Rule 409s ("Invalid rule operation"). Fail fast with a typed
-  // error pointing at Email.CatchAll, and leave the singleton untouched.
+  // error pointing at Email.CatchAll — that error is the proof no write
+  // happened. Sibling EmailCatchAll / WorkerTarget files PUT the same
+  // zone singleton concurrently, so do not snapshot enabled/name/actions
+  // (those race); the catch-all id is stable and proves we did not mint
+  // a second rule.
   test.provider(
     "refuses a sole { type: 'all' } matcher and leaves the catch-all untouched (#413)",
     (stack) =>
@@ -211,9 +195,6 @@ describe.sequential.skipIf(!emailRoutingScoped)("EmailRule", () => {
         yield* enableRouting(zoneId);
 
         const before = yield* getCatchAll(zoneId);
-        yield* Effect.addFinalizer(() =>
-          restoreCatchAll(zoneId, before).pipe(Effect.ignore),
-        );
 
         const error = yield* stack
           .deploy(
@@ -234,9 +215,6 @@ describe.sequential.skipIf(!emailRoutingScoped)("EmailRule", () => {
 
         const after = yield* getCatchAll(zoneId);
         expect(after.id).toEqual(before.id);
-        expect(after.enabled).toEqual(before.enabled);
-        expect(after.name ?? "").toEqual(before.name ?? "");
-        expect(after.actions).toEqual(before.actions);
 
         yield* stack.destroy();
       }).pipe(logLevel),

--- a/packages/alchemy/test/Cloudflare/Email/EmailRule.test.ts
+++ b/packages/alchemy/test/Cloudflare/Email/EmailRule.test.ts
@@ -109,24 +109,30 @@ const purgeRuleByTo = (zoneId: string, to: string) =>
   });
 
 /**
- * Pull the {@link OwnedBySomeoneElse} value out of a Cause regardless of
- * whether the engine raised it as a typed failure or a defect.
+ * Pull a tagged error out of a Cause regardless of whether the engine
+ * raised it as a typed failure or a defect.
  */
-const findOwnedError = (
-  cause: Cause.Cause<unknown>,
-): OwnedBySomeoneElse | undefined =>
-  cause.reasons
-    .map((reason) =>
-      Cause.isFailReason(reason)
-        ? reason.error
-        : Cause.isDieReason(reason)
-          ? reason.defect
-          : undefined,
-    )
-    .find(
-      (value): value is OwnedBySomeoneElse =>
-        value instanceof OwnedBySomeoneElse,
-    );
+const findCauseError =
+  <E>(is: (value: unknown) => value is E) =>
+  (cause: Cause.Cause<unknown>): E | undefined =>
+    cause.reasons
+      .map((reason) =>
+        Cause.isFailReason(reason)
+          ? reason.error
+          : Cause.isDieReason(reason)
+            ? reason.defect
+            : undefined,
+      )
+      .find(is);
+
+const findOwnedError = findCauseError(
+  (value): value is OwnedBySomeoneElse => value instanceof OwnedBySomeoneElse,
+);
+
+const findCatchAllError = findCauseError(
+  (value): value is CatchAllRuleNotSupported =>
+    value instanceof CatchAllRuleNotSupported,
+);
 
 describe.sequential.skipIf(!emailRoutingScoped)("EmailRule", () => {
   // Canonical `list()` test (zone-scoped collection): email routing rules live
@@ -217,8 +223,12 @@ describe.sequential.skipIf(!emailRoutingScoped)("EmailRule", () => {
               actions: [{ type: "drop" }],
             }),
           )
-          .pipe(Effect.flip);
-
+          .pipe(
+            Effect.as(undefined),
+            Effect.catchCause((cause) =>
+              Effect.succeed(findCatchAllError(cause)),
+            ),
+          );
         expect(error).toBeInstanceOf(CatchAllRuleNotSupported);
         expect(String(error)).toContain("Cloudflare.Email.CatchAll");
 


### PR DESCRIPTION
`Cloudflare.Email.Rule` with `matchers: [{ type: "all" }]` still POSTs `/zones/{zone_id}/email/routing/rules` on first deploy and 409s (`Conflict: Invalid rule operation`) because the zone catch-all already exists once Email Routing is enabled.

Main already has `Email.CatchAll` (PUT `/rules/catch_all`, restore-on-destroy singleton) and `Rule.list` already filters the catch-all out — but `reconcile` still branched create vs update on `output?.ruleId`.

Fail fast rather than delegating to the catch-all endpoint. CatchAll's lifecycle is different (never physically create/delete; restore the pre-management state on destroy), and `deleteRule` on that id is the same 409. `EmailEventSource` already routes all-matcher subscriptions to CatchAll.

```ts
yield* Cloudflare.Email.Rule("CatchAll", {
  zone: "example.com",
  matchers: [{ type: "all" }],
  actions: [{ type: "drop" }],
});
// CatchAllRuleNotSupported — use Cloudflare.Email.CatchAll
```

Non-catch-all rules now observe → ensure → sync: `read` locates an existing rule by matcher identity and brands it `Unowned`; with `adopt(true)` reconcile updates in place instead of duplicating.

No distilled patch: fail-fast never calls `createRule` with `{ type: "all" }`.

Closes #413
