### PR TITLE
feat(aws/dsql): apply SQL migrations during cluster deploy

### DIFF
--- a/packages/alchemy/src/AWS/DSQL/Cluster.ts
+++ b/packages/alchemy/src/AWS/DSQL/Cluster.ts
@@ -4,13 +4,33 @@ import * as Schedule from "effect/Schedule";
 import * as Stream from "effect/Stream";
 import { Unowned } from "../../AdoptPolicy.ts";
 import { isResolved } from "../../Diff.ts";
+import { InstanceId } from "../../InstanceId.ts";
 import * as Provider from "../../Provider.ts";
 import { Resource } from "../../Resource.ts";
+import {
+  diffMigrations,
+  migrationsAttrs,
+  migrationsInputOf,
+  stampedOf,
+  type MigrationsInput,
+} from "../../SQL/Migrations/index.ts";
+import { validateDsqlMigrations } from "./MigrationSql.ts";
+import { runDsqlMigrations } from "./Migrations.ts";
 import { createInternalTags, diffTags, hasAlchemyTags } from "../../Tags.ts";
 import { AWSEnvironment } from "../Environment.ts";
 import type { Providers } from "../Providers.ts";
 
 export interface ClusterProps {
+  /**
+   * SQL migrations directory, `{ dir, table? }`, or a Drizzle.Schema output.
+   * Applied as admin using the deploy identity (requires dsql:DbConnectAdmin
+   * and the optional `pg` peer). Files are checked before cluster mutation.
+   * DDL runs one statement at a time; completed statements survive retries.
+   * CREATE INDEX is adapted to ASYNC and awaited. Explicit transaction
+   * control and serial columns are rejected. Use UUIDs or bigint identity
+   * columns with an explicit CACHE. Applied migration files are immutable.
+   */
+  migrations?: MigrationsInput;
   /**
    * Enables deletion protection. While enabled the cluster cannot be deleted;
    * the provider automatically disables it during delete so `stack.destroy()`
@@ -34,6 +54,12 @@ export interface Cluster extends Resource<
   "AWS.DSQL.Cluster",
   ClusterProps,
   {
+    /** Directory used by the current migration configuration. */
+    migrationsDir: string | undefined;
+    /** Applied-migrations bookkeeping table. */
+    migrationsTable: string | undefined;
+    /** SHA256 hashes used to detect migration file changes during plan. */
+    migrationsHashes: Record<string, string>;
     /** The unique cluster identifier assigned by DSQL. */
     clusterId: string;
     /** The ARN of the cluster. */
@@ -82,6 +108,35 @@ export interface Cluster extends Resource<
  * });
  * ```
  *
+ * ### Applying SQL migrations
+ * **Example:** Drizzle-generated PostgreSQL migrations
+ * ```typescript
+ * const schema = yield* Drizzle.Schema("Schema", {
+ *   schema: "./src/schema.ts",
+ *   dialect: "postgres",
+ * });
+ * const cluster = yield* Cluster("Database", { migrations: schema.out });
+ * ```
+ *
+ * **Example:** Hand-written SQL migrations
+ * ```typescript
+ * const cluster = yield* Cluster("Database", { migrations: "./migrations" });
+ * ```
+ *
+ * ### Recovering an interrupted migration <!-- api-prose -->
+ * DSQL cannot roll back a whole migration. Alchemy records completed statements
+ * in `<migrationsTable>__progress` and serializes deploys with
+ * `__alchemy_dsql_migration_lock`. Server-rejected statements can be retried;
+ * a running index job is resumed on the next deploy. After a disconnect with
+ * an uncertain outcome, inspect the indicated statement and database first.
+ * With all migrators stopped, set the progress row to `ready`, advancing
+ * `next_statement` only if that statement committed (it is zero-based), then
+ * remove a stale lock row if one remains. Never clear progress blindly.
+ *
+ * Automatic conversion of a different tool's existing history is refused
+ * because DSQL cannot atomically combine the table DDL and history copy.
+ * Convert that history explicitly before adopting an already-migrated database.
+ *
  * @resource
  */
 export const Cluster = Resource<Cluster>("AWS.DSQL.Cluster");
@@ -108,7 +163,11 @@ export const ClusterProvider = () =>
       const readTags = Effect.fn(function* (arn: string) {
         const response = yield* dsql
           .listTagsForResource({ resourceArn: arn })
-          .pipe(Effect.catch(() => Effect.succeed(undefined)));
+          .pipe(
+            Effect.catchTag("ResourceNotFoundException", () =>
+              Effect.succeed(undefined),
+            ),
+          );
         return Object.fromEntries(
           Object.entries(response?.tags ?? {}).filter(
             (entry): entry is [string, string] => typeof entry[1] === "string",
@@ -116,13 +175,26 @@ export const ClusterProvider = () =>
         );
       });
 
-      // Bounded readiness wait. DSQL clusters usually reach ACTIVE within a
-      // minute; budget ~5 min (60 * 5s) so slow provisioning still converges
-      // without risking the test wall.
+      const findCluster = Effect.fn(function* (id: string, instanceId: string) {
+        const summaries = yield* dsql.listClusters
+          .items({})
+          .pipe(Stream.runCollect);
+        for (const summary of summaries) {
+          const tags = yield* readTags(summary.arn);
+          if (
+            tags["alchemy::instance"] === instanceId &&
+            (yield* hasAlchemyTags(id, tags))
+          ) {
+            return yield* readCluster(summary.identifier);
+          }
+        }
+      });
+
+      // Bound readiness to 50 seconds; a later deploy can resume provisioning.
       const waitForActive = Effect.fn(function* (identifier: string) {
         const policy = Schedule.max([
           Schedule.fixed("5 seconds"),
-          Schedule.recurs(60),
+          Schedule.recurs(10),
         ]);
         return yield* readCluster(identifier).pipe(
           Effect.flatMap((cluster) => {
@@ -147,19 +219,25 @@ export const ClusterProvider = () =>
       const toAttrs = (
         cluster: dsql.GetClusterOutput | dsql.CreateClusterOutput,
         region: string,
-      ) => ({
+      ): Cluster["Attributes"] => ({
         clusterId: cluster.identifier,
         clusterArn: cluster.arn,
         status: cluster.status,
         endpoint: cluster.endpoint ?? endpointFor(cluster.identifier, region),
         deletionProtectionEnabled: cluster.deletionProtectionEnabled,
+        migrationsDir: undefined,
+        migrationsTable: undefined,
+        migrationsHashes: {},
       });
 
       return {
         stables: ["clusterId", "clusterArn", "endpoint"],
 
-        diff: Effect.fn(function* ({ olds = {}, news }) {
+        diff: Effect.fn(function* ({ olds = {}, news, output }) {
           if (!isResolved(news)) return undefined;
+          const input = migrationsInputOf(news);
+          if (input)
+            yield* validateDsqlMigrations(input, output?.migrationsHashes);
           // KMS key is create-only; changing it forces a replacement.
           if (
             (news.kmsEncryptionKey ?? undefined) !==
@@ -167,35 +245,58 @@ export const ClusterProvider = () =>
           ) {
             return { action: "replace" } as const;
           }
+          if (yield* diffMigrations({ news, output })) {
+            return { action: "update" } as const;
+          }
         }),
 
         read: Effect.fn(function* ({ id, output }) {
-          if (output?.clusterId === undefined) return undefined;
           const { region } = yield* AWSEnvironment.current;
-          const cluster = yield* readCluster(output.clusterId);
+          const cluster = output?.clusterId
+            ? yield* readCluster(output.clusterId)
+            : yield* findCluster(id, yield* InstanceId);
           if (cluster === undefined || cluster.status === "DELETED") {
             return undefined;
           }
           const tags = yield* readTags(cluster.arn);
-          const attrs = toAttrs(cluster, region);
+          const attrs = {
+            ...toAttrs(cluster, region),
+            migrationsDir: output?.migrationsDir,
+            migrationsTable: output?.migrationsTable,
+            migrationsHashes: output?.migrationsHashes ?? {},
+          };
           return (yield* hasAlchemyTags(id, tags)) ? attrs : Unowned(attrs);
         }),
 
-        reconcile: Effect.fn(function* ({ id, news = {}, output, session }) {
+        reconcile: Effect.fn(function* ({
+          id,
+          instanceId,
+          news = {},
+          output,
+          session,
+        }) {
+          const input = migrationsInputOf(news);
+          if (input)
+            yield* validateDsqlMigrations(input, output?.migrationsHashes);
           const { region } = yield* AWSEnvironment.current;
           const internalTags = yield* createInternalTags(id);
-          const desiredTags = { ...internalTags, ...news.tags };
+          const desiredTags = {
+            ...news.tags,
+            ...internalTags,
+            "alchemy::instance": instanceId,
+          };
 
           // 1. Observe — cloud state is authoritative; output caches the id.
           let observed =
             output?.clusterId === undefined
-              ? undefined
+              ? yield* findCluster(id, instanceId)
               : yield* readCluster(output.clusterId);
 
           // 2. Ensure — create if missing. DSQL assigns the identifier.
           let identifier = observed?.identifier ?? output?.clusterId;
           if (observed === undefined) {
             const created = yield* dsql.createCluster({
+              clientToken: instanceId,
               deletionProtectionEnabled:
                 news.deletionProtectionEnabled ?? false,
               kmsEncryptionKey: news.kmsEncryptionKey,
@@ -238,7 +339,15 @@ export const ClusterProvider = () =>
           }
 
           yield* session.note(identifier!);
-          return toAttrs(observed, region);
+          const attrs = toAttrs(observed, region);
+          const run = input
+            ? yield* runDsqlMigrations({
+                endpoint: attrs.endpoint,
+                input,
+                stamped: stampedOf(output),
+              })
+            : undefined;
+          return { ...attrs, ...migrationsAttrs({ input, run, output }) };
         }),
 
         delete: Effect.fn(function* ({ output }) {
@@ -264,7 +373,7 @@ export const ClusterProvider = () =>
               while: (e) => e._tag === "ConflictException",
               schedule: Schedule.max([
                 Schedule.fixed("5 seconds"),
-                Schedule.recurs(24),
+                Schedule.recurs(10),
               ]),
             }),
           );

--- a/packages/alchemy/src/AWS/DSQL/MigrationSql.ts
+++ b/packages/alchemy/src/AWS/DSQL/MigrationSql.ts
@@ -1,0 +1,227 @@
+import * as Effect from "effect/Effect";
+import { hashMigrations } from "../../SQL/SqlFile.ts";
+import {
+  MigrationError,
+  readMigrationRecords,
+  type NormalizedMigrationsInput,
+} from "../../SQL/Migrations/index.ts";
+
+/**
+ * Split PostgreSQL scripts without splitting quoted values, identifiers,
+ * dollar-quoted bodies, or nested comments. The parallel mask preserves
+ * offsets while hiding literals and comments from capability checks.
+ */
+export const parseDsqlStatements = (sql: string) => {
+  const statements: Array<{ sql: string; code: string }> = [];
+  let start = 0;
+  let code = "";
+  const push = (end: number) => {
+    if (code.trim()) statements.push({ sql: sql.slice(start, end), code });
+    start = end + 1;
+    code = "";
+  };
+  for (let i = 0; i < sql.length;) {
+    const begin = i;
+    if (sql.startsWith("--", i)) {
+      const end = sql.indexOf("\n", i);
+      i = end < 0 ? sql.length : end;
+    } else if (sql.startsWith("/*", i)) {
+      let depth = 1;
+      i += 2;
+      while (i < sql.length && depth > 0) {
+        if (sql.startsWith("/*", i)) {
+          depth++;
+          i += 2;
+        } else if (sql.startsWith("*/", i)) {
+          depth--;
+          i += 2;
+        } else i++;
+      }
+      if (depth) throw new Error("Unterminated SQL comment");
+    } else if (sql[i] === "'" || sql[i] === '"') {
+      const quote = sql[i++];
+      const escaped =
+        quote === "'" && /(?:^|\W)[eE]$/.test(sql.slice(0, begin));
+      let closed = false;
+      while (i < sql.length) {
+        if (escaped && sql[i] === "\\") {
+          i += 2;
+          continue;
+        }
+        if (sql[i++] === quote) {
+          if (sql[i] === quote) {
+            i++;
+            continue;
+          }
+          closed = true;
+          break;
+        }
+      }
+      if (!closed) throw new Error("Unterminated SQL quote");
+    } else {
+      const dollar = /^\$(?:[A-Za-z_][A-Za-z_0-9]*)?\$/.exec(sql.slice(i))?.[0];
+      if (dollar) {
+        const end = sql.indexOf(dollar, i + dollar.length);
+        if (end < 0) throw new Error("Unterminated SQL dollar quote");
+        i = end + dollar.length;
+      } else {
+        if (sql[i] === ";") push(i);
+        else code += sql[i];
+        i++;
+        continue;
+      }
+    }
+    // Keep literals as opaque tokens so invalid literal-only SQL is not skipped.
+    code +=
+      (sql[begin] === '"' || sql[begin] === "'" || sql[begin] === "$"
+        ? "_"
+        : " ") + " ".repeat(i - begin - 1);
+  }
+  push(sql.length);
+  return statements;
+};
+
+/** Validate known DSQL incompatibilities; this is not a full SQL parser. */
+export const prepareDsqlStatements = (sql: string, migration: string) =>
+  Effect.try({
+    try: () =>
+      parseDsqlStatements(sql).map((statement) => {
+        const code = statement.code;
+        let reason: string | undefined;
+        if (
+          /^\s*(BEGIN|COMMIT|END|ROLLBACK|ABORT|SAVEPOINT|RELEASE|START\s+TRANSACTION|PREPARE\s+TRANSACTION|SET\s+(?:LOCAL\s+|SESSION\s+)?(?:TRANSACTION|CHARACTERISTICS))\b/i.test(
+            code,
+          )
+        ) {
+          reason =
+            "Transaction control is managed by Alchemy; DSQL permits one DDL statement per transaction and cannot combine DDL with bookkeeping.";
+        } else if (
+          /^\s*(?:CREATE|ALTER)\s+TABLE\b/i.test(code) &&
+          /[\w$]+\s+(?:smallserial|serial|bigserial|serial2|serial4|serial8)\b/i.test(
+            code,
+          )
+        ) {
+          reason =
+            "Use a UUID primary key or a bigint identity with an explicit CACHE instead of serial.";
+        } else if (
+          /^\s*CREATE\s+SEQUENCE\b/i.test(code) ||
+          /\bAS\s+IDENTITY\b/i.test(code)
+        ) {
+          const definitions = /^\s*CREATE\s+SEQUENCE\b/i.test(code)
+            ? [code]
+            : [...code.matchAll(/\bAS\s+IDENTITY\b(?:\s*\(([^)]*)\))?/gi)].map(
+                (match) => match[1] ?? "",
+              );
+          if (
+            definitions.some((definition) => {
+              const cache = /\bCACHE\s+(\d+)\b/i.exec(definition)?.[1];
+              return (
+                cache === undefined ||
+                (Number(cache) !== 1 && Number(cache) < 65536)
+              );
+            })
+          ) {
+            reason =
+              "DSQL sequences and identity columns require an explicit CACHE of 1 or at least 65536.";
+          }
+        }
+        if (/^\s*(?:SET|RESET)\b/i.test(code)) {
+          reason =
+            "Session settings cannot be changed inside DSQL migration files. Qualify table names with their schema instead of changing search_path.";
+        }
+        const index = /^\s*CREATE\s+(?:UNIQUE\s+)?INDEX\b/i.exec(code);
+        if (index && /\bCONCURRENTLY\b/i.test(code)) {
+          reason = "Use CREATE INDEX ASYNC instead of CONCURRENTLY on DSQL.";
+        }
+        if (reason)
+          throw new Error(
+            `Unsupported DSQL migration ${migration}: ${reason}\nStatement:\n${statement.sql.trim()}`,
+          );
+        let prepared = statement.sql;
+        // Drizzle emits ordinary PostgreSQL CREATE INDEX ... USING btree.
+        // DSQL's equivalent is CREATE INDEX ASYNC without the access method.
+        if (index) {
+          const using = /\bUSING\s+btree\b/i.exec(code);
+          if (using)
+            prepared =
+              prepared.slice(0, using.index) +
+              prepared.slice(using.index + using[0].length);
+          if (!/^\s*ASYNC\b/i.test(code.slice(index[0].length))) {
+            prepared =
+              prepared.slice(0, index[0].length) +
+              " ASYNC" +
+              prepared.slice(index[0].length);
+          }
+        }
+        return prepared.trim();
+      }),
+    catch: (cause) =>
+      new MigrationError({
+        message: `DSQL migration ${migration}: ${cause instanceof Error ? cause.message : String(cause)}`,
+        cause,
+      }),
+  });
+
+/** Run before cluster mutation, and during diff when the directory resolves. */
+export const validateDsqlMigrations = (
+  input: NormalizedMigrationsInput,
+  appliedHashes: Record<string, string> = {},
+) =>
+  Effect.gen(function* () {
+    const hashes = yield* hashMigrations(input.dir).pipe(
+      Effect.mapError(
+        (cause) =>
+          new MigrationError({
+            message: `Failed to read DSQL migrations from ${input.dir}`,
+            cause,
+          }),
+      ),
+    );
+    for (const [name, expected] of Object.entries(appliedHashes)) {
+      if (hashes[name] !== expected) {
+        return yield* new MigrationError({
+          message: `Migration ${name} has changed since the last successful deploy. Expected SHA256: ${expected}; actual SHA256: ${hashes[name] ?? "file missing"}. Restore it and create a new migration instead.`,
+        });
+      }
+    }
+    const records = yield* readMigrationRecords(input.dir);
+    for (const record of records) {
+      yield* prepareDsqlStatements(record.sql, record.name);
+    }
+  });
+
+/** Resolve a named index's table for checking an IF NOT EXISTS no-op. */
+export const dsqlIndexTarget = (sql: string) => {
+  const statement = parseDsqlStatements(sql)[0];
+  if (!statement) return undefined;
+  const prefix =
+    /^\s*CREATE\s+(?:UNIQUE\s+)?INDEX\s+ASYNC\s+(?:IF\s+NOT\s+EXISTS\s+)?/i.exec(
+      statement.code,
+    );
+  if (!prefix) return undefined;
+  const identifier = /^(?:"(?:[^"]|"")*"|[A-Za-z_][A-Za-z_0-9$]*)/;
+  const name = identifier.exec(statement.sql.slice(prefix[0].length))?.[0];
+  if (!name) return undefined;
+  const afterName = prefix[0].length + name.length;
+  const on = /^\s+ON\s+(?:ONLY\s+)?/i.exec(statement.code.slice(afterName));
+  if (!on) return undefined;
+  const tableStart = afterName + on[0].length;
+  let table = identifier.exec(statement.sql.slice(tableStart))?.[0];
+  if (!table) return undefined;
+  const dot = /^\s*\.\s*/.exec(statement.code.slice(tableStart + table.length));
+  if (dot) {
+    const next = identifier.exec(
+      statement.sql.slice(tableStart + table.length + dot[0].length),
+    )?.[0];
+    if (!next) return undefined;
+    table = `${table}${statement.sql.slice(tableStart + table.length, tableStart + table.length + dot[0].length)}${next}`;
+  }
+  if (!/^\s*\(/.test(statement.code.slice(tableStart + table.length)))
+    return undefined;
+  return {
+    name: name.startsWith('"')
+      ? name.slice(1, -1).replaceAll('""', '"')
+      : name.toLowerCase(),
+    table,
+  };
+};

--- a/packages/alchemy/src/AWS/DSQL/Migrations.ts
+++ b/packages/alchemy/src/AWS/DSQL/Migrations.ts
@@ -1,0 +1,308 @@
+import * as Effect from "effect/Effect";
+import * as Redacted from "effect/Redacted";
+import * as Schedule from "effect/Schedule";
+import type { Client } from "pg";
+import {
+  MigrationError,
+  quoteIdentifier,
+  resolveMigrations,
+  runMigrations,
+  type NormalizedMigrationsInput,
+  type SqlExecutor,
+  type StampedMigrationsState,
+} from "../../SQL/Migrations/index.ts";
+import { importPg } from "../../SQL/PostgresDriver.ts";
+import { generateDbAuthToken } from "../Connection/DbAuthToken.ts";
+import {
+  dsqlIndexTarget,
+  parseDsqlStatements,
+  prepareDsqlStatements,
+} from "./MigrationSql.ts";
+
+const migrationError = (cause: unknown) =>
+  new MigrationError({
+    message: `DSQL migration failed: ${cause instanceof Error ? cause.message : String(cause)}`,
+    cause,
+  });
+
+/** Acquire a verified TLS connection using the deploy identity's admin token. */
+export const withDsqlClient = <A, E, R>(
+  endpoint: string,
+  use: (client: Client) => Effect.Effect<A, E, R>,
+) =>
+  Effect.gen(function* () {
+    const password = yield* generateDbAuthToken({
+      service: "dsql",
+      hostname: endpoint,
+      action: "DbConnectAdmin",
+    });
+    return yield* Effect.acquireUseRelease(
+      Effect.tryPromise({
+        try: async () => {
+          const { Client } = await importPg();
+          const client = new Client({
+            host: endpoint,
+            port: 5432,
+            user: "admin",
+            database: "postgres",
+            password: Redacted.value(password),
+            ssl: { rejectUnauthorized: true },
+            connectionTimeoutMillis: 10_000,
+            statement_timeout: 30_000,
+            query_timeout: 35_000,
+          });
+          // pg emits idle socket failures as events; the next query reports the
+          // unusable connection through the typed migration error channel.
+          client.on("error", () => {});
+          try {
+            await client.connect();
+          } catch (error) {
+            await client.end().catch(() => {});
+            throw error;
+          }
+          return client;
+        },
+        catch: migrationError,
+      }),
+      use,
+      (client) => Effect.promise(() => client.end().catch(() => {})),
+    );
+  });
+
+/**
+ * DSQL executes every statement in autocommit. A durable progress row records
+ * completed statements, and a running row deliberately blocks replay after an
+ * ambiguous disconnect. PostgreSQL ERROR responses confirm statement rollback;
+ * those statements can be retried. Async jobs are persisted before polling.
+ */
+export const makeDsqlMigrationExecutor = (
+  client: Pick<Client, "query">,
+  table: string,
+): SqlExecutor => {
+  const progress = quoteIdentifier(`${table}__progress`, "postgres");
+  const query: SqlExecutor["query"] = (sql, params) =>
+    Effect.tryPromise({
+      try: async () =>
+        (await client.query(sql, [...(params ?? [])])).rows as Array<
+          Record<string, unknown>
+        >,
+      catch: migrationError,
+    }).pipe(
+      Effect.retry({
+        while: (error) => sqlState(error.cause) === "40001",
+        schedule: Schedule.max([
+          Schedule.exponential("100 millis"),
+          Schedule.recurs(5),
+        ]),
+      }),
+    );
+  const batch: SqlExecutor["batch"] = (statements) =>
+    Effect.forEach(statements, (sql) => query(sql), { discard: true });
+
+  const waitForJob = (job: string) =>
+    Effect.gen(function* () {
+      for (let attempt = 0; attempt < 10; attempt++) {
+        const [row] = yield* query(
+          "SELECT status, details FROM sys.jobs WHERE job_id = $1",
+          [job],
+        );
+        if (row?.status === "completed") return;
+        if (row?.status === "failed") {
+          return yield* new MigrationError({
+            message: `DSQL index job ${job} failed: ${row.details}. Drop the invalid index and repair the migration progress before retrying.`,
+          });
+        }
+        if (!row)
+          return yield* new MigrationError({
+            message: `DSQL index job ${job} is no longer available. Verify the index and repair the migration progress before retrying.`,
+          });
+        if (attempt < 9) yield* Effect.sleep("5 seconds");
+      }
+      return yield* new MigrationError({
+        message: `DSQL index job ${job} is still running after 45 seconds. Retry the deploy to continue waiting.`,
+      });
+    });
+
+  return {
+    dialect: "postgres",
+    migrationTableId: "uuid",
+    transactionalDdl: false,
+    verifyMigrationHashes: true,
+    query,
+    batch,
+    applyMigration: (record, bookkeeping) =>
+      Effect.gen(function* () {
+        const statements = [
+          ...(yield* prepareDsqlStatements(record.sql, record.name)),
+          bookkeeping,
+        ];
+        yield* query(`CREATE TABLE IF NOT EXISTS ${progress} (
+        name text PRIMARY KEY, hash text NOT NULL,
+        next_statement integer NOT NULL, status text NOT NULL, job_id text
+      )`);
+        let [state] = yield* query(
+          `SELECT hash, next_statement, status, job_id FROM ${progress} WHERE name = $1`,
+          [record.name],
+        );
+        if (!state) {
+          yield* query(
+            `INSERT INTO ${progress} (name, hash, next_statement, status) VALUES ($1, $2, 0, 'ready')`,
+            [record.name, record.hash],
+          );
+          state = { hash: record.hash, next_statement: 0, status: "ready" };
+        }
+        if (state.hash !== record.hash) {
+          return yield* new MigrationError({
+            message: `DSQL migration ${record.name} changed after it started. Restore the original file (SHA256 ${state.hash}); actual SHA256: ${record.hash}.`,
+          });
+        }
+        const nextStatement = Number(state.next_statement);
+        if (
+          !Number.isSafeInteger(nextStatement) ||
+          nextStatement < 0 ||
+          nextStatement >= statements.length ||
+          !["ready", "running", "waiting"].includes(String(state.status)) ||
+          (state.status === "waiting" && typeof state.job_id !== "string")
+        ) {
+          return yield* new MigrationError({
+            message: `DSQL migration ${record.name} has inconsistent progress in ${progress}. Inspect and repair its history before deploying.`,
+          });
+        }
+        if (state.status === "running") {
+          return yield* new MigrationError({
+            message: `DSQL migration ${record.name}, statement ${Number(state.next_statement) + 1} has an uncertain outcome. Inspect the database before repairing ${progress}; Alchemy will not replay it automatically.`,
+          });
+        }
+        for (
+          let index = Number(state.next_statement);
+          index < statements.length;
+          index++
+        ) {
+          if (state.status === "waiting" && state.job_id) {
+            yield* waitForJob(String(state.job_id));
+          } else {
+            yield* query(
+              `UPDATE ${progress} SET status = 'running', job_id = NULL WHERE name = $1`,
+              [record.name],
+            );
+            const rows = yield* query(statements[index]).pipe(
+              Effect.catchTag("MigrationError", (error) =>
+                // ERROR is a server-confirmed failed autocommit statement. A
+                // socket error/timeout has no such assurance: leave it running.
+                serverRejected(error.cause)
+                  ? query(
+                      `UPDATE ${progress} SET status = 'ready' WHERE name = $1`,
+                      [record.name],
+                    ).pipe(Effect.andThen(Effect.fail(error)))
+                  : Effect.fail(error),
+              ),
+            );
+            const isIndex = /^\s*CREATE\s+(?:UNIQUE\s+)?INDEX\s+ASYNC\b/i.test(
+              parseDsqlStatements(statements[index])[0]?.code ?? "",
+            );
+            const job = isIndex ? rows[0]?.job_id : undefined;
+            if (isIndex && job === undefined) {
+              const target = dsqlIndexTarget(statements[index]);
+              const existing = target
+                ? yield* query(
+                    `SELECT i.indisvalid FROM pg_index i
+                 JOIN pg_class c ON c.oid = i.indexrelid
+                 WHERE c.relname = $1 AND i.indrelid = to_regclass($2)`,
+                    [target.name, target.table],
+                  )
+                : [];
+              if (existing[0]?.indisvalid !== true) {
+                return yield* new MigrationError({
+                  message: `DSQL index statement in ${record.name} returned no job ID and the index could not be verified as valid. Inspect the existing index before advancing the progress row in ${progress}.`,
+                });
+              }
+            }
+            if (job !== undefined) {
+              yield* query(
+                `UPDATE ${progress} SET status = 'waiting', job_id = $2 WHERE name = $1`,
+                [record.name, job],
+              );
+              yield* waitForJob(String(job));
+            }
+          }
+          yield* query(
+            `UPDATE ${progress} SET next_statement = $2, status = 'ready', job_id = NULL WHERE name = $1`,
+            [record.name, index + 1],
+          );
+          state.status = "ready";
+        }
+      }),
+  };
+};
+
+const sqlState = (cause: unknown) =>
+  typeof cause === "object" && cause !== null && "code" in cause
+    ? cause.code
+    : undefined;
+const serverRejected = (cause: unknown) =>
+  typeof cause === "object" &&
+  cause !== null &&
+  "severity" in cause &&
+  cause.severity === "ERROR" &&
+  typeof sqlState(cause) === "string";
+
+/**
+ * One cluster-wide durable mutex serializes migrators even across different
+ * migration table names. It has no lease: a crashed owner must be inspected
+ * before its lock is removed, so a slow DDL cannot outlive a stolen lease.
+ */
+export const withDsqlMigrationLock = <A, E, R>(
+  executor: SqlExecutor,
+  use: Effect.Effect<A, E, R>,
+) =>
+  Effect.gen(function* () {
+    const owner = crypto.randomUUID();
+    yield* executor.query(
+      `CREATE TABLE IF NOT EXISTS "__alchemy_dsql_migration_lock" (id integer PRIMARY KEY, owner uuid NOT NULL)`,
+    );
+    yield* executor
+      .query(
+        `INSERT INTO "__alchemy_dsql_migration_lock" (id, owner) VALUES (1, $1)`,
+        [owner],
+      )
+      .pipe(
+        Effect.mapError(
+          (cause) =>
+            new MigrationError({
+              message:
+                "Could not acquire the DSQL migration lock. Another deploy may be active. After a crashed deploy, inspect migration progress and confirm the old process stopped before deleting the row in __alchemy_dsql_migration_lock.",
+              cause,
+            }),
+        ),
+      );
+    const result = yield* Effect.result(use);
+    // A failed release is surfaced; a retained lock must never look successful.
+    yield* executor.query(
+      `DELETE FROM "__alchemy_dsql_migration_lock" WHERE id = 1 AND owner = $1`,
+      [owner],
+    );
+    return yield* Effect.fromResult(result);
+  }).pipe(Effect.uninterruptible);
+
+export const runDsqlMigrations = (options: {
+  endpoint: string;
+  input: NormalizedMigrationsInput;
+  stamped: StampedMigrationsState;
+}) =>
+  runMigrations({
+    ...options,
+    withExecutor: (apply) =>
+      withDsqlClient(options.endpoint, (client) => {
+        const table = resolveMigrations(options).table;
+        if (new TextEncoder().encode(`${table}__progress`).length > 63) {
+          return Effect.fail(
+            new MigrationError({
+              message:
+                "DSQL migration table names must leave room for the __progress suffix within PostgreSQL's 63-byte identifier limit.",
+            }),
+          );
+        }
+        const executor = makeDsqlMigrationExecutor(client, table);
+        return withDsqlMigrationLock(executor, apply(executor));
+      }),
+  });

--- a/packages/alchemy/src/SQL/Migrations/AlchemyFormat.ts
+++ b/packages/alchemy/src/SQL/Migrations/AlchemyFormat.ts
@@ -25,7 +25,11 @@ export const ALCHEMY_DEFAULT_TABLE = "__alchemy_migrations";
  * format Alchemy ever writes. Migrating from drizzle/prisma/wrangler
  * bookkeeping is a one-way conversion performed once (see `Convert.ts`).
  */
-const createTableSql = (table: string, dialect: MigrationDialect): string => {
+const createTableSql = (
+  table: string,
+  dialect: MigrationDialect,
+  id?: "uuid",
+): string => {
   const quoted = quoteIdentifier(table, dialect);
   switch (dialect) {
     case "sqlite":
@@ -38,7 +42,7 @@ const createTableSql = (table: string, dialect: MigrationDialect): string => {
 );`;
     case "postgres":
       return `CREATE TABLE IF NOT EXISTS ${quoted} (
-  id SERIAL PRIMARY KEY,
+  id ${id === "uuid" ? "uuid DEFAULT gen_random_uuid()" : "SERIAL"} PRIMARY KEY,
   hash text NOT NULL,
   created_at bigint,
   name text,
@@ -92,6 +96,11 @@ const rebuildInPlace = (options: {
 }) =>
   Effect.gen(function* () {
     const { executor, table, records, nameExpr } = options;
+    if (executor.transactionalDdl === false) {
+      return yield* new MigrationError({
+        message: `Cannot automatically rebuild migration history in "${table}" on a target without transactional DDL. Convert the history explicitly before deploying.`,
+      });
+    }
     const dialect = executor.dialect;
     const quoted = quoteIdentifier(table, dialect);
     const rows = yield* executor.query(
@@ -116,7 +125,7 @@ const rebuildInPlace = (options: {
     const temp = `${table}_alchemy_upgrade`;
     yield* executor.batch([
       `DROP TABLE IF EXISTS ${quoteIdentifier(temp, dialect)};`,
-      createTableSql(temp, dialect).replace(
+      createTableSql(temp, dialect, executor.migrationTableId).replace(
         "CREATE TABLE IF NOT EXISTS",
         "CREATE TABLE",
       ),
@@ -143,8 +152,13 @@ const ensureTable = (options: {
         const converted = history
           ? yield* matchForeignRows({ history, records })
           : [];
+        if (converted.length > 0 && executor.transactionalDdl === false) {
+          return yield* new MigrationError({
+            message: `Cannot automatically copy foreign migration history into "${table}" without transactional DDL. Convert the history explicitly before deploying.`,
+          });
+        }
         yield* executor.batch([
-          createTableSql(table, executor.dialect),
+          createTableSql(table, executor.dialect, executor.migrationTableId),
           ...converted.map((row) =>
             convertedRowInsertSql(table, executor.dialect, row),
           ),
@@ -214,7 +228,8 @@ const appliedNames = (executor: SqlExecutor, table: string) =>
  * Apply pending migrations with Alchemy's bookkeeping. Idempotent: each
  * migration's statements and its bookkeeping INSERT go through
  * `executor.batch` as one unit (a transaction on pg/mysql, one batched
- * query on D1, which has no transactions over HTTP).
+ * query on D1, which has no transactions over HTTP). Nontransactional DDL
+ * targets can supply `applyMigration` to checkpoint individual statements.
  *
  * Applied-detection is name-keyed with layout aliasing: pre-registry
  * Alchemy recorded drizzle-layout migrations under `<dir>/migration.sql`
@@ -230,6 +245,38 @@ export const applyAlchemyFormat = (options: {
     if (records.length === 0) return;
     yield* ensureTable({ executor, table, records });
     const applied = yield* appliedNames(executor, table);
+    if (executor.verifyMigrationHashes) {
+      const rows = yield* executor.query(
+        `SELECT name, hash FROM ${quoteIdentifier(table, executor.dialect)};`,
+      );
+      // Check the entire history before executing any pending migration.
+      const normalize = (name: string) => name.replace(/\/migration\.sql$/, "");
+      for (const row of rows) {
+        if (
+          row.name == null ||
+          !records.some(
+            (record) => normalize(record.name) === normalize(String(row.name)),
+          )
+        ) {
+          return yield* new MigrationError({
+            message: `Applied migration ${row.name ?? "(unnamed)"} is missing from the directory. Restore the original migration files before deploying.`,
+          });
+        }
+      }
+      for (const record of records) {
+        const row = rows.find(
+          (row) =>
+            row.name === record.name ||
+            row.name === `${record.name}/migration.sql` ||
+            row.name === record.name.replace(/\/migration\.sql$/, ""),
+        );
+        if (row && row.hash !== record.hash) {
+          return yield* new MigrationError({
+            message: `Migration ${record.name} has changed since it was applied. Expected SHA256: ${row.hash}; actual SHA256: ${record.hash}. Create a new migration instead.`,
+          });
+        }
+      }
+    }
     for (const record of records) {
       if (
         applied.has(record.name) ||
@@ -238,9 +285,9 @@ export const applyAlchemyFormat = (options: {
       ) {
         continue;
       }
-      yield* executor.batch([
-        ...record.statements,
-        insertSql(table, executor.dialect, record),
-      ]);
+      const bookkeeping = insertSql(table, executor.dialect, record);
+      yield* executor.applyMigration
+        ? executor.applyMigration(record, bookkeeping)
+        : executor.batch([...record.statements, bookkeeping]);
     }
   });

--- a/packages/alchemy/src/SQL/Migrations/Format.ts
+++ b/packages/alchemy/src/SQL/Migrations/Format.ts
@@ -34,6 +34,17 @@ export interface MigrationRecord {
  */
 export interface SqlExecutor {
   readonly dialect: MigrationDialect;
+  /** PostgreSQL targets without SERIAL can use UUID bookkeeping IDs. */
+  readonly migrationTableId?: "uuid";
+  /** False when DDL cannot commit atomically with history conversion. */
+  readonly transactionalDdl?: boolean;
+  /** Reject edits to migrations already recorded in the database. */
+  readonly verifyMigrationHashes?: boolean;
+  /** Override atomic batches for targets requiring durable statement progress. */
+  readonly applyMigration?: (
+    record: MigrationRecord,
+    bookkeeping: string,
+  ) => Effect.Effect<void, MigrationError>;
   /**
    * Run a single query and return its rows as objects. `params` bind as
    * `?`/`$n` placeholders; adapters without native parameter support inline

--- a/packages/alchemy/src/SQL/Migrations/Introspect.ts
+++ b/packages/alchemy/src/SQL/Migrations/Introspect.ts
@@ -1,5 +1,5 @@
 import * as Effect from "effect/Effect";
-import type { SqlExecutor } from "./Format.ts";
+import type { MigrationError, SqlExecutor } from "./Format.ts";
 import { quoteIdentifier, sqlLiteral } from "./Records.ts";
 
 export interface TableColumn {
@@ -16,7 +16,7 @@ export const tableColumns = (
   executor: SqlExecutor,
   table: string,
   schema?: string,
-): Effect.Effect<TableColumn[], never, never> => {
+): Effect.Effect<TableColumn[], MigrationError, never> => {
   switch (executor.dialect) {
     case "sqlite":
       return executor
@@ -48,7 +48,6 @@ export const tableColumns = (
               type: String(row.type ?? "").toUpperCase(),
             })),
           ),
-          Effect.catch(() => Effect.succeed([])),
         );
     case "mysql":
       return executor

--- a/packages/alchemy/src/SQL/Migrations/Registry.ts
+++ b/packages/alchemy/src/SQL/Migrations/Registry.ts
@@ -111,16 +111,21 @@ export const applyMigrations = (options: {
 > =>
   Effect.gen(function* () {
     const { resolved, executor } = options;
-    const layout = yield* detectLayout(resolved.dir);
-    const records =
-      layout === "flat"
-        ? yield* readFlatRecords(resolved.dir)
-        : yield* readDrizzleDirRecords(resolved.dir);
+    const records = yield* readMigrationRecords(resolved.dir);
     yield* applyAlchemyFormat({
       executor,
       table: resolved.table,
       records,
     });
+  });
+
+/** Read any supported migration directory into the shared record format. */
+export const readMigrationRecords = (dir: string) =>
+  Effect.gen(function* () {
+    const layout = yield* detectLayout(dir);
+    return yield* layout === "flat"
+      ? readFlatRecords(dir)
+      : readDrizzleDirRecords(dir);
   });
 
 const hashMigrationsDir = (dir: string) =>

--- a/packages/alchemy/src/SQL/Migrations/index.ts
+++ b/packages/alchemy/src/SQL/Migrations/index.ts
@@ -31,6 +31,7 @@ export {
   migrationsAttrs,
   migrationsInputOf,
   runMigrations,
+  readMigrationRecords,
   normalizeMigrationsInput,
   resolveMigrations,
   stampedOf,

--- a/packages/alchemy/test/AWS/DSQL/ClusterMigrations.test.ts
+++ b/packages/alchemy/test/AWS/DSQL/ClusterMigrations.test.ts
@@ -1,0 +1,87 @@
+import * as AWS from "@/AWS";
+import { Cluster } from "@/AWS/DSQL/Cluster.ts";
+import { withDsqlClient } from "@/AWS/DSQL/Migrations.ts";
+import * as Drizzle from "@/Drizzle";
+import * as Test from "@/Test/Alchemy";
+import { expect } from "alchemy-test";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Path from "effect/Path";
+
+const { test } = Test.make({
+  providers: Layer.mergeAll(AWS.providers(), Drizzle.providers()),
+});
+const schema = new URL("./fixtures/migrations/schema.ts", import.meta.url)
+  .pathname;
+
+test.provider(
+  "DSQL consumes Drizzle migrations, detects file changes, and preserves data",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const out = yield* fs.makeTempDirectoryScoped();
+      const deploy = Effect.gen(function* () {
+        const generated = yield* Drizzle.Schema("Schema", {
+          schema,
+          out,
+          dialect: "postgres",
+        });
+        return yield* Cluster("Database", { migrations: generated.out });
+      });
+      const query = (endpoint: string, sql: string) =>
+        withDsqlClient(endpoint, (client) =>
+          Effect.tryPromise(() => client.query(sql)),
+        );
+      yield* Effect.gen(function* () {
+        const created = yield* stack.deploy(deploy);
+        const rows = yield* query(
+          created.endpoint,
+          "SELECT name, hash FROM __alchemy_migrations",
+        );
+        expect(rows.rows).toHaveLength(1);
+        expect(rows.rows[0].hash).toMatch(/^[a-f0-9]{64}$/);
+        const indexes = yield* query(
+          created.endpoint,
+          "SELECT indisvalid FROM pg_index WHERE indexrelid = 'users_email_idx'::regclass",
+        );
+        expect(indexes.rows[0].indisvalid).toBe(true);
+        yield* query(
+          created.endpoint,
+          "INSERT INTO users(id, email) VALUES ('00000000-0000-0000-0000-000000000001', 'test@example.com')",
+        );
+
+        // A file addition at the same migrations path must trigger a resource update.
+        const next = path.join(out, "20990101000000_evolve");
+        yield* fs.makeDirectory(next);
+        yield* fs.writeFileString(
+          path.join(next, "migration.sql"),
+          `
+      ALTER TABLE users ADD COLUMN nickname text;
+      ALTER TABLE users ADD COLUMN active boolean NOT NULL DEFAULT true;
+      ALTER TABLE users DROP COLUMN nickname;
+      ALTER TABLE users RENAME COLUMN email TO address;
+    `,
+        );
+        const updated = yield* stack.deploy(deploy);
+        expect(updated.clusterId).toBe(created.clusterId);
+        expect(Object.keys(updated.migrationsHashes)).toHaveLength(2);
+        const user = yield* query(
+          updated.endpoint,
+          "SELECT address, active FROM users",
+        );
+        expect(user.rows).toEqual([
+          { address: "test@example.com", active: true },
+        ]);
+        yield* stack.deploy(deploy);
+        const history = yield* query(
+          updated.endpoint,
+          "SELECT name FROM __alchemy_migrations",
+        );
+        expect(history.rows).toHaveLength(2);
+      }).pipe(Effect.ensuring(stack.destroy().pipe(Effect.orDie)));
+    }),
+  { timeout: 120_000 },
+);

--- a/packages/alchemy/test/AWS/DSQL/ClusterMigrations.unit.test.ts
+++ b/packages/alchemy/test/AWS/DSQL/ClusterMigrations.unit.test.ts
@@ -1,0 +1,157 @@
+import { Cluster, ClusterProvider } from "@/AWS/DSQL/Cluster.ts";
+import * as Provider from "@/Provider.ts";
+import { AWSEnvironment } from "@/AWS/Environment.ts";
+import { Stack } from "@/Stack.ts";
+import { Stage } from "@/Stage.ts";
+import { Credentials } from "@distilled.cloud/aws/Credentials";
+import { Region } from "@distilled.cloud/aws/Region";
+import { readFlatRecords } from "@/SQL/Migrations/index.ts";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { expect, layer } from "alchemy-test";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as Path from "effect/Path";
+import * as Result from "effect/Result";
+
+const describe = layer(NodeServices.layer);
+const getProvider = Provider.Provider<Cluster>(Cluster.Type).pipe(
+  Effect.provide(ClusterProvider()),
+  Effect.provide(
+    Layer.mergeAll(
+      Layer.succeed(
+        AWSEnvironment,
+        Effect.die("Unexpected AWS environment access"),
+      ),
+      Layer.succeed(
+        Credentials,
+        Effect.die("Unexpected AWS credential access"),
+      ),
+      Layer.succeed(Region, Effect.die("Unexpected AWS region access")),
+      Layer.succeed(
+        HttpClient.HttpClient,
+        HttpClient.make(() => Effect.die("Unexpected HTTP request")),
+      ),
+      Layer.succeed(Stack, {
+        name: "test",
+        stage: "test",
+        resources: {},
+        bindings: {},
+        actions: {},
+      }),
+      Layer.succeed(Stage, "test"),
+    ),
+  ),
+);
+const diffInput = {
+  id: "Database",
+  fqn: "Database",
+  instanceId: "instance",
+  olds: {},
+  oldBindings: [],
+  newBindings: [],
+};
+
+describe("DSQL migration lifecycle", (it) => {
+  it.effect(
+    "diff detects changed migration content at an unchanged directory path",
+    () =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const dir = yield* fs.makeTempDirectoryScoped();
+        const file = path.join(dir, "0001_users.sql");
+        yield* fs.writeFileString(
+          file,
+          "CREATE TABLE users(id uuid PRIMARY KEY);",
+        );
+        const [record] = yield* readFlatRecords(dir);
+        const provider = yield* getProvider;
+        const output: Cluster["Attributes"] = {
+          clusterId: "cluster",
+          clusterArn: "arn",
+          status: "ACTIVE",
+          endpoint: "endpoint",
+          deletionProtectionEnabled: false,
+          migrationsDir: dir,
+          migrationsTable: "__alchemy_migrations",
+          migrationsHashes: { [record.name]: record.hash },
+        };
+        expect(
+          yield* provider.diff!({
+            ...diffInput,
+            news: { migrations: dir },
+            output,
+          }),
+        ).toBeUndefined();
+        yield* fs.writeFileString(
+          path.join(dir, "0002_email.sql"),
+          "ALTER TABLE users ADD COLUMN email text;",
+        );
+        expect(
+          yield* provider.diff!({
+            ...diffInput,
+            news: { migrations: dir },
+            output,
+          }),
+        ).toEqual({ action: "update" });
+        yield* fs.writeFileString(
+          file,
+          "CREATE TABLE users(id text PRIMARY KEY);",
+        );
+        const edited = yield* Effect.result(
+          provider.diff!({ ...diffInput, news: { migrations: dir }, output }),
+        );
+        expect(Result.isFailure(edited)).toBe(true);
+        if (Result.isFailure(edited))
+          expect(String(edited.failure)).toContain("Expected SHA256");
+      }),
+  );
+
+  it.effect(
+    "preflight rejects an invalid later migration before accessing AWS",
+    () =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const path = yield* Path.Path;
+        const dir = yield* fs.makeTempDirectoryScoped();
+        yield* fs.writeFileString(
+          path.join(dir, "0001_users.sql"),
+          "CREATE TABLE users(id uuid PRIMARY KEY);",
+        );
+        yield* fs.writeFileString(
+          path.join(dir, "0002_bad.sql"),
+          "BEGIN; CREATE TABLE bad(id uuid); COMMIT;",
+        );
+        const provider = yield* getProvider;
+        const planned = yield* Effect.result(
+          provider.diff!({
+            ...diffInput,
+            news: { migrations: dir },
+            output: undefined,
+          }),
+        );
+        expect(Result.isFailure(planned)).toBe(true);
+        if (Result.isFailure(planned))
+          expect(String(planned.failure)).toContain("0002_bad.sql");
+        // Deliberately provide no AWS environment or credentials. Preflight must
+        // fail before provisioning/tagging or opening any database connection.
+        const deployed = yield* Effect.result(
+          provider.reconcile({
+            id: "Database",
+            fqn: "Database",
+            instanceId: "instance",
+            news: { migrations: dir },
+            olds: undefined,
+            output: undefined,
+            bindings: [],
+            session: { note: () => Effect.void } as never,
+          }),
+        );
+        expect(Result.isFailure(deployed)).toBe(true);
+        if (Result.isFailure(deployed))
+          expect(String(deployed.failure)).toContain("0002_bad.sql");
+      }),
+  );
+});

--- a/packages/alchemy/test/AWS/DSQL/MigrationSql.test.ts
+++ b/packages/alchemy/test/AWS/DSQL/MigrationSql.test.ts
@@ -1,0 +1,99 @@
+import { prepareDsqlStatements } from "@/AWS/DSQL/MigrationSql.ts";
+import { expect, test } from "alchemy-test";
+import * as Effect from "effect/Effect";
+import * as Result from "effect/Result";
+
+test.effect(
+  "DSQL splits scripts without splitting SQL literals or comments",
+  () =>
+    Effect.gen(function* () {
+      const statements = yield* prepareDsqlStatements(
+        `
+    -- CREATE SEQUENCE nope;
+    CREATE TABLE "serial" (id uuid PRIMARY KEY, value text DEFAULT 'a;''b');
+    /* outer ; /* inner ; */ */ INSERT INTO "serial" VALUES (gen_random_uuid(), $$a;b$$);
+    INSERT INTO "serial" VALUES (gen_random_uuid(), E'a\\';b');
+  `,
+        "0001.sql",
+      );
+      expect(statements).toHaveLength(3);
+      expect(statements[0]).toContain("'a;''b'");
+      expect(statements[1]).toContain("$$a;b$$");
+    }),
+);
+
+test.effect(
+  "DSQL adapts Drizzle indexes and accepts current foreign key and sequence syntax",
+  () =>
+    Effect.gen(function* () {
+      const statements = yield* prepareDsqlStatements(
+        `
+    CREATE TABLE users (id uuid PRIMARY KEY);
+    --> statement-breakpoint
+    CREATE TABLE posts (id uuid PRIMARY KEY, user_id uuid REFERENCES users(id));
+    CREATE INDEX "posts_user" ON "posts" USING btree ("user_id");
+    CREATE UNIQUE INDEX ASYNC "users_id" ON users (id);
+    CREATE SEQUENCE ids CACHE 65536;
+  `,
+        "schema",
+      );
+      expect(statements).toHaveLength(5);
+      expect(statements[2]).toBe(
+        'CREATE INDEX ASYNC "posts_user" ON "posts"  ("user_id")',
+      );
+      expect(statements[3]).toBe(
+        'CREATE UNIQUE INDEX ASYNC "users_id" ON users (id)',
+      );
+    }),
+);
+
+for (const sql of [
+  "BEGIN; CREATE TABLE users(id uuid); COMMIT;",
+  "CREATE TABLE users(id serial PRIMARY KEY);",
+  "CREATE SEQUENCE ids;",
+  "CREATE INDEX CONCURRENTLY users_id ON users(id);",
+  "CREATE TABLE users(id bigint GENERATED ALWAYS AS IDENTITY);",
+  "CREATE TABLE users(id text DEFAULT 'unterminated);",
+]) {
+  test.effect(`DSQL preflight rejects ${sql}`, () =>
+    Effect.gen(function* () {
+      const result = yield* Effect.result(
+        prepareDsqlStatements(sql, "0004_users.sql"),
+      );
+      expect(Result.isFailure(result)).toBe(true);
+      if (Result.isFailure(result))
+        expect(result.failure.message).toContain("0004_users.sql");
+    }),
+  );
+}
+
+for (const sql of [
+  "CREATE SEQUENCE ids CACHE 65535;",
+  "CREATE TABLE users(a bigint GENERATED ALWAYS AS IDENTITY (CACHE 65536), b bigint GENERATED ALWAYS AS IDENTITY);",
+  "SET search_path TO another_schema;",
+]) {
+  test.effect(
+    `DSQL validates all sequence definitions and session settings: ${sql}`,
+    () =>
+      Effect.gen(function* () {
+        expect(
+          Result.isFailure(
+            yield* Effect.result(prepareDsqlStatements(sql, "0001.sql")),
+          ),
+        ).toBe(true);
+      }),
+  );
+}
+
+test.effect(
+  "DSQL retains literal-only statements for database validation",
+  () =>
+    Effect.gen(function* () {
+      expect(
+        yield* prepareDsqlStatements(
+          "'not a command'; $$nor is this$$; -- comment",
+          "0001.sql",
+        ),
+      ).toEqual(["'not a command'", "$$nor is this$$"]);
+    }),
+);

--- a/packages/alchemy/test/AWS/DSQL/Migrations.test.ts
+++ b/packages/alchemy/test/AWS/DSQL/Migrations.test.ts
@@ -1,0 +1,372 @@
+import {
+  makeDsqlMigrationExecutor,
+  withDsqlMigrationLock,
+} from "@/AWS/DSQL/Migrations.ts";
+import {
+  applyAlchemyFormat,
+  MigrationError,
+  type MigrationRecord,
+} from "@/SQL/Migrations/index.ts";
+import { Database, type SQLQueryBindings } from "bun:sqlite";
+import { expect, test } from "alchemy-test";
+import * as Effect from "effect/Effect";
+import * as Result from "effect/Result";
+import { createHash } from "node:crypto";
+import type { Client } from "pg";
+
+const record = (name: string, sql: string): MigrationRecord => ({
+  name,
+  sql,
+  hash: createHash("sha256").update(sql).digest("hex"),
+  statements: [sql],
+  createdAtMillis: undefined,
+});
+const users = record(
+  "0001_users.sql",
+  "CREATE TABLE users (id text PRIMARY KEY); ALTER TABLE users ADD COLUMN email text;",
+);
+
+/** A pg query seam backed by real SQLite SQL/history, with injectable failures. */
+const database = (indexExists?: boolean) => {
+  const db = new Database(":memory:");
+  const calls: string[] = [];
+  let reject: ((sql: string) => void) | undefined;
+  const client = {
+    query: async (sql: string, params: unknown[] = []) => {
+      calls.push(sql);
+      reject?.(sql);
+      if (sql.includes("information_schema.columns")) {
+        const name = /table_name = '([^']+)'/.exec(sql)![1];
+        return { rows: db.query(`PRAGMA table_info("${name}")`).all() };
+      }
+      if (/CREATE (UNIQUE )?INDEX ASYNC/.test(sql))
+        return { rows: indexExists !== undefined ? [] : [{ job_id: "job-1" }] };
+      if (sql.includes("FROM pg_index"))
+        return { rows: [{ indisvalid: indexExists }] };
+      if (sql.includes("FROM sys.jobs"))
+        return { rows: [{ status: "completed" }] };
+      const compatible = sql
+        .replace(/\$(\d+)/g, "?$1")
+        .replaceAll('"drizzle".', "")
+        .replace(
+          "uuid DEFAULT gen_random_uuid() PRIMARY KEY",
+          "text PRIMARY KEY DEFAULT (lower(hex(randomblob(16))))",
+        )
+        .replace(
+          "timestamp with time zone DEFAULT now()",
+          "text DEFAULT CURRENT_TIMESTAMP",
+        );
+      return {
+        rows: db.query(compatible).all(...(params as SQLQueryBindings[])),
+      };
+    },
+  } as unknown as Pick<Client, "query">;
+  const executor = makeDsqlMigrationExecutor(client, "__alchemy_migrations");
+  const apply = (records: MigrationRecord[]) =>
+    withDsqlMigrationLock(
+      executor,
+      applyAlchemyFormat({ executor, table: "__alchemy_migrations", records }),
+    );
+  return {
+    db,
+    calls,
+    executor,
+    apply,
+    reject: (fn?: (sql: string) => void) => {
+      reject = fn;
+    },
+  };
+};
+
+test.effect(
+  "DSQL applies multi-statement SQL separately and skips applied files",
+  () =>
+    Effect.gen(function* () {
+      const target = database();
+      yield* target.apply([users]);
+      yield* target.apply([users]);
+      expect(
+        target.db.query("SELECT name, hash FROM __alchemy_migrations").all(),
+      ).toEqual([{ name: users.name, hash: users.hash }]);
+      expect(
+        target.calls.filter((sql) => sql.startsWith("CREATE TABLE users")),
+      ).toHaveLength(1);
+      expect(
+        target.calls.some((sql) =>
+          /\b(BEGIN|COMMIT|ROLLBACK|SERIAL)\b/.test(sql),
+        ),
+      ).toBe(false);
+      target.db.close();
+    }),
+);
+
+test.effect("DSQL rejects changed history before running pending SQL", () =>
+  Effect.gen(function* () {
+    const target = database();
+    yield* target.apply([users]);
+    const result = yield* Effect.result(
+      target.apply([
+        record(users.name, users.sql + " -- edited"),
+        record("0002_posts.sql", "CREATE TABLE posts(id text PRIMARY KEY)"),
+      ]),
+    );
+    expect(Result.isFailure(result)).toBe(true);
+    if (Result.isFailure(result))
+      expect(result.failure.message).toContain("Expected SHA256");
+    expect(
+      target.calls.some((sql) => sql.startsWith("CREATE TABLE posts")),
+    ).toBe(false);
+    target.db.close();
+  }),
+);
+
+test.effect(
+  "DSQL resumes after a server-rejected statement without repeating committed DDL",
+  () =>
+    Effect.gen(function* () {
+      const target = database();
+      target.reject((sql) => {
+        if (sql.startsWith("ALTER TABLE users"))
+          throw Object.assign(new Error("denied"), {
+            code: "42501",
+            severity: "ERROR",
+          });
+      });
+      expect(
+        Result.isFailure(yield* Effect.result(target.apply([users]))),
+      ).toBe(true);
+      expect(
+        target.db.query("SELECT * FROM __alchemy_migrations").all(),
+      ).toHaveLength(0);
+      target.reject();
+      yield* target.apply([users]);
+      expect(
+        target.calls.filter((sql) => sql.startsWith("CREATE TABLE users")),
+      ).toHaveLength(1);
+      expect(
+        target.db.query("SELECT * FROM __alchemy_migrations").all(),
+      ).toHaveLength(1);
+      target.db.close();
+    }),
+);
+
+test.effect(
+  "DSQL blocks ambiguous failures and changes to partially applied files",
+  () =>
+    Effect.gen(function* () {
+      const target = database();
+      target.reject((sql) => {
+        if (sql.startsWith("ALTER TABLE users"))
+          throw new Error("connection lost");
+      });
+      yield* Effect.result(target.apply([users]));
+      target.reject();
+      const ambiguous = yield* Effect.result(target.apply([users]));
+      expect(Result.isFailure(ambiguous)).toBe(true);
+      if (Result.isFailure(ambiguous))
+        expect(ambiguous.failure.message).toContain("uncertain outcome");
+      const changed = yield* Effect.result(
+        target.apply([record(users.name, users.sql + " -- changed")]),
+      );
+      if (Result.isFailure(changed))
+        expect(changed.failure.message).toContain("changed after it started");
+      else throw new Error("Expected changed migration rejection");
+      expect(
+        target.calls.filter((sql) => sql.startsWith("ALTER TABLE users")),
+      ).toHaveLength(1);
+      target.db.close();
+    }),
+);
+
+test.effect("DSQL waits for indexes before recording completion", () =>
+  Effect.gen(function* () {
+    const target = database();
+    yield* target.apply([
+      users,
+      record(
+        "0002_index.sql",
+        'CREATE INDEX "email_idx" ON users USING btree(email);',
+      ),
+    ]);
+    const index = target.calls.findIndex((sql) =>
+      sql.startsWith("CREATE INDEX ASYNC"),
+    );
+    const wait = target.calls.findIndex((sql) => sql.includes("FROM sys.jobs"));
+    const insert = target.calls.findIndex(
+      (sql) =>
+        sql.startsWith('INSERT INTO "__alchemy_migrations"') &&
+        sql.includes("0002_index"),
+    );
+    expect(index).toBeGreaterThan(-1);
+    expect(wait).toBeGreaterThan(index);
+    expect(insert).toBeGreaterThan(wait);
+    target.db.close();
+  }),
+);
+
+test.effect(
+  "DSQL refuses a concurrent migrator and releases the lock after known failure",
+  () =>
+    Effect.gen(function* () {
+      const target = database();
+      yield* withDsqlMigrationLock(
+        target.executor,
+        Effect.gen(function* () {
+          const concurrent = yield* Effect.result(target.apply([users]));
+          expect(Result.isFailure(concurrent)).toBe(true);
+          expect(
+            target.calls.some((sql) => sql.startsWith("CREATE TABLE users")),
+          ).toBe(false);
+        }),
+      );
+      yield* Effect.result(
+        withDsqlMigrationLock(
+          target.executor,
+          Effect.fail(new MigrationError({ message: "failure" })),
+        ),
+      );
+      yield* target.apply([users]);
+      target.db.close();
+    }),
+);
+
+test.effect("DSQL resumes a persisted index job after a polling failure", () =>
+  Effect.gen(function* () {
+    const target = database();
+    const indexed = record(
+      "0002_index.sql",
+      "CREATE INDEX email_idx ON users(email);",
+    );
+    target.reject((sql) => {
+      if (sql.includes("FROM sys.jobs"))
+        throw new Error("polling connection lost");
+    });
+    expect(
+      Result.isFailure(yield* Effect.result(target.apply([users, indexed]))),
+    ).toBe(true);
+    expect(
+      target.db.query("SELECT name FROM __alchemy_migrations").all(),
+    ).toHaveLength(1);
+    target.reject();
+    yield* target.apply([users, indexed]);
+    expect(
+      target.calls.filter((sql) => sql.startsWith("CREATE INDEX ASYNC")),
+    ).toHaveLength(1);
+    expect(
+      target.db.query("SELECT name FROM __alchemy_migrations").all(),
+    ).toHaveLength(2);
+    target.db.close();
+  }),
+);
+
+test.effect(
+  "DSQL refuses non-atomic conversion of existing foreign history",
+  () =>
+    Effect.gen(function* () {
+      const target = database();
+      target.db.exec(
+        "CREATE TABLE __drizzle_migrations (id integer PRIMARY KEY, hash text, created_at bigint, name text, applied_at text)",
+      );
+      target.db
+        .query("INSERT INTO __drizzle_migrations (hash, name) VALUES (?, ?)")
+        .run(users.hash, users.name);
+      const result = yield* Effect.result(target.apply([users]));
+      expect(Result.isFailure(result)).toBe(true);
+      if (Result.isFailure(result))
+        expect(result.failure.message).toContain("without transactional DDL");
+      expect(
+        target.calls.some((sql) =>
+          sql.startsWith('CREATE TABLE IF NOT EXISTS "__alchemy_migrations"'),
+        ),
+      ).toBe(false);
+      target.db.close();
+    }),
+);
+
+test.effect(
+  "DSQL does not interpret application query results as index jobs",
+  () =>
+    Effect.gen(function* () {
+      const target = database();
+      yield* target.apply([
+        record("0001_query.sql", "SELECT 'application-value' AS job_id;"),
+      ]);
+      expect(target.calls.some((sql) => sql.includes("FROM sys.jobs"))).toBe(
+        false,
+      );
+      target.db.close();
+    }),
+);
+
+for (const valid of [true, false]) {
+  test.effect(
+    `DSQL verifies an existing index's validity (${valid}) before recording a no-op`,
+    () =>
+      Effect.gen(function* () {
+        const target = database(valid);
+        const indexed = record(
+          "0002_index.sql",
+          'CREATE INDEX IF NOT EXISTS "email_idx" ON "public"."users"("email");',
+        );
+        const result = yield* Effect.result(target.apply([users, indexed]));
+        expect(Result.isSuccess(result)).toBe(valid);
+        expect(
+          target.db.query("SELECT name FROM __alchemy_migrations").all(),
+        ).toHaveLength(valid ? 2 : 1);
+        target.db.close();
+      }),
+  );
+}
+
+test.effect(
+  "DSQL fails closed when migration-history introspection fails",
+  () =>
+    Effect.gen(function* () {
+      const target = database();
+      target.reject((sql) => {
+        if (sql.includes("information_schema.columns"))
+          throw Object.assign(new Error("catalog denied"), {
+            code: "42501",
+            severity: "ERROR",
+          });
+      });
+      const result = yield* Effect.result(target.apply([users]));
+      expect(Result.isFailure(result)).toBe(true);
+      if (Result.isFailure(result))
+        expect(result.failure.message).toContain("catalog denied");
+      expect(
+        target.calls.some((sql) =>
+          sql.startsWith('CREATE TABLE IF NOT EXISTS "__alchemy_migrations"'),
+        ),
+      ).toBe(false);
+      expect(
+        target.calls.some((sql) => sql.startsWith("CREATE TABLE users")),
+      ).toBe(false);
+      target.db.close();
+    }),
+);
+
+test.effect(
+  "DSQL rejects an invalid recovery checkpoint instead of skipping pending SQL",
+  () =>
+    Effect.gen(function* () {
+      const target = database();
+      target.reject((sql) => {
+        if (sql.startsWith("ALTER TABLE users"))
+          throw new Error("connection lost");
+      });
+      yield* Effect.result(target.apply([users]));
+      target.reject();
+      target.db.exec(
+        "UPDATE __alchemy_migrations__progress SET next_statement = 999, status = 'ready'",
+      );
+      const result = yield* Effect.result(target.apply([users]));
+      expect(Result.isFailure(result)).toBe(true);
+      if (Result.isFailure(result))
+        expect(result.failure.message).toContain("inconsistent progress");
+      expect(
+        target.db.query("SELECT * FROM __alchemy_migrations").all(),
+      ).toHaveLength(0);
+      target.db.close();
+    }),
+);

