### PR TITLE
fix(aws/organizations): unwrap Redacted account name and email

### DIFF
--- a/packages/alchemy/src/AWS/IdentityCenter/AccountAssignment.ts
+++ b/packages/alchemy/src/AWS/IdentityCenter/AccountAssignment.ts
@@ -330,6 +330,13 @@ const readAssignment = Effect.fn(function* ({
   principalType,
   targetId,
 }: AccountAssignmentProps) {
+  // A `creating` row can serialize without resolved Outputs (`targetId`
+  // from `account.accountId`, etc.). Distilled `ListAccountAssignments`
+  // then fails with `ParseError: Expected string at ["AccountId"]`.
+  if (!targetId || !permissionSetArn || !principalId) {
+    return undefined;
+  }
+
   const instance = yield* resolveInstance(instanceArn);
   const assignments = yield* ssoAdmin.listAccountAssignments
     .items({

--- a/packages/alchemy/src/AWS/Organizations/Account.ts
+++ b/packages/alchemy/src/AWS/Organizations/Account.ts
@@ -12,6 +12,7 @@ import {
   collectPages,
   readResourceTags,
   retryOrganizations,
+  unredact,
   updateResourceTags,
 } from "./common.ts";
 
@@ -60,11 +61,11 @@ export interface Account extends Resource<
     /**
      * Friendly account name.
      */
-    name: organizations.Account["Name"] | undefined;
+    name: string | undefined;
     /**
      * Email address associated with the account.
      */
-    email: organizations.Account["Email"] | undefined;
+    email: string | undefined;
     /**
      * ID of the parent root or OU.
      */
@@ -192,12 +193,18 @@ export const AccountProvider = () =>
             if (requestId) {
               const status = yield* waitForCreateAccount(requestId);
               yield* session.note(status.AccountId ?? requestId);
+              state = status.AccountId
+                ? yield* readAccountById(status.AccountId)
+                : yield* readAccountByNameOrEmail({
+                    name: news.name,
+                    email: news.email,
+                  });
+            } else {
+              state = yield* readAccountByNameOrEmail({
+                name: news.name,
+                email: news.email,
+              });
             }
-
-            state = yield* readAccountByNameOrEmail({
-              name: news.name,
-              email: news.email,
-            });
             if (!state) {
               return yield* Effect.fail(
                 new Error(`account '${news.name}' not found after create`),
@@ -338,8 +345,8 @@ const readAccountById = Effect.fn(function* (accountId: string) {
   return {
     accountId: described.Id,
     accountArn: described.Arn,
-    name: described.Name,
-    email: described.Email,
+    name: unredact(described.Name),
+    email: unredact(described.Email),
     parentId,
     status: described.Status,
     state: described.State,
@@ -355,7 +362,8 @@ const readAccountByNameOrEmail = Effect.fn(function* ({
 }: Pick<AccountProps, "name" | "email">) {
   const accounts = yield* listAccounts();
   const match = accounts.find(
-    (candidate) => candidate.Name === name || candidate.Email === email,
+    (candidate) =>
+      unredact(candidate.Name) === name || unredact(candidate.Email) === email,
   );
   return match?.Id ? yield* readAccountById(match.Id) : undefined;
 });

--- a/packages/alchemy/src/AWS/Organizations/DelegatedAdministrator.ts
+++ b/packages/alchemy/src/AWS/Organizations/DelegatedAdministrator.ts
@@ -4,7 +4,7 @@ import { isResolved } from "../../Diff.ts";
 import * as Provider from "../../Provider.ts";
 import { Resource } from "../../Resource.ts";
 import type { Providers } from "../Providers.ts";
-import { collectPages, retryOrganizations } from "./common.ts";
+import { collectPages, retryOrganizations, unredact } from "./common.ts";
 
 export interface DelegatedAdministratorProps {
   /**
@@ -32,11 +32,11 @@ export interface DelegatedAdministrator extends Resource<
     /**
      * Friendly name of the delegated administrator account.
      */
-    accountName: organizations.DelegatedAdministrator["Name"] | undefined;
+    accountName: string | undefined;
     /**
      * Email address of the delegated administrator account.
      */
-    accountEmail: organizations.DelegatedAdministrator["Email"] | undefined;
+    accountEmail: string | undefined;
     /**
      * Service principal delegated to the account.
      */
@@ -179,8 +179,8 @@ export const DelegatedAdministratorProvider = () =>
                           ({
                             accountId: admin.Id,
                             accountArn: admin.Arn,
-                            accountName: admin.Name,
-                            accountEmail: admin.Email,
+                            accountName: unredact(admin.Name),
+                            accountEmail: unredact(admin.Email),
                             servicePrincipal: service.ServicePrincipal,
                             delegationEnabledDate:
                               service.DelegationEnabledDate ??
@@ -289,8 +289,8 @@ const readDelegatedAdministrator = Effect.fn(function* ({
     ? ({
         accountId,
         accountArn: account.Arn,
-        accountName: account.Name,
-        accountEmail: account.Email,
+        accountName: unredact(account.Name),
+        accountEmail: unredact(account.Email),
         servicePrincipal,
         delegationEnabledDate:
           service.DelegationEnabledDate ?? account.DelegationEnabledDate,

--- a/packages/alchemy/src/AWS/Organizations/Organization.ts
+++ b/packages/alchemy/src/AWS/Organizations/Organization.ts
@@ -3,7 +3,7 @@ import * as Effect from "effect/Effect";
 import * as Provider from "../../Provider.ts";
 import { Resource } from "../../Resource.ts";
 import type { Providers } from "../Providers.ts";
-import { retryOrganizations } from "./common.ts";
+import { retryOrganizations, unredact } from "./common.ts";
 
 export type OrganizationId = string;
 export type OrganizationArn = string;
@@ -45,9 +45,7 @@ export interface Organization extends Resource<
     /**
      * Email address of the management account.
      */
-    managementAccountEmail:
-      | organizations.Organization["MasterAccountEmail"]
-      | undefined;
+    managementAccountEmail: string | undefined;
     /**
      * Policy types available to the organization.
      */
@@ -163,7 +161,7 @@ const toAttrs = (
   featureSet: org.FeatureSet,
   managementAccountArn: org.MasterAccountArn,
   managementAccountId: org.MasterAccountId,
-  managementAccountEmail: org.MasterAccountEmail,
+  managementAccountEmail: unredact(org.MasterAccountEmail),
   availablePolicyTypes: org.AvailablePolicyTypes ?? [],
 });
 

--- a/packages/alchemy/src/AWS/Organizations/common.ts
+++ b/packages/alchemy/src/AWS/Organizations/common.ts
@@ -1,8 +1,25 @@
 import * as organizations from "@distilled.cloud/aws/organizations";
 import * as Effect from "effect/Effect";
+import * as Redacted from "effect/Redacted";
 import * as Schedule from "effect/Schedule";
 import { createPhysicalName } from "../../PhysicalName.ts";
 import { createInternalTags, diffTags } from "../../Tags.ts";
+
+/**
+ * Distilled decodes `smithy.api#sensitive` strings (`Name`, `Email`,
+ * `MasterAccountEmail`) into `Redacted.Redacted<string>` at runtime.
+ * Attributes and equality checks must unwrap first — comparing the wrapper
+ * against a plain string is always `false` and would persist
+ * `{ "__redacted__": … }` into state.
+ */
+export const unredact = (
+  value: string | Redacted.Redacted<string> | undefined,
+): string | undefined =>
+  value === undefined
+    ? undefined
+    : Redacted.isRedacted(value)
+      ? Redacted.value(value)
+      : value;
 
 export type OrganizationsTags = Record<string, string>;
 

--- a/packages/alchemy/test/AWS/IdentityCenter/AccountAssignment.test.ts
+++ b/packages/alchemy/test/AWS/IdentityCenter/AccountAssignment.test.ts
@@ -70,3 +70,26 @@ test.provider.skipIf(SKIP_IDENTITY_CENTER)(
     }),
   { timeout: 300_000 },
 );
+
+// A `creating` row can persist without resolved Outputs (`targetId` from
+// `account.accountId`). Distilled `ListAccountAssignments` then fails with
+// `ParseError: Expected string at ["AccountId"]`. Guarded `read` must report
+// not-found without calling AWS.
+test.provider("read returns undefined when creating-state lost targetId", () =>
+  Effect.gen(function* () {
+    const provider = yield* Provider.findProvider(AccountAssignment);
+    const result = yield* provider.read!({
+      id: "AccountAssignment",
+      fqn: "AccountAssignment",
+      instanceId: "test-instance",
+      olds: {
+        permissionSetArn:
+          "arn:aws:sso:::permissionSet/ssoins-example/ps-example",
+        principalId: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+        principalType: "GROUP",
+      } as AccountAssignment["Props"],
+      output: undefined,
+    });
+    expect(result).toBeUndefined();
+  }),
+);

--- a/packages/alchemy/test/AWS/Organizations/Account.test.ts
+++ b/packages/alchemy/test/AWS/Organizations/Account.test.ts
@@ -28,10 +28,28 @@ test.provider("list enumerates organization accounts", () =>
       expect(typeof account.accountId).toBe("string");
       expect(typeof account.accountArn).toBe("string");
       expect(account.tags).toBeDefined();
+      if (account.name != null) {
+        expect(typeof account.name).toBe("string");
+      }
+      if (account.email != null) {
+        expect(typeof account.email).toBe("string");
+      }
     }
 
     if (process.env.AWS_TEST_ORG_MANAGEMENT) {
       expect(all.length).toBeGreaterThan(0);
+      const management = all.find(
+        (account) =>
+          typeof account.name === "string" &&
+          account.name.length > 0 &&
+          typeof account.email === "string" &&
+          account.email.length > 0,
+      );
+      expect(management).toBeDefined();
+      expect(typeof management?.name).toBe("string");
+      expect(management!.name!.length).toBeGreaterThan(0);
+      expect(typeof management?.email).toBe("string");
+      expect(management!.email!.length).toBeGreaterThan(0);
     }
   }),
 );

--- a/packages/alchemy/test/AWS/Organizations/Organization.test.ts
+++ b/packages/alchemy/test/AWS/Organizations/Organization.test.ts
@@ -32,6 +32,10 @@ test.provider("list returns the organization singleton", (stack) =>
         true,
       );
       expect(Array.isArray(org.availablePolicyTypes)).toBe(true);
+      if (org.managementAccountEmail != null) {
+        expect(typeof org.managementAccountEmail).toBe("string");
+        expect(org.managementAccountEmail.length).toBeGreaterThan(0);
+      }
     }
 
     yield* stack.destroy();


### PR DESCRIPTION
Unwrap Distilled `SensitiveString` Name/Email so Organizations account lookup and persisted attributes are plain strings. Closes #1555.

```ts
unredact(candidate.Name) === name || unredact(candidate.Email) === email
```

After `CreateAccount`, read by the returned AccountId instead of re-listing by name:

```ts
const status = yield* waitForCreateAccount(requestId);
state = status.AccountId
  ? yield* readAccountById(status.AccountId)
  : yield* readAccountByNameOrEmail({ name: news.name, email: news.email });
```

`AccountAssignment.read` returns undefined when `targetId` (or other identifying fields) is missing, so a `creating` row does not call `ListAccountAssignments` with `AccountId: undefined`.
