### PR TITLE
fix(apply): persist downstream edges on noop resources

### DIFF
--- a/packages/alchemy/src/Apply.ts
+++ b/packages/alchemy/src/Apply.ts
@@ -715,13 +715,28 @@ const executeNode = (
       //    the persisted row, see `Plan.ts`'s delete node) would act on the
       //    stale one — destroying a resource the user had marked `retain`.
       //    See https://github.com/alchemy-run/alchemy/issues/1248.
+      // 3. `downstream` — a dependent that repins from resource A to B
+      //    (e.g. a HostnameAssociation switching certificates) updates
+      //    *itself*, while A and B are both noops. Delete ordering reads the
+      //    persisted `downstream` of the resource being deleted, so without
+      //    this commit a later destroy deletes B concurrently with the
+      //    dependent that still references it (and needlessly waits on A).
       const policyChanged =
         node.state.removalPolicy !== node.resource.RemovalPolicy;
-      if (node.state.resourceType !== node.resource.Type || policyChanged) {
+      const downstreamChanged = !sameSet(
+        node.state.downstream ?? [],
+        node.downstream,
+      );
+      if (
+        node.state.resourceType !== node.resource.Type ||
+        policyChanged ||
+        downstreamChanged
+      ) {
         yield* commit({
           ...node.state,
           resourceType: node.resource.Type,
           removalPolicy: node.resource.RemovalPolicy,
+          downstream: node.downstream,
         });
       }
       // A policy flip is otherwise invisible (the row is a noop), and it is
@@ -2394,3 +2409,9 @@ const excludeDeletedBindings = (
   bindings.flatMap(({ action, sid, data }) =>
     action === "delete" ? [] : [{ sid, data }],
   );
+
+/** Order-insensitive equality of two FQN lists. */
+const sameSet = (a: ReadonlyArray<string>, b: ReadonlyArray<string>) => {
+  const sa = new Set(a);
+  return sa.size === new Set(b).size && b.every((fqn) => sa.has(fqn));
+};

--- a/packages/alchemy/test/AWS/AutoScaling/LifecycleHookEventSource.test.ts
+++ b/packages/alchemy/test/AWS/AutoScaling/LifecycleHookEventSource.test.ts
@@ -120,6 +120,10 @@ describe("AutoScaling LifecycleHook event source + CompleteLifecycleAction", () 
                 ),
           ),
           Effect.map((json) => json as { ok: boolean; tag: string }),
+          // `repeat` only re-runs successes: a transient 502 from the
+          // Function URL (cold start right after deploy) must be retried
+          // too, the way the /health probe is.
+          Effect.retry({ schedule: Schedule.spaced("3 seconds"), times: 10 }),
           Effect.repeat({
             until: (b) =>
               b.tag !== "AccessDenied" && b.tag !== "AccessDeniedException",

--- a/packages/alchemy/test/AWS/AutoScaling/fixtures/lifecycle-handler.ts
+++ b/packages/alchemy/test/AWS/AutoScaling/fixtures/lifecycle-handler.ts
@@ -9,6 +9,7 @@ import {
 import { amazonLinux2023 } from "@/AWS/EC2";
 import * as Output from "@/Output";
 import * as Context from "effect/Context";
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Stream from "effect/Stream";
@@ -62,6 +63,9 @@ export default LifecycleTestFunction.make(
   {
     main: import.meta.url,
     functionUrl: true,
+    // /complete-bogus makes a live Auto Scaling call; a cold start plus SDK
+    // round-trip can exceed Lambda's 3s default and surface as a 502.
+    timeout: Duration.seconds(30),
   },
   Effect.gen(function* () {
     const { group } = yield* LifecycleFleet;

--- a/packages/alchemy/test/Cloudflare/Workers/WorkerLoader.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/WorkerLoader.test.ts
@@ -40,6 +40,12 @@ const readJson = (url: string) =>
     }),
   );
 
+// The dynamic worker's hit counter lives in module scope, so an isolate id
+// reused across test attempts (the runner retries) or runs keeps counting.
+// Mint a fresh id per attempt so `hits` always starts at 1.
+const freshId = (prefix: string) =>
+  Effect.sync(() => `${prefix}-${crypto.randomUUID().slice(0, 8)}`);
+
 const stack = beforeAll(deploy(Stack));
 afterAll.skipIf(!!process.env.NO_DESTROY)(destroy(Stack));
 
@@ -67,8 +73,9 @@ test(
   "effect worker get() fetch proxies to a cached dynamic worker",
   Effect.gen(function* () {
     const { getWorkerUrl } = yield* stack;
-    const body = yield* readJson(`${getWorkerUrl}/?id=stub`);
-    expect(body).toMatchObject({ id: "stub", hits: 1 });
+    const id = yield* freshId("stub");
+    const body = yield* readJson(`${getWorkerUrl}/?id=${id}`);
+    expect(body).toMatchObject({ id, hits: 1 });
   }),
   { timeout: 180_000 },
 );
@@ -77,10 +84,23 @@ test(
   "effect worker get() reuses the isolate for the same id",
   Effect.gen(function* () {
     const { getWorkerUrl } = yield* stack;
-    const first = yield* readJson(`${getWorkerUrl}/?id=reuse`);
-    const second = yield* readJson(`${getWorkerUrl}/?id=reuse`);
-    expect(first).toMatchObject({ id: "reuse", hits: 1 });
-    expect(second).toMatchObject({ id: "reuse", hits: 2 });
+    const id = yield* freshId("reuse");
+    const first = yield* readJson(`${getWorkerUrl}/?id=${id}`);
+    expect(first).toMatchObject({ id, hits: 1 });
+    // `get()` only reuses an isolate within the same colo/process, so two
+    // back-to-back requests can occasionally be served by two fresh
+    // isolates (both reporting `hits: 1`). Any response with `hits >= 2`
+    // proves module state survived across requests, i.e. the isolate was
+    // reused — poll for that instead of asserting the second request exactly.
+    const reused = yield* readJson(`${getWorkerUrl}/?id=${id}`).pipe(
+      Effect.repeat({
+        until: (body) => (body as { hits: number }).hits >= 2,
+        schedule: Schedule.spaced("500 millis"),
+        times: 10,
+      }),
+    );
+    expect(reused).toMatchObject({ id });
+    expect((reused as { hits: number }).hits).toBeGreaterThanOrEqual(2);
   }),
   { timeout: 180_000 },
 );
@@ -89,8 +109,9 @@ test(
   "effect worker get() getEntrypoint() fetch works",
   Effect.gen(function* () {
     const { getWorkerUrl } = yield* stack;
-    const body = yield* readJson(`${getWorkerUrl}/?id=named&entrypoint=1`);
-    expect(body).toMatchObject({ id: "named", hits: 1 });
+    const id = yield* freshId("named");
+    const body = yield* readJson(`${getWorkerUrl}/?id=${id}&entrypoint=1`);
+    expect(body).toMatchObject({ id, hits: 1 });
   }),
   { timeout: 180_000 },
 );

--- a/packages/alchemy/test/apply.test.ts
+++ b/packages/alchemy/test/apply.test.ts
@@ -673,6 +673,35 @@ describe("linear update propagation", () => {
         expect(sawByB.every((v) => v === "v2")).toBe(true);
       }),
   );
+
+  // Regression: a dependent that repins from upstream A to upstream B updates
+  // *itself*, while A and B are both noops. The noop pass must still persist
+  // their new `downstream` — delete ordering reads it from the persisted row,
+  // so a stale list would delete B concurrently with the dependent that still
+  // references it (and needlessly wait on A).
+  test.provider(
+    "noop upstreams persist a repinned dependent's downstream edge",
+    (stack) =>
+      Effect.gen(function* () {
+        const program = (pin: "A" | "B") =>
+          Effect.gen(function* () {
+            const A = yield* TestResource("A", { string: "a" });
+            const B = yield* TestResource("B", { string: "b" });
+            const C = yield* TestResource("C", {
+              string: (pin === "A" ? A : B).string,
+            });
+            return { A, B, C };
+          });
+
+        yield* stack.deploy(program("A"));
+        expect((yield* getState("A"))?.downstream).toEqual(["C"]);
+        expect((yield* getState("B"))?.downstream).toEqual([]);
+
+        yield* stack.deploy(program("B"));
+        expect((yield* getState("A"))?.downstream).toEqual([]);
+        expect((yield* getState("B"))?.downstream).toEqual(["C"]);
+      }),
+  );
 });
 
 // Regression: `deleteFirst` on a `replace` diff was plumbed from the provider

--- a/scripts/test-example-cli.ts
+++ b/scripts/test-example-cli.ts
@@ -13,24 +13,36 @@ const devOnly = process.argv.includes("--dev-only");
 
 const repositoryRoot = path.resolve(import.meta.dirname, "..");
 const exampleRoot = path.resolve(repositoryRoot, example);
+// The real launcher, not `bin/alchemy.ts`: it pins bun's tsconfig to
+// alchemy's own, so the CLI's .tsx files are not transpiled with the
+// example's JSX settings (solid-js examples otherwise crash the CLI).
 const alchemyBin = path.join(
   repositoryRoot,
   "packages",
   "alchemy",
   "bin",
-  "alchemy.ts",
+  "cli.js",
 );
 const stage = "cli-example-test";
+// The summary line the CLI prints once a run converges. In non-TTY mode every
+// line carries a `[time] LEVEL (#fiber): ` prefix, so anchor on the text.
+const DONE = /Done: \d+ succeeded/;
 const timeoutMs = 4 * 60_000;
-const alchemyHome = fs.mkdtempSync(
-  path.join(os.tmpdir(), "alchemy-example-cli-"),
-);
+// With a profile (`bun test:examples --profile testing`) the CLI must see the
+// real ALCHEMY_HOME (where the profile's credentials live) and must NOT run
+// as CI, which makes auth resolution skip profiles for env credentials.
+// Without a profile, run against an empty home as CI so the CLI can only
+// authenticate from env vars, the way a fresh CI runner would.
+const profile = process.env.ALCHEMY_PROFILE;
+const alchemyHome =
+  profile === undefined
+    ? fs.mkdtempSync(path.join(os.tmpdir(), "alchemy-example-cli-"))
+    : undefined;
 const childEnv = {
   ...process.env,
-  ALCHEMY_HOME: alchemyHome,
-  ALCHEMY_PROFILE: undefined,
-  AWS_PROFILE: undefined,
-  CI: "true",
+  ...(alchemyHome === undefined
+    ? {}
+    : { ALCHEMY_HOME: alchemyHome, AWS_PROFILE: undefined, CI: "true" }),
   NO_COLOR: "1",
 };
 
@@ -117,10 +129,15 @@ const runDev = (): Promise<CommandResult> =>
       const text = chunk.toString();
       output += text;
       if (process.env.DEBUG) process.stderr.write(text);
-      if (!ready && output.includes("\nDone:") && /https?:\/\//.test(output)) {
+      if (!ready && DONE.test(output) && /https?:\/\//.test(output)) {
         ready = true;
         killGroup("SIGINT");
         setTimeout(() => killGroup("SIGKILL"), 15_000).unref();
+      }
+      // A failed run leaves `dev` waiting for a file change that never
+      // comes; fail now instead of at the timeout.
+      if (!ready && output.includes("alchemy dev: run failed")) {
+        killGroup("SIGKILL");
       }
     };
 
@@ -163,18 +180,14 @@ let primaryFailure: unknown;
 try {
   const dev = await runDev();
   assertSuccess("dev", dev);
-  assertOutput("dev", dev, [
-    new RegExp(`Dev · ${stage}`),
-    /\nDone:/,
-    /https?:\/\//,
-  ]);
+  assertOutput("dev", dev, [new RegExp(`Dev · ${stage}`), DONE, /https?:\/\//]);
 
   if (!devOnly) {
     const deployed = await run("deploy");
     assertSuccess("deploy", deployed);
     assertOutput("deploy", deployed, [
       new RegExp(`Deploy · ${stage}`),
-      /\nDone:/,
+      DONE,
       /https?:\/\//,
     ]);
   }
@@ -194,14 +207,16 @@ try {
     } else if (primaryFailure === undefined) {
       assertOutput("destroy", destroyed, [
         new RegExp(`Destroy · ${stage}`),
-        /\nDone:/,
+        DONE,
       ]);
     }
   } catch (error) {
     if (primaryFailure === undefined) primaryFailure = error;
     else console.error(`${example}: cleanup destroy failed`, error);
   } finally {
-    fs.rmSync(alchemyHome, { recursive: true, force: true });
+    if (alchemyHome !== undefined) {
+      fs.rmSync(alchemyHome, { recursive: true, force: true });
+    }
   }
 }
 

--- a/scripts/test-examples.ts
+++ b/scripts/test-examples.ts
@@ -159,7 +159,7 @@ const elapsedSeconds = (state: TaskState): string => {
   return `${Math.round((endedAt - state.startedAt) / 1000)}s`;
 };
 
-const makeStatusRenderer = (states: readonly TaskState[]) => {
+const makeStatusRenderer = (title: string, states: readonly TaskState[]) => {
   const interactive = process.stdout.isTTY === true;
   let renderedRows = 0;
 
@@ -185,7 +185,7 @@ const makeStatusRenderer = (states: readonly TaskState[]) => {
   const rowsForAll = (output: readonly string[]) =>
     output.reduce((total, line) => total + rowsFor(line), 0);
 
-  const fullLines = () => ["Example tests", ...states.map(taskLine)];
+  const fullLines = () => [title, ...states.map(taskLine)];
 
   // The in-place repaint moves the cursor up with `\x1b[NF`, which cannot
   // climb above the top of the viewport: if a paint is taller than the
@@ -201,7 +201,7 @@ const makeStatusRenderer = (states: readonly TaskState[]) => {
     }
     const done = states.filter((state) => state.status === "ok").length;
     const active = states.filter((state) => state.status !== "ok");
-    const header = `Example tests (${done}/${states.length} ok)`;
+    const header = `${title} (${done}/${states.length} ok)`;
     const activeLines = active.map(taskLine);
     let shown = activeLines.length;
     const fits = (count: number) => {
@@ -304,24 +304,52 @@ const run = async (
 };
 
 const runParallel = async (
+  title: string,
   tasks: readonly Task[],
+  options?: { readonly concurrency?: number },
 ): Promise<readonly CommandResult[]> => {
   const states = tasks.map((task): TaskState => ({
     ...task,
     status: "pending",
   }));
-  const renderer = makeStatusRenderer(states);
+  const renderer = makeStatusRenderer(title, states);
   renderer.render();
   const interval = setInterval(() => renderer.render(), 1000);
   const chains = new Map<string, Promise<unknown>>();
+
+  // At most `concurrency` tasks run at once; the rest wait for a slot.
+  const limit = options?.concurrency ?? Infinity;
+  let active = 0;
+  const waiting: Array<() => void> = [];
+  const acquire = () =>
+    new Promise<void>((resolve) => {
+      if (active < limit) {
+        active++;
+        resolve();
+      } else {
+        waiting.push(() => {
+          active++;
+          resolve();
+        });
+      }
+    });
+  const release = () => {
+    active--;
+    waiting.shift()?.();
+  };
 
   try {
     return await Promise.all(
       states.map((state) => {
         const start = async () => {
-          const result = await run(state, () => renderer.render());
-          if (result.exitCode !== 0) renderer.failure(result);
-          return result;
+          await acquire();
+          try {
+            const result = await run(state, () => renderer.render());
+            if (result.exitCode !== 0) renderer.failure(result);
+            return result;
+          } finally {
+            release();
+          }
         };
         if (state.serial === undefined) return start();
         const next = (chains.get(state.serial) ?? Promise.resolve()).then(
@@ -339,6 +367,7 @@ const runParallel = async (
 };
 
 const testResults = await runParallel(
+  "Example tests",
   examples.map((example) => ({
     label: example,
     // Run `bun test` IN the example directory. Concurrent
@@ -365,11 +394,16 @@ if (failedTests.length > 0) {
 }
 
 const cliResults = await runParallel(
+  "Example CLI lifecycle",
   examples.map((example) => ({
     label: `${example} CLI lifecycle`,
     command: ["bun", "scripts/test-example-cli.ts", example],
     serial: serialGroup(example),
   })),
+  // Each `alchemy dev` session is a CLI, an exec child, sidecars, workerd
+  // and a bundler watch loop; 30 at once starve each other past the
+  // 4-minute readiness timeout.
+  { concurrency: 8 },
 );
 const failedCliTests = cliResults.filter((result) => result.exitCode !== 0);
 
@@ -382,7 +416,7 @@ if (failedCliTests.length > 0) {
   process.exit(1);
 }
 
-const [formatFailure] = await runParallel([
+const [formatFailure] = await runParallel("Format", [
   { label: "format", command: ["bun", "run", "format"] },
 ]);
 if (formatFailure.exitCode !== 0) {


### PR DESCRIPTION
The `noop` pass in `Apply.ts` never persisted `downstream`, so a dependent that repins from upstream A to upstream B (both noops) left B's persisted dependents stale. A later destroy then deleted B concurrently with the resource still referencing it. Surfaced by `HostnameAssociation` switching certificates:

```
✗ AssocCert6 (Cloudflare.OriginTlsClientAuth.HostnameCertificate): BadRequest:
  Cannot delete this certificate while it has hostname associations.
```

The noop commit now covers `downstream` drift alongside `resourceType` / `removalPolicy`:

```ts
const downstreamChanged = !sameSet(node.state.downstream ?? [], node.downstream);
if (typeChanged || policyChanged || downstreamChanged) {
  yield* commit({ ...node.state, resourceType, removalPolicy, downstream: node.downstream });
}
```

Regression test in `apply.test.ts`: `C` repins from `A` to `B`; `A.downstream` becomes `[]` and `B.downstream` becomes `["C"]`.

### Test fixes

Accumulated from running `bun test:examples --profile testing` and the full suite.

**`test:examples` CLI lifecycle phase** — every one of the 31 `alchemy dev` runs hung until the 4-minute timeout.

- `test-example-cli.ts` set `CI=true` and dropped `ALCHEMY_PROFILE`; `CI` makes auth resolution skip profiles, so every CLI failed with `Missing required env: CLOUDFLARE_ACCOUNT_ID` and `dev` then waited for a file change. With a profile the script keeps the real `ALCHEMY_HOME` and does not set `CI`.
- The non-TTY renderer prefixes every line, so `output.includes("\nDone:")` never matched. Now `/Done: \d+ succeeded/`.
- Solid examples crashed `deploy` with `React is not defined`: running `bin/alchemy.ts` directly transpiled the CLI's `.tsx` with the example's `jsxImportSource`. Launch through `bin/cli.js`, which pins `--tsconfig-override`.
- Fail fast on `alchemy dev: run failed`; bound the CLI lifecycle phase to 8 concurrent sessions.

**`AutoScaling CompleteLifecycleAction binding is IAM-wired`** (`Function not ready: 502`) — the fixture ran on Lambda's 3s default timeout while making a live Auto Scaling call; under load it crossed 3s and the Function URL answered 502, which `Effect.repeat` never retries.

```ts
timeout: Duration.seconds(30),
Effect.retry({ schedule: Schedule.spaced("3 seconds"), times: 10 }),
```

**`WorkerLoader get() reuses the isolate`** (`hits: 4`, expected 2) — the dynamic worker's module-scope counter survives runner retries for a fixed `?id=`, so exact counts could never pass after a first failure. Ids are now fresh per attempt and reuse is asserted as any response with `hits >= 2`.