--- a/packages/alchemy/test/AWS/DSQL/fixtures/migrations/schema.ts
+++ b/packages/alchemy/test/AWS/DSQL/fixtures/migrations/schema.ts
@@ -1,0 +1,10 @@
+import { pgTable, text, uuid, index } from "drizzle-orm/pg-core";
+
+export const users = pgTable(
+  "users",
+  {
+    id: uuid("id").primaryKey(),
+    email: text("email").notNull(),
+  },
+  (table) => [index("users_email_idx").on(table.email)],
+);

--- a/packages/alchemy/test/Drizzle/Schema.test.ts
+++ b/packages/alchemy/test/Drizzle/Schema.test.ts
@@ -357,3 +357,45 @@ test.provider(
       expect(yield* readMigrationDirs(ws.out)).toEqual(initialDirs);
     }),
 );
+
+test.provider(
+  "generates DSQL-compatible PostgreSQL SQL without a new dialect",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+      const { prepareDsqlStatements } = yield* Effect.promise(
+        () => import("@/AWS/DSQL/MigrationSql.ts"),
+      );
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      const ws = yield* stageWorkspace(`
+      import { pgTable, uuid, text, index } from "drizzle-orm/pg-core";
+      export const users = pgTable("users", {
+        id: uuid("id").primaryKey(), email: text("email").notNull(),
+      }, (table) => [index("users_email_idx").on(table.email)]);
+    `);
+      yield* Effect.gen(function* () {
+        yield* stack.deploy(
+          Drizzle.Schema("Schema", {
+            schema: ws.schemaPath,
+            out: ws.out,
+            dialect: "postgres",
+          }),
+        );
+        const dirs = yield* readMigrationDirs(ws.out);
+        expect(dirs).toHaveLength(1);
+        const sql = yield* fs.readFileString(
+          path.join(ws.out, dirs[0], "migration.sql"),
+        );
+        expect(sql).toContain('"id" uuid PRIMARY KEY');
+        const statements = yield* prepareDsqlStatements(sql, dirs[0]);
+        expect(statements).toHaveLength(2);
+        expect(statements[1]).toContain("INDEX ASYNC");
+      }).pipe(
+        Effect.ensuring(stack.destroy().pipe(Effect.orDie)),
+        Effect.ensuring(
+          fs.remove(ws.root, { recursive: true }).pipe(Effect.orDie),
+        ),
+      );
+    }),
+);

