### PR TITLE
chore(test): serialize the floci-backed examples, bump floci to 1.6.0-alchemy.11

### DIFF
--- a/packages/floci/src/index.ts
+++ b/packages/floci/src/index.ts
@@ -37,7 +37,7 @@ import * as path from "node:path";
  * workflow. Bumping this pin (with a new `x.y.z-alchemy.N` tag) is how an
  * emulator change reaches users.
  */
-export const DEFAULT_FLOCI_IMAGE = "ghcr.io/alchemy-run/floci:1.6.0-alchemy.10";
+export const DEFAULT_FLOCI_IMAGE = "ghcr.io/alchemy-run/floci:1.6.0-alchemy.11";
 
 /** Default gateway port (LocalStack-compatible). */
 export const DEFAULT_FLOCI_PORT = 4566;

--- a/scripts/floci-image.ts
+++ b/scripts/floci-image.ts
@@ -1,0 +1,28 @@
+/**
+ * Point the floci-backed suites at a locally built emulator when one exists.
+ *
+ * `pnpm floci:build` tags the `submodules/floci` checkout as `floci:dev`;
+ * that is how an emulator patch gets exercised before its release image is
+ * published to GHCR. When no such image exists the env is left unset so the
+ * floci package resolves the pinned release image — hard-defaulting to a
+ * missing ref would fail every suite's `docker run` before a test can run.
+ *
+ * Must run before any child `bun test` is spawned: `ensureFloci` reads
+ * `ALCHEMY_FLOCI_IMAGE` in the child, and a container running a different
+ * image than the resolved one is recreated.
+ */
+export const preferLocalFlociImage = (label: string): void => {
+  if (process.env.ALCHEMY_FLOCI_IMAGE) return;
+  const devImage = Bun.spawnSync(["docker", "image", "inspect", "floci:dev"], {
+    stdout: "ignore",
+    stderr: "ignore",
+  });
+  if (devImage.exitCode === 0) {
+    process.env.ALCHEMY_FLOCI_IMAGE = "floci:dev";
+    console.log(`${label}: using locally built floci:dev image`);
+  } else {
+    console.log(
+      `${label}: no local floci:dev image (pnpm floci:build) — using the pinned release image`,
+    );
+  }
+};

--- a/scripts/test-aws-floci.ts
+++ b/scripts/test-aws-floci.ts
@@ -10,6 +10,7 @@
  * Extra alchemy-test args are forwarded (`-t`, `--retry`, paths, …).
  */
 import { Glob } from "bun";
+import { preferLocalFlociImage } from "./floci-image.ts";
 import { existsSync, readFileSync, statSync } from "node:fs";
 import { join, relative, resolve } from "node:path";
 
