### PR TITLE
fix(cloudflare): register Worker ExportedHandler methods as listeners

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/InferEnv.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/InferEnv.ts
@@ -41,7 +41,7 @@ import type { RateLimitBinding } from "./RateLimitBinding.ts";
 import type { RpcErrorEnvelope, RpcStreamEnvelope } from "./Rpc.ts";
 import type { SecretKeyBinding } from "./SecretKeyBinding.ts";
 import type { VersionMetadataBinding } from "./VersionMetadataBinding.ts";
-import type { ExportedHandlerMethod, Worker } from "./Worker.ts";
+import type { ExportedHandlerMethod, RpcMethods, Worker } from "./Worker.ts";
 import type { WorkerEntrypointBinding } from "./WorkerEntrypoint.ts";
 import type { WorkerLoader as WorkerLoaderResource } from "./WorkerLoader.ts";
 
@@ -168,17 +168,19 @@ export type GetBindingType<T> =
  * where envelopes are decoded for you.
  */
 export type RpcWireShape<Shape> = {
-  [
-    K in keyof Shape as K extends ExportedHandlerMethod ? never : K
-  ]: Shape[K] extends (...args: infer A) => Effect.Effect<infer T, any, any>
+  [K in keyof RpcMethods<Shape>]: RpcMethods<Shape>[K] extends (
+    ...args: infer A
+  ) => Effect.Effect<infer T, any, any>
     ? (...args: A) => Promise<T | RpcErrorEnvelope>
-    : Shape[K] extends (...args: infer A) => Stream.Stream<any, any, any>
+    : RpcMethods<Shape>[K] extends (
+          ...args: infer A
+        ) => Stream.Stream<any, any, any>
       ? (...args: A) => Promise<RpcStreamEnvelope | RpcErrorEnvelope>
-      : Shape[K] extends Effect.Effect<infer T, any, any>
+      : RpcMethods<Shape>[K] extends Effect.Effect<infer T, any, any>
         ? Promise<T | RpcErrorEnvelope>
-        : Shape[K] extends Stream.Stream<any, any, any>
+        : RpcMethods<Shape>[K] extends Stream.Stream<any, any, any>
           ? Promise<RpcStreamEnvelope | RpcErrorEnvelope>
-          : Shape[K] extends (...args: infer A) => infer R
+          : RpcMethods<Shape>[K] extends (...args: infer A) => infer R
             ? (...args: A) => Promise<Awaited<R>>
-            : Promise<Shape[K]>;
+            : Promise<RpcMethods<Shape>[K]>;
 };

--- a/packages/alchemy/src/Cloudflare/Workers/InferEnv.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/InferEnv.ts
@@ -41,7 +41,7 @@ import type { RateLimitBinding } from "./RateLimitBinding.ts";
 import type { RpcErrorEnvelope, RpcStreamEnvelope } from "./Rpc.ts";
 import type { SecretKeyBinding } from "./SecretKeyBinding.ts";
 import type { VersionMetadataBinding } from "./VersionMetadataBinding.ts";
-import type { Worker } from "./Worker.ts";
+import type { ExportedHandlerMethod, Worker } from "./Worker.ts";
 import type { WorkerEntrypointBinding } from "./WorkerEntrypoint.ts";
 import type { WorkerLoader as WorkerLoaderResource } from "./WorkerLoader.ts";
 
@@ -160,15 +160,17 @@ export type GetBindingType<T> =
  * `RpcErrorEnvelope`, `RpcStreamEnvelope`), so the mapped types reflect what
  * the raw binding actually resolves to. `fetch` is dropped from the user
  * shape and re-introduced via `Service` so callers get the standard