--- a/website/src/content/docs/aws/frontend/full-stack-tanstack-rpc-drizzle.mdx
+++ b/website/src/content/docs/aws/frontend/full-stack-tanstack-rpc-drizzle.mdx
@@ -8,7 +8,7 @@ sidebar:
 import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
 
 export const deps = `@effect/atom-react @effect/sql-pg drizzle-orm effect pg`;
-export const devDeps = `@alchemy.run/frontend-frameworks`;
+export const devDeps = `@alchemy.run/frontend-frameworks drizzle-kit`;
 
 This guide ties four pieces into one deployable app:
 
@@ -124,15 +124,22 @@ its endpoint is public and gated by IAM.
 ```typescript
 // src/backend/database.ts
 import * as AWS from "alchemy/AWS";
+import * as Drizzle from "alchemy/Drizzle";
+import * as Effect from "effect/Effect";
 
-export const Database = AWS.DSQL.Cluster("Database", {});
+export const Database = Effect.gen(function* () {
+  const schema = yield* Drizzle.Schema("Schema", {
+    schema: "./src/backend/schema.ts",
+    dialect: "postgres",
+  });
+  return yield* AWS.DSQL.Cluster("Database", { migrations: schema.out });
+});
 ```
 
 ## 3. The table
 
-DSQL drops two Postgres features this schema would otherwise reach for: there
-are no sequences (so no `serial`) and no foreign keys. A `uuid` primary key
-generated in the handler stays well inside the supported surface:
+Use a `uuid` primary key generated in the handler. UUIDs avoid coordination
+for ID allocation and work directly with Drizzle's PostgreSQL schema generator:
 
 ```typescript
 // src/backend/schema.ts
@@ -149,13 +156,18 @@ export const Todos = pgTable("todos", {
 export const relations = defineRelations({ Todos }, () => ({}));
 ```
 