@@ -94,25 +95,7 @@ for (const root of requestedRoots) {
 
 process.env.ALCHEMY_TEST_DEV = "1";
 
-// Prefer a locally built `floci:dev` (pnpm floci:build) when it exists —
-// that's how unreleased emulator patches get exercised by this suite. When
-// it doesn't, leave the env unset so the floci package resolves the pinned
-// release image; hard-defaulting to a missing image fails every suite's
-// `docker run` before a single test can run.
-if (!process.env.ALCHEMY_FLOCI_IMAGE) {
-  const devImage = Bun.spawnSync(
-    ["docker", "image", "inspect", "floci:dev"],
-    { stdout: "ignore", stderr: "ignore" },
-  );
-  if (devImage.exitCode === 0) {
-    process.env.ALCHEMY_FLOCI_IMAGE = "floci:dev";
-    console.log("test:aws:floci: using locally built floci:dev image");
-  } else {
-    console.log(
-      "test:aws:floci: no local floci:dev image (pnpm floci:build) — using the pinned release image",
-    );
-  }
-}
+preferLocalFlociImage("test:aws:floci");
 
 if (!flags.includes("--profile")) {
   flags.unshift("--profile", "testing");
@@ -140,8 +123,7 @@ if (!flags.includes("--concurrency") && !flags.includes("-c")) {
 // loop"). Set `ALCHEMY_FLOCI_NO_RESET=1` to keep state across runs while
 // iterating on a single suite.
 if (!process.env.ALCHEMY_FLOCI_NO_RESET) {
-  const endpoint =
-    process.env.AWS_ENDPOINT_URL ?? "http://localhost:4566";
+  const endpoint = process.env.AWS_ENDPOINT_URL ?? "http://localhost:4566";
   try {
     const res = await fetch(`${endpoint}/_floci/state/reset`, {
       method: "POST",

--- a/scripts/test-examples.ts
+++ b/scripts/test-examples.ts
@@ -1,4 +1,4 @@
-export {};
+import { preferLocalFlociImage } from "./floci-image.ts";
 
 // `bun test:examples --profile testing` — the example suites read the
 // profile from `ALCHEMY_PROFILE` (`Test.make({ profile: process.env.ALCHEMY_PROFILE })`),
@@ -23,6 +23,11 @@ export {};
     process.env.ALCHEMY_PROFILE = profile;
   }
 }
+
+// The AWS examples run against the floci emulator: use the locally built
+// image when there is one so an emulator fix is testable before its
+// release image lands on GHCR.
+preferLocalFlociImage("test:examples");
 
 const examples = [
   "./examples/cloudflare-dev",
@@ -112,6 +117,13 @@ const examples = [
   "./examples/fly-postgres",
 ] as const;
 
+// The AWS examples share one floci emulator container (`alchemy-floci`):
+// two `alchemy dev` sessions ensuring it at the same time race to recreate
+// it on an image bump and hot-swap each other's Lambda code, so they run
+// one at a time. Everything else stays concurrent.
+const serialGroup = (example: string): string | undefined =>
+  example.startsWith("./examples/aws-") ? "floci" : undefined;
+
 type CommandResult = {
   label: string;
   command: readonly string[];
@@ -120,10 +132,15 @@ type CommandResult = {
   stderr: string;
 };
 
-type TaskState = {
+type Task = {
   label: string;
   command: readonly string[];
   cwd?: string;
+  /** Tasks sharing a key run one at a time, in list order. */
+  serial?: string;
+};
+
+type TaskState = Task & {
   status: "pending" | "running" | "ok" | "failed";
   startedAt?: number;
   endedAt?: number;
@@ -287,11 +304,7 @@ const run = async (
 };
 
 const runParallel = async (
-  tasks: readonly {
-    label: string;
-    command: readonly string[];
-    cwd?: string;
-  }[],
+  tasks: readonly Task[],
 ): Promise<readonly CommandResult[]> => {
   const states = tasks.map((task): TaskState => ({
     ...task,
@@ -300,13 +313,23 @@ const runParallel = async (
   const renderer = makeStatusRenderer(states);
   renderer.render();
   const interval = setInterval(() => renderer.render(), 1000);
+  const chains = new Map<string, Promise<unknown>>();
 
   try {
     return await Promise.all(
-      states.map(async (state) => {
-        const result = await run(state, () => renderer.render());
-        if (result.exitCode !== 0) renderer.failure(result);
-        return result;
+      states.map((state) => {
+        const start = async () => {
+          const result = await run(state, () => renderer.render());
+          if (result.exitCode !== 0) renderer.failure(result);
+          return result;
+        };
+        if (state.serial === undefined) return start();
+        const next = (chains.get(state.serial) ?? Promise.resolve()).then(
+          start,
+          start,
+        );
+        chains.set(state.serial, next);
+        return next;
       }),
     );
   } finally {
@@ -324,6 +347,7 @@ const testResults = await runParallel(
     // ever spawn the actual test process.
     command: ["bun", "test"] as const,
     cwd: example,
+    serial: serialGroup(example),
   })),
 );
 const failedTests = testResults.filter((result) => result.exitCode !== 0);
@@ -344,6 +368,7 @@ const cliResults = await runParallel(
   examples.map((example) => ({
     label: `${example} CLI lifecycle`,
     command: ["bun", "scripts/test-example-cli.ts", example],
+    serial: serialGroup(example),
   })),
 );
 const failedCliTests = cliResults.filter((result) => result.exitCode !== 0);


### PR DESCRIPTION
Fix the `aws-dev` / `aws-lambda` example tests failing under `pnpm test:examples`.

### Run the AWS examples one at a time

Both examples share the one `alchemy-floci` container. Two `alchemy dev` sessions ensuring it concurrently raced to recreate it on an image bump and hot-swapped each other's Lambda code. `test-examples.ts` now serializes tasks that share a `serial` key (both the `bun test` and CLI-lifecycle phases); everything else stays concurrent.

```ts
const serialGroup = (example: string) =>
  example.startsWith("./examples/aws-") ? "floci" : undefined;
```

### floci `WarmPool` re-pooled stale code after a hot swap

A Lambda container busy serving an invocation while its function was updated was skipped by `drainFunction` and returned to the pool with the old code, so the hot-swapped marker never appeared. Fixed in [alchemy-run/floci#12](https://github.com/alchemy-run/floci/pull/12), released as `1.6.0-alchemy.11`; this bumps `DEFAULT_FLOCI_IMAGE` and the `submodules/floci` pointer.

### `test:examples` prefers a locally built emulator

```ts
// scripts/floci-image.ts, used by test-examples.ts and test-aws-floci.ts
preferLocalFlociImage("test:examples"); // ALCHEMY_FLOCI_IMAGE=floci:dev when `pnpm floci:build` produced one
```

An emulator fix is testable before its release image lands on GHCR; with no local image the pinned release is used as before.