- * `(input, init?) => Promise<Response>` signature.
+ * `(input, init?) => Promise<Response>` signature. Other
+ * {@link ExportedHandlerMethod}s (`scheduled`, `email`, `queue`, …) are
+ * dropped too — they are event listeners, not RPC methods.
  *
  * Use {@link toRpcAsync} to wrap a binding into a Promise<T>-flavored view
  * where envelopes are decoded for you.
  */
 export type RpcWireShape<Shape> = {
-  [K in keyof Shape as K extends "fetch" ? never : K]: Shape[K] extends (
-    ...args: infer A
-  ) => Effect.Effect<infer T, any, any>
+  [
+    K in keyof Shape as K extends ExportedHandlerMethod ? never : K
+  ]: Shape[K] extends (...args: infer A) => Effect.Effect<infer T, any, any>
     ? (...args: A) => Promise<T | RpcErrorEnvelope>
     : Shape[K] extends (...args: infer A) => Stream.Stream<any, any, any>
       ? (...args: A) => Promise<RpcStreamEnvelope | RpcErrorEnvelope>

--- a/packages/alchemy/src/Cloudflare/Workers/Rpc.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Rpc.ts
@@ -13,6 +13,7 @@ import type * as RpcClientError from "effect/unstable/rpc/RpcClientError";
 import { asEffectOrStream, decodeRpcResult, RpcCallError } from "../../Rpc.ts";
 import { isYieldableEffect } from "../../Util/effect.ts";
 import { fromCloudflareFetcher } from "../Fetcher.ts";
+import { isExportedHandlerMethod } from "./Worker.ts";
 
 // The transport-agnostic RPC wire protocol (envelopes, error types, stream
 // encode/decode, `asEffectOrStream`, and the plain-`fetch` client/server) now
@@ -46,6 +47,10 @@ export const makeRpcStub = <Shape>(
       if (!isLazy && prop in target) return target[prop];
       if (typeof prop !== "string" && typeof prop !== "symbol") {
         return target[prop];
+      }
+      // ExportedHandler methods are event listeners, not RPC methods.
+      if (typeof prop === "string" && isExportedHandlerMethod(prop)) {
+        return undefined;
       }
       return (...args: any[]) =>
         asEffectOrStream(

--- a/packages/alchemy/src/Cloudflare/Workers/RpcAsync.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/RpcAsync.ts
@@ -5,22 +5,25 @@ import { isRpcErrorEnvelope, isRpcStreamEnvelope } from "../Bridge.ts";
 import {
   isExportedHandlerMethod,
   type ExportedHandlerMethod,
+  type RpcMethods,
 } from "./Worker.ts";
 
 export type RpcAsync<Shape> = {
-  [
-    K in keyof Shape as K extends ExportedHandlerMethod ? never : K
-  ]: Shape[K] extends (...args: infer A) => Effect.Effect<infer T, any, any>
+  [K in keyof RpcMethods<Shape>]: RpcMethods<Shape>[K] extends (
+    ...args: infer A
+  ) => Effect.Effect<infer T, any, any>
     ? (...args: A) => Promise<T>
-    : Shape[K] extends (...args: infer A) => Stream.Stream<any, any, any>
+    : RpcMethods<Shape>[K] extends (
+          ...args: infer A
+        ) => Stream.Stream<any, any, any>
       ? (...args: A) => Promise<ReadableStream<Uint8Array>>
-      : Shape[K] extends Effect.Effect<infer T, any, any>
+      : RpcMethods<Shape>[K] extends Effect.Effect<infer T, any, any>
         ? Promise<T>
-        : Shape[K] extends Stream.Stream<any, any, any>
+        : RpcMethods<Shape>[K] extends Stream.Stream<any, any, any>
           ? Promise<ReadableStream<Uint8Array>>
-          : Shape[K] extends (...args: infer A) => infer R
+          : RpcMethods<Shape>[K] extends (...args: infer A) => infer R
             ? (...args: A) => Promise<Awaited<R>>
-            : Promise<Shape[K]>;
+            : Promise<RpcMethods<Shape>[K]>;
 };
 
 /**

--- a/packages/alchemy/src/Cloudflare/Workers/RpcAsync.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/RpcAsync.ts
@@ -2,11 +2,15 @@ import type * as Effect from "effect/Effect";
 import type * as Stream from "effect/Stream";
 import type { Rpc } from "../../Rpc.ts";
 import { isRpcErrorEnvelope, isRpcStreamEnvelope } from "../Bridge.ts";
+import {
+  isExportedHandlerMethod,
+  type ExportedHandlerMethod,
+} from "./Worker.ts";
 
 export type RpcAsync<Shape> = {
-  [K in keyof Shape as K extends "fetch" ? never : K]: Shape[K] extends (
-    ...args: infer A
-  ) => Effect.Effect<infer T, any, any>
+  [
+    K in keyof Shape as K extends ExportedHandlerMethod ? never : K
+  ]: Shape[K] extends (...args: infer A) => Effect.Effect<infer T, any, any>
     ? (...args: A) => Promise<T>
     : Shape[K] extends (...args: infer A) => Stream.Stream<any, any, any>
       ? (...args: A) => Promise<ReadableStream<Uint8Array>>
@@ -25,8 +29,9 @@ export type RpcAsync<Shape> = {
  * test code) can `await` RPC methods directly.
  *
  * The proxy:
- * - leaves `fetch` / `connect` / `Symbol.dispose` and other non-string keys
- *   passing through to the underlying binding unchanged,
+ * - leaves `fetch` / other {@link ExportedHandlerMethod}s / `connect` /
+ *   `Symbol.dispose` and other non-string keys passing through to the
+ *   underlying binding unchanged (event handlers are not RPC methods),
  * - turns each `Effect<T>` / `Stream<T>` method into a `Promise<T>` /
  *   `Promise<ReadableStream<Uint8Array>>`,
  * - unwraps the wire envelopes produced by the Effect-side RPC bridge:
@@ -77,9 +82,14 @@ export type RpcAsync<Shape> = {
 export const toRpcAsync = <W>(stub: any): RpcAsync<Rpc.Shape<W>> & Service =>
   new Proxy(stub, {
     get: (target, prop) => {
-      // `Service` methods (fetch/connect) and any non-string keys (Symbol.dispose, etc.)
-      // pass through to the underlying Cloudflare binding unchanged.
-      if (typeof prop !== "string" || prop === "fetch" || prop === "connect") {
+      // `Service` methods (fetch/connect), ExportedHandler event methods
+      // (scheduled/email/queue/…), and any non-string keys (Symbol.dispose,
+      // etc.) pass through to the underlying Cloudflare binding unchanged.
+      if (
+        typeof prop !== "string" ||
+        prop === "connect" ||
+        isExportedHandlerMethod(prop)
+      ) {
         const value = (target as any)[prop];
         return typeof value === "function" ? value.bind(target) : value;
       }

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -281,6 +281,21 @@ export const ExportedHandlerMethods = [
   "queue",
 ] as const satisfies (keyof cf.ExportedHandler)[];
 
+export type ExportedHandlerMethod = (typeof ExportedHandlerMethods)[number];
+
+const exportedHandlerMethodSet: ReadonlySet<string> = new Set(
+  ExportedHandlerMethods,
+);
+
+/**
+ * True when `name` is a Cloudflare `ExportedHandler` method (`fetch`,
+ * `scheduled`, `email`, `queue`, …). Those are event listeners, not RPC
+ * methods on the Worker's service-binding interface.
+ */
+export const isExportedHandlerMethod = (
+  name: string,
+): name is ExportedHandlerMethod => exportedHandlerMethodSet.has(name);
+
 export type WorkerServices =
   | Worker
   | Request

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -283,6 +283,20 @@ export const ExportedHandlerMethods = [
 
 export type ExportedHandlerMethod = (typeof ExportedHandlerMethods)[number];
 
+/**
+ * RPC-callable methods on a Worker init shape. Drops Cloudflare
+ * `ExportedHandler` event methods (`fetch`, `scheduled`, `email`,
+ * `queue`, …). The string-index key of {@link MainRpc} is stripped
+ * first so `Omit` over a Worker class does not widen remaining methods
+ * to the index-signature union.
+ */
+export type RpcMethods<Shape> = Omit<
+  {
+    [K in keyof Shape as string extends K ? never : K]: Shape[K];
+  },
+  ExportedHandlerMethod
+>;
+
 const exportedHandlerMethodSet: ReadonlySet<string> = new Set(
   ExportedHandlerMethods,
 );

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerBinding.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerBinding.ts
@@ -32,14 +32,18 @@ import type { WorkflowLike } from "../Workflows/Workflow.ts";
 import type { AIBinding } from "./AIBinding.ts";
 import type { AnyBindingEffect } from "./Binding.ts";
 import type { Assets } from "./Assets.ts";
-import type { URLEffect } from "./Worker.ts";
 import type { BrowserBinding } from "./BrowserBinding.ts";
 import type { DurableObjectLike } from "./DurableObject.ts";
 import type { RateLimitBinding } from "./RateLimitBinding.ts";
 import { makeRpcStub } from "./Rpc.ts";
 import type { SecretKeyBinding } from "./SecretKeyBinding.ts";
 import type { VersionMetadataBinding } from "./VersionMetadataBinding.ts";
-import { Worker, WorkerEnvironment } from "./Worker.ts";
+import {
+  Worker,
+  WorkerEnvironment,
+  type RpcMethods,
+  type URLEffect,
+} from "./Worker.ts";
 import type { WorkerEntrypointBinding } from "./WorkerEntrypoint.ts";
 import type { WorkerLoader } from "./WorkerLoader.ts";
 
@@ -243,5 +247,5 @@ export const bindWorker = Effect.fn(function* <Shape, Req = never>(
   const stubEff = WorkerEnvironment.pipe(
     Effect.map((env) => (env as Record<string, unknown>)[worker.LogicalId]),
   );
-  return makeRpcStub<Shape>(stubEff);
+  return makeRpcStub<RpcMethods<Shape>>(stubEff);
 });

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerBridge.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerBridge.ts
@@ -32,6 +32,7 @@ import {
 } from "./Rpc.ts";
 import {
   ExportedHandlerMethods,
+  isExportedHandlerMethod,
   Worker,
   WorkerEnvironment,
   WorkerExecutionContext,
@@ -173,6 +174,8 @@ export const makeWorkerBridge = (
         get: (target, prop) => {
           if (typeof prop !== "string") return (target as any)[prop];
           if (prop in target) return (target as any)[prop];
+          // ExportedHandler methods are event listeners, not RPC methods.
+          if (isExportedHandlerMethod(prop)) return (target as any)[prop];
           return (...args: unknown[]) =>
             processEvent(
               (built) => {
@@ -449,6 +452,7 @@ export const makeRpcProxy = (
     get: (target, prop) => {
       if (typeof prop !== "string") return (target as any)[prop];
       if (prop in target) return (target as any)[prop];
+      if (isExportedHandlerMethod(prop)) return (target as any)[prop];
       return (...args: unknown[]) =>
         userShape
           .pipe(

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerBridge.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerBridge.ts
@@ -32,7 +32,6 @@ import {
 } from "./Rpc.ts";
 import {
   ExportedHandlerMethods,
-  isExportedHandlerMethod,
   Worker,
   WorkerEnvironment,
   WorkerExecutionContext,
@@ -174,8 +173,6 @@ export const makeWorkerBridge = (
         get: (target, prop) => {
           if (typeof prop !== "string") return (target as any)[prop];
           if (prop in target) return (target as any)[prop];
-          // ExportedHandler methods are event listeners, not RPC methods.
-          if (isExportedHandlerMethod(prop)) return (target as any)[prop];
           return (...args: unknown[]) =>
             processEvent(
               (built) => {
@@ -452,7 +449,6 @@ export const makeRpcProxy = (
     get: (target, prop) => {
       if (typeof prop !== "string") return (target as any)[prop];
       if (prop in target) return (target as any)[prop];
-      if (isExportedHandlerMethod(prop)) return (target as any)[prop];
       return (...args: unknown[]) =>
         userShape
           .pipe(

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerRuntimeContext.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerRuntimeContext.ts
@@ -87,6 +87,8 @@ export const makeWorkerRuntimeContext = (id: string): WorkerRuntimeContext => {
               if (!isWorkerEvent(event) || event.type !== method) return;
               const methodHandler = shape![method];
               if (typeof methodHandler === "function") {
+                // A failing handler Effect rejects the WorkerEntrypoint
+                // promise (Cloudflare may retry scheduled/queue).
                 return methodHandler(event.input) as Effect.Effect<
                   unknown,
                   never,

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerRuntimeContext.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerRuntimeContext.ts
@@ -13,6 +13,8 @@ import type { DurableObjectExport } from "./DurableObject.ts";
 import { makeRequestHandler } from "./HttpServer.ts";
 import {
   ExportedHandlerMethods,
+  isExportedHandlerMethod,
+  isWorkerEvent,
   WorkerEnvironment,
   WorkerExecutionContext,
   WorkerTypeId,
@@ -59,11 +61,46 @@ export const makeWorkerRuntimeContext = (id: string): WorkerRuntimeContext => {
       handler: HttpEffect<Req> | Effect.Effect<HttpEffect<Req>>,
       options?: { shape?: Record<string, unknown> },
     ) => {
-      // Capture the user's full default-export shape so `exports` can
-      // expose any non-handler methods on it as RPC methods on the
-      // deployed `WorkerEntrypoint` subclass — see `__rpc__` below.
-      if (options?.shape) userShape = options.shape;
-      return ctx.listen(makeRequestHandler(handler));
+      // Capture the user's default-export shape for RPC, omitting
+      // ExportedHandler methods (`fetch`, `scheduled`, `email`, `queue`,
+      // …). Those are event listeners, not WorkerEntrypoint RPC methods.
+      const shape = options?.shape;
+      if (shape) {
+        userShape = Object.fromEntries(
+          Object.entries(shape).filter(
+            ([key]) => !isExportedHandlerMethod(key),
+          ),
+        );
+      }
+      const registerFetch = ctx.listen(makeRequestHandler(handler));
+
+      const nonFetchMethods = ExportedHandlerMethods.filter(
+        (method) => method !== "fetch" && shape?.[method] != null,
+      );
+      if (nonFetchMethods.length === 0) return registerFetch;
+
+      return Effect.all(
+        [
+          registerFetch,
+          ...nonFetchMethods.map((method) =>
+            ctx.listen(((event: any) => {
+              if (!isWorkerEvent(event) || event.type !== method) return;
+              const methodHandler = shape![method];
+              if (typeof methodHandler === "function") {
+                return methodHandler(event.input) as Effect.Effect<
+                  unknown,
+                  never,
+                  never
+                >;
+              }
+              if (Effect.isEffect(methodHandler)) {
+                return methodHandler as Effect.Effect<unknown, never, never>;
+              }
+            }) as Serverless.FunctionListener),
+          ),
+        ],
+        { discard: true },
+      );
     },
     listen: ((
       handler:

--- a/packages/alchemy/test/Cloudflare/Workers/WorkerRuntimeContext.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/WorkerRuntimeContext.test.ts
@@ -1,6 +1,21 @@
+import { toRpcAsync } from "@/Cloudflare/Workers/RpcAsync.ts";
 import { makeWorkerRuntimeContext } from "@/Cloudflare/Workers/WorkerRuntimeContext.ts";
-import * as Effect from "effect/Effect";
 import { describe, expect, it } from "alchemy-test";
+import * as Effect from "effect/Effect";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+
+const dispatch = async (
+  exports: Record<string, any>,
+  type: string,
+  input: unknown,
+) => {
+  const [program, services] = exports.default[type](
+    input,
+    {},
+    {} as ExecutionContext,
+  );
+  await Effect.runPromise(program.pipe(Effect.provide(services)));
+};
 
 describe("WorkerRuntimeContext", () => {
   it("dispatches an event to every listener for that event type", async () => {
@@ -25,14 +40,98 @@ describe("WorkerRuntimeContext", () => {
     );
 
     const exports = await Effect.runPromise(ctx.exports);
-    const [program, services] = exports.default.queue(
-      { queue: "queue-a", messages: [] },
-      {},
-      {} as ExecutionContext,
-    );
-
-    await Effect.runPromise(program.pipe(Effect.provide(services)));
+    await dispatch(exports, "queue", { queue: "queue-a", messages: [] });
 
     expect(observed).toEqual(["first", "second"]);
+  });
+
+  it("registers ExportedHandler methods from the serve shape as listeners", async () => {
+    const ctx = makeWorkerRuntimeContext("shape-handlers");
+    const observed: string[] = [];
+
+    await Effect.runPromise(
+      ctx.serve(Effect.succeed(HttpServerResponse.text("ok")), {
+        shape: {
+          fetch: Effect.succeed(HttpServerResponse.text("ok")),
+          scheduled: (controller: { cron: string }) =>
+            Effect.sync(() => {
+              observed.push(`scheduled:${controller.cron}`);
+            }),
+          queue: (batch: { queue: string }) =>
+            Effect.sync(() => {
+              observed.push(`queue:${batch.queue}`);
+            }),
+          email: (message: { from: string }) =>
+            Effect.sync(() => {
+              observed.push(`email:${message.from}`);
+            }),
+          greet: (name: string) => Effect.succeed(`hello ${name}`),
+        },
+      }),
+    );
+
+    const exports = await Effect.runPromise(ctx.exports);
+    await dispatch(exports, "scheduled", { cron: "* * * * *" });
+    await dispatch(exports, "queue", { queue: "inbox", messages: [] });
+    await dispatch(exports, "email", { from: "a@example.com" });
+
+    expect(observed).toEqual([
+      "scheduled:* * * * *",
+      "queue:inbox",
+      "email:a@example.com",
+    ]);
+  });
+
+  it("omits ExportedHandler methods from the RPC shape captured by serve()", async () => {
+    const ctx = makeWorkerRuntimeContext("rpc-shape");
+
+    await Effect.runPromise(
+      ctx.serve(Effect.succeed(HttpServerResponse.text("ok")), {
+        shape: {
+          fetch: Effect.succeed(HttpServerResponse.text("ok")),
+          scheduled: () => Effect.void,
+          email: () => Effect.void,
+          queue: () => Effect.void,
+          greet: (name: string) => Effect.succeed(`hello ${name}`),
+        },
+      }),
+    );
+
+    const shape = ctx.shape();
+    expect(shape.fetch).toBeUndefined();
+    expect(shape.scheduled).toBeUndefined();
+    expect(shape.email).toBeUndefined();
+    expect(shape.queue).toBeUndefined();
+    expect(typeof shape.greet).toBe("function");
+    expect(await Effect.runPromise(shape.greet("sam"))).toBe("hello sam");
+  });
+});
+
+describe("toRpcAsync", () => {
+  it("does not wrap ExportedHandler methods as RPC", async () => {
+    const scheduled = async () => "from-native-scheduled";
+    const stub = {
+      fetch: async () => new Response("ok"),
+      connect: () => undefined,
+      scheduled,
+      greet: async () => ({
+        _tag: "~alchemy/rpc/error" as const,
+        error: { message: "rpc-only" },
+      }),
+    };
+
+    const rpc = toRpcAsync<{
+      greet: () => Effect.Effect<never, { message: string }>;
+      scheduled: () => Effect.Effect<string>;
+    }>(stub);
+
+    // Handler methods pass through to the underlying binding (no envelope
+    // decode). RPC methods still unwrap envelopes.
+    expect(
+      await (
+        rpc as unknown as { scheduled: () => Promise<string> }
+      ).scheduled(),
+    ).toBe("from-native-scheduled");
+    await expect(rpc.greet()).rejects.toThrow("rpc-only");
   });
 });

--- a/packages/alchemy/test/Cloudflare/Workers/WorkerShapeHandlers.local.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/WorkerShapeHandlers.local.test.ts
@@ -1,0 +1,88 @@
+import * as Cloudflare from "@/Cloudflare/index.ts";
+import * as Test from "@/Test/Alchemy";
+import { expect } from "alchemy-test";
+import * as Data from "effect/Data";
+import * as Effect from "effect/Effect";
+import { MinimumLogLevel } from "effect/References";
+import * as Schedule from "effect/Schedule";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import ShapeScheduledWorker from "./fixtures/shape-handlers/worker.ts";
+
+const { test } = Test.make({
+  providers: Cloudflare.providers(),
+  dev: true,
+});
+
+const logLevel = Effect.provideService(
+  MinimumLogLevel,
+  process.env.DEBUG ? "Debug" : "Info",
+);
+
+class WorkerNotReady extends Data.TaggedError("WorkerNotReady")<{
+  status: number;
+}> {}
+
+/**
+ * Under `alchemy dev` the Worker's cron triggers expose Miniflare's manual
+ * trigger route (`/cdn-cgi/handler/scheduled?cron=...&time=...`). Driving
+ * that route exercises the same `scheduled()` dispatch as a live cron fire,
+ * without waiting for a minute boundary — and without `CronEventSource`.
+ */
+test.provider(
+  "local worker fires the shape-level scheduled() via the manual trigger route",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const deployed = yield* stack.deploy(
+        Effect.gen(function* () {
+          const worker = yield* ShapeScheduledWorker;
+          return { worker };
+        }),
+      );
+
+      expect(deployed.worker.url).toMatch(/^http:\/\/localhost:\d+$/);
+      expect(deployed.worker.crons).toContain("* * * * *");
+
+      const url = deployed.worker.url;
+      const client = yield* HttpClient.HttpClient;
+
+      yield* Effect.gen(function* () {
+        const res = yield* client.post(`${url}/reset`);
+        if (res.status !== 200) {
+          return yield* Effect.fail(new WorkerNotReady({ status: res.status }));
+        }
+      }).pipe(
+        Effect.retry({
+          schedule: Schedule.exponential("500 millis"),
+          times: 10,
+        }),
+      );
+
+      const scheduledTime = Date.now();
+      const trigger = yield* client.post(
+        `${url}/cdn-cgi/handler/scheduled?cron=${encodeURIComponent("* * * * *")}&time=${scheduledTime}`,
+      );
+      expect(trigger.status).toBe(200);
+      expect(yield* trigger.text).toBe("ok");
+
+      const times = yield* Effect.gen(function* () {
+        const res = yield* client.get(`${url}/times`);
+        if (res.status !== 200) return [];
+        const body = (yield* res.json) as { times?: unknown };
+        return Array.isArray(body.times) ? body.times : [];
+      }).pipe(
+        Effect.catch(() => Effect.succeed([] as unknown[])),
+        Effect.repeat({
+          schedule: Schedule.spaced("500 millis"),
+          until: (times): boolean => times.length > 0,
+          times: 10,
+        }),
+      );
+
+      expect(times).toContain(scheduledTime);
+
+      yield* stack.destroy();
+    }).pipe(logLevel),
+  { timeout: 180_000 },
+);

--- a/packages/alchemy/test/Cloudflare/Workers/WorkerShapeHandlers.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/WorkerShapeHandlers.test.ts
@@ -65,5 +65,5 @@ test.skipIf(!!process.env.FAST)(
       expect(t).toBeGreaterThanOrEqual(resetAt);
     }
   }).pipe(logLevel),
-  { timeout: 180_000 },
+  { timeout: 240_000 },
 );

--- a/packages/alchemy/test/Cloudflare/Workers/WorkerShapeHandlers.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/WorkerShapeHandlers.test.ts
@@ -1,0 +1,69 @@
+import * as Cloudflare from "@/Cloudflare";
+import * as Test from "@/Test/Alchemy";
+import { expect } from "alchemy-test";
+import * as Effect from "effect/Effect";
+import { MinimumLogLevel } from "effect/References";
+import * as Schedule from "effect/Schedule";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import Stack from "./fixtures/shape-handlers/stack.ts";
+
+const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
+  providers: Cloudflare.providers(),
+  state: Cloudflare.state(),
+});
+
+const logLevel = Effect.provideService(
+  MinimumLogLevel,
+  process.env.DEBUG ? "Debug" : "Info",
+);
+
+const stack = beforeAll(deploy(Stack));
+afterAll.skipIf(!!process.env.NO_DESTROY)(destroy(Stack));
+
+test.skipIf(!!process.env.FAST)(
+  "deployed worker fires the shape-level scheduled handler on its cron trigger",
+  Effect.gen(function* () {
+    const { url, crons } = yield* stack;
+    expect(crons).toContain("* * * * *");
+
+    const client = yield* HttpClient.HttpClient;
+
+    // Reset any leftover state from prior runs. Doubles as a readiness probe —
+    // a fresh workers.dev URL can take a few seconds to start serving 200s.
+    yield* Effect.gen(function* () {
+      const res = yield* client.post(`${url}/reset`);
+      if (res.status !== 200) {
+        return yield* Effect.fail(new Error(`Worker not ready: ${res.status}`));
+      }
+    }).pipe(
+      Effect.retry({
+        schedule: Schedule.exponential("500 millis"),
+        times: 10,
+      }),
+    );
+    const resetAt = Date.now();
+
+    // Cloudflare cron granularity is one minute and there's some propagation
+    // delay after deploy, so we poll up to ~3 minutes for the first fire.
+    const times = yield* Effect.gen(function* () {
+      const res = yield* client.get(`${url}/times`);
+      if (res.status !== 200) return [];
+      const body = (yield* res.json) as { times?: unknown };
+      if (!Array.isArray(body.times)) return [];
+      return body.times.filter((t) => t >= resetAt);
+    }).pipe(
+      Effect.catch(() => Effect.succeed([])),
+      Effect.repeat({
+        schedule: Schedule.spaced("5 seconds"),
+        until: (recent) => recent.length > 0,
+        times: 36,
+      }),
+    );
+
+    expect(times.length).toBeGreaterThan(0);
+    for (const t of times) {
+      expect(t).toBeGreaterThanOrEqual(resetAt);
+    }
+  }).pipe(logLevel),
+  { timeout: 180_000 },
+);

--- a/packages/alchemy/test/Cloudflare/Workers/WorkerShapeHandlers.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/WorkerShapeHandlers.test.ts
@@ -43,8 +43,9 @@ test.skipIf(!!process.env.FAST)(
     );
     const resetAt = Date.now();
 
-    // Cloudflare cron granularity is one minute and there's some propagation
-    // delay after deploy, so we poll up to ~3 minutes for the first fire.
+    // Cloudflare's minimum cron is one minute. After `/reset` we wait for
+    // the *next* fire (the one during deploy is discarded), so this body
+    // is skipIf FAST and can take ~1–2 minutes — not a retry hang.
     const times = yield* Effect.gen(function* () {
       const res = yield* client.get(`${url}/times`);
       if (res.status !== 200) return [];
@@ -54,9 +55,9 @@ test.skipIf(!!process.env.FAST)(
     }).pipe(
       Effect.catch(() => Effect.succeed([])),
       Effect.repeat({
-        schedule: Schedule.spaced("5 seconds"),
+        schedule: Schedule.spaced("3 seconds"),
         until: (recent) => recent.length > 0,
-        times: 36,
+        times: 50,
       }),
     );
 
@@ -65,5 +66,5 @@ test.skipIf(!!process.env.FAST)(
       expect(t).toBeGreaterThanOrEqual(resetAt);
     }
   }).pipe(logLevel),
-  { timeout: 240_000 },
+  { timeout: 180_000 },
 );

--- a/packages/alchemy/test/Cloudflare/Workers/WorkerShapeHandlers.types.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/WorkerShapeHandlers.types.ts
@@ -1,6 +1,9 @@
 import type { RpcWireShape } from "@/Cloudflare/Workers/InferEnv.ts";
 import type { RpcAsync } from "@/Cloudflare/Workers/RpcAsync.ts";
-import type { ExportedHandlerMethod } from "@/Cloudflare/Workers/Worker.ts";
+import type {
+  ExportedHandlerMethod,
+  RpcMethods,
+} from "@/Cloudflare/Workers/Worker.ts";
 import type { Rpc } from "@/Rpc.ts";
 import type * as Effect from "effect/Effect";
 
@@ -12,10 +15,24 @@ type Shape = {
   greet: (name: string) => Effect.Effect<string>;
 };
 
+type Methods = RpcMethods<Shape>;
 type Async = RpcAsync<Shape>;
 type Wire = RpcWireShape<Shape>;
 
 type Assert<T extends true> = T;
+type KeysEqual<A, B> = [keyof A] extends [keyof B]
+  ? [keyof B] extends [keyof A]
+    ? true
+    : false
+  : false;
+
+type _GreetOnMethods = Assert<"greet" extends keyof Methods ? true : false>;
+type _ScheduledNotOnMethods = Assert<
+  "scheduled" extends keyof Methods ? false : true
+>;
+type _EmailNotOnMethods = Assert<"email" extends keyof Methods ? false : true>;
+type _QueueNotOnMethods = Assert<"queue" extends keyof Methods ? false : true>;
+type _FetchNotOnMethods = Assert<"fetch" extends keyof Methods ? false : true>;
 
 type _GreetOnAsync = Assert<"greet" extends keyof Async ? true : false>;
 type _ScheduledNotOnAsync = Assert<
@@ -32,8 +49,11 @@ type _ScheduledNotOnWire = Assert<
 type _EmailNotOnWire = Assert<"email" extends keyof Wire ? false : true>;
 type _QueueNotOnWire = Assert<"queue" extends keyof Wire ? false : true>;
 
-// The Rpc brand on the Worker keeps the full init shape (including handlers);
-// exclusion happens at the RPC client (`RpcAsync`) and wire (`RpcWireShape`).
+// RpcAsync / RpcWireShape / bindWorker (RpcMethods) share one key set.
+type _AsyncKeysMatchMethods = Assert<KeysEqual<Async, Methods>>;
+type _WireKeysMatchMethods = Assert<KeysEqual<Wire, Methods>>;
+
+// The Rpc brand on the Worker keeps the full init shape (including handlers).
 type _RpcBrandKeepsScheduled = Assert<
   "scheduled" extends keyof Rpc.Shape<Rpc<Shape>> ? true : false
 >;

--- a/packages/alchemy/test/Cloudflare/Workers/WorkerShapeHandlers.types.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/WorkerShapeHandlers.types.ts
@@ -1,0 +1,42 @@
+import type { RpcWireShape } from "@/Cloudflare/Workers/InferEnv.ts";
+import type { RpcAsync } from "@/Cloudflare/Workers/RpcAsync.ts";
+import type { ExportedHandlerMethod } from "@/Cloudflare/Workers/Worker.ts";
+import type { Rpc } from "@/Rpc.ts";
+import type * as Effect from "effect/Effect";
+
+type Shape = {
+  fetch: Effect.Effect<unknown>;
+  scheduled: (controller: unknown) => Effect.Effect<void>;
+  email: (message: unknown) => Effect.Effect<void>;
+  queue: (batch: unknown) => Effect.Effect<void>;
+  greet: (name: string) => Effect.Effect<string>;
+};
+
+type Async = RpcAsync<Shape>;
+type Wire = RpcWireShape<Shape>;
+
+type Assert<T extends true> = T;
+
+type _GreetOnAsync = Assert<"greet" extends keyof Async ? true : false>;
+type _ScheduledNotOnAsync = Assert<
+  "scheduled" extends keyof Async ? false : true
+>;
+type _EmailNotOnAsync = Assert<"email" extends keyof Async ? false : true>;
+type _QueueNotOnAsync = Assert<"queue" extends keyof Async ? false : true>;
+type _FetchNotOnAsync = Assert<"fetch" extends keyof Async ? false : true>;
+
+type _GreetOnWire = Assert<"greet" extends keyof Wire ? true : false>;
+type _ScheduledNotOnWire = Assert<
+  "scheduled" extends keyof Wire ? false : true
+>;
+type _EmailNotOnWire = Assert<"email" extends keyof Wire ? false : true>;
+type _QueueNotOnWire = Assert<"queue" extends keyof Wire ? false : true>;
+
+// The Rpc brand on the Worker keeps the full init shape (including handlers);
+// exclusion happens at the RPC client (`RpcAsync`) and wire (`RpcWireShape`).
+type _RpcBrandKeepsScheduled = Assert<
+  "scheduled" extends keyof Rpc.Shape<Rpc<Shape>> ? true : false
+>;
+type _HandlerUnionIncludesScheduled = Assert<
+  "scheduled" extends ExportedHandlerMethod ? true : false
+>;

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/shape-handlers/stack.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/shape-handlers/stack.ts
@@ -1,0 +1,19 @@
+import * as Cloudflare from "@/Cloudflare";
+import * as Alchemy from "@/index.ts";
+import * as Effect from "effect/Effect";
+import ShapeScheduledWorker from "./worker.ts";
+
+export default Alchemy.Stack(
+  "WorkerShapeHandlersStack",
+  {
+    providers: Cloudflare.providers(),
+    state: Cloudflare.state(),
+  },
+  Effect.gen(function* () {
+    const worker = yield* ShapeScheduledWorker;
+    return {
+      url: worker.url.as<string>(),
+      crons: worker.crons,
+    };
+  }),
+);

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/shape-handlers/worker.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/shape-handlers/worker.ts
@@ -1,0 +1,72 @@
+import * as Cloudflare from "@/Cloudflare/index.ts";
+import * as Effect from "effect/Effect";
+import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+
+/**
+ * Durable Object that records each `scheduledTime` the shape-level
+ * `scheduled` handler sees. The test polls `snapshot()` via the worker's
+ * `GET /times` route to verify the cron actually dispatched to the shape
+ * method (not a `CronEventSource` listener).
+ */
+export class ShapeScheduledCounter extends Cloudflare.DurableObject<ShapeScheduledCounter>()(
+  "ShapeScheduledCounter",
+  Effect.gen(function* () {
+    const state = yield* Cloudflare.DurableObjectState;
+    return Effect.gen(function* () {
+      let times = (yield* state.storage.get<number[]>("times")) ?? [];
+      return {
+        record: Effect.fn(function* (time: number) {
+          times = [...times, time];
+          yield* state.storage.put("times", times);
+        }),
+        snapshot: () => Effect.succeed({ times }),
+        reset: Effect.fn(function* () {
+          times = [];
+          yield* state.storage.put("times", times);
+        }),
+      };
+    });
+  }),
+) {}
+
+/**
+ * Fixture worker for `WorkerShapeHandlers.test.ts`.
+ *
+ * Returns `scheduled` on the Worker init shape (the #414 reproduction) plus
+ * an RPC method `greet` so tests can assert handler methods are registered
+ * as listeners while remaining excluded from the RPC interface. Cron
+ * Triggers are attached via the `crons` prop — not `CronEventSource`.
+ */
+export default class ShapeScheduledWorker extends Cloudflare.Worker<ShapeScheduledWorker>()(
+  "ShapeScheduledWorker",
+  {
+    main: import.meta.url,
+    crons: ["* * * * *"],
+  },
+  Effect.gen(function* () {
+    const counters = yield* ShapeScheduledCounter;
+
+    return {
+      fetch: Effect.gen(function* () {
+        const request = yield* HttpServerRequest;
+        const url = new URL(request.url, "http://x");
+
+        if (request.method === "GET" && url.pathname === "/times") {
+          const snapshot = yield* counters.getByName("default").snapshot();
+          return yield* HttpServerResponse.json(snapshot);
+        }
+
+        if (request.method === "POST" && url.pathname === "/reset") {
+          yield* counters.getByName("default").reset();
+          return yield* HttpServerResponse.json({ ok: true });
+        }
+
+        return HttpServerResponse.text("Not Found", { status: 404 });
+      }),
+      scheduled: (controller: { scheduledTime: number }) =>
+        counters.getByName("default").record(controller.scheduledTime),
+      greet: (name: string) => Effect.succeed(`hello ${name}`),
+    };
+  }),
+) {}


### PR DESCRIPTION
`serve()` now registers a listener for every non-fetch `ExportedHandler` method present on the Worker init shape (`email`, `queue`, `scheduled`, …). Those methods are stripped from the RPC shape at runtime and omitted from `RpcAsync` / `RpcWireShape` / `bindWorker` (`RpcMethods<Shape>`), so they are not WorkerEntrypoint RPC methods.

```ts
return {
  fetch: Effect.succeed(HttpServerResponse.text("ok")),
  scheduled: (controller) => record(controller.scheduledTime),
  greet: (name: string) => Effect.succeed(`hello ${name}`),
};
```

Addresses the two notes on the closed [#415](https://github.com/alchemy-run/alchemy/pull/415): tests, and excluding handlers from the Worker RPC interface.

The live cron test is `skipIf(FAST)` because Cloudflare's minimum trigger is one minute (the body waits for the fire after `/reset`). Dispatch is covered in ~4s by the local `cdn-cgi` fixture.

Closes #414