-:::note
-`Drizzle.Schema` generates migration SQL that a database resource applies on
-deploy, but that `migrations` wiring exists on `Neon.Branch`, `Fly.Postgres`,
-`Planetscale.PostgresBranch`, and `Cloudflare.D1.Database` — not on DSQL. So
-this app creates its one table with an idempotent `CREATE TABLE IF NOT EXISTS`
-from a `/setup` route on the backend (step 4), run once after the first deploy.
-:::
+`Drizzle.Schema` generates PostgreSQL migration files, and `DSQL.Cluster`
+applies them during deploy using your AWS identity's `dsql:DbConnectAdmin`
+permission. Install `drizzle-kit` as a development dependency and commit the
+migration directory. Hand-written SQL directories work too.
+
+DSQL executes each statement separately. Alchemy adapts `CREATE INDEX` to
+`CREATE INDEX ASYNC`, waits for the index, and tracks completed statements for
+retries. Migration files must not include `BEGIN`/`COMMIT` wrappers. Use UUIDs
+instead of `serial`; DSQL also supports foreign keys and bigint identity
+columns, with an explicit sequence cache. See the
+[DSQL migration recovery notes](/providers/aws/dsql/cluster) for interrupted
+deploys.
 
 ## 4. The backend RPC Lambda
 
