### PR TITLE
test(cloudflare/workers): pin CORS headers on plain Worker fetch

### DIFF
--- a/packages/alchemy/test/Cloudflare/Workers/Cors.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/Cors.test.ts
@@ -1,0 +1,112 @@
+import * as Cloudflare from "@/Cloudflare/index.ts";
+import * as Alchemy from "@/index.ts";
+import * as Test from "@/Test/Alchemy";
+import { expect } from "alchemy-test";
+import * as Effect from "effect/Effect";
+import * as Schedule from "effect/Schedule";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
+import type { HttpClientResponse } from "effect/unstable/http/HttpClientResponse";
+import CorsWorker from "./fixtures/cors-worker.ts";
+
+const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
+  providers: Cloudflare.providers(),
+});
+
+const ORIGIN = "https://example.test";
+
+const Stack = Alchemy.Stack(
+  "WorkersCorsStack",
+  { providers: Cloudflare.providers(), state: Cloudflare.state() },
+  Effect.gen(function* () {
+    const worker = yield* CorsWorker;
+    return { url: worker.url.as<string>() };
+  }),
+);
+
+const stack = beforeAll(deploy(Stack));
+afterAll.skipIf(!!process.env.NO_DESTROY)(destroy(Stack));
+
+// Raw HttpClient does not fail on non-2xx, so Effect.retry would not fire
+// through the freshly-deployed workers.dev 404/500 window. Fail non-2xx
+// explicitly so the first request retries until the edge is ready.
+const requestUntilReady = (
+  effect: Effect.Effect<HttpClientResponse, unknown, never>,
+) =>
+  effect.pipe(
+    Effect.flatMap(
+      Effect.fn(function* (res) {
+        return res.status >= 200 && res.status < 300
+          ? res
+          : yield* Effect.fail(
+              new Error(`Worker not ready: ${res.status} ${yield* res.text}`),
+            );
+      }),
+    ),
+    Effect.retry({
+      schedule: Schedule.exponential("500 millis"),
+      times: 10,
+    }),
+  );
+
+test(
+  "HttpMiddleware.cors() adds Access-Control-Allow-Origin on OPTIONS preflight",
+  Effect.gen(function* () {
+    const { url } = yield* stack;
+    const client = yield* HttpClient.HttpClient;
+
+    const res = yield* requestUntilReady(
+      client.execute(
+        HttpClientRequest.make("OPTIONS")(`${url}/hello`).pipe(
+          HttpClientRequest.setHeaders({
+            Origin: ORIGIN,
+            "Access-Control-Request-Method": "GET",
+          }),
+        ),
+      ),
+    );
+    expect(res.status).toBe(204);
+    expect(res.headers["access-control-allow-origin"]).toBe("*");
+  }),
+  { timeout: 120_000 },
+);
+
+test(
+  "HttpMiddleware.cors() adds Access-Control-Allow-Origin on GET responses",
+  Effect.gen(function* () {
+    const { url } = yield* stack;
+    const client = yield* HttpClient.HttpClient;
+
+    const res = yield* requestUntilReady(
+      client.execute(
+        HttpClientRequest.get(`${url}/hello`).pipe(
+          HttpClientRequest.setHeaders({ Origin: ORIGIN }),
+        ),
+      ),
+    );
+    expect(res.status).toBe(200);
+    const body = (yield* res.json) as { message: string };
+    expect(body.message).toBe("world");
+    expect(res.headers["access-control-allow-origin"]).toBe("*");
+  }),
+  { timeout: 120_000 },
+);
+
+test(
+  "HttpMiddleware.cors() adds Access-Control-Allow-Origin on POST responses",
+  Effect.gen(function* () {
+    const { url } = yield* stack;
+    const client = yield* HttpClient.HttpClient;
+
+    const res = yield* requestUntilReady(
+      client.execute(
+        HttpClientRequest.post(`${url}/hello`).pipe(
+          HttpClientRequest.setHeaders({ Origin: ORIGIN }),
+        ),
+      ),
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers["access-control-allow-origin"]).toBe("*");
+  }),
+  { timeout: 120_000 },
+);

