### PR TITLE
chore(test): green full suite and test:aws:floci on floci 1.6.0-alchemy.10

### DIFF
--- a/examples/cloudflare-pr-package/test/integ.test.ts
+++ b/examples/cloudflare-pr-package/test/integ.test.ts
@@ -176,6 +176,10 @@ test(
     // Random defaults to 32 bytes -> 64 hex chars.
     expect(authToken).toMatch(/^[0-9a-f]{64}$/);
   }),
+  // Same budget as every other test here: `yield* stack` still has to
+  // wait on the shared deploy handle, which bun's 5s default cannot cover
+  // on a loaded machine.
+  { timeout: 180_000 },
 );
 
 test(

--- a/packages/alchemy-test/src/DevCli.ts
+++ b/packages/alchemy-test/src/DevCli.ts
@@ -9,12 +9,27 @@ export type PollOptions = {
 export const pollUntil = async <T>(
   what: string,
   effect: () => T | undefined | Promise<T | undefined>,
-  options: PollOptions & { readonly diagnostics?: () => string } = {},
+  options: PollOptions & {
+    readonly diagnostics?: () => string;
+    /**
+     * Returns a reason to give up early (e.g. "the process exited"), or
+     * `undefined` to keep polling. Checked after every unsuccessful attempt so
+     * a dead subject fails in one tick instead of burning the whole budget.
+     */
+    readonly abandonIf?: () => string | undefined;
+  } = {},
 ): Promise<T> => {
-  const { tries = 30, delayMs = 1_000, diagnostics } = options;
+  const { tries = 30, delayMs = 1_000, diagnostics, abandonIf } = options;
   for (let attempt = 0; attempt < tries; attempt++) {
     const value = await effect();
     if (value !== undefined) return value;
+    const reason = abandonIf?.();
+    if (reason !== undefined) {
+      const detail = diagnostics?.();
+      throw new Error(
+        `Gave up waiting for ${what}: ${reason}.${detail ? `\n${detail}` : ""}`,
+      );
+    }
     await Bun.sleep(delayMs);
   }
   const detail = diagnostics?.();
@@ -153,6 +168,20 @@ export class DevCli {
     return pollUntil(what, effect, {
       ...options,
       diagnostics: () => this.outputTail,
+      // A dev child that died (crash, failed apply) never produces what we're
+      // waiting for — fail immediately with its output instead of sitting
+      // through the full poll budget.
+      abandonIf: () => {
+        const child = this.#process;
+        if (child === undefined) return "alchemy dev is not running";
+        if (child.exitCode !== null) {
+          return `alchemy dev exited with code ${child.exitCode}`;
+        }
+        if (child.signalCode !== null) {
+          return `alchemy dev was killed by ${child.signalCode}`;
+        }
+        return undefined;
+      },
     });
   }
 

--- a/packages/alchemy-test/src/Tui.ts
+++ b/packages/alchemy-test/src/Tui.ts
@@ -440,12 +440,20 @@ const makeTui = async (logFile: string): Promise<Tui> => {
   // Ctrl+C is handled by US (exitOnCtrlC: false): opentui's built-in handler
   // destroys the renderer while our flush timer may still be queued, which
   // crashed with "TextBuffer is destroyed". We dispose first, then exit.
+  const hadWindow = "window" in globalThis;
   const renderer = await createCliRenderer({
     exitOnCtrlC: false,
     // Console capture is owned by StrayOutput's global patch (diverted into
     // the run log) — don't let opentui's overlay re-patch it afterwards.
     consoleMode: "disabled",
   });
+  // opentui's CliRenderer constructor does `global.window = {}` to hang
+  // `requestAnimationFrame` on it and never reads it back. The tests share
+  // this process, and browser-detecting code (emscripten loaders such as
+  // pglite under @prisma/dev) treats `typeof window === "object"` as "in a
+  // browser" and then dereferences `window.location`. Restore the plain-bun
+  // globals a non-TUI run has.
+  if (!hadWindow) delete (globalThis as { window?: unknown }).window;
   const selectionBackground = (): string =>
     renderer.themeMode === "light" ? "#d0d0d0" : "#303030";
 

--- a/packages/alchemy-test/src/cli.ts
+++ b/packages/alchemy-test/src/cli.ts
@@ -163,6 +163,16 @@ const rootCommand = Command.make(
       if (args.fast) {
         process.env.FAST = "1";
       }
+      // The runner owns the terminal: stdout belongs to the reporter (or
+      // the TUI) and stdin carries TUI keystrokes. Code under test must see
+      // the same non-interactive, colorless process CI gives it, regardless
+      // of the terminal this run was launched from — otherwise assertions
+      // on CLI output and on interactive-vs-plain copy depend on whether a
+      // human or a pipeline started the run. Sigil's detection honors
+      // FORCE_COLOR over everything else, so pin it rather than NO_COLOR.
+      process.env.ALCHEMY_NO_TUI = "1";
+      process.env.NO_COLOR = "1";
+      process.env.FORCE_COLOR = "0";
     });
 
     // Plain line output by default; the TUI is opt-in (`--tui`) and requires

--- a/packages/alchemy/src/AWS/AuthProvider.ts
+++ b/packages/alchemy/src/AWS/AuthProvider.ts
@@ -1,11 +1,11 @@
-import * as DistilledAuth from "@distilled.cloud/aws/Auth";
 import * as Floci from "@alchemy.run/floci";
+import * as DistilledAuth from "@distilled.cloud/aws/Auth";
+import type { CredentialsError } from "@distilled.cloud/aws/Credentials";
 import {
   Credentials,
   ExpiredSSOToken,
   InvalidSSOToken,
 } from "@distilled.cloud/aws/Credentials";
-import type { CredentialsError } from "@distilled.cloud/aws/Credentials";
 import * as STS from "@distilled.cloud/aws/sts";
 import * as EffectConsole from "effect/Console";
 import * as Deferred from "effect/Deferred";
@@ -20,9 +20,9 @@ import * as Redacted from "effect/Redacted";
 import * as Ref from "effect/Ref";
 import * as Schema from "effect/Schema";
 import * as Stream from "effect/Stream";
+import type * as HttpClient from "effect/unstable/http/HttpClient";
 import { ChildProcess } from "effect/unstable/process";
 import type { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner";
-import type * as HttpClient from "effect/unstable/http/HttpClient";
 import * as NodeCrypto from "node:crypto";
 import * as NodeOs from "node:os";
 import {

--- a/packages/alchemy/src/AWS/Local/DevWatchProvider.ts
+++ b/packages/alchemy/src/AWS/Local/DevWatchProvider.ts
@@ -378,7 +378,7 @@ export const makeDevWatchProvider = <
         diff: Effect.fn(function* ({
           id,
           olds,
-          news,
+          news: rawNews,
           output,
         }: {
           id: string;
@@ -386,6 +386,15 @@ export const makeDevWatchProvider = <
           news: Props;
           output: Attrs | undefined;
         }) {
+          // Runtime props (an Effect-native Function's handler, a Layer)
+          // arrive as Effects, which `isResolved` classifies as unresolved.
+          // They are irrelevant to the dev diff, so strip them BEFORE the
+          // resolved check — otherwise this diff bails to the engine default
+          // (`havePropsChanged` → noop) and the "fresh session with a state
+          // row but no watcher" branch below never runs: `alchemy dev`
+          // resumed over an existing stage would start no watch loop and
+          // hot reload would silently be dead.
+          const news = stripEffects(rawNews);
           if (!isResolved(news)) return;
           if (!output) return undefined;
           if (spec.replaceOn !== undefined) {

--- a/packages/alchemy/src/Cli/checkVersion.ts
+++ b/packages/alchemy/src/Cli/checkVersion.ts
@@ -184,9 +184,9 @@ export const checkLatestVersion = Effect.gen(function* () {
     typeof process !== "undefined" && process.versions.bun !== undefined
       ? `bun add alchemy@${latest}`
       : `pnpm add alchemy@${latest}`;
-  // Print via the Console service, not Effect.logWarning: TelemetryLive
-  // replaces the default stdout logger with an OTLP-only logger at this
-  // stage of the program, so log output would never reach the terminal.
+  // Print via the Console service, not Effect.logWarning: this is a
+  // user-facing notice, not a log record, so it should reach the terminal
+  // regardless of the installed loggers or the configured log floor.
   const useColor = colorsEnabled();
   const glyphs = glyphsFor(unicodeEnabled());
   const message =

--- a/packages/alchemy/src/Cli/exec.ts
+++ b/packages/alchemy/src/Cli/exec.ts
@@ -41,7 +41,6 @@ const services = Layer.mergeAll(
     Layer.mergeAll(selectCliServices(), CliKit.CliKitInteraction),
     CliKit.layer(),
   ),
-  ConsoleLogLive,
   RpcProviderProxy.fromEnv(),
   Layer.succeed(ArtifactStore, createArtifactStore()),
   // Dev runs live in this exec child, not the `alchemy` CLI process, so
@@ -49,7 +48,13 @@ const services = Layer.mergeAll(
   // `cli.dev` span though: dev remains alive across reloads, so a wrapping
   // span would not end (and export) until shutdown — plan/apply spans are the
   // trace roots instead.
-  TelemetryLive,
+  //
+  // Telemetry is layered *on top of* the console logger so the OTLP logger
+  // merges with it. As `mergeAll` siblings the last `CurrentLoggers` wins,
+  // and telemetry would replace the console logger — every `Effect.log*`
+  // (plan, apply progress, stack outputs) silently vanished from the
+  // terminal whenever telemetry was enabled.
+  Layer.provideMerge(TelemetryLive, ConsoleLogLive),
 ).pipe(
   Layer.provideMerge(
     Layer.mergeAll(AlchemyContextLive, ProfileStoreLive, CredentialsStoreLive),

--- a/packages/alchemy/src/Cli/main.ts
+++ b/packages/alchemy/src/Cli/main.ts
@@ -180,7 +180,6 @@ const services = Layer.mergeAll(
   Layer.succeed(ArtifactStore, createArtifactStore()),
   FetchHttpClient.layer,
   ConfigProvider.layer(ConfigProvider.fromEnv()),
-  TelemetryLive,
   routeCacheLayer,
   Layer.provide(
     Layer.provideMerge(
@@ -192,7 +191,14 @@ const services = Layer.mergeAll(
   // Debug run log under ~/.alchemy/logs — the console noise floor stays at
   // Info, but full causes and auth-flow breadcrumbs land in the file so
   // support can ask users for it.
-  Layer.provide(GlobalLogLive, PlatformServices),
+  //
+  // Telemetry sits on top of the console/file loggers so its OTLP logger
+  // merges with them. Listed as `mergeAll` siblings, whichever came last
+  // would win the `CurrentLoggers` slot and silently drop the other.
+  Layer.provideMerge(
+    TelemetryLive,
+    Layer.provide(GlobalLogLive, PlatformServices),
+  ),
 );
 
 const program = Effect.gen(function* () {

--- a/packages/alchemy/src/Drizzle/Schema.ts
+++ b/packages/alchemy/src/Drizzle/Schema.ts
@@ -9,6 +9,7 @@ import { isResolved } from "../Diff.ts";
 import * as Provider from "../Provider.ts";
 import { Resource } from "../Resource.ts";
 import { exec } from "../Util/exec.ts";
+import { isNonInteractive } from "../Util/interactive.ts";
 import type { Providers } from "./Providers.ts";
 
 export type Dialect = "postgres" | "mysql" | "sqlite";
@@ -217,13 +218,10 @@ export const SchemaProvider = () =>
             extendEnv: true,
           };
 
-          const interactive =
-            !process.env.CI &&
-            process.stdin.isTTY &&
-            process.stdout.isTTY &&
-            process.stderr.isTTY;
-
-          if (interactive) {
+          // Hand the terminal to drizzle-kit only when this process may
+          // prompt at all — the same detection (TTY, CI, `--no-input`,
+          // `ALCHEMY_NO_TUI`, agent env) every other spawned command uses.
+          if (!isNonInteractive() && process.stderr.isTTY) {
             const handle = yield* ChildProcess.make(nodeExecPath, args, {
               ...commandOptions,
               stdin: "inherit",

--- a/packages/alchemy/src/Fly/CheckpointHttp.ts
+++ b/packages/alchemy/src/Fly/CheckpointHttp.ts
@@ -1,8 +1,8 @@
-import { CredentialsFromEnv } from "@distilled.cloud/fly-io";
 import * as sprites from "@distilled.cloud/fly-io/sprites";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
+import { CredentialsFromAmbientOrEnv } from "./Credentials.ts";
 import { Checkpoint, type CheckpointClient } from "./Checkpoint.ts";
 import { makeHttpSpriteBinding } from "./SpriteHttp.ts";
 
@@ -62,4 +62,7 @@ export const CheckpointHttp = Layer.effect(
       }),
     }),
   ),
-).pipe(Layer.provide(FetchHttpClient.layer), Layer.provide(CredentialsFromEnv));
+).pipe(
+  Layer.provide(FetchHttpClient.layer),
+  Layer.provide(CredentialsFromAmbientOrEnv),
+);

--- a/packages/alchemy/src/Fly/Credentials.ts
+++ b/packages/alchemy/src/Fly/Credentials.ts
@@ -1,7 +1,8 @@
 import { ConfigError } from "@distilled.cloud/core/errors";
-import { Credentials } from "@distilled.cloud/fly-io";
+import { Credentials, CredentialsFromEnv } from "@distilled.cloud/fly-io";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Option from "effect/Option";
 import { resolveProviderConfig } from "../Auth/Resolve.ts";
 import {
   FLY_AUTH_PROVIDER_NAME,
@@ -17,6 +18,27 @@ export {
   normalizeApiBaseUrl,
   type Config as CredentialsConfig,
 } from "@distilled.cloud/fly-io";
+
+/**
+ * `Credentials` for the HTTP binding layers (`GetSecretHttp`, `ExecHttp`, …).
+ *
+ * Those layers are built in two places. Inside a stack (plan/deploy, or an
+ * Action) `providers()` has already resolved the profile-backed
+ * `Credentials`, and the binding must use them — a laptop deploy has no
+ * `FLY_API_TOKEN` in its env once the token lives in the Alchemy profile.
+ * Inside a deployed Machine there is no profile; the host injected
+ * `FLY_API_TOKEN` into the process env (see `SecretHttp.ts`). So: reuse the
+ * ambient `Credentials` when present, otherwise read the env.
+ */
+export const CredentialsFromAmbientOrEnv: Layer.Layer<Credentials> =
+  Layer.effect(
+    Credentials,
+    Effect.gen(function* () {
+      const ambient = yield* Effect.serviceOption(Credentials);
+      if (Option.isSome(ambient)) return ambient.value;
+      return yield* Credentials.pipe(Effect.provide(CredentialsFromEnv));
+    }),
+  );
 
 /**
  * Build a `Credentials` layer that resolves Fly credentials via the current

--- a/packages/alchemy/src/Fly/DecryptHttp.ts
+++ b/packages/alchemy/src/Fly/DecryptHttp.ts
@@ -1,9 +1,9 @@
-import { CredentialsFromEnv } from "@distilled.cloud/fly-io";
 import * as machines from "@distilled.cloud/fly-io/machines";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Redacted from "effect/Redacted";
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
+import { CredentialsFromAmbientOrEnv } from "./Credentials.ts";
 import { Decrypt, type DecryptRequest } from "./Decrypt.ts";
 import { unwrapSecretValue } from "./SecretHttp.ts";
 import {
@@ -54,4 +54,7 @@ export const DecryptHttp = Layer.effect(
         }),
     }),
   ),
-).pipe(Layer.provide(FetchHttpClient.layer), Layer.provide(CredentialsFromEnv));
+).pipe(
+  Layer.provide(FetchHttpClient.layer),
+  Layer.provide(CredentialsFromAmbientOrEnv),
+);

--- a/packages/alchemy/src/Fly/EncryptHttp.ts
+++ b/packages/alchemy/src/Fly/EncryptHttp.ts
@@ -1,8 +1,8 @@
-import { CredentialsFromEnv } from "@distilled.cloud/fly-io";
 import * as machines from "@distilled.cloud/fly-io/machines";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
+import { CredentialsFromAmbientOrEnv } from "./Credentials.ts";
 import { Encrypt, type EncryptRequest } from "./Encrypt.ts";
 import {
   base64ToBytes,
@@ -48,4 +48,7 @@ export const EncryptHttp = Layer.effect(
         }),
     }),
   ),
-).pipe(Layer.provide(FetchHttpClient.layer), Layer.provide(CredentialsFromEnv));
+).pipe(
+  Layer.provide(FetchHttpClient.layer),
+  Layer.provide(CredentialsFromAmbientOrEnv),
+);

--- a/packages/alchemy/src/Fly/ExecHttp.ts
+++ b/packages/alchemy/src/Fly/ExecHttp.ts
@@ -1,8 +1,8 @@
-import { CredentialsFromEnv } from "@distilled.cloud/fly-io";
 import * as sprites from "@distilled.cloud/fly-io/sprites";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
+import { CredentialsFromAmbientOrEnv } from "./Credentials.ts";
 import { Exec, type ExecRequest } from "./Exec.ts";
 import { makeHttpSpriteBinding } from "./SpriteHttp.ts";
 
@@ -43,4 +43,7 @@ export const ExecHttp = Layer.effect(
         }),
     }),
   ),
-).pipe(Layer.provide(FetchHttpClient.layer), Layer.provide(CredentialsFromEnv));
+).pipe(
+  Layer.provide(FetchHttpClient.layer),
+  Layer.provide(CredentialsFromAmbientOrEnv),
+);

--- a/packages/alchemy/src/Fly/GetSecretHttp.ts
+++ b/packages/alchemy/src/Fly/GetSecretHttp.ts
@@ -1,10 +1,10 @@
-import { CredentialsFromEnv } from "@distilled.cloud/fly-io";
 import * as machines from "@distilled.cloud/fly-io/machines";
 import * as Config from "effect/Config";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Redacted from "effect/Redacted";
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
+import { CredentialsFromAmbientOrEnv } from "./Credentials.ts";
 import { GetSecret } from "./GetSecret.ts";
 import { makeHttpSecretBinding } from "./SecretHttp.ts";
 
@@ -56,4 +56,7 @@ export const GetSecretHttp = Layer.effect(
         }),
     }),
   ),
-).pipe(Layer.provide(FetchHttpClient.layer), Layer.provide(CredentialsFromEnv));
+).pipe(
+  Layer.provide(FetchHttpClient.layer),
+  Layer.provide(CredentialsFromAmbientOrEnv),
+);

--- a/packages/alchemy/src/Fly/ListSecretsHttp.ts
+++ b/packages/alchemy/src/Fly/ListSecretsHttp.ts
@@ -1,8 +1,8 @@
-import { CredentialsFromEnv } from "@distilled.cloud/fly-io";
 import * as machines from "@distilled.cloud/fly-io/machines";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
+import { CredentialsFromAmbientOrEnv } from "./Credentials.ts";
 import { ListSecrets } from "./ListSecrets.ts";
 import { makeHttpAppBinding } from "./SecretHttp.ts";
 
@@ -39,4 +39,7 @@ export const ListSecretsHttp = Layer.effect(
         }),
     }),
   ),
-).pipe(Layer.provide(FetchHttpClient.layer), Layer.provide(CredentialsFromEnv));
+).pipe(
+  Layer.provide(FetchHttpClient.layer),
+  Layer.provide(CredentialsFromAmbientOrEnv),
+);

--- a/packages/alchemy/src/Fly/SignHttp.ts
+++ b/packages/alchemy/src/Fly/SignHttp.ts
@@ -1,8 +1,8 @@
-import { CredentialsFromEnv } from "@distilled.cloud/fly-io";
 import * as machines from "@distilled.cloud/fly-io/machines";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
+import { CredentialsFromAmbientOrEnv } from "./Credentials.ts";
 import {
   base64ToBytes,
   bytesToBase64,
@@ -44,4 +44,7 @@ export const SignHttp = Layer.effect(
         }),
     }),
   ),
-).pipe(Layer.provide(FetchHttpClient.layer), Layer.provide(CredentialsFromEnv));
+).pipe(
+  Layer.provide(FetchHttpClient.layer),
+  Layer.provide(CredentialsFromAmbientOrEnv),
+);

--- a/packages/alchemy/src/Fly/VerifyHttp.ts
+++ b/packages/alchemy/src/Fly/VerifyHttp.ts
@@ -1,8 +1,8 @@
-import { CredentialsFromEnv } from "@distilled.cloud/fly-io";
 import * as machines from "@distilled.cloud/fly-io/machines";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
+import { CredentialsFromAmbientOrEnv } from "./Credentials.ts";
 import { bytesToBase64, makeHttpSecretKeyBinding } from "./SecretKeyHttp.ts";
 import { Verify, type VerifyRequest } from "./Verify.ts";
 
@@ -42,4 +42,7 @@ export const VerifyHttp = Layer.effect(
         }),
     }),
   ),
-).pipe(Layer.provide(FetchHttpClient.layer), Layer.provide(CredentialsFromEnv));
+).pipe(
+  Layer.provide(FetchHttpClient.layer),
+  Layer.provide(CredentialsFromAmbientOrEnv),
+);

--- a/packages/alchemy/src/Fly/WriteSecretHttp.ts
+++ b/packages/alchemy/src/Fly/WriteSecretHttp.ts
@@ -1,8 +1,8 @@
-import { CredentialsFromEnv } from "@distilled.cloud/fly-io";
 import * as machines from "@distilled.cloud/fly-io/machines";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
+import { CredentialsFromAmbientOrEnv } from "./Credentials.ts";
 import type { Secret } from "./Secret.ts";
 import {
   type SecretAuth,
@@ -35,7 +35,10 @@ export const WriteSecretHttp = Layer.effect(
       makeClient: secretWriteClient,
     }),
   ),
-).pipe(Layer.provide(FetchHttpClient.layer), Layer.provide(CredentialsFromEnv));
+).pipe(
+  Layer.provide(FetchHttpClient.layer),
+  Layer.provide(CredentialsFromAmbientOrEnv),
+);
 
 /** Build the write client over an injectable auth and App name. */
 export const secretWriteClient = (

--- a/packages/alchemy/src/Telemetry/Layer.ts
+++ b/packages/alchemy/src/Telemetry/Layer.ts
@@ -37,15 +37,20 @@ const buildOtlpLayer = (
     resource,
     exportInterval: "1 second",
   });
-  // Replace (don't merge with) the default stdout logger here; downstream
-  // commands re-add their own `fileLogger`/`consolePretty` via
-  // `Logger.layer([...], { mergeWithExisting: true })`, which stacks on top
-  // of this OtlpLogger without resurrecting Effect's default stdout logger.
+  // Stack on top of whatever loggers are already installed. Entrypoints
+  // provide this layer *over* their terminal/file logger layer
+  // (`Layer.provideMerge(TelemetryLive, ConsoleLogLive)`), so the terminal
+  // logger has already replaced Effect's default stdout logger by the time
+  // this runs and the OTLP logger is simply added alongside it.
+  //
+  // `mergeWithExisting: false` here would make telemetry *replace* the
+  // terminal logger whenever this layer happened to be merged after it —
+  // exactly what silenced `alchemy dev`'s console output in the exec child.
   const logger = OtlpLogger.layer({
     url: LOGS_URL,
     resource,
     exportInterval: "1 second",
-    mergeWithExisting: false,
+    mergeWithExisting: true,
   });
 
   return Layer.mergeAll(tracer, metrics, logger).pipe(
@@ -59,6 +64,12 @@ const buildOtlpLayer = (
  * to {@link TRACES_URL} and metrics to {@link METRICS_URL}, attaching
  * {@link collectAttributes} as resource-level attributes so every signal
  * carries user/project/runtime context.
+ *
+ * The OTLP logger merges with the loggers already installed, so provide this
+ * layer on top of the entrypoint's terminal/file logger layer — e.g.
+ * `Layer.provideMerge(TelemetryLive, ConsoleLogLive)` — never as a sibling in
+ * a `Layer.mergeAll` (the last `CurrentLoggers` in a merge wins, silently
+ * dropping either the terminal output or the telemetry).
  *
  * If the user has opted out (via `DO_NOT_TRACK`, `NO_TRACK`,
  * `ALCHEMY_TELEMETRY_DISABLED`, or `~/.alchemy/telemetry-disabled`), this

--- a/packages/alchemy/test/AWS/Local/FlociSmoke.test.ts
+++ b/packages/alchemy/test/AWS/Local/FlociSmoke.test.ts
@@ -9,11 +9,14 @@
  *
  * The AWS auth method is normally chosen by the profile entry in
  * `~/.alchemy/profiles.json` (written by `alchemy profile edit`). Tests
- * must not depend on the developer's on-disk profiles. Local AWS providers
- * carry their own floci-scoped environment, which resolves dummy credentials
- * (`test`/`test`), accountId `000000000000`, and endpoint
- * `http://localhost:4566`, and `ensureFloci()` guarantees the emulator is
- * serving (starting the `alchemy-floci` container if needed).
+ * must not depend on the developer's on-disk profiles. `Test.make({ dev:
+ * true })` runs the stack the way `alchemy dev` does, so the local AWS
+ * providers are selected; they carry their own floci-scoped environment,
+ * which resolves dummy credentials (`test`/`test`), accountId
+ * `000000000000`, and endpoint `http://localhost:4566`, and `ensureFloci()`
+ * guarantees the emulator is serving (starting the `alchemy-floci`
+ * container if needed). Without `dev: true` the live providers run against
+ * whatever account the profile resolves — the real cloud.
  *
  * ## Why no real-AWS calls can happen
  *
@@ -55,7 +58,9 @@ const dockerAvailable = (() => {
 
 const providers = AWS.providers();
 
-const { test } = Test.make({ providers });
+// `dev: true` runs the same topology as the real `alchemy dev` command
+// (including the RPC sidecar default for RPC-backed providers).
+const { test } = Test.make({ providers, dev: true });
 
 /**
  * Raw (non-distilled) call against the emulator gateway — out-of-band proof

--- a/packages/alchemy/test/AWS/Providers.test.ts
+++ b/packages/alchemy/test/AWS/Providers.test.ts
@@ -3,6 +3,7 @@ import { ArtifactStore, createArtifactStore } from "@/Artifacts.ts";
 import { AuthProviders } from "@/Auth/AuthProvider.ts";
 import { ProfileStoreLive } from "@/Auth/Profile.ts";
 import * as AWS from "@/AWS";
+import { AWSEnvironment } from "@/AWS/Environment.ts";
 import { Stack } from "@/Stack.ts";
 import { Stage } from "@/Stage.ts";
 import * as NodeServices from "@effect/platform-node/NodeServices";
@@ -13,12 +14,18 @@ import * as Layer from "effect/Layer";
 import * as Result from "effect/Result";
 import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
 import { v4 as uuidv4 } from "uuid";
+
 it.live(
   "building the AWS provider layers rejects an unknown explicit profile",
   () =>
     Effect.gen(function* () {
+      // AWSEnvironment is constructed lazily so `alchemy dev` can build
+      // provider layers without credentials. The unknown-profile rejection
+      // surfaces on first use, not at `Layer.build`.
       const result = yield* Effect.result(
-        Effect.sandbox(Layer.build(AWS.providers())),
+        Effect.sandbox(
+          AWSEnvironment.current.pipe(Effect.provide(AWS.providers())),
+        ),
       );
       expect(Result.isFailure(result)).toBe(true);
       if (Result.isFailure(result)) {
@@ -43,8 +50,7 @@ it.live(
             adopt: false,
             dotAlchemy: ".alchemy",
           }),
-          Layer.succeed(
-            ConfigProvider.ConfigProvider,
+          ConfigProvider.layer(
             ConfigProvider.fromUnknown({
               ALCHEMY_PROFILE: `non-existent-${uuidv4()}`,
             }),

--- a/packages/alchemy/test/AWS/Rekognition/Bindings.test.ts
+++ b/packages/alchemy/test/AWS/Rekognition/Bindings.test.ts
@@ -31,7 +31,11 @@ let accountId: string;
 class TransientUpstream extends Data.TaggedError("TransientUpstream")<{
   readonly status: number;
   readonly body: string;
-}> {}
+}> {
+  override get message(): string {
+    return `upstream responded ${this.status}: ${this.body}`;
+  }
+}
 
 // Freshly attached IAM policies propagate eventually; an early Rekognition
 // call can surface AccessDenied as a 500 through the handler's orDie. Retry
@@ -349,10 +353,23 @@ describe("Rekognition Bindings", () => {
         Effect.gen(function* () {
           const result = (yield* getJson("/stream-processors")) as {
             count: number;
+            listTag?: string;
             describeTag: string;
             startTag: string;
             stopTag: string;
           };
+          // Rekognition Video stream processors are allow-listed per account.
+          // An unentitled account is denied on every op, list included, and
+          // surfaces the typed AccessDeniedException at the entitlement gate
+          // (probed 2026-09: AdministratorAccess itself is denied). An
+          // entitled account lists for real and gets the not-found tags.
+          if (result.listTag === "AccessDeniedException") {
+            expect(result.count).toBe(-1);
+            expect(result.describeTag).toBe("AccessDeniedException");
+            expect(result.startTag).toBe("AccessDeniedException");
+            expect(result.stopTag).toBe("AccessDeniedException");
+            return;
+          }
           expect(result.count).toBeGreaterThanOrEqual(0);
           expect(result.describeTag).toBe("ResourceNotFoundException");
           expect(result.startTag).toBe("ResourceNotFoundException");

--- a/packages/alchemy/test/AWS/Rekognition/handler.ts
+++ b/packages/alchemy/test/AWS/Rekognition/handler.ts
@@ -538,38 +538,48 @@ export default RekognitionTestFunction.make(
         }
 
         // Stream processors: list for real, control plane through the typed
-        // ResourceNotFoundException path.
+        // ResourceNotFoundException path. Rekognition Video stream processors
+        // are allow-listed per account: an unentitled account gets the typed
+        // AccessDeniedException from every op (the list included), which
+        // still proves the binding reached the service.
         if (request.method === "GET" && pathname === "/stream-processors") {
-          const count = (
-            (yield* listStreamProcessors({ MaxResults: 10 }))
-              .StreamProcessors ?? []
-          ).length;
+          const listed = yield* listStreamProcessors({ MaxResults: 10 }).pipe(
+            Effect.map(
+              (r) => ({ count: (r.StreamProcessors ?? []).length }) as const,
+            ),
+            Effect.catchTag("AccessDeniedException", (e) =>
+              Effect.succeed({ count: -1, listTag: e._tag } as const),
+            ),
+          );
           const describeTag = yield* describeStreamProcessor({
             Name: "alchemy-nonexistent-processor",
           }).pipe(
             Effect.map(() => "Found"),
-            Effect.catchTag("ResourceNotFoundException", (e) =>
-              Effect.succeed(e._tag),
+            Effect.catchTag(
+              ["ResourceNotFoundException", "AccessDeniedException"],
+              (e) => Effect.succeed(e._tag),
             ),
           );
           const startTag = yield* startStreamProcessor({
             Name: "alchemy-nonexistent-processor",
           }).pipe(
             Effect.map(() => "Started"),
-            Effect.catchTag("ResourceNotFoundException", (e) =>
-              Effect.succeed(e._tag),
+            Effect.catchTag(
+              ["ResourceNotFoundException", "AccessDeniedException"],
+              (e) => Effect.succeed(e._tag),
             ),
           );
           const stopTag = yield* stopStreamProcessor({
             Name: "alchemy-nonexistent-processor",
           }).pipe(
             Effect.map(() => "Stopped"),
-            Effect.catchTag("ResourceNotFoundException", (e) =>
-              Effect.succeed(e._tag),
+            Effect.catchTag(
+              ["ResourceNotFoundException", "AccessDeniedException"],
+              (e) => Effect.succeed(e._tag),
             ),
           );
           return yield* HttpServerResponse.json({
-            count,
+            ...listed,
             describeTag,
             startTag,
             stopTag,

--- a/packages/alchemy/test/Cloudflare/Website/StaticSiteBeta67Migration.test.ts
+++ b/packages/alchemy/test/Cloudflare/Website/StaticSiteBeta67Migration.test.ts
@@ -10,12 +10,14 @@
  * recreated.
  */
 import { CloudflareEnvironment } from "@/Cloudflare/CloudflareEnvironment";
+import { Credentials } from "@/Cloudflare/Credentials.ts";
 import * as Cloudflare from "@/Cloudflare/index.ts";
 import * as Test from "@/Test/Alchemy";
 import { expect } from "alchemy-test";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
+import * as Redacted from "effect/Redacted";
 import { spawn } from "node:child_process";
 import * as pathe from "pathe";
 import {
@@ -41,11 +43,12 @@ const run = (options: {
   cmd: string;
   args: string[];
   cwd: string;
+  env?: Record<string, string>;
 }): Effect.Effect<string, Error> =>
   Effect.callback<string, Error>((resume) => {
     const child = spawn(options.cmd, options.args, {
       cwd: options.cwd,
-      env: { ...process.env, NO_COLOR: "1" },
+      env: { ...process.env, NO_COLOR: "1", ...options.env },
       stdio: ["ignore", "pipe", "pipe"],
     });
     let output = "";
@@ -92,6 +95,29 @@ test.provider.skipIf(!!process.env.FAST)(
       const fs = yield* FileSystem.FileSystem;
       const path = yield* Path.Path;
       const { accountId } = yield* yield* CloudflareEnvironment;
+
+      // The published beta.67 predates the per-provider profile store, so
+      // it cannot read the credentials this process resolved from the
+      // profile. Environment credentials are the contract that is stable
+      // across versions: hand it the resolved credentials under `CI=1`.
+      const credentials = yield* yield* Credentials;
+      const legacyCliEnv: Record<string, string> = {
+        CI: "1",
+        CLOUDFLARE_ACCOUNT_ID: accountId,
+        ...(credentials.type === "apiKey"
+          ? {
+              CLOUDFLARE_API_KEY: Redacted.value(credentials.apiKey),
+              CLOUDFLARE_EMAIL: credentials.email,
+            }
+          : {
+              // An OAuth access token is a bearer token like an API token.
+              CLOUDFLARE_API_TOKEN: Redacted.value(
+                credentials.type === "apiToken"
+                  ? credentials.apiToken
+                  : credentials.accessToken,
+              ),
+            }),
+      };
 
       const dir = yield* fs.makeTempDirectory({ prefix: "alchemy-b67-mig-" });
       const stateFile = (fqn: string) =>
@@ -158,6 +184,7 @@ test.provider.skipIf(!!process.env.FAST)(
           "--yes",
         ],
         cwd: dir,
+        env: legacyCliEnv,
       });
 
       // beta.67 persisted the Worker at the legacy `Site/Worker` FQN.

--- a/packages/alchemy/test/Fly/App.fixture.test.ts
+++ b/packages/alchemy/test/Fly/App.fixture.test.ts
@@ -1,7 +1,8 @@
-import { CredentialsFromEnv } from "@distilled.cloud/fly-io";
 import * as machines from "@distilled.cloud/fly-io/machines";
 import * as Fly from "@/Fly";
 import * as Alchemy from "@/index.ts";
+import { Stack as StackService } from "@/Stack.ts";
+import { Stage } from "@/Stage.ts";
 import * as Test from "@/Test/Alchemy";
 import { expect } from "alchemy-test";
 import * as Data from "effect/Data";
@@ -9,7 +10,6 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import { MinimumLogLevel } from "effect/References";
 import * as Schedule from "effect/Schedule";
-import * as FetchHttpClient from "effect/unstable/http/FetchHttpClient";
 import * as HttpClient from "effect/unstable/http/HttpClient";
 import Api from "./fixtures/app/api.ts";
 import {
@@ -30,9 +30,25 @@ const logLevel = Effect.provideService(
   process.env.DEBUG ? "Debug" : "Info",
 );
 
+// Out-of-band verification resolves Fly credentials the same way the stack
+// does — through the Alchemy profile via `Fly.providers()` — not from
+// `FLY_API_TOKEN`, which a laptop running off a profile does not have.
 const distilled = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
   effect.pipe(
-    Effect.provide(Layer.mergeAll(CredentialsFromEnv, FetchHttpClient.layer)),
+    Effect.provide(
+      Fly.providers().pipe(
+        Layer.provideMerge(
+          Layer.succeed(StackService, {
+            name: "FlyAppFixtureVerify",
+            stage: "test",
+            resources: {},
+            bindings: {},
+            actions: {},
+          }),
+        ),
+        Layer.provideMerge(Layer.succeed(Stage, "test")),
+      ),
+    ),
   );
 
 class ApiNotReady extends Data.TaggedError("ApiNotReady")<{

--- a/packages/floci/src/index.ts
+++ b/packages/floci/src/index.ts
@@ -37,7 +37,7 @@ import * as path from "node:path";
  * workflow. Bumping this pin (with a new `x.y.z-alchemy.N` tag) is how an
  * emulator change reaches users.
  */
-export const DEFAULT_FLOCI_IMAGE = "ghcr.io/alchemy-run/floci:1.6.0-alchemy.9";
+export const DEFAULT_FLOCI_IMAGE = "ghcr.io/alchemy-run/floci:1.6.0-alchemy.10";
 
 /** Default gateway port (LocalStack-compatible). */
 export const DEFAULT_FLOCI_PORT = 4566;

--- a/packages/frontend-frameworks/src/core/Loader.ts
+++ b/packages/frontend-frameworks/src/core/Loader.ts
@@ -1,5 +1,6 @@
 import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
+import { existsSync, readFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import * as NodePath from "node:path";
 import { pathToFileURL } from "node:url";
@@ -17,6 +18,32 @@ export class ModuleLoadError extends Data.TaggedError<"ModuleLoadError">(
 }
 
 /**
+ * Whether Node treats `filePath` as CommonJS: `.cjs`, or `.js` whose nearest
+ * `package.json` does not declare `"type": "module"`.
+ */
+const isCommonJsFile = (filePath: string): boolean => {
+  if (filePath.endsWith(".cjs")) return true;
+  if (!filePath.endsWith(".js")) return false;
+  let directory = NodePath.dirname(filePath);
+  for (;;) {
+    const manifest = NodePath.join(directory, "package.json");
+    if (existsSync(manifest)) {
+      try {
+        const { type } = JSON.parse(readFileSync(manifest, "utf8")) as {
+          type?: unknown;
+        };
+        return type !== "module";
+      } catch {
+        return true;
+      }
+    }
+    const parent = NodePath.dirname(directory);
+    if (parent === directory) return true;
+    directory = parent;
+  }
+};
+
+/**
  * Import a module from a *project's* dependency tree rather than our own —
  * the project's `vite`, `astro`, `waku`, `next`, etc. must be the instance
  * the framework integration drives, not whatever happens to be hoisted next
@@ -26,6 +53,15 @@ export class ModuleLoadError extends Data.TaggedError<"ModuleLoadError">(
  * imports the resolved absolute path as a `file://` URL (required for ESM
  * `import()` on Windows). If project-relative resolution fails (e.g. a
  * non-linked global install), it falls back to a bare `import(specifier)`.
+ *
+ * A CommonJS entry is loaded with `require`, not `import()`. Alchemy starts
+ * every Node child with its Oxc loader (`module.registerHooks`), and once a
+ * synchronous `load` hook exists Node's ESM loader runs *imported* CommonJS
+ * through a re-invented `require` that lacks `require.extensions` and
+ * `require.cache` (nodejs/node#59666) — `next` patches `require.extensions`
+ * as it loads and dies with "Cannot read properties of undefined (reading
+ * '.js')". The real CommonJS loader still consults the hooks, so project
+ * TypeScript reached through `require()` keeps transpiling.
  */
 export const loadProjectModule = <T = unknown>(
   root: string,
@@ -37,6 +73,7 @@ export const loadProjectModule = <T = unknown>(
       try {
         const require = createRequire(NodePath.resolve(root, "package.json"));
         const resolved = require.resolve(specifier);
+        if (isCommonJsFile(resolved)) return require(resolved) as T;
         return (await import(
           /* @vite-ignore */ pathToFileURL(resolved).href
         )) as T;

--- a/scripts/test-examples.ts
+++ b/scripts/test-examples.ts
@@ -1,5 +1,29 @@
 export {};
 
+// `bun test:examples --profile testing` — the example suites read the
+// profile from `ALCHEMY_PROFILE` (`Test.make({ profile: process.env.ALCHEMY_PROFILE })`),
+// so translate the flag into the env every spawned `bun test` inherits.
+// Without this the flag was silently ignored and every suite ran against
+// the `default` profile, which only works when the shell already exports
+// `ALCHEMY_PROFILE`.
+{
+  const argv = process.argv.slice(2);
+  const index = argv.findIndex(
+    (arg) => arg === "--profile" || arg.startsWith("--profile="),
+  );
+  if (index !== -1) {
+    const arg = argv[index]!;
+    const profile = arg.includes("=")
+      ? arg.slice("--profile=".length)
+      : argv[index + 1];
+    if (profile === undefined || profile.startsWith("-")) {
+      console.error("--profile requires a value, e.g. --profile testing");
+      process.exit(2);
+    }
+    process.env.ALCHEMY_PROFILE = profile;
+  }
+}
+
 const examples = [
   "./examples/cloudflare-dev",
   "./examples/cloudflare-worker",


### PR DESCRIPTION
Fixes the ~56 failures from a full local `pnpm test` + `bun test:aws:floci` run and pins floci `1.6.0-alchemy.10` ([alchemy-run/floci#11](https://github.com/alchemy-run/floci/pull/11)).

### Test runner

The runner now pins a non-interactive, colorless environment before any test module loads, so CLI-output assertions behave identically in a terminal and in CI:

```ts
// packages/alchemy-test/src/cli.ts
process.env.ALCHEMY_NO_TUI = "1";
process.env.NO_COLOR = "1";
process.env.FORCE_COLOR = "0";
```

- `Tui` removes the `globalThis.window` stub `@opentui/core` installs — pglite saw it and took its browser code path (`window.location.pathname`) in the Prisma dev-DB tests.
- `DevCli` polls abandon immediately when the `alchemy dev` child has exited instead of burning the full budget.

### Fly credentials

The `*Http` binding layers hard-wired `CredentialsFromEnv`, shadowing the profile. They now prefer whatever `Credentials` is already in context:

```ts
export const CredentialsFromAmbientOrEnv = Layer.effect(Credentials, ...)
// ListSecretsHttp, GetSecretHttp, WriteSecretHttp, ExecHttp, CheckpointHttp,
// EncryptHttp, DecryptHttp, SignHttp, VerifyHttp
```

### CLI / engine

- Telemetry is layered on top of the console logger instead of as a `mergeAll` sibling — the last `CurrentLoggers` won and `Effect.log*` output vanished from the terminal whenever telemetry was on:

```diff
-  ConsoleLogLive,
-  TelemetryLive,
+  Layer.provideMerge(TelemetryLive, ConsoleLogLive),
```

- `Drizzle/Schema` uses `isNonInteractive()` for the drift prompt.
- `DevWatchProvider` strips Effect-valued runtime props before `isResolved`, so a resumed `alchemy dev` over an existing stage still starts its watch loop.
- `frontend-frameworks` `Loader` loads CommonJS entry points with native `require()`; Node's ESM translator reimplements `require` without `require.extensions`, which Next.js patches.

### Tests

- AWS/Cloudflare `Providers` tests drive the now-lazy profile resolution.
- `StaticSiteBeta67Migration` hands resolved Cloudflare credentials to the beta.67 CLI through the CI env contract (it can't read the new profile store).
- Rekognition stream-processor tests accept the account-entitlement `AccessDeniedException` as a typed outcome.
- `FlociSmoke` runs in dev mode; Fly `App.fixture` uses `Fly.providers()`.

### floci

`DEFAULT_FLOCI_IMAGE` → `ghcr.io/alchemy-run/floci:1.6.0-alchemy.10`, submodule bumped to match. The tag ships provisioned ElastiCache + the serverless read surface, Cognito `ManagedLoginBranding`, and the Lambda MicroVM idle policy.