@@ -169,11 +181,9 @@ per invocation — a ~15-minute token can never outlive its pool.
 // src/backend/api.ts
 import * as AWS from "alchemy/AWS";
 import * as Drizzle from "alchemy/Drizzle/Postgres";
-import { eq, sql } from "drizzle-orm";
+import { eq } from "drizzle-orm";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
-import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
-import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 import { RpcSerialization, RpcServer } from "effect/unstable/rpc";
 import { Database } from "./database.ts";
 import { Todo, TodoNotFound, TodoRpcs } from "./rpc.ts";
@@ -257,25 +267,7 @@ export default class Backend extends AWS.Lambda.Function<Backend>()(
     );
 
     return {
-      fetch: Effect.gen(function* () {
-        const request = yield* HttpServerRequest;
-
-        // One-time table bootstrap. DSQL runs DDL as autocommit statements
-        // outside DML transactions, so this is a single `execute`.
-        if (new URL(request.originalUrl).pathname === "/setup") {
-          yield* db.execute(sql`
-            CREATE TABLE IF NOT EXISTS todos (
-              id uuid PRIMARY KEY,
-              text text NOT NULL,
-              done boolean NOT NULL,
-              created_at timestamptz NOT NULL
-            )
-          `);
-          return yield* HttpServerResponse.json({ ok: true });
-        }
-
-        return yield* rpc;
-      }).pipe(Effect.orDie),
+      fetch: rpc.pipe(Effect.orDie),
     };
   }).pipe(Effect.provide(AWS.DSQL.ConnectHttp)),
 ) {}
