### PR TITLE
fix(cli): update Sigil to fix terminal input corruption

### DIFF
--- a/packages/alchemy/package.json
+++ b/packages/alchemy/package.json
@@ -422,7 +422,7 @@
     "@alchemy.run/cloudflare-runtime": "workspace:*",
     "@alchemy.run/floci": "workspace:*",
     "@alchemy.run/node-utils": "workspace:*",
-    "@alchemy.run/sigil": "0.0.0-alpha.9",
+    "@alchemy.run/sigil": "0.0.0-alpha.10",
     "@aws-sdk/credential-providers": "catalog:aws",
     "@distilled.cloud/aws": "workspace:*",
     "@distilled.cloud/axiom": "workspace:*",

--- a/packages/alchemy/test/Cli/CliKit.test.tsx
+++ b/packages/alchemy/test/Cli/CliKit.test.tsx
@@ -115,6 +115,13 @@ class InputStream extends PassThrough {
 
   setRawMode(mode: boolean) {
     this.isRaw = mode;
+    if (mode) {
+      // Size-only consumers no longer query capabilities. Input is ready once
+      // the raw-mode reader attaches; a query may temporarily detach it.
+      setImmediate(() => {
+        if (this.listenerCount("readable") > 0) this.resolveReady?.();
+      });
+    }
     return this;
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4793,8 +4793,8 @@ importers:
         specifier: workspace:*
         version: link:../node-utils
       '@alchemy.run/sigil':
-        specifier: 0.0.0-alpha.9
-        version: 0.0.0-alpha.9(@types/react@19.2.18)(react-devtools-core@7.0.1)(react@19.2.8)
+        specifier: 0.0.0-alpha.10
+        version: 0.0.0-alpha.10(@types/react@19.2.18)(react-devtools-core@7.0.1)(react@19.2.8)
       '@aws-sdk/credential-providers':
         specifier: catalog:aws
         version: 3.1095.0
@@ -7066,8 +7066,8 @@ importers:
 
 packages:
 
-  '@alchemy.run/sigil@0.0.0-alpha.9':
-    resolution: {integrity: sha512-ws3yQ1WfNxp26S+Dxu/HfZ437gDIO+9aZ8mKhNTyrELIakOL45wfx2swZLnLKNsXqrjk7TNHjNyejIarbjrlNw==}
+  '@alchemy.run/sigil@0.0.0-alpha.10':
+    resolution: {integrity: sha512-lsTxOZeJdyJH34leBaECAXomwjtN8fZh2fL8wnkZPOg6dU5gBwkoVZQs8Yd5Gg4X17zbShDq6ctv0VHYrQp3/w==}
     engines: {node: '>=22'}
     peerDependencies:
       '@types/react': '>=19.2.0'
@@ -19769,7 +19769,7 @@ packages:
 
 snapshots:
 
-  '@alchemy.run/sigil@0.0.0-alpha.9(@types/react@19.2.18)(react-devtools-core@7.0.1)(react@19.2.8)':
+  '@alchemy.run/sigil@0.0.0-alpha.10(@types/react@19.2.18)(react-devtools-core@7.0.1)(react@19.2.8)':
     dependencies:
       react: 19.2.8
       react-reconciler: 0.33.0(react@19.2.8)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -181,7 +181,7 @@ patchedDependencies:
   "@astrojs/starlight@0.42.0": patches/@astrojs%2Fstarlight@0.42.0.patch
   starlight-blog@0.29.0: patches/starlight-blog@0.29.0.patch
 minimumReleaseAgeExclude:
-  - "@alchemy.run/sigil@0.0.0-alpha.9"
+  - "@alchemy.run/sigil@0.0.0-alpha.10"
   - "@effect/atom-react@4.0.0-rc.112"
   - "@effect/platform-bun@4.0.0-rc.112"
   - "@effect/platform-node-shared@4.0.0-rc.112"


### PR DESCRIPTION
Terminal capability replies could appear as text in profile inputs and leak into the shell when exiting, particularly in Cursor and on slow terminals. Upgrade Sigil to `0.0.0-alpha.10`, which preserves fragmented replies across query timeouts, filters them before input handling, and avoids capability probes when only window dimensions are needed.

Update the lockfile and release-age exception for alpha.10. Let the CLI test input stream signal readiness when its reader attaches, since window-size consumers no longer issue a device query.

Validation: all 88 `test/Cli/CliKit.test.tsx` tests pass against the released package. Manually verified clean text entry, Escape cancellation, and Ctrl+C exit in Cursor; the user also confirmed alpha.10 works.
