### PR TITLE
fix(test): deflake AutoScaling CompleteLifecycleAction binding test

### DIFF
--- a/packages/alchemy/test/AWS/AutoScaling/LifecycleHookEventSource.test.ts
+++ b/packages/alchemy/test/AWS/AutoScaling/LifecycleHookEventSource.test.ts
@@ -120,6 +120,10 @@ describe("AutoScaling LifecycleHook event source + CompleteLifecycleAction", () 
                 ),
           ),
           Effect.map((json) => json as { ok: boolean; tag: string }),
+          // `repeat` only re-runs successes: a transient 502 from the
+          // Function URL (cold start right after deploy) must be retried
+          // too, the way the /health probe is.
+          Effect.retry({ schedule: Schedule.spaced("3 seconds"), times: 10 }),
           Effect.repeat({
             until: (b) =>
               b.tag !== "AccessDenied" && b.tag !== "AccessDeniedException",

--- a/packages/alchemy/test/AWS/AutoScaling/fixtures/lifecycle-handler.ts
+++ b/packages/alchemy/test/AWS/AutoScaling/fixtures/lifecycle-handler.ts
@@ -9,6 +9,7 @@ import {
 import { amazonLinux2023 } from "@/AWS/EC2";
 import * as Output from "@/Output";
 import * as Context from "effect/Context";
+import * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Stream from "effect/Stream";
@@ -62,6 +63,9 @@ export default LifecycleTestFunction.make(
   {
     main: import.meta.url,
     functionUrl: true,
+    // /complete-bogus makes a live Auto Scaling call; a cold start plus SDK
+    // round-trip can exceed Lambda's 3s default and surface as a 502.
+    timeout: Duration.seconds(30),
   },
   Effect.gen(function* () {
     const { group } = yield* LifecycleFleet;


### PR DESCRIPTION
Fix the flaky `CompleteLifecycleAction binding is IAM-wired` test (`Function not ready: 502`).

The fixture ran on Lambda's 3s default timeout while `/complete-bogus` does a live Auto Scaling call. A cold invocation measures ~2.5s alone; under the full suite's load it crosses 3s, Lambda kills it, and the Function URL answers 502. The test then failed outright because `Effect.repeat` only re-runs successes — a non-200 was never retried, unlike the `/health` probe in `beforeAll`.

```ts
// fixtures/lifecycle-handler.ts
timeout: Duration.seconds(30),

// LifecycleHookEventSource.test.ts — retry the failure path too
Effect.retry({ schedule: Schedule.spaced("3 seconds"), times: 10 }),
Effect.repeat({ until: (b) => b.tag !== "AccessDenied" && ..., ... }),
```