@@ -302,13 +294,15 @@ travels to it as a plain environment variable:
 // alchemy.run.ts
 import * as Alchemy from "alchemy";
 import * as AWS from "alchemy/AWS";
+import * as Drizzle from "alchemy/Drizzle";
 import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
 import Backend from "./src/backend/api.ts";
 
 export default Alchemy.Stack(
   "AwsTanstackRpcDrizzle",
   {
-    providers: AWS.providers(),
+    providers: Layer.mergeAll(AWS.providers(), Drizzle.providers()),
     state: AWS.state(),
   },
   Effect.gen(function* () {
@@ -525,11 +519,8 @@ Alchemy will guide you through it on the first deploy.
 bun alchemy deploy
 ```
 
-Then create the table once, using the `backendUrl` from the deploy output:
-
-```sh
-curl -X POST "$BACKEND_URL/setup"
-```
+The deploy generates and applies the database migrations before provisioning
+the backend Lambda.
 
 Open `websiteUrl` and add a few todos — each checkbox toggle and delete
 round-trips through the full stack and the list refreshes itself.


### PR DESCRIPTION
DSQL clusters could not consume Alchemy SQL migrations, so the TanStack + Drizzle guide bootstrapped its table through a `/setup` HTTP route. `AWS.DSQL.Cluster` now accepts `migrations`, including a directory path or `Drizzle.Schema` output, and applies migrations during deployment using an IAM-authenticated admin connection.

```ts
const schema = yield* Drizzle.Schema("Schema", {
  schema: "./src/schema.ts",
  dialect: "postgres",
});
const database = yield* AWS.DSQL.Cluster("Database", {
  migrations: schema.out,
});
```

The implementation reuses Alchemy's migration directory readers and `__alchemy_migrations` bookkeeping, with executor hooks for DSQL's DDL semantics:

- Execute statements individually, persist progress, and serialize migrators with a durable cluster-wide lock. Confirmed failures can retry; ambiguous outcomes require inspection before replay.
- Adapt ordinary `CREATE INDEX` to `CREATE INDEX ASYNC`, persist job IDs, and await or resume index creation.
- Validate known SQL incompatibilities before cluster mutation and reject modified or missing applied migrations. Refuse automatic history conversion that would require transactional DDL.
- Recover cluster creation after a failed deployment using an instance tag and idempotency token.

The tutorial now generates and applies migrations during deploy and removes the setup route. Drizzle's existing PostgreSQL generator remains unchanged.

### Verification

- `mise exec bun@1.3.13 -- timeout 240 pnpm test test/AWS/DSQL/MigrationSql.test.ts test/AWS/DSQL/Migrations.test.ts test/AWS/DSQL/ClusterMigrations.unit.test.ts test/SQL/Migrations --sequential --retry 0 --timeout 90000` — 61 tests passed, covering parsing, preflight, hashes, recovery, async indexes, locking, and shared migration behavior. Executor tests use a SQLite-backed query seam; they do not establish live DSQL compatibility.
- `mise exec bun@1.3.13 -- timeout 240 pnpm test test/Drizzle/Schema.test.ts --test-name-pattern 'generates DSQL-compatible' --sequential --retry 0 --timeout 90000` — passed after the finalizer typing fixes.
- `GOMEMLIMIT=4GiB GOGC=50 pnpm exec tsc -b --builders 1 --singleThreaded --verbose` — full workspace passed with zero errors; final run took 87 seconds and peaked at 3.67 GiB. The preceding source build peaked at 4.38 GiB.
- `pnpm docs:gen`, `pnpm docs:check-jsdoc`, formatting, and `git diff --check` — passed.

### Remaining live validation

Draft pending the real DSQL integration test. The attempted run failed before AWS mutation with `ProfileError: Profile 'testing' does not exist`. With that profile configured, run:

```sh
mise exec bun@1.3.13 -- timeout 240 pnpm test test/AWS/DSQL/ClusterMigrations.test.ts --profile testing --sequential --retry 0 --timeout 120000
```