--- a/packages/alchemy/test/Cloudflare/Workers/HttpServer.cors.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/HttpServer.cors.test.ts
@@ -20,18 +20,20 @@ const corsRequest = (method: string, extraHeaders?: Record<string, string>) =>
   new Request("https://worker.test/hello", {
     method,
     headers: { Origin: ORIGIN, ...extraHeaders },
-  }) as any;
+  });
+
+// `makeRequestEffect` is typed `as any` at its return; pin R to `never` so
+// `it.effect` does not see `Effect<void, unknown, unknown>`.
+const handleCors = (request: Request): Effect.Effect<Response> =>
+  makeRequestEffect<never>(request as any, corsHandler);
 
 describe("makeRequestEffect drains HttpMiddleware.cors() pre-response handlers", () => {
   it.effect("tags GET responses with Access-Control-Allow-Origin", () =>
     Effect.gen(function* () {
-      const response = yield* makeRequestEffect(
-        corsRequest("GET"),
-        corsHandler,
-      );
+      const response = yield* handleCors(corsRequest("GET"));
       expect(response.status).toBe(200);
       expect(response.headers.get("access-control-allow-origin")).toBe("*");
-      expect(yield* Effect.promise(() => response.json())).toEqual({
+      expect(yield* Effect.tryPromise(() => response.json())).toEqual({
         message: "world",
       });
     }),
@@ -39,9 +41,8 @@ describe("makeRequestEffect drains HttpMiddleware.cors() pre-response handlers",
 
   it.effect("tags OPTIONS preflight with Access-Control-Allow-Origin", () =>
     Effect.gen(function* () {
-      const response = yield* makeRequestEffect(
+      const response = yield* handleCors(
         corsRequest("OPTIONS", { "Access-Control-Request-Method": "GET" }),
-        corsHandler,
       );
       expect(response.status).toBe(204);
       expect(response.headers.get("access-control-allow-origin")).toBe("*");
@@ -50,10 +51,7 @@ describe("makeRequestEffect drains HttpMiddleware.cors() pre-response handlers",
 
   it.effect("tags POST responses with Access-Control-Allow-Origin", () =>
     Effect.gen(function* () {
-      const response = yield* makeRequestEffect(
-        corsRequest("POST"),
-        corsHandler,
-      );
+      const response = yield* handleCors(corsRequest("POST"));
       expect(response.status).toBe(200);
       expect(response.headers.get("access-control-allow-origin")).toBe("*");
     }),

--- a/packages/alchemy/test/Cloudflare/Workers/HttpServer.cors.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/HttpServer.cors.test.ts
@@ -1,0 +1,61 @@
+import { makeRequestEffect } from "@/Cloudflare/Workers/HttpServer.ts";
+import { describe, expect, it } from "alchemy-test";
+import * as Effect from "effect/Effect";
+import * as HttpMiddleware from "effect/unstable/http/HttpMiddleware";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+
+/**
+ * In-process pin of #175 / #404: wrapping a plain fetch handler with
+ * `HttpMiddleware.cors()` must stamp Access-Control-Allow-Origin on
+ * non-preflight responses, not only OPTIONS. Live coverage of the same
+ * shape lives in Cors.test.ts (deployed Worker).
+ */
+const ORIGIN = "https://example.test";
+
+const corsHandler = HttpMiddleware.cors()(
+  HttpServerResponse.json({ message: "world" }),
+);
+
+const corsRequest = (method: string, extraHeaders?: Record<string, string>) =>
+  new Request("https://worker.test/hello", {
+    method,
+    headers: { Origin: ORIGIN, ...extraHeaders },
+  }) as any;
+
+describe("makeRequestEffect drains HttpMiddleware.cors() pre-response handlers", () => {
+  it.effect("tags GET responses with Access-Control-Allow-Origin", () =>
+    Effect.gen(function* () {
+      const response = yield* makeRequestEffect(
+        corsRequest("GET"),
+        corsHandler,
+      );
+      expect(response.status).toBe(200);
+      expect(response.headers.get("access-control-allow-origin")).toBe("*");
+      expect(yield* Effect.promise(() => response.json())).toEqual({
+        message: "world",
+      });
+    }),
+  );
+
+  it.effect("tags OPTIONS preflight with Access-Control-Allow-Origin", () =>
+    Effect.gen(function* () {
+      const response = yield* makeRequestEffect(
+        corsRequest("OPTIONS", { "Access-Control-Request-Method": "GET" }),
+        corsHandler,
+      );
+      expect(response.status).toBe(204);
+      expect(response.headers.get("access-control-allow-origin")).toBe("*");
+    }),
+  );
+
+  it.effect("tags POST responses with Access-Control-Allow-Origin", () =>
+    Effect.gen(function* () {
+      const response = yield* makeRequestEffect(
+        corsRequest("POST"),
+        corsHandler,
+      );
+      expect(response.status).toBe(200);
+      expect(response.headers.get("access-control-allow-origin")).toBe("*");
+    }),
+  );
+});

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/cors-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/cors-worker.ts
@@ -1,0 +1,25 @@
+import * as Cloudflare from "@/Cloudflare/index.ts";
+import * as Effect from "effect/Effect";
+import * as HttpMiddleware from "effect/unstable/http/HttpMiddleware";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+
+/**
+ * Plain Cloudflare.Worker whose `fetch` is piped through
+ * `HttpMiddleware.cors()`. Regression fixture for #175: preflight used
+ * to work while GET responses omitted Access-Control-Allow-Origin
+ * because the Worker adapter skipped Effect's pre-response handler queue
+ * (fixed in #404).
+ */
+export default class CorsWorker extends Cloudflare.Worker<CorsWorker>()(
+  "CorsWorker",
+  {
+    main: import.meta.url,
+  },
+  Effect.gen(function* () {
+    return {
+      fetch: HttpMiddleware.cors()(
+        HttpServerResponse.json({ message: "world" }),
+      ),
+    };
+  }),
+) {}


### PR DESCRIPTION
Issue #175 is already fixed on main by #404: the Cloudflare Worker HTTP adapter now routes the handler through `EffectHttp.toHandled`, so `HttpMiddleware.cors()` pre-response handlers run on GET/POST, not only OPTIONS.

HttpApi coverage added in #404 uses `HttpRouter.cors` on a POST. This PR pins the original #175 shape: a plain `Cloudflare.Worker` whose `fetch` is `HttpMiddleware.cors()(handler)`.

```ts
return {
  fetch: HttpMiddleware.cors()(
    HttpServerResponse.json({ message: "world" }),
  ),
};
```

- In-process: `makeRequestEffect` asserts `Access-Control-Allow-Origin` on OPTIONS, GET, and POST
- Live: deploys the fixture Worker and asserts the same headers on the wire

No adapter change. Closes #175.
