### PR TITLE
fix(prisma): rewrite leaked @internal/extension-* specifiers

### DIFF
--- a/packages/alchemy/src/Prisma/ORM/Contract.ts
+++ b/packages/alchemy/src/Prisma/ORM/Contract.ts
@@ -287,7 +287,7 @@ export const ContractProvider = () =>
           );
           const emitted = yield* emit(news);
           // Emits leak unpublished @internal/* specifiers (through rc.8);
-          // rewrite them to the public @prisma/orm-postgres/* subpaths.
+          // rewrite them to the public @prisma/orm-* packages.
           yield* rewriteEmittedTypes(emitted.files.dts);
           const migrationsDir = resolveMigrationsDir(news);
           let packages = yield* readMigrationPackages(migrationsDir);

--- a/packages/alchemy/src/Prisma/ORM/internal.ts
+++ b/packages/alchemy/src/Prisma/ORM/internal.ts
@@ -286,22 +286,24 @@ export interface MigrateShowResult {
 /**
  * Prisma ORM v8 bug workaround (through 8.0.0-rc.8): `contract emit` writes
  * the Prisma monorepo's `@internal/*` aliases into `contract.d.ts` instead of
- * the public `@prisma/orm-postgres/*` subpaths. Those packages are not
- * published, so the emitted types would not resolve in a user project.
+ * the public `@prisma/orm-*` packages. Those packages are not published, so
+ * the emitted types would not resolve in a user project.
  * Longest-prefix-first so `sql-contract` is not eaten by `contract`.
+ * `@internal/extension-<name>/` maps to `@prisma/orm-extension-<name>/`.
  */
 const INTERNAL_SPECIFIER_REWRITES: ReadonlyArray<readonly [string, string]> = [
   ["@internal/adapter-postgres/", "@prisma/orm-postgres/adapter/"],
   ["@internal/target-postgres/", "@prisma/orm-postgres/target/"],
   ["@internal/sql-contract/", "@prisma/orm-postgres/family-contract/"],
   ["@internal/contract/", "@prisma/orm-postgres/contract/"],
+  ["@internal/extension-", "@prisma/orm-extension-"],
 ];
 
 /**
- * Rewrite leaked `@internal/*` import specifiers in an emitted
- * `contract.d.ts` to their public `@prisma/orm-postgres/*` equivalents.
- * A no-op for PSL-authored emits (which never contain them); fails
- * actionably if an unmapped `@internal/*` specifier remains.
+ * Rewrite leaked `@internal/*` specifiers in an emitted `contract.d.ts` to
+ * their public `@prisma/orm-*` equivalents. A no-op for PSL-authored emits
+ * (which never contain them); fails actionably if an unmapped `@internal/*`
+ * specifier remains.
  */
 export const rewriteEmittedTypes = (dtsPath: string) =>
   Effect.gen(function* () {

--- a/packages/alchemy/test/Prisma/ORM/internal.test.ts
+++ b/packages/alchemy/test/Prisma/ORM/internal.test.ts
@@ -1,0 +1,76 @@
+import { rewriteEmittedTypes } from "@/Prisma/ORM/internal.ts";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { expect, layer } from "alchemy-test";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Path from "effect/Path";
+import * as Result from "effect/Result";
+
+const describe = layer(NodeServices.layer);
+
+const writeDts = (contents: string) =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
+    const dir = yield* fs.makeTempDirectory({
+      prefix: "alchemy-prisma-rewrite-",
+    });
+    const dtsPath = path.join(dir, "contract.d.ts");
+    yield* fs.writeFileString(dtsPath, contents);
+    return dtsPath;
+  });
+
+describe("rewriteEmittedTypes", (it) => {
+  it.effect(
+    "maps leaked @internal/extension-* specifiers to @prisma/orm-extension-*",
+    () =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        // Imports already use the public package. Prisma still writes the
+        // unpublished @internal/extension-* name as a string in the type
+        // body (through 8.0.0-rc.8).
+        const dtsPath = yield* writeDts(`
+import type { Vector } from "@prisma/orm-extension-pgvector/codec-types";
+type Pgvector = { package: "@internal/extension-pgvector/codec-types" };
+type Parade = { package: "@internal/extension-paradedb/pack" };
+`);
+        yield* rewriteEmittedTypes(dtsPath);
+        const dts = yield* fs.readFileString(dtsPath);
+        expect(dts).not.toContain("@internal/");
+        expect(dts).toContain('"@prisma/orm-extension-pgvector/codec-types"');
+        expect(dts).toContain('"@prisma/orm-extension-paradedb/pack"');
+      }),
+  );
+
+  it.effect(
+    "still maps postgres @internal/* prefixes when an extension specifier is present",
+    () =>
+      Effect.gen(function* () {
+        const fs = yield* FileSystem.FileSystem;
+        const dtsPath = yield* writeDts(`
+import type { X } from "@internal/adapter-postgres/operation-types";
+import type { Y } from "@internal/contract/types";
+type Pack = { package: "@internal/extension-pgvector/pack" };
+`);
+        yield* rewriteEmittedTypes(dtsPath);
+        const dts = yield* fs.readFileString(dtsPath);
+        expect(dts).not.toContain("@internal/");
+        expect(dts).toContain("@prisma/orm-postgres/adapter/operation-types");
+        expect(dts).toContain("@prisma/orm-postgres/contract/types");
+        expect(dts).toContain("@prisma/orm-extension-pgvector/pack");
+      }),
+  );
+
+  it.effect("fails when an unmapped @internal/* specifier remains", () =>
+    Effect.gen(function* () {
+      const dtsPath = yield* writeDts(
+        `type Leak = { package: "@internal/unknown-pkg/types" };\n`,
+      );
+      const result = yield* Effect.result(rewriteEmittedTypes(dtsPath));
+      expect(Result.isFailure(result)).toBe(true);
+      if (Result.isFailure(result)) {
+        expect(String(result.failure)).toContain("@internal/unknown-pkg/");
+      }
+    }),
+  );
+});


### PR DESCRIPTION
Follow-up to #1198.

`Prisma.Contract` fails deploy when a contract uses `@prisma/orm-extension-pgvector`.

`contract emit` writes unpublished `@internal/extension-*` names into `contract.d.ts` as string values. Imports already use the public package names. The rewrite list did not map the extension prefix. The leftover `@internal/` check then fails the deploy.

This PR maps `@internal/extension-` to `@prisma/orm-extension-`. That covers pgvector and other official Prisma extension packages.