### PR TITLE
fix(deps): update to effect 4.0.0-rc.113

### DIFF
--- a/examples/aws-dev/src/ApiFunction.ts
+++ b/examples/aws-dev/src/ApiFunction.ts
@@ -144,7 +144,7 @@ export default class ApiFunction extends Lambda.Function<ApiFunction>()(
         const url = new URL(request.originalUrl);
 
         if (url.pathname === "/") {
-          const variable = yield* Config.string("MY_VARIABLE");
+          const variable = yield* Config.String("MY_VARIABLE");
           return yield* HttpServerResponse.json({ marker: MARKER, variable });
         }
 

--- a/examples/cloudflare-dev/alchemy.run.ts
+++ b/examples/cloudflare-dev/alchemy.run.ts
@@ -76,7 +76,7 @@ const AsyncWorker = (deps: {
           className: "QueueMessages",
         }),
         MY_VARIABLE: "my-variable-abc123",
-        MY_SECRET: Config.redacted("MY_SECRET").pipe(
+        MY_SECRET: Config.Redacted("MY_SECRET").pipe(
           Config.withDefault(Redacted.make("my-secret-abc123")),
         ),
         // The worker's own URL, injected as a plain-text binding (`self_url`).

--- a/examples/cloudflare-dev/src/EffectWorker.ts
+++ b/examples/cloudflare-dev/src/EffectWorker.ts
@@ -42,7 +42,7 @@ export default class EffectWorker extends Cloudflare.Worker<EffectWorker>()(
   {
     main: import.meta.url,
     dev: {
-      port: Config.number("PORT").pipe(Config.withDefault(1338)),
+      port: Config.Number("PORT").pipe(Config.withDefault(1338)),
     },
     build: {
       bundleAnalyzer: true,

--- a/examples/cloudflare-dev/src/NotifyWorkflow.ts
+++ b/examples/cloudflare-dev/src/NotifyWorkflow.ts
@@ -14,9 +14,9 @@ export default class NotifyWorkflow extends Cloudflare.Workflow<NotifyWorkflow>(
   "Notifier",
   Effect.gen(function* () {
     // Bind a `secret_text` on the workflow at plantime. Using a literal
-    // (instead of `Config.redacted("WORKFLOW_SECRET")`) keeps the integ
+    // (instead of `Config.Redacted("WORKFLOW_SECRET")`) keeps the integ
     // test self-contained — no `.env` setup required.
-    const secret = yield* Config.redacted("WORKFLOW_SECRET").pipe(
+    const secret = yield* Config.Redacted("WORKFLOW_SECRET").pipe(
       Config.withDefault(Redacted.make(WORKFLOW_SECRET_VALUE)),
     );
     // Regression guard for https://github.com/alchemy-run/alchemy/pull/71

--- a/examples/cloudflare-worker-async/alchemy.run.ts
+++ b/examples/cloudflare-worker-async/alchemy.run.ts
@@ -28,7 +28,7 @@ export const Worker = Cloudflare.Worker("Worker", {
   env: {
     // Self-contained default so the example deploys without external secrets;
     // the integ test asserts this value round-trips through env.API_KEY.
-    API_KEY: Config.redacted("SOME_API_KEY").pipe(
+    API_KEY: Config.Redacted("SOME_API_KEY").pipe(
       Config.withDefault("SOME_API_KEY"),
     ),
     DB,

--- a/examples/cloudflare-worker/src/NotifyWorkflow.ts
+++ b/examples/cloudflare-worker/src/NotifyWorkflow.ts
@@ -17,7 +17,7 @@ export default class NotifyWorkflow extends Cloudflare.Workflow<NotifyWorkflow>(
   Effect.gen(function* () {
     const rooms = yield* Room;
 
-    const secret = yield* Config.redacted("WORKFLOW_SECRET").pipe(
+    const secret = yield* Config.Redacted("WORKFLOW_SECRET").pipe(
       Config.withDefault(WORKFLOW_SECRET_VALUE),
     );
 

--- a/examples/dev-stress/src/ApiFunction.ts
+++ b/examples/dev-stress/src/ApiFunction.ts
@@ -75,7 +75,7 @@ export default class ApiFunction extends Lambda.Function<ApiFunction>()(
         const url = new URL(request.originalUrl);
 
         if (url.pathname === "/") {
-          const variable = yield* Config.string("LAMBDA_VARIABLE");
+          const variable = yield* Config.String("LAMBDA_VARIABLE");
           return yield* HttpServerResponse.json({
             marker: LAMBDA_MARKER,
             variable,

--- a/examples/docker-postgres/alchemy.run.ts
+++ b/examples/docker-postgres/alchemy.run.ts
@@ -15,7 +15,7 @@ export default Alchemy.Stack(
     state: Alchemy.localState(),
   },
   Effect.gen(function* () {
-    const configuredPassword = yield* Config.redacted("POSTGRES_PASSWORD").pipe(
+    const configuredPassword = yield* Config.Redacted("POSTGRES_PASSWORD").pipe(
       Config.option,
     );
     const password = yield* Option.match(configuredPassword, {

--- a/examples/fly-service/src/api.ts
+++ b/examples/fly-service/src/api.ts
@@ -7,7 +7,7 @@ import { API_PORT, Marker, SECRET_NAME, Site } from "./shared.ts";
 
 /**
  * HTTP Service: Fly injects {@link Marker} as env `{@link SECRET_NAME}`.
- * Read it from `fetch` with `Config.string` — never the plaintext.
+ * Read it from `fetch` with `Config.String` — never the plaintext.
  */
 export default class Api extends Fly.Service<Api>()(
   "Api",
@@ -25,7 +25,7 @@ export default class Api extends Fly.Service<Api>()(
       fetch: Effect.gen(function* () {
         const request = yield* HttpServerRequest;
         const url = new URL(request.url, "http://service");
-        const value = yield* Config.string(SECRET_NAME).pipe(
+        const value = yield* Config.String(SECRET_NAME).pipe(
           Effect.orElseSucceed(() => ""),
         );
         const body = {

--- a/examples/fly-sprite/src/box.ts
+++ b/examples/fly-sprite/src/box.ts
@@ -8,7 +8,7 @@ import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 
 /**
  * HTTP Sprite. Yield FileSystem in init, not inside fetch.
- * Config.redacted is written onto the Sprite at deploy time.
+ * Config.Redacted is written onto the Sprite at deploy time.
  */
 export default class Box extends Fly.Sprite<Box>()(
   "Box",
@@ -18,10 +18,10 @@ export default class Box extends Fly.Sprite<Box>()(
     port: 3000,
   },
   Effect.gen(function* () {
-    const marker = yield* Config.string("SPRITE_MARKER").pipe(
+    const marker = yield* Config.String("SPRITE_MARKER").pipe(
       Config.withDefault("hello-from-fly-sprite"),
     );
-    const apiKey = yield* Config.redacted("API_KEY").pipe(
+    const apiKey = yield* Config.Redacted("API_KEY").pipe(
       Config.withDefault(Redacted.make("unused")),
     );
     const fs = yield* FileSystem.FileSystem;

--- a/examples/hetzner-server/alchemy.run.ts
+++ b/examples/hetzner-server/alchemy.run.ts
@@ -13,7 +13,7 @@ export default Alchemy.Stack(
     state: Alchemy.localState(),
   },
   Effect.gen(function* () {
-    const publicKey = yield* Config.string("SSH_PUBLIC_KEY").pipe(
+    const publicKey = yield* Config.String("SSH_PUBLIC_KEY").pipe(
       Config.withDefault(DEFAULT_PUBLIC_KEY),
     );
     const key = yield* Hetzner.SshKey("deploy", { publicKey });

--- a/examples/hetzner-website-vite/src/api.ts
+++ b/examples/hetzner-website-vite/src/api.ts
@@ -37,7 +37,7 @@ export default class Api extends Hetzner.Service<Api>()(
   }),
   Effect.succeed({
     fetch: Effect.gen(function* () {
-      const databaseUrl = yield* Config.redacted("DATABASE_URL");
+      const databaseUrl = yield* Config.Redacted("DATABASE_URL");
       const db = yield* Drizzle.Postgres(Effect.succeed(databaseUrl));
       const request = yield* HttpServerRequest;
       const path = new URL(request.url, "http://service").pathname;

--- a/examples/prisma-compute-effect/src/Api.ts
+++ b/examples/prisma-compute-effect/src/Api.ts
@@ -5,7 +5,7 @@ import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 import { Connection, Project, region, appNameConfig } from "./Database.ts";
 
-const messageConfig = Config.string("PRISMA_EFFECT_MESSAGE").pipe(
+const messageConfig = Config.String("PRISMA_EFFECT_MESSAGE").pipe(
   Effect.orElseSucceed(() => "hello from Effect-native Prisma Compute"),
 );
 

--- a/examples/prisma-compute-effect/src/Database.ts
+++ b/examples/prisma-compute-effect/src/Database.ts
@@ -7,7 +7,7 @@ export const region = "eu-west-3" as const;
 
 export const appNameConfig = Effect.gen(function* () {
   const stage = yield* Stage;
-  return yield* Config.string("PRISMA_EFFECT_APP").pipe(
+  return yield* Config.String("PRISMA_EFFECT_APP").pipe(
     Effect.orElseSucceed(() => `alchemy-prisma-compute-effect-${stage}`),
   );
 });
@@ -16,7 +16,7 @@ export const Project = Prisma.Project(
   "Project",
   Effect.gen(function* () {
     return {
-      name: yield* Config.string("PRISMA_PROJECT").pipe(
+      name: yield* Config.String("PRISMA_PROJECT").pipe(
         Effect.orElseSucceed(() => undefined),
       ),
       createDatabase: false,

--- a/examples/prisma-tanstack-start/alchemy.run.ts
+++ b/examples/prisma-tanstack-start/alchemy.run.ts
@@ -9,7 +9,7 @@ import * as Layer from "effect/Layer";
 import * as Redacted from "effect/Redacted";
 
 const tanstackMessageConfig = (fallback: string) =>
-  Config.string("TANSTACK_MESSAGE").pipe(Effect.orElseSucceed(() => fallback));
+  Config.String("TANSTACK_MESSAGE").pipe(Effect.orElseSucceed(() => fallback));
 
 export default Alchemy.Stack(
   "PrismaTanstackStart",
@@ -19,13 +19,13 @@ export default Alchemy.Stack(
   },
   Effect.gen(function* () {
     const stage = yield* Alchemy.Stage;
-    const appName = yield* Config.string("PRISMA_TANSTACK_APP").pipe(
+    const appName = yield* Config.String("PRISMA_TANSTACK_APP").pipe(
       Effect.orElseSucceed(() => `alchemy-prisma-tanstack-start-${stage}`),
     );
-    const customDomainHostname = yield* Config.string(
+    const customDomainHostname = yield* Config.String(
       "PRISMA_TANSTACK_DOMAIN",
     ).pipe(Effect.orElseSucceed(() => undefined));
-    const devPort = yield* Config.number("PRISMA_TANSTACK_DEV_PORT").pipe(
+    const devPort = yield* Config.Number("PRISMA_TANSTACK_DEV_PORT").pipe(
       Effect.orElseSucceed(() => 3000),
     );
 
@@ -34,7 +34,7 @@ export default Alchemy.Stack(
     // `createDatabase: false` keeps the example explicit so the database below
     // is visible as its own Alchemy resource.
     const project = yield* Prisma.Project("Project", {
-      name: yield* Config.string("PRISMA_PROJECT").pipe(
+      name: yield* Config.String("PRISMA_PROJECT").pipe(
         Effect.orElseSucceed(() => undefined),
       ),
       createDatabase: false,

--- a/examples/railway-service/alchemy.run.ts
+++ b/examples/railway-service/alchemy.run.ts
@@ -3,7 +3,7 @@
  *
  * - `Site` — parent Project (`src/shared.ts`)
  * - `Staging` — extra Environment (production is on the Project)
- * - `Marker` — shared Variable the Api reads via `Config.string`
+ * - `Marker` — shared Variable the Api reads via `Config.String`
  * - `Disk` — Volume the Worker mounts with `MountVolume`
  * - `Db` — Postgres + `ConnectPostgres` / Drizzle
  * - `Mysql` — MySQL (same shape as Postgres)

--- a/examples/railway-service/src/api.ts
+++ b/examples/railway-service/src/api.ts
@@ -61,7 +61,7 @@ export default class Api extends Railway.Service<Api>()(
         const path = new URL(request.url, "http://service").pathname;
 
         if (path === "/secret") {
-          const value = yield* Config.string(SECRET_NAME).pipe(
+          const value = yield* Config.String(SECRET_NAME).pipe(
             Effect.orElseSucceed(() => ""),
           );
           return yield* HttpServerResponse.json({

--- a/examples/railway-service/src/shared.ts
+++ b/examples/railway-service/src/shared.ts
@@ -28,7 +28,7 @@ export const Staging = Railway.Environment("Staging", {
 
 /**
  * Shared project variable. {@link Api} pulls it into service env with
- * `Railway.ref("shared", SECRET_NAME)` and reads it via `Config.string`.
+ * `Railway.ref("shared", SECRET_NAME)` and reads it via `Config.String`.
  */
 export const Marker = Railway.Variable("Marker", {
   project: Site,

--- a/examples/railway-website-vite/alchemy.run.ts
+++ b/examples/railway-website-vite/alchemy.run.ts
@@ -7,7 +7,7 @@ import * as Option from "effect/Option";
 import Api from "./src/api.ts";
 import { Db, Site } from "./src/shared.ts";
 
-const RAILWAY_TEST_DOMAIN = Config.string("RAILWAY_TEST_DOMAIN").pipe(
+const RAILWAY_TEST_DOMAIN = Config.String("RAILWAY_TEST_DOMAIN").pipe(
   Config.option,
   Config.map(Option.getOrUndefined),
 );

--- a/fixtures/tanstack-start/e2e.config.ts
+++ b/fixtures/tanstack-start/e2e.config.ts
@@ -3,7 +3,7 @@ import * as Options from "@alchemy.run/cloudflare-test-tools/e2e/Options";
 import * as Config from "effect/Config";
 import * as Effect from "effect/Effect";
 
-export default Config.string("TEST_POSTGRES_URL").pipe(
+export default Config.String("TEST_POSTGRES_URL").pipe(
   Config.orElse(() => Config.succeed("")),
   Effect.map((url) =>
     Options.make({

--- a/fixtures/tanstack-start/src/db.ts
+++ b/fixtures/tanstack-start/src/db.ts
@@ -13,7 +13,7 @@ const services = Layer.mergeAll(
 
 export const fetchSql = () =>
   Effect.gen(function* () {
-    const url = yield* Config.redacted("TEST_POSTGRES_URL");
+    const url = yield* Config.Redacted("TEST_POSTGRES_URL");
     const client = yield* PgClient.make({ url });
     const result = yield* client`SELECT 1`;
     return result;

--- a/packages/alchemy-test/src/cli.ts
+++ b/packages/alchemy-test/src/cli.ts
@@ -38,37 +38,37 @@ import { run, type RunOptions } from "./Runner.ts";
 import { captureStrayOutput } from "./StrayOutput.ts";
 import { TuiReporter } from "./Tui.ts";
 
-const paths = Argument.string("paths").pipe(
+const paths = Argument.String("paths").pipe(
   Argument.withDescription("Test files or directories (default: ./test)"),
   Argument.variadic(),
 );
 
-const testNamePattern = Flag.string("test-name-pattern").pipe(
+const testNamePattern = Flag.String("test-name-pattern").pipe(
   Flag.withAlias("t"),
   Flag.withDescription("Only run tests whose title matches this regex"),
   Flag.optional,
 );
 
-const exclude = Flag.string("exclude").pipe(
+const exclude = Flag.String("exclude").pipe(
   Flag.withDescription(
     "Skip test files under this path (repeatable). Existing files/directories exclude by prefix; anything else is a case-insensitive substring filter. Explicitly passing an excluded path as a positional argument overrides the exclusion.",
   ),
   Flag.atLeast(0),
 );
 
-const timeout = Flag.integer("timeout").pipe(
+const timeout = Flag.Int("timeout").pipe(
   Flag.withDescription("Default per-test timeout in milliseconds"),
   Flag.withDefault(120_000),
 );
 
-const retry = Flag.integer("retry").pipe(
+const retry = Flag.Int("retry").pipe(
   Flag.withDescription(
     "Times a failing test is retried before failing the run",
   ),
   Flag.withDefault(2),
 );
 
-const concurrency = Flag.string("concurrency").pipe(
+const concurrency = Flag.String("concurrency").pipe(
   Flag.withAlias("c"),
   Flag.withDescription(
     'Maximum number of files running concurrently: a number (default 32) or "unbounded". Unbounded runs of large suites saturate the event loop and drown real failures in spurious 0ms beforeAll timeouts.',
@@ -87,26 +87,26 @@ const toConcurrency = (value: string): number | "unbounded" => {
   return parsed;
 };
 
-const sequential = Flag.boolean("sequential").pipe(
+const sequential = Flag.Boolean("sequential").pipe(
   Flag.withDescription("Run tests within each file sequentially"),
   Flag.withDefault(false),
 );
 
-const tui = Flag.boolean("tui").pipe(
+const tui = Flag.Boolean("tui").pipe(
   Flag.withDescription(
     "Opt in to the interactive TUI (default is plain line output)",
   ),
   Flag.withDefault(false),
 );
 
-const profile = Flag.string("profile").pipe(
+const profile = Flag.String("profile").pipe(
   Flag.withDescription(
     'Set ALCHEMY_PROFILE for the run (e.g. "testing") before any test module is imported',
   ),
   Flag.optional,
 );
 
-const fast = Flag.boolean("fast").pipe(
+const fast = Flag.Boolean("fast").pipe(
   Flag.withDescription(
     "Set FAST=1 — suites skip their slow tests (long-provisioning resources, smoke tests)",
   ),

--- a/packages/alchemy/src/AWS/Bedrock/LanguageModel.ts
+++ b/packages/alchemy/src/AWS/Bedrock/LanguageModel.ts
@@ -252,14 +252,14 @@ export const makeLanguageModelLayer = (
   Layer.effect(AiLanguageModel.LanguageModel, makeLanguageModel(options));
 
 /**
- * Build an {@link AiLanguageModel.Service} that proxies generateText /
+ * Build an {@link AiLanguageModel.LanguageModel} that proxies generateText /
  * streamText through the Bedrock Converse API.
  */
 export const makeLanguageModel = ({
   converse,
   converseStream,
   parameters,
-}: MakeLanguageModelOptions): Effect.Effect<AiLanguageModel.Service> =>
+}: MakeLanguageModelOptions): Effect.Effect<AiLanguageModel.LanguageModel> =>
   AiLanguageModel.make({
     generateText: (options) =>
       Effect.gen(function* () {

--- a/packages/alchemy/src/AWS/EKS/KubernetesAdapter.ts
+++ b/packages/alchemy/src/AWS/EKS/KubernetesAdapter.ts
@@ -303,8 +303,8 @@ const program = tag.pipe(
     layer.pipe(Layer.provideMerge(Layer.effect(
       Stack,
       Effect.all([
-        Config.string("ALCHEMY_STACK_NAME"),
-        Config.string("ALCHEMY_STAGE")
+        Config.String("ALCHEMY_STACK_NAME"),
+        Config.String("ALCHEMY_STAGE")
       ]).pipe(
         Effect.map(([name, stage]) => ({
           name,
@@ -388,8 +388,8 @@ const program = tag.pipe(
     layer.pipe(Layer.provideMerge(Layer.effect(
       Stack,
       Effect.all([
-        Config.string("ALCHEMY_STACK_NAME"),
-        Config.string("ALCHEMY_STAGE")
+        Config.String("ALCHEMY_STACK_NAME"),
+        Config.String("ALCHEMY_STAGE")
       ]).pipe(
         Effect.map(([name, stage]) => ({
           name,

--- a/packages/alchemy/src/AWS/Environment.ts
+++ b/packages/alchemy/src/AWS/Environment.ts
@@ -15,15 +15,15 @@ import {
   type AwsResolvedCredentials,
 } from "./AuthProvider.ts";
 
-export const AWS_PROFILE = Config.string("AWS_PROFILE").pipe(
+export const AWS_PROFILE = Config.String("AWS_PROFILE").pipe(
   Config.withDefault("default"),
 );
 
-export const AWS_REGION = Config.string("AWS_REGION");
-export const AWS_ACCOUNT_ID = Config.string("AWS_ACCOUNT_ID");
-export const AWS_ACCESS_KEY_ID = Config.string("AWS_ACCESS_KEY_ID");
-export const AWS_SECRET_ACCESS_KEY = Config.redacted("AWS_SECRET_ACCESS_KEY");
-export const AWS_SESSION_TOKEN = Config.redacted("AWS_SESSION_TOKEN");
+export const AWS_REGION = Config.String("AWS_REGION");
+export const AWS_ACCOUNT_ID = Config.String("AWS_ACCOUNT_ID");
+export const AWS_ACCESS_KEY_ID = Config.String("AWS_ACCESS_KEY_ID");
+export const AWS_SECRET_ACCESS_KEY = Config.Redacted("AWS_SECRET_ACCESS_KEY");
+export const AWS_SESSION_TOKEN = Config.Redacted("AWS_SESSION_TOKEN");
 
 export type AccountID = string;
 export type RegionID = string;

--- a/packages/alchemy/src/AWS/Lambda/Function.ts
+++ b/packages/alchemy/src/AWS/Lambda/Function.ts
@@ -1012,7 +1012,7 @@ export const Function: Platform<
       get: <T>(key: string) =>
         // Key is already canonical (see RuntimeContext.sanitizeKey). Read
         // straight from `process.env` — see `unpackEnvValue` for why this
-        // must never resolve through `Config.string`.
+        // must never resolve through `Config.String`.
         Effect.sync(() => unpackEnvValue<T>(process.env[key])),
       serve: (handler: HttpEffect) =>
         // @ts-ignore

--- a/packages/alchemy/src/AWS/Lambda/MicrovmRuntimeContext.ts
+++ b/packages/alchemy/src/AWS/Lambda/MicrovmRuntimeContext.ts
@@ -59,7 +59,7 @@ export const makeMicrovmRuntimeContext = (
       }),
     get: <T>(key: string) =>
       // Read straight from `process.env` — see `unpackEnvValue` for why
-      // this must never resolve through `Config.string`.
+      // this must never resolve through `Config.String`.
       Effect.sync(() => unpackEnvValue<T>(process.env[key]) as T),
     run: ((effect: Effect.Effect<void, never, any>) =>
       Effect.sync(() => {

--- a/packages/alchemy/src/Alchemist/routes/nuke.ts
+++ b/packages/alchemy/src/Alchemist/routes/nuke.ts
@@ -52,7 +52,7 @@ export const scan = Effect.fn("Alchemist.nuke.scan")(function* (
   input: ScanInput,
 ) {
   const report = withSpanEvents(yield* Progress);
-  const debug = yield* Config.string("DEBUG").pipe(
+  const debug = yield* Config.String("DEBUG").pipe(
     Config.withDefault(""),
     Effect.map((value) => value.length > 0),
   );

--- a/packages/alchemy/src/Auth/AuthProvider.ts
+++ b/packages/alchemy/src/Auth/AuthProvider.ts
@@ -149,7 +149,7 @@ export const presentEnvironment = (
     for (const variable of environment) {
       let found: string | undefined;
       for (const name of [variable.name, ...(variable.alternatives ?? [])]) {
-        const value = yield* Config.option(Config.string(name));
+        const value = yield* Config.option(Config.String(name));
         if (Option.isSome(value) && value.value !== "") {
           found = name;
           break;

--- a/packages/alchemy/src/Auth/Demand.ts
+++ b/packages/alchemy/src/Auth/Demand.ts
@@ -280,7 +280,7 @@ export const demandCredentials = Effect.fn("Alchemy.demandCredentials")(
       yield* Effect.serviceOption(ProfileStore),
     );
     if (registry === undefined || profile === undefined) return;
-    const ci = yield* Config.boolean("CI").pipe(Config.withDefault(false));
+    const ci = yield* Config.Boolean("CI").pipe(Config.withDefault(false));
     // CI credentials come exclusively from the environment. Do not require
     // or inspect a local profile first: CI runners intentionally have no
     // profile manifest, and doing so would also risk consulting a developer's

--- a/packages/alchemy/src/Auth/Env.ts
+++ b/packages/alchemy/src/Auth/Env.ts
@@ -5,7 +5,7 @@ import * as Interaction from "../Interaction.ts";
 import { AuthError } from "./AuthProvider.ts";
 
 export const getEnv = (key: string) =>
-  Config.option(Config.string(key)).pipe(
+  Config.option(Config.String(key)).pipe(
     Effect.map(Option.getOrUndefined),
     Effect.mapError(
       (cause) =>
@@ -17,7 +17,7 @@ export const getEnv = (key: string) =>
   );
 
 export const getEnvRequired = (key: string) =>
-  Config.string(key).pipe(
+  Config.String(key).pipe(
     Effect.mapError(
       (cause) =>
         new AuthError({ message: `Missing required env: ${key}`, cause }),
@@ -25,7 +25,7 @@ export const getEnvRequired = (key: string) =>
   );
 
 export const getEnvRedacted = (key: string) =>
-  Config.option(Config.redacted(key)).pipe(
+  Config.option(Config.Redacted(key)).pipe(
     Effect.map(Option.getOrUndefined),
     Effect.mapError(
       (cause) =>
@@ -37,7 +37,7 @@ export const getEnvRedacted = (key: string) =>
   );
 
 export const getEnvRedactedRequired = (key: string) =>
-  Config.redacted(key).pipe(
+  Config.Redacted(key).pipe(
     Effect.mapError(
       (cause) =>
         new AuthError({ message: `Missing required env: ${key}`, cause }),

--- a/packages/alchemy/src/Auth/Profile.ts
+++ b/packages/alchemy/src/Auth/Profile.ts
@@ -35,7 +35,7 @@ export {
 } from "./Paths.ts";
 
 /** Config key selecting a directory under `~/.alchemy/profiles`. */
-export const ALCHEMY_PROFILE = Config.string("ALCHEMY_PROFILE");
+export const ALCHEMY_PROFILE = Config.String("ALCHEMY_PROFILE");
 
 /** Version of the synthesized in-memory manifest returned by readManifest. */
 export const PROFILE_MANIFEST_VERSION = 3;

--- a/packages/alchemy/src/Auth/Resolve.ts
+++ b/packages/alchemy/src/Auth/Resolve.ts
@@ -78,7 +78,7 @@ export const resolveProviderConfig = <
         };
       }
     }
-    const ci = yield* Config.boolean("CI").pipe(Config.withDefault(false));
+    const ci = yield* Config.Boolean("CI").pipe(Config.withDefault(false));
     if (ci) {
       if (auth.readEnvironment === undefined) {
         return yield* Effect.fail(

--- a/packages/alchemy/src/Cli/LoggingCli.ts
+++ b/packages/alchemy/src/Cli/LoggingCli.ts
@@ -214,7 +214,7 @@ export const LoggingCli = Layer.effect(
     // (no requirements on the returned Effects).
     const promptContext = yield* Effect.context<Prompt.Environment>();
     const confirm = (options: Prompt.ConfirmOptions) =>
-      Prompt.confirm(options).pipe(
+      Prompt.Confirm(options).pipe(
         Effect.catchTag("QuitError", () => Effect.succeed(false)),
         Effect.provideContext(promptContext),
       );

--- a/packages/alchemy/src/Cli/commands/aws.ts
+++ b/packages/alchemy/src/Cli/commands/aws.ts
@@ -9,13 +9,13 @@ import { confirmOrDecline } from "./confirm.ts";
 import { envFile, yes } from "./flags.ts";
 import { instrumentCommand } from "./instrument.ts";
 
-const awsProfile = Flag.string("aws-profile").pipe(
+const awsProfile = Flag.String("aws-profile").pipe(
   Flag.withDescription("AWS CLI/SSO profile to use for bootstrap credentials"),
   Flag.optional,
   Flag.map(Option.getOrElse(() => "default")),
 );
 
-const awsRegion = Flag.string("region").pipe(
+const awsRegion = Flag.String("region").pipe(
   Flag.withDescription(
     "AWS region to bootstrap (defaults to AWS_REGION env var)",
   ),

--- a/packages/alchemy/src/Cli/commands/cloudflare.ts
+++ b/packages/alchemy/src/Cli/commands/cloudflare.ts
@@ -47,7 +47,7 @@ export const formatCreatedCloudflareToken = (
     ),
   ].join("\n");
 
-const cloudflareForce = Flag.boolean("force").pipe(
+const cloudflareForce = Flag.Boolean("force").pipe(
   Flag.withDescription(
     "Force a full redeploy even if the state-store worker already exists. " +
       "Without this flag, an existing worker is adopted and only its credentials are refreshed.",
@@ -55,7 +55,7 @@ const cloudflareForce = Flag.boolean("force").pipe(
   Flag.withDefault(false),
 );
 
-const cloudflareWorkerName = Flag.string("worker-name").pipe(
+const cloudflareWorkerName = Flag.String("worker-name").pipe(
   Flag.withDescription(
     "Override the default state-store worker name (advanced; only needed for multiple state stores per account).",
   ),
@@ -132,7 +132,7 @@ const teardownCommand = Command.make(
   Command.withDescription("Tear down the Cloudflare state store"),
   Command.unlisted,
 );
-const allPermissionsFlag = Flag.boolean("all-permissions").pipe(
+const allPermissionsFlag = Flag.Boolean("all-permissions").pipe(
   Flag.withDescription(
     "Grant the token EVERY Cloudflare permission group (a 'god token'). " +
       "Use with care — it has full access to your account.",
@@ -140,7 +140,7 @@ const allPermissionsFlag = Flag.boolean("all-permissions").pipe(
   Flag.withDefault(false),
 );
 
-const tokenNameFlag = Flag.string("name").pipe(
+const tokenNameFlag = Flag.String("name").pipe(
   Flag.withDescription(
     "Name for the API token. Defaults to 'alchemy' (or 'alchemy-all-permissions').",
   ),
@@ -148,7 +148,7 @@ const tokenNameFlag = Flag.string("name").pipe(
   Flag.map(Option.getOrUndefined),
 );
 
-const tokenAccountIdFlag = Flag.string("account-id").pipe(
+const tokenAccountIdFlag = Flag.String("account-id").pipe(
   Flag.withDescription(
     "Cloudflare account ID(s) to scope the token to (comma-separated for " +
       "multiple). If omitted, you'll be prompted to select from your accounts.",
@@ -217,7 +217,7 @@ const createTokenCommand = Command.make(
         );
       const apiKey =
         (yield* read(
-          Config.string("CLOUDFLARE_API_KEY").pipe(Config.option),
+          Config.String("CLOUDFLARE_API_KEY").pipe(Config.option),
         )) ??
         (yield* prompt.prompt.password({
           message:
@@ -226,7 +226,7 @@ const createTokenCommand = Command.make(
             value.trim().length === 0 ? "Required" : undefined,
         }));
       const email =
-        (yield* read(Config.string("CLOUDFLARE_EMAIL").pipe(Config.option))) ??
+        (yield* read(Config.String("CLOUDFLARE_EMAIL").pipe(Config.option))) ??
         (yield* prompt.prompt.text({
           message: "Cloudflare account email",
           validate: (value) =>
@@ -307,7 +307,7 @@ const createTokenCommand = Command.make(
   ),
 ).pipe(Command.withDescription("Create a scoped Cloudflare API token"));
 
-const tailFlag = Flag.boolean("tail").pipe(
+const tailFlag = Flag.Boolean("tail").pipe(
   Flag.withAlias("t"),
   Flag.withDescription(
     "Stream logs in real time via the Cloudflare tail websocket instead of fetching past entries.",
@@ -315,12 +315,12 @@ const tailFlag = Flag.boolean("tail").pipe(
   Flag.withDefault(false),
 );
 
-const limitFlag = Flag.integer("limit").pipe(
+const limitFlag = Flag.Int("limit").pipe(
   Flag.withDescription("Number of log entries to fetch (ignored with --tail)"),
   Flag.withDefault(100),
 );
 
-const sinceFlag = Flag.string("since").pipe(
+const sinceFlag = Flag.String("since").pipe(
   Flag.withDescription(
     "Fetch logs since this time (e.g. '1h', '30m', '2024-01-01T00:00:00Z')",
   ),

--- a/packages/alchemy/src/Cli/commands/deploy.ts
+++ b/packages/alchemy/src/Cli/commands/deploy.ts
@@ -51,7 +51,7 @@ const stackSpanAttrs = (args: StackCommandOptions) => ({
   "alchemy.detect_drift": !!args.detectDrift,
 });
 
-const adopt = Flag.boolean("adopt").pipe(
+const adopt = Flag.Boolean("adopt").pipe(
   Flag.withDescription(
     "Adopt pre-existing cloud resources that conflict with this stack instead of failing. " +
       "Useful for re-importing infrastructure into a fresh state store.",
@@ -59,12 +59,12 @@ const adopt = Flag.boolean("adopt").pipe(
   Flag.withDefault(false),
 );
 
-const detailed = Flag.boolean("detailed").pipe(
+const detailed = Flag.Boolean("detailed").pipe(
   Flag.withDescription("Show declared resource properties as YAML"),
   Flag.withDefault(false),
 );
 
-const detectDrift = Flag.boolean("detect-drift").pipe(
+const detectDrift = Flag.Boolean("detect-drift").pipe(
   Flag.withDescription(
     "Detect infrastructure drift and offer to repair it before deploying",
   ),

--- a/packages/alchemy/src/Cli/commands/drift.ts
+++ b/packages/alchemy/src/Cli/commands/drift.ts
@@ -12,7 +12,7 @@ import { config, envFile, profile, resolveStage, stage } from "./flags.ts";
 import { instrumentCommand } from "./instrument.ts";
 import { renderApply, renderPlanning } from "./render.ts";
 
-const repairFlag = Flag.boolean("repair").pipe(
+const repairFlag = Flag.Boolean("repair").pipe(
   Flag.withDescription("Repair detected drift without prompting"),
   Flag.withDefault(false),
 );

--- a/packages/alchemy/src/Cli/commands/flags.ts
+++ b/packages/alchemy/src/Cli/commands/flags.ts
@@ -10,12 +10,12 @@ import * as Flag from "effect/unstable/cli/Flag";
 import { loadConfigProvider } from "../../Util/ConfigProvider.ts";
 import { UserInputError } from "./errors.ts";
 
-export const USER = Config.string("USER").pipe(
-  Config.orElse(() => Config.string("USERNAME")),
+export const USER = Config.String("USER").pipe(
+  Config.orElse(() => Config.String("USERNAME")),
   Config.withDefault("unknown"),
 );
 
-export const ALCHEMY_STAGE = Config.string("ALCHEMY_STAGE").pipe(
+export const ALCHEMY_STAGE = Config.String("ALCHEMY_STAGE").pipe(
   Config.option,
   Effect.map(Option.getOrUndefined),
 );
@@ -23,7 +23,7 @@ export const ALCHEMY_STAGE = Config.string("ALCHEMY_STAGE").pipe(
 const STAGE_NAME_PATTERN = /^[a-z0-9]+([-_a-z0-9]+)*$/i;
 
 const makeStageFlag = (kind: "live" | "dev") =>
-  Flag.string("stage").pipe(
+  Flag.String("stage").pipe(
     Flag.withSchema(
       Schema.String.check(Schema.isPattern(/^[a-z0-9]+([-_a-z0-9]+)*$/gi)),
     ),
@@ -75,45 +75,45 @@ export const resolveStage = Effect.fn(function* (
   );
 });
 
-export const envFile = Flag.file("env-file").pipe(
+export const envFile = Flag.File("env-file").pipe(
   Flag.optional,
   Flag.withDescription(
     "File to load environment variables from, defaults to .env",
   ),
 );
 
-export const dryRun = Flag.boolean("dry-run").pipe(
+export const dryRun = Flag.Boolean("dry-run").pipe(
   Flag.withDescription("Dry run the deployment, do not actually deploy"),
   Flag.withDefault(false),
 );
 
-export const yes = Flag.boolean("yes").pipe(
+export const yes = Flag.Boolean("yes").pipe(
   Flag.withAlias("y"),
   Flag.withDescription("Yes to all prompts"),
   Flag.withDefault(false),
 );
 
-export const force = Flag.boolean("force").pipe(
+export const force = Flag.Boolean("force").pipe(
   Flag.withDescription(
     "Force updates for resources that would otherwise no-op",
   ),
   Flag.withDefault(false),
 );
 
-export const config = Flag.file("config", { mustExist: true }).pipe(
+export const config = Flag.File("config", { mustExist: true }).pipe(
   Flag.withDescription("Alchemy entrypoint file (default: alchemy.run.ts)"),
   Flag.withAlias("c"),
   Flag.withDefault("alchemy.run.ts"),
 );
 
-export const optionalConfig = Flag.file("config", { mustExist: true }).pipe(
+export const optionalConfig = Flag.File("config", { mustExist: true }).pipe(
   Flag.withDescription("Alchemy entrypoint file (default: alchemy.run.ts)"),
   Flag.withAlias("c"),
   Flag.optional,
   Flag.map(Option.getOrUndefined),
 );
 
-export const configPath = Argument.file("config", { mustExist: true }).pipe(
+export const configPath = Argument.File("config", { mustExist: true }).pipe(
   Argument.withDescription("Alchemy entrypoint file (default: alchemy.run.ts)"),
   Argument.optional,
   Argument.map(Option.getOrUndefined),
@@ -158,7 +158,7 @@ export const resolveStackArgs =
       return { ...resolved, stage };
     });
 
-export const profile = Flag.string("profile").pipe(
+export const profile = Flag.String("profile").pipe(
   Flag.withDescription(
     "Auth profile to use. Defaults to $ALCHEMY_PROFILE or 'default'.",
   ),

--- a/packages/alchemy/src/Cli/commands/logs.ts
+++ b/packages/alchemy/src/Cli/commands/logs.ts
@@ -17,18 +17,18 @@ import {
 } from "./flags.ts";
 import { instrumentCommand } from "./instrument.ts";
 
-const logsLimit = Flag.integer("limit").pipe(
+const logsLimit = Flag.Int("limit").pipe(
   Flag.withDescription("Number of log entries to fetch (default: 100)"),
   Flag.withDefault(100),
 );
 
-const tail = Flag.boolean("tail").pipe(
+const tail = Flag.Boolean("tail").pipe(
   Flag.withAlias("t"),
   Flag.withDescription("Continue streaming new log entries"),
   Flag.withDefault(false),
 );
 
-const resources = Flag.string("resource").pipe(
+const resources = Flag.String("resource").pipe(
   Flag.withAlias("r"),
   Flag.withDescription(
     "Comma-separated logical resource IDs to include (for example Worker,Api)",
@@ -37,7 +37,7 @@ const resources = Flag.string("resource").pipe(
   Flag.map(Option.getOrUndefined),
 );
 
-const logsSince = Flag.string("since").pipe(
+const logsSince = Flag.String("since").pipe(
   Flag.withDescription(
     "Fetch logs since this time (e.g. '1h', '30m', '2024-01-01T00:00:00Z')",
   ),

--- a/packages/alchemy/src/Cli/commands/nuke.ts
+++ b/packages/alchemy/src/Cli/commands/nuke.ts
@@ -23,45 +23,45 @@ import {
 } from "./flags.ts";
 import { instrumentCommand } from "./instrument.ts";
 
-const includeFlag = Flag.string("include").pipe(
+const includeFlag = Flag.String("include").pipe(
   Flag.withDescription("Glob of provider IDs to include (repeatable)"),
   Flag.atLeast(0),
 );
-const excludeFlag = Flag.string("exclude").pipe(
+const excludeFlag = Flag.String("exclude").pipe(
   Flag.withDescription("Glob of provider IDs to exclude (repeatable)"),
   Flag.atLeast(0),
 );
-const filterFlag = Flag.string("filter").pipe(
+const filterFlag = Flag.String("filter").pipe(
   Flag.withDescription(
     "JavaScript expression evaluated with resource in scope; matching resources are excluded from deletion (repeatable)",
   ),
   Flag.atLeast(0),
 );
-const concurrencyFlag = Flag.integer("concurrency").pipe(
+const concurrencyFlag = Flag.Int("concurrency").pipe(
   Flag.withDescription(
     "Maximum providers processed in parallel; 0 is unbounded",
   ),
   Flag.withDefault(16),
   Flag.map((value): number | "unbounded" => (value <= 0 ? "unbounded" : value)),
 );
-const timeoutFlag = Flag.integer("timeout").pipe(
+const timeoutFlag = Flag.Int("timeout").pipe(
   Flag.withDescription("Per-provider timeout in seconds"),
   Flag.withDefault(120),
   Flag.map(Duration.seconds),
 );
-const independentFlag = Flag.boolean("independent").pipe(
+const independentFlag = Flag.Boolean("independent").pipe(
   Flag.withDescription("Retry each resource independently"),
   Flag.withDefault(false),
 );
-const retriesFlag = Flag.integer("retries").pipe(
+const retriesFlag = Flag.Int("retries").pipe(
   Flag.withDescription("Independent retries per resource"),
   Flag.withDefault(10),
 );
-const localFlag = Flag.boolean("local").pipe(
+const localFlag = Flag.Boolean("local").pipe(
   Flag.withDescription("Target only locally emulated providers"),
   Flag.withDefault(false),
 );
-const dryRunFlag = Flag.boolean("dry-run").pipe(
+const dryRunFlag = Flag.Boolean("dry-run").pipe(
   Flag.withDescription("Scan and show targets without deleting"),
   Flag.withDefault(false),
 );

--- a/packages/alchemy/src/Cli/commands/profile/commands.ts
+++ b/packages/alchemy/src/Cli/commands/profile/commands.ts
@@ -28,16 +28,16 @@ import {
 } from "./flows.ts";
 import { profileHub } from "./hub.ts";
 
-const profileName = Argument.string("name").pipe(
+const profileName = Argument.String("name").pipe(
   Argument.withDescription("Profile name"),
 );
 
-const newProfileName = Argument.string("new-name").pipe(
+const newProfileName = Argument.String("new-name").pipe(
   Argument.withDescription("New profile name"),
   Argument.optional,
 );
 
-const refreshProviders = Flag.string("provider").pipe(
+const refreshProviders = Flag.String("provider").pipe(
   Flag.withDescription(
     "Refresh only this connected provider (repeatable; defaults to all)",
   ),
@@ -139,26 +139,26 @@ const renameCommand = Command.make(
   ),
 );
 
-const addProviders = Flag.string("add").pipe(
+const addProviders = Flag.String("add").pipe(
   Flag.withDescription("Connect a provider to the profile (repeatable)"),
   Flag.atLeast(0),
 );
 
-const reconfigureProviders = Flag.string("reconfigure").pipe(
+const reconfigureProviders = Flag.String("reconfigure").pipe(
   Flag.withDescription(
     "Re-run a connected provider's configuration (repeatable)",
   ),
   Flag.atLeast(0),
 );
 
-const removeProviders = Flag.string("remove").pipe(
+const removeProviders = Flag.String("remove").pipe(
   Flag.withDescription(
     "Log out a connected provider and disconnect it (repeatable)",
   ),
   Flag.atLeast(0),
 );
 
-const methodFlag = Flag.string("method").pipe(
+const methodFlag = Flag.String("method").pipe(
   Flag.withDescription(
     "Configure non-interactively using this method (each provider documents its methods and fields in `alchemy profile edit --help`)",
   ),
@@ -166,7 +166,7 @@ const methodFlag = Flag.string("method").pipe(
   Flag.map(Option.getOrUndefined),
 );
 
-const setFlag = Flag.string("set").pipe(
+const setFlag = Flag.String("set").pipe(
   Flag.withDescription(
     "Field for non-interactive configure: name=value, name=env:VAR, or name=- to read the value from stdin (repeatable)",
   ),

--- a/packages/alchemy/src/Cli/commands/provider.ts
+++ b/packages/alchemy/src/Cli/commands/provider.ts
@@ -12,7 +12,7 @@ import { config, envFile, profile } from "./flags.ts";
 import { instrumentCommand } from "./instrument.ts";
 
 /** Optional repeatable filter for checking a subset of registered providers. */
-const checkedProviders = Flag.string("provider").pipe(
+const checkedProviders = Flag.String("provider").pipe(
   Flag.withDescription(
     "Check only this provider (repeatable; defaults to every provider the stack registers)",
   ),

--- a/packages/alchemy/src/Cli/commands/state.ts
+++ b/packages/alchemy/src/Cli/commands/state.ts
@@ -16,7 +16,7 @@ import { envFile, profile, yes } from "./flags.ts";
 import { confirmOrDecline } from "./confirm.ts";
 import { instrumentCommand } from "./instrument.ts";
 
-const backend = Flag.choice("backend", [
+const backend = Flag.Literals("backend", [
   "configured",
   "local",
   "cloudflare",
@@ -25,19 +25,19 @@ const backend = Flag.choice("backend", [
   Flag.withDescription("State backend (default: configured)"),
   Flag.withDefault("configured" as const),
 );
-const config = Flag.file("config").pipe(
+const config = Flag.File("config").pipe(
   Flag.withDescription("Alchemy entrypoint file (default: alchemy.run.ts)"),
   Flag.withAlias("c"),
   Flag.withDefault("alchemy.run.ts"),
 );
-const pathArgument = Argument.string("path").pipe(
+const pathArgument = Argument.String("path").pipe(
   Argument.withDescription("State path (stack/stage/namespace/resource)"),
   Argument.optional,
 );
-const requiredPathArgument = Argument.string("path").pipe(
+const requiredPathArgument = Argument.String("path").pipe(
   Argument.withDescription("State path (stack/stage/namespace/resource)"),
 );
-const recursive = Flag.boolean("recursive").pipe(
+const recursive = Flag.Boolean("recursive").pipe(
   Flag.withAlias("r"),
   Flag.withDescription("Operate recursively on directories"),
   Flag.withDefault(false),

--- a/packages/alchemy/src/Cli/exec.ts
+++ b/packages/alchemy/src/Cli/exec.ts
@@ -69,7 +69,7 @@ const services = Layer.mergeAll(
 );
 
 /** `alchemy dev` normally parks forever; set for single-pass runs (tests). */
-const devOnce = Config.string("ALCHEMY_DEV_ONCE").pipe(
+const devOnce = Config.String("ALCHEMY_DEV_ONCE").pipe(
   Config.withDefault(""),
   Effect.map((value) => value === "1" || value === "true"),
 );

--- a/packages/alchemy/src/Cli/main.ts
+++ b/packages/alchemy/src/Cli/main.ts
@@ -109,8 +109,8 @@ const commands = await Promise.all(
  * (capability detection runs while the service layers are built, before flag
  * parsing); this registration exists so the parser accepts the flag.
  */
-const NoInput = GlobalFlag.setting("no-input")({
-  flag: Flag.boolean("no-input").pipe(
+const NoInput = GlobalFlag.Setting("no-input")({
+  flag: Flag.Boolean("no-input").pipe(
     Flag.withDescription(
       "Disable prompts and the interactive TUI (plain output; commands needing input fail)",
     ),
@@ -226,7 +226,7 @@ const mainEffect = program.pipe(
 );
 
 /** Fully wired CLI program. */
-export const main: Effect.Effect<
+export const main = mainEffect as Effect.Effect<
   void,
   Effect.Error<typeof mainEffect>
-> = mainEffect;
+>;

--- a/packages/alchemy/src/Cloudflare/AI/GatewayProvider.ts
+++ b/packages/alchemy/src/Cloudflare/AI/GatewayProvider.ts
@@ -146,7 +146,7 @@ export type GatewayProvider = Resource<
  * const secret = yield* Cloudflare.SecretsStore.Secret("OpenAiKey", {
  *   store,
  *   name: "my-gateway_openai_default",
- *   value: yield* Config.redacted("OPENAI_API_KEY"),
+ *   value: yield* Config.Redacted("OPENAI_API_KEY"),
  *   scopes: ["ai_gateway"],
  * });
  *

--- a/packages/alchemy/src/Cloudflare/AI/LanguageModel.ts
+++ b/packages/alchemy/src/Cloudflare/AI/LanguageModel.ts
@@ -65,7 +65,7 @@ export const makeLanguageModelLayer = (
   Layer.effect(AiLanguageModel.LanguageModel, makeLanguageModel(options));
 
 /**
- * Build a {@link AiLanguageModel.Service} that proxies generateText/streamText
+ * Build a {@link AiLanguageModel.LanguageModel} that proxies generateText/streamText
  * through the supplied AI Gateway client to a Workers AI model.
  */
 export const makeLanguageModel = ({
@@ -73,7 +73,7 @@ export const makeLanguageModel = ({
   model,
   parameters,
 }: LanguageModelOptions): Effect.Effect<
-  AiLanguageModel.Service,
+  AiLanguageModel.LanguageModel,
   never,
   RuntimeContext
 > =>

--- a/packages/alchemy/src/Cloudflare/AI/ProviderKey.ts
+++ b/packages/alchemy/src/Cloudflare/AI/ProviderKey.ts
@@ -104,7 +104,7 @@ export type ProviderKey = {
  *   store,
  *   gatewayId: gateway.gatewayId,
  *   providerSlug: "openai",
- *   value: yield* Config.redacted("OPENAI_API_KEY"),
+ *   value: yield* Config.Redacted("OPENAI_API_KEY"),
  * });
  * ```
  *
@@ -116,7 +116,7 @@ export type ProviderKey = {
  *   store,
  *   gatewayId: gateway.gatewayId,
  *   providerSlug: "openai",
- *   value: yield* Config.redacted("OPENAI_API_KEY"),
+ *   value: yield* Config.Redacted("OPENAI_API_KEY"),
  * });
  *
  * const evals = yield* Cloudflare.AI.ProviderKey("OpenAiEvalsKey", {
@@ -124,7 +124,7 @@ export type ProviderKey = {
  *   gatewayId: gateway.gatewayId,
  *   providerSlug: "openai",
  *   alias: "evals",
- *   value: yield* Config.redacted("OPENAI_EVALS_API_KEY"),
+ *   value: yield* Config.Redacted("OPENAI_EVALS_API_KEY"),
  * });
  * ```
  *

--- a/packages/alchemy/src/Cloudflare/Access.ts
+++ b/packages/alchemy/src/Cloudflare/Access.ts
@@ -74,7 +74,7 @@ export const AccessLive = Layer.effect(
       );
 
     const getEnv = (name: string) =>
-      Config.string(name)
+      Config.String(name)
 
         .pipe(Effect.catchTag("ConfigError", () => Effect.succeed(undefined)));
 

--- a/packages/alchemy/src/Cloudflare/Alerting/Webhook.ts
+++ b/packages/alchemy/src/Cloudflare/Alerting/Webhook.ts
@@ -100,7 +100,7 @@ export type NotificationWebhook = Resource<
  * const webhook = yield* Cloudflare.Alerting.NotificationWebhook("AlertsHook", {
  *   name: "production-alerts",
  *   url: "https://alerts.example.com/cf",
- *   secret: yield* Config.redacted("WEBHOOK_SECRET"),
+ *   secret: yield* Config.Redacted("WEBHOOK_SECRET"),
  * });
  * ```
  *

--- a/packages/alchemy/src/Cloudflare/CloudflareEnvironment.ts
+++ b/packages/alchemy/src/Cloudflare/CloudflareEnvironment.ts
@@ -17,7 +17,7 @@ export class CloudflareEnvironment extends Context.Service<
   readonly kind = "Environment" as const;
 }
 
-const CLOUDFLARE_ACCOUNT_ID = Config.string("CLOUDFLARE_ACCOUNT_ID");
+const CLOUDFLARE_ACCOUNT_ID = Config.String("CLOUDFLARE_ACCOUNT_ID");
 
 export const fromEnv = () =>
   Layer.effect(

--- a/packages/alchemy/src/Cloudflare/Containers/ContainerPlatform.ts
+++ b/packages/alchemy/src/Cloudflare/Containers/ContainerPlatform.ts
@@ -111,7 +111,7 @@ export const ContainerPlatform: Platform<
           }),
         get: <T>(key: string) =>
           // Read straight from `process.env` — see `unpackEnvValue` for why
-          // this must never resolve through `Config.string`.
+          // this must never resolve through `Config.String`.
           Effect.sync(() => unpackEnvValue<T>(process.env[key]) as T),
         run: ((effect: Effect.Effect<void, never, any>) =>
           Effect.sync(() => {

--- a/packages/alchemy/src/Cloudflare/Fetcher.ts
+++ b/packages/alchemy/src/Cloudflare/Fetcher.ts
@@ -1,12 +1,8 @@
 import type * as cf from "@cloudflare/workers-types";
 import * as Cause from "effect/Cause";
-import * as Deferred from "effect/Deferred";
 import * as Effect from "effect/Effect";
-import * as FiberSet from "effect/FiberSet";
 import { pipe } from "effect/Function";
-import * as Latch from "effect/Latch";
 import * as Schedule from "effect/Schedule";
-import * as Scope from "effect/Scope";
 import * as HttpBody from "effect/unstable/http/HttpBody";
 import * as HttpClient from "effect/unstable/http/HttpClient";
 import {
@@ -235,177 +231,28 @@ export const toHttpClient = (fetcher: {
 
 export const fromCloudflareSocket = (
   cfSocket: globalThis.Socket | cf.Socket,
-): Socket.Socket => {
-  const latch = Latch.makeUnsafe(false);
-  let currentFiberSet: FiberSet.FiberSet<any, any> | undefined;
-  let writerRef: WritableStreamDefaultWriter<Uint8Array> | undefined;
-  const encoder = new TextEncoder();
-  const closeError = (code: number, closeReason?: string) =>
-    new Socket.SocketError({
-      reason: new Socket.SocketCloseError({ code, closeReason }),
-    });
-
-  const runRaw = <_, E, R>(
-    handler: (_: string | Uint8Array) => Effect.Effect<_, E, R> | void,
-    opts?: { readonly onOpen?: Effect.Effect<void> | undefined },
-  ): Effect.Effect<void, Socket.SocketError | E, R> =>
-    Effect.scopedWith(
-      Effect.fn(function* (scope) {
-        // Cloudflare exposes connection establishment as a promise rather than an
-        // event emitter, so we normalize that into the same SocketOpenError shape
-        // Effect uses for the official adapters.
-        yield* Effect.tryPromise({
-          try: () => cfSocket.opened,
-          catch: (cause) =>
-            new Socket.SocketError({
-              reason: new Socket.SocketOpenError({
-                kind: "Unknown",
-                cause,
-              }),
-            }),
-        });
-
-        const reader = cfSocket.readable.getReader();
-        // Mirror `fromTransformStream`: the reader is scoped to a single `runRaw`
-        // invocation and is always cancelled when that scope closes.
-        yield* Scope.addFinalizer(
-          scope,
-          Effect.promise(() => reader.cancel()),
-        );
-
-        const fiberSet = yield* FiberSet.make<
-          any,
-          E | Socket.SocketError
-        >().pipe(Scope.provide(scope));
-        const runFork = yield* FiberSet.runtime(fiberSet)<R>();
-
-        // Keep the remote-close watcher inside the FiberSet instead of attaching a
-        // raw `.then(...)` callback. That matches Effect's pattern of keeping all
-        // background work scoped and lets `FiberSet.join` observe close outcomes.
-        yield* Effect.tryPromise({
-          try: async () => {
-            await cfSocket.closed;
-            throw closeError(1000);
-          },
-          catch: (cause) =>
-            Socket.isSocketError(cause) ? cause : closeError(1006),
-        }).pipe(FiberSet.run(fiberSet));
-
-        // The read loop itself follows `fromTransformStream`: fork the loop into
-        // the FiberSet so handler effects can run concurrently while `join`
-        // remains the single completion point for the socket session.
-        yield* Effect.tryPromise({
-          try: async () => {
-            while (true) {
-              const { done, value } = await reader.read();
-              if (done) {
-                throw closeError(1000);
-              }
-              const result = handler(value);
-              if (Effect.isEffect(result)) {
-                runFork(result);
-              }
-            }
-          },
-          catch: (cause) =>
-            Socket.isSocketError(cause)
-              ? cause
-              : new Socket.SocketError({
-                  reason: new Socket.SocketReadError({ cause }),
-                }),
-        }).pipe(FiberSet.run(fiberSet));
-
-        currentFiberSet = fiberSet;
-        // Writers are gated on the latch exactly like the official adapters so a
-        // caller cannot send data before the read side has been fully installed.
-        latch.openUnsafe();
-        if (opts?.onOpen) yield* opts.onOpen;
-
-        return yield* Effect.catchFilter(
-          FiberSet.join(fiberSet),
-          Socket.SocketCloseError.filterClean(
-            (code) => code === 1000 || code === 1006,
+): Socket.Socket =>
+  // `fromTransformStream` snapshots fiber context, then waits to acquire
+  // the streams until a consumer opens the reader. `runSync` is only that
+  // snapshot — connection still happens on first `socket.reader`.
+  Effect.runSync(
+    Socket.fromTransformStream(
+      Effect.tryPromise({
+        try: () =>
+          Promise.resolve(cfSocket.opened).then(
+            () =>
+              ({
+                readable: cfSocket.readable,
+                writable: cfSocket.writable,
+              }) as Socket.InputTransformStream,
           ),
-          () => Effect.void,
-        );
-      }),
-    ).pipe(
-      Effect.ensuring(
-        Effect.sync(() => {
-          latch.closeUnsafe();
-          currentFiberSet = undefined;
-        }),
-      ),
-    );
-
-  const run = <_, E, R>(
-    handler: (_: Uint8Array) => Effect.Effect<_, E, R> | void,
-    opts?: { readonly onOpen?: Effect.Effect<void> | undefined },
-  ): Effect.Effect<void, Socket.SocketError | E, R> =>
-    runRaw(
-      (data) =>
-        typeof data === "string"
-          ? handler(encoder.encode(data))
-          : handler(data),
-      opts,
-    );
-
-  const decoder = new TextDecoder();
-  const runString = <_, E, R>(
-    handler: (_: string) => Effect.Effect<_, E, R> | void,
-    opts?: { readonly onOpen?: Effect.Effect<void> | undefined },
-  ): Effect.Effect<void, Socket.SocketError | E, R> =>
-    runRaw(
-      (data) =>
-        typeof data === "string"
-          ? handler(data)
-          : handler(decoder.decode(data)),
-      opts,
-    );
-
-  const write = (
-    chunk: Uint8Array | string | Socket.CloseEvent,
-  ): Effect.Effect<void, Socket.SocketError> =>
-    latch.whenOpen(
-      Effect.suspend(() => {
-        if (Socket.isCloseEvent(chunk)) {
-          // `fromTransformStream` signals a local close by completing the
-          // FiberSet's deferred rather than trying to force stream semantics that
-          // don't exist. We do the same here so `runRaw` unwinds through `join`.
-          return Deferred.fail(
-            currentFiberSet!.deferred,
-            closeError(chunk.code, chunk.reason),
-          );
-        }
-        if (!writerRef) {
-          writerRef = cfSocket.writable.getWriter();
-        }
-        const data = typeof chunk === "string" ? encoder.encode(chunk) : chunk;
-        return Effect.tryPromise({
-          try: () => writerRef!.write(data),
-          catch: (cause) =>
-            new Socket.SocketError({
-              reason: new Socket.SocketWriteError({ cause }),
+        catch: (cause) =>
+          new Socket.SocketError({
+            reason: new Socket.SocketOpenError({
+              kind: "Unknown",
+              cause,
             }),
-        });
+          }),
       }),
-    );
-
-  const writer = Effect.acquireRelease(Effect.succeed(write), () =>
-    // Treat writer shutdown as best-effort cleanup. Cloudflare may already have
-    // closed the writable side by the time the scope releases.
-    Effect.promise(async () => {
-      if (writerRef) {
-        await writerRef.close().catch(() => {});
-      }
-    }),
+    ),
   );
-
-  return Socket.Socket.of({
-    [Socket.TypeId]: Socket.TypeId,
-    run,
-    runRaw,
-    runString,
-    writer,
-  });
-};

--- a/packages/alchemy/src/Cloudflare/Hyperdrive/Connection.ts
+++ b/packages/alchemy/src/Cloudflare/Hyperdrive/Connection.ts
@@ -142,7 +142,7 @@ export type Connection = Resource<
  *     port: 5432,
  *     database: "app",
  *     user: "app",
- *     password: yield* Config.redacted("DB_PASSWORD"),
+ *     password: yield* Config.Redacted("DB_PASSWORD"),
  *   },
  * });
  * ```

--- a/packages/alchemy/src/Cloudflare/Logs.ts
+++ b/packages/alchemy/src/Cloudflare/Logs.ts
@@ -170,58 +170,66 @@ export const CloudflareLogs = Effect.gen(function* () {
 
       const queue = yield* Queue.make<LogLine, Cause.Done>();
 
-      yield* socket
-        .runRaw((raw) => {
-          const text =
-            typeof raw === "string" ? raw : new TextDecoder().decode(raw);
-          const data: TailEventMessage = JSON.parse(text);
-          const eventTs = new Date(data.eventTimestamp ?? Date.now());
+      const decoder = new TextDecoder();
+      const offerTailMessage = (raw: Uint8Array) => {
+        const data: TailEventMessage = JSON.parse(decoder.decode(raw));
+        const eventTs = new Date(data.eventTimestamp ?? Date.now());
 
-          if (data.event && "request" in data.event) {
-            const reqEvent = data.event;
-            const pathname = (() => {
-              try {
-                return new URL(reqEvent.request.url).pathname;
-              } catch {
-                return reqEvent.request.url;
-              }
-            })();
-            const status = reqEvent.response?.status ?? 500;
-            Queue.offerUnsafe(queue, {
-              timestamp: eventTs,
-              message: `${reqEvent.request.method} ${pathname} > ${status} (cpu: ${Math.round(data.cpuTime)}ms, wall: ${Math.round(data.wallTime)}ms)`,
-            });
-          }
+        if (data.event && "request" in data.event) {
+          const reqEvent = data.event;
+          const pathname = (() => {
+            try {
+              return new URL(reqEvent.request.url).pathname;
+            } catch {
+              return reqEvent.request.url;
+            }
+          })();
+          const status = reqEvent.response?.status ?? 500;
+          Queue.offerUnsafe(queue, {
+            timestamp: eventTs,
+            message: `${reqEvent.request.method} ${pathname} > ${status} (cpu: ${Math.round(data.cpuTime)}ms, wall: ${Math.round(data.wallTime)}ms)`,
+          });
+        }
 
-          for (const log of data.logs) {
-            const msg = log.message.join(" ");
-            Queue.offerUnsafe(queue, {
-              timestamp: new Date(log.timestamp),
-              message: log.level === "log" ? msg : `${log.level}: ${msg}`,
-            });
-          }
+        for (const log of data.logs) {
+          const msg = log.message.join(" ");
+          Queue.offerUnsafe(queue, {
+            timestamp: new Date(log.timestamp),
+            message: log.level === "log" ? msg : `${log.level}: ${msg}`,
+          });
+        }
 
-          for (const exception of data.exceptions) {
-            Queue.offerUnsafe(queue, {
-              timestamp: new Date(exception.timestamp),
-              message: `${exception.name} ${exception.message}\n${exception.stack}`,
-            });
-          }
-        })
-        .pipe(
-          Effect.ensuring(
-            Effect.all([
-              deleteScriptTail({
-                scriptName: opts.scriptName,
-                id: tailId,
-                accountId: opts.accountId,
-              }).pipe(Effect.ignore),
-              Queue.end(queue),
-            ]),
-          ),
-          Effect.ignore,
-          Effect.forkChild(),
-        );
+        for (const exception of data.exceptions) {
+          Queue.offerUnsafe(queue, {
+            timestamp: new Date(exception.timestamp),
+            message: `${exception.name} ${exception.message}\n${exception.stack}`,
+          });
+        }
+      };
+
+      yield* Socket.toStream(socket).pipe(
+        Stream.runForEach((raw) => Effect.sync(() => offerTailMessage(raw))),
+        Effect.catchIf(
+          (error) =>
+            Socket.isSocketError(error) &&
+            error.reason._tag === "SocketCloseError" &&
+            (error.reason.code === 1000 || error.reason.code === 1006),
+          () => Effect.void,
+        ),
+        Effect.ensuring(
+          Effect.all([
+            deleteScriptTail({
+              scriptName: opts.scriptName,
+              id: tailId,
+              accountId: opts.accountId,
+            }).pipe(Effect.ignore),
+            Queue.end(queue),
+          ]),
+        ),
+        Effect.scoped,
+        Effect.ignore,
+        Effect.forkChild(),
+      );
 
       return Stream.fromQueue(queue);
     });

--- a/packages/alchemy/src/Cloudflare/MagicTransit/IpsecTunnel.ts
+++ b/packages/alchemy/src/Cloudflare/MagicTransit/IpsecTunnel.ts
@@ -137,7 +137,7 @@ export type IpsecTunnel = Resource<
  *   cloudflareEndpoint: "203.0.113.1",
  *   customerEndpoint: "198.51.100.1",
  *   interfaceAddress: "10.213.0.10/31",
- *   psk: yield* Config.redacted("IPSEC_PSK"),
+ *   psk: yield* Config.Redacted("IPSEC_PSK"),
  * });
  * ```
  *

--- a/packages/alchemy/src/Cloudflare/MtlsCertificate/MtlsCertificate.ts
+++ b/packages/alchemy/src/Cloudflare/MtlsCertificate/MtlsCertificate.ts
@@ -132,7 +132,7 @@ export type MtlsCertificate = Resource<
  * const cert = yield* Cloudflare.MtlsCertificate.MtlsCertificate("origin-client-cert", {
  *   ca: false,
  *   certificates: leafPem,
- *   privateKey: yield* Config.redacted("ORIGIN_CLIENT_KEY"),
+ *   privateKey: yield* Config.Redacted("ORIGIN_CLIENT_KEY"),
  * });
  * ```
  *

--- a/packages/alchemy/src/Cloudflare/OriginTlsClientAuth/Certificate.ts
+++ b/packages/alchemy/src/Cloudflare/OriginTlsClientAuth/Certificate.ts
@@ -95,7 +95,7 @@ export type Certificate = Resource<
  * const cert = yield* Cloudflare.OriginTlsClientAuth.Certificate("AopCert", {
  *   zoneId: zone.zoneId,
  *   certificate: clientCertPem,
- *   privateKey: yield* Config.redacted("AOP_CLIENT_KEY"),
+ *   privateKey: yield* Config.Redacted("AOP_CLIENT_KEY"),
  * });
  * ```
  *
@@ -105,7 +105,7 @@ export type Certificate = Resource<
  * const cert = yield* Cloudflare.OriginTlsClientAuth.Certificate("AopCert", {
  *   zoneId: zone.zoneId,
  *   certificate: clientCertPem,
- *   privateKey: yield* Config.redacted("AOP_CLIENT_KEY"),
+ *   privateKey: yield* Config.Redacted("AOP_CLIENT_KEY"),
  * });
  *
  * yield* Cloudflare.OriginTlsClientAuth.Setting("Aop", {

--- a/packages/alchemy/src/Cloudflare/OriginTlsClientAuth/HostnameAssociation.ts
+++ b/packages/alchemy/src/Cloudflare/OriginTlsClientAuth/HostnameAssociation.ts
@@ -96,7 +96,7 @@ export type HostnameAssociation = Resource<
  * const cert = yield* Cloudflare.OriginTlsClientAuth.HostnameCertificate("AopHostCert", {
  *   zoneId: zone.zoneId,
  *   certificate: clientCertPem,
- *   privateKey: yield* Config.redacted("AOP_CLIENT_KEY"),
+ *   privateKey: yield* Config.Redacted("AOP_CLIENT_KEY"),
  * });
  *
  * yield* Cloudflare.OriginTlsClientAuth.HostnameAssociation("AopHost", {

--- a/packages/alchemy/src/Cloudflare/OriginTlsClientAuth/HostnameCertificate.ts
+++ b/packages/alchemy/src/Cloudflare/OriginTlsClientAuth/HostnameCertificate.ts
@@ -97,7 +97,7 @@ export type HostnameCertificate = Resource<
  * const cert = yield* Cloudflare.OriginTlsClientAuth.HostnameCertificate("AopHostCert", {
  *   zoneId: zone.zoneId,
  *   certificate: clientCertPem,
- *   privateKey: yield* Config.redacted("AOP_CLIENT_KEY"),
+ *   privateKey: yield* Config.Redacted("AOP_CLIENT_KEY"),
  * });
  * ```
  *
@@ -107,7 +107,7 @@ export type HostnameCertificate = Resource<
  * const cert = yield* Cloudflare.OriginTlsClientAuth.HostnameCertificate("AopHostCert", {
  *   zoneId: zone.zoneId,
  *   certificate: clientCertPem,
- *   privateKey: yield* Config.redacted("AOP_CLIENT_KEY"),
+ *   privateKey: yield* Config.Redacted("AOP_CLIENT_KEY"),
  * });
  *
  * yield* Cloudflare.OriginTlsClientAuth.HostnameAssociation("AopHost", {

--- a/packages/alchemy/src/Cloudflare/OriginTlsClientAuth/Setting.ts
+++ b/packages/alchemy/src/Cloudflare/OriginTlsClientAuth/Setting.ts
@@ -70,7 +70,7 @@ export type Setting = Resource<
  * const cert = yield* Cloudflare.OriginTlsClientAuth.Certificate("AopCert", {
  *   zoneId: zone.zoneId,
  *   certificate: clientCertPem,
- *   privateKey: yield* Config.redacted("AOP_CLIENT_KEY"),
+ *   privateKey: yield* Config.Redacted("AOP_CLIENT_KEY"),
  * });
  *
  * yield* Cloudflare.OriginTlsClientAuth.Setting("Aop", {

--- a/packages/alchemy/src/Cloudflare/Pipelines/LegacyPipeline.ts
+++ b/packages/alchemy/src/Cloudflare/Pipelines/LegacyPipeline.ts
@@ -178,8 +178,8 @@ export type LegacyPipeline = Resource<
  *   destination: {
  *     bucket: bucket.bucketName,
  *     credentials: {
- *       accessKeyId: yield* Config.redacted("R2_ACCESS_KEY_ID"),
- *       secretAccessKey: yield* Config.redacted("R2_SECRET_ACCESS_KEY"),
+ *       accessKeyId: yield* Config.Redacted("R2_ACCESS_KEY_ID"),
+ *       secretAccessKey: yield* Config.Redacted("R2_SECRET_ACCESS_KEY"),
  *     },
  *   },
  * });

--- a/packages/alchemy/src/Cloudflare/Pipelines/Sink.ts
+++ b/packages/alchemy/src/Cloudflare/Pipelines/Sink.ts
@@ -235,8 +235,8 @@ export type Sink = Resource<
  *   config: {
  *     bucket: bucket.bucketName,
  *     credentials: {
- *       accessKeyId: yield* Config.redacted("R2_ACCESS_KEY_ID"),
- *       secretAccessKey: yield* Config.redacted("R2_SECRET_ACCESS_KEY"),
+ *       accessKeyId: yield* Config.Redacted("R2_ACCESS_KEY_ID"),
+ *       secretAccessKey: yield* Config.Redacted("R2_SECRET_ACCESS_KEY"),
  *     },
  *     path: "ingest",
  *     rollingPolicy: { intervalSeconds: 30 },
@@ -262,7 +262,7 @@ export type Sink = Resource<
  *     bucket: bucket.bucketName,
  *     tableName: "events",
  *     namespace: "default",
- *     token: yield* Config.redacted("CATALOG_TOKEN"),
+ *     token: yield* Config.Redacted("CATALOG_TOKEN"),
  *   },
  * });
  * ```

--- a/packages/alchemy/src/Cloudflare/R2/BucketSippy.ts
+++ b/packages/alchemy/src/Cloudflare/R2/BucketSippy.ts
@@ -158,12 +158,12 @@ export type BucketSippy = Resource<
  *     provider: "aws",
  *     bucket: "legacy-media",
  *     region: "us-east-1",
- *     accessKeyId: yield* Config.redacted("AWS_ACCESS_KEY_ID"),
- *     secretAccessKey: yield* Config.redacted("AWS_SECRET_ACCESS_KEY"),
+ *     accessKeyId: yield* Config.Redacted("AWS_ACCESS_KEY_ID"),
+ *     secretAccessKey: yield* Config.Redacted("AWS_SECRET_ACCESS_KEY"),
  *   },
  *   destination: {
- *     accessKeyId: yield* Config.redacted("R2_ACCESS_KEY_ID"),
- *     secretAccessKey: yield* Config.redacted("R2_SECRET_ACCESS_KEY"),
+ *     accessKeyId: yield* Config.Redacted("R2_ACCESS_KEY_ID"),
+ *     secretAccessKey: yield* Config.Redacted("R2_SECRET_ACCESS_KEY"),
  *   },
  * });
  * ```
@@ -177,11 +177,11 @@ export type BucketSippy = Resource<
  *     provider: "gcs",
  *     bucket: "legacy-media",
  *     clientEmail: "sippy@my-project.iam.gserviceaccount.com",
- *     privateKey: yield* Config.redacted("GCS_PRIVATE_KEY"),
+ *     privateKey: yield* Config.Redacted("GCS_PRIVATE_KEY"),
  *   },
  *   destination: {
- *     accessKeyId: yield* Config.redacted("R2_ACCESS_KEY_ID"),
- *     secretAccessKey: yield* Config.redacted("R2_SECRET_ACCESS_KEY"),
+ *     accessKeyId: yield* Config.Redacted("R2_ACCESS_KEY_ID"),
+ *     secretAccessKey: yield* Config.Redacted("R2_SECRET_ACCESS_KEY"),
  *   },
  * });
  * ```

--- a/packages/alchemy/src/Cloudflare/StateStore/State.ts
+++ b/packages/alchemy/src/Cloudflare/StateStore/State.ts
@@ -53,7 +53,7 @@ import {
   TokenValue,
 } from "./Token.ts";
 
-const CI = Config.boolean("CI").pipe(Config.withDefault(false));
+const CI = Config.Boolean("CI").pipe(Config.withDefault(false));
 
 export const state = () =>
   Layer.effect(
@@ -1185,7 +1185,7 @@ const annotateAccountHash = (noTrack?: boolean) =>
   Effect.gen(function* () {
     if (noTrack === true) return;
     if (noTrack === undefined) {
-      const fromEnv = yield* Config.boolean("NO_TRACK").pipe(
+      const fromEnv = yield* Config.Boolean("NO_TRACK").pipe(
         Config.withDefault(false),
       );
       if (fromEnv) return;

--- a/packages/alchemy/src/Cloudflare/Website/Nuxt.ts
+++ b/packages/alchemy/src/Cloudflare/Website/Nuxt.ts
@@ -134,7 +134,7 @@ export interface NuxtProps<
  * ```typescript
  * const site = yield* Cloudflare.Website.Nuxt("Website", {
  *   env: {
- *     API_KEY: Config.redacted("API_KEY"),
+ *     API_KEY: Config.Redacted("API_KEY"),
  *   },
  * });
  *

--- a/packages/alchemy/src/Cloudflare/Website/Octane.ts
+++ b/packages/alchemy/src/Cloudflare/Website/Octane.ts
@@ -132,7 +132,7 @@ export interface OctaneProps<
  *
  * const site = yield* Cloudflare.Website.Octane("Website", {
  *   env: {
- *     API_KEY: Config.redacted("API_KEY"),
+ *     API_KEY: Config.Redacted("API_KEY"),
  *   },
  * });
  * ```

--- a/packages/alchemy/src/Cloudflare/Website/SvelteKit.ts
+++ b/packages/alchemy/src/Cloudflare/Website/SvelteKit.ts
@@ -94,7 +94,7 @@ export interface SvelteKitProps<
  * ```typescript
  * const site = yield* Cloudflare.Website.SvelteKit("Website", {
  *   env: {
- *     API_KEY: Config.redacted("API_KEY"),
+ *     API_KEY: Config.Redacted("API_KEY"),
  *   },
  * });
  *

--- a/packages/alchemy/src/Cloudflare/Workers/CloudflareTracer.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/CloudflareTracer.ts
@@ -104,7 +104,7 @@ export const layer: Layer.Layer<never> = Layer.effect(
         );
       },
       context(primitive, fiber) {
-        return contextFor(fiber.currentSpan)(() =>
+        return contextFor(fiber.cache.span)(() =>
           primitive["~effect/Effect/evaluate"](fiber),
         );
       },

--- a/packages/alchemy/src/Cloudflare/Workers/DurableObjectState.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/DurableObjectState.ts
@@ -113,7 +113,7 @@ export const fromDurableObjectState = (
       const context = yield* Effect.context<R>();
       // The failure is typed away as before: a rejected gate is the
       // platform resetting the object, not a value a caller handles.
-      return yield* Effect.tryPromise<T, never>(() =>
+      return yield* Effect.promise(() =>
         state.blockConcurrencyWhile(() =>
           Effect.runPromise(callback().pipe(Effect.provide(context))),
         ),

--- a/packages/alchemy/src/Cloudflare/Workers/DurableObjectStorage.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/DurableObjectStorage.ts
@@ -191,19 +191,19 @@ export const fromDurableObjectTransaction = (
   txn: cf.DurableObjectTransaction,
 ): DurableObjectTransaction => ({
   get: ((keyOrKeys: string | string[], options?: cf.DurableObjectGetOptions) =>
-    Effect.tryPromise(() => txn.get(keyOrKeys as any, options))) as any,
+    Effect.promise(() => txn.get(keyOrKeys as any, options))) as any,
   list: (options?: cf.DurableObjectListOptions) =>
-    Effect.tryPromise(() => txn.list(options)),
+    Effect.promise(() => txn.list(options)),
   put: ((
     keyOrEntries: string | Record<string, unknown>,
     valueOrOptions?: unknown,
     maybeOptions?: cf.DurableObjectPutOptions,
   ) =>
     typeof keyOrEntries === "string"
-      ? Effect.tryPromise(() =>
+      ? Effect.promise(() =>
           txn.put(keyOrEntries, valueOrOptions, maybeOptions),
         )
-      : Effect.tryPromise(() =>
+      : Effect.promise(() =>
           txn.put(
             keyOrEntries,
             valueOrOptions as cf.DurableObjectPutOptions | undefined,
@@ -212,35 +212,35 @@ export const fromDurableObjectTransaction = (
   delete: ((
     keyOrKeys: string | string[],
     options?: cf.DurableObjectPutOptions,
-  ) => Effect.tryPromise(() => txn.delete(keyOrKeys as any, options))) as any,
+  ) => Effect.promise(() => txn.delete(keyOrKeys as any, options))) as any,
   rollback: () => Effect.sync(() => txn.rollback()),
   getAlarm: (options?: cf.DurableObjectGetAlarmOptions) =>
-    Effect.tryPromise(() => txn.getAlarm(options)),
+    Effect.promise(() => txn.getAlarm(options)),
   setAlarm: (
     scheduledTime: number | Date,
     options?: cf.DurableObjectSetAlarmOptions,
-  ) => Effect.tryPromise(() => txn.setAlarm(scheduledTime, options)),
+  ) => Effect.promise(() => txn.setAlarm(scheduledTime, options)),
   deleteAlarm: (options?: cf.DurableObjectSetAlarmOptions) =>
-    Effect.tryPromise(() => txn.deleteAlarm(options)),
+    Effect.promise(() => txn.deleteAlarm(options)),
 });
 
 export const fromDurableObjectStorage = (
   storage: cf.DurableObjectStorage,
 ): DurableObjectStorage => ({
   get: ((keyOrKeys: string | string[], options?: cf.DurableObjectGetOptions) =>
-    Effect.tryPromise(() => storage.get(keyOrKeys as any, options))) as any,
+    Effect.promise(() => storage.get(keyOrKeys as any, options))) as any,
   list: (options?: cf.DurableObjectListOptions) =>
-    Effect.tryPromise(() => storage.list(options)),
+    Effect.promise(() => storage.list(options)),
   put: ((
     keyOrEntries: string | Record<string, unknown>,
     valueOrOptions?: unknown,
     maybeOptions?: cf.DurableObjectPutOptions,
   ) =>
     typeof keyOrEntries === "string"
-      ? Effect.tryPromise(() =>
+      ? Effect.promise(() =>
           storage.put(keyOrEntries, valueOrOptions, maybeOptions),
         )
-      : Effect.tryPromise(() =>
+      : Effect.promise(() =>
           storage.put(
             keyOrEntries,
             valueOrOptions as cf.DurableObjectPutOptions | undefined,
@@ -249,10 +249,9 @@ export const fromDurableObjectStorage = (
   delete: ((
     keyOrKeys: string | string[],
     options?: cf.DurableObjectPutOptions,
-  ) =>
-    Effect.tryPromise(() => storage.delete(keyOrKeys as any, options))) as any,
+  ) => Effect.promise(() => storage.delete(keyOrKeys as any, options))) as any,
   deleteAll: (options?: cf.DurableObjectPutOptions) =>
-    Effect.tryPromise(() => storage.deleteAll(options)),
+    Effect.promise(() => storage.deleteAll(options)),
   transaction: <T, R = never>(
     closure: (txn: DurableObjectTransaction) => Effect.Effect<T, never, R>,
   ) =>
@@ -260,7 +259,7 @@ export const fromDurableObjectStorage = (
       const context = yield* Effect.context<R>();
       // The failure is typed away as before: a rejected transaction has
       // rolled back, and the rejection reaches the caller as a defect.
-      return yield* Effect.tryPromise<T, never>(() =>
+      return yield* Effect.promise(() =>
         storage.transaction((txn) =>
           Effect.runPromise(
             closure(fromDurableObjectTransaction(txn)).pipe(
@@ -271,20 +270,19 @@ export const fromDurableObjectStorage = (
       );
     }),
   getAlarm: (options?: cf.DurableObjectGetAlarmOptions) =>
-    Effect.tryPromise(() => storage.getAlarm(options)),
+    Effect.promise(() => storage.getAlarm(options)),
   setAlarm: (
     scheduledTime: number | Date,
     options?: cf.DurableObjectSetAlarmOptions,
-  ) => Effect.tryPromise(() => storage.setAlarm(scheduledTime, options)),
+  ) => Effect.promise(() => storage.setAlarm(scheduledTime, options)),
   deleteAlarm: (options?: cf.DurableObjectSetAlarmOptions) =>
-    Effect.tryPromise(() => storage.deleteAlarm(options)),
-  sync: () => Effect.tryPromise(() => storage.sync()),
+    Effect.promise(() => storage.deleteAlarm(options)),
+  sync: () => Effect.promise(() => storage.sync()),
   sql: fromSqlStorage(storage.sql),
   kv: storage.kv,
-  getCurrentBookmark: () =>
-    Effect.tryPromise(() => storage.getCurrentBookmark()),
+  getCurrentBookmark: () => Effect.promise(() => storage.getCurrentBookmark()),
   getBookmarkForTime: (timestamp: number | Date) =>
-    Effect.tryPromise(() => storage.getBookmarkForTime(timestamp)),
+    Effect.promise(() => storage.getBookmarkForTime(timestamp)),
   onNextSessionRestoreBookmark: (bookmark: string) =>
-    Effect.tryPromise(() => storage.onNextSessionRestoreBookmark(bookmark)),
+    Effect.promise(() => storage.onNextSessionRestoreBookmark(bookmark)),
 });

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -814,8 +814,8 @@ export interface WorkerProps<
    * - Resource references (R2 bucket, KV namespace, D1 database,
    *   another Worker, Durable Object, etc.) — emitted as the
    *   corresponding native binding.
-   * - `effect/Config` values (`Config.redacted`, `Config.string`,
-   *   `Config.number`, …) — resolved at deploy time and bound as
+   * - `effect/Config` values (`Config.Redacted`, `Config.String`,
+   *   `Config.Number`, …) — resolved at deploy time and bound as
    *   `secret_text` on Cloudflare regardless of the `Config`
    *   constructor used. See
    *   [Secrets & env](/cloudflare/security/secrets-env).

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
@@ -955,7 +955,7 @@ export const shouldObserveWorkerCrons = (
  * (`<subdomain>` in `https://<script>.<subdomain>.workers.dev`). When set,
  * Worker URL construction skips `GET /accounts/{id}/workers/subdomain`.
  */
-const CLOUDFLARE_WORKERS_SUBDOMAIN = Config.string(
+const CLOUDFLARE_WORKERS_SUBDOMAIN = Config.String(
   "CLOUDFLARE_WORKERS_SUBDOMAIN",
 ).pipe(
   Config.map((value) => value.trim()),

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerRuntimeContext.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerRuntimeContext.ts
@@ -42,7 +42,7 @@ export const makeWorkerRuntimeContext = (id: string): WorkerRuntimeContext => {
         Effect.map(Option.getOrUndefined),
         // Key is already canonical (see RuntimeContext.sanitizeKey). Read
         // straight from `WorkerEnvironment` — see `unpackEnvValue` for why
-        // this must never resolve through `Config.string`.
+        // this must never resolve through `Config.String`.
         Effect.map((env) => unpackEnvValue(env?.[key])),
       ) as any,
     set: (key: string, output: Output.Output) =>

--- a/packages/alchemy/src/Docker/Container.ts
+++ b/packages/alchemy/src/Docker/Container.ts
@@ -159,7 +159,7 @@ export interface Container extends Resource<
  * ### Secret Environment
  * **Example:** Redacted env var
  * ```typescript
- * const password = yield* Config.redacted("POSTGRES_PASSWORD");
+ * const password = yield* Config.Redacted("POSTGRES_PASSWORD");
  * const db = yield* Docker.Container("postgres", {
  *   image: "postgres:18-alpine",
  *   environment: {

--- a/packages/alchemy/src/Docker/Docker.ts
+++ b/packages/alchemy/src/Docker/Docker.ts
@@ -465,7 +465,7 @@ export interface CommandOutput {
   stderr: string;
 }
 
-const DockerBin = Config.string("DOCKER_BIN").pipe(
+const DockerBin = Config.String("DOCKER_BIN").pipe(
   Effect.orElseSucceed(() => "docker"),
 );
 

--- a/packages/alchemy/src/Docker/Image.ts
+++ b/packages/alchemy/src/Docker/Image.ts
@@ -118,7 +118,7 @@ export interface Image extends Resource<
  *   registry: {
  *     server: "ghcr.io",
  *     username: "octocat",
- *     password: Config.redacted("GITHUB_TOKEN"),
+ *     password: Config.Redacted("GITHUB_TOKEN"),
  *   },
  * });
  * ```

--- a/packages/alchemy/src/Docker/Registry.ts
+++ b/packages/alchemy/src/Docker/Registry.ts
@@ -5,7 +5,7 @@ export interface ImageRegistry {
   server: string;
   /** Registry username. */
   username: string;
-  /** Registry password. Use `Redacted.make(...)` or `Config.redacted(...)`. */
+  /** Registry password. Use `Redacted.make(...)` or `Config.Redacted(...)`. */
   password: Redacted.Redacted<string>;
 }
 

--- a/packages/alchemy/src/Docker/RemoteImage.ts
+++ b/packages/alchemy/src/Docker/RemoteImage.ts
@@ -109,7 +109,7 @@ export interface RemoteImage extends Resource<
  *   registry: {
  *     server: "ghcr.io",
  *     username: "octocat",
- *     password: Config.redacted("GITHUB_TOKEN"),
+ *     password: Config.Redacted("GITHUB_TOKEN"),
  *   },
  * });
  * ```

--- a/packages/alchemy/src/Fly/BucketBinding.ts
+++ b/packages/alchemy/src/Fly/BucketBinding.ts
@@ -85,13 +85,13 @@ const scopeFromResource = (bucket: Bucket) =>
   });
 
 const scopeFromEnv = Effect.gen(function* () {
-  const bucketName = yield* Config.string("BUCKET_NAME");
-  const accessKeyId = yield* Config.string("AWS_ACCESS_KEY_ID");
-  const secretAccessKey = yield* Config.redacted("AWS_SECRET_ACCESS_KEY");
-  const endpoint = yield* Config.string("AWS_ENDPOINT_URL_S3").pipe(
-    Config.orElse(() => Config.string("AWS_ENDPOINT_URL")),
+  const bucketName = yield* Config.String("BUCKET_NAME");
+  const accessKeyId = yield* Config.String("AWS_ACCESS_KEY_ID");
+  const secretAccessKey = yield* Config.Redacted("AWS_SECRET_ACCESS_KEY");
+  const endpoint = yield* Config.String("AWS_ENDPOINT_URL_S3").pipe(
+    Config.orElse(() => Config.String("AWS_ENDPOINT_URL")),
   );
-  const region = yield* Config.string("AWS_REGION").pipe(
+  const region = yield* Config.String("AWS_REGION").pipe(
     Config.withDefault("auto"),
   );
   return {

--- a/packages/alchemy/src/Fly/GetSecretHttp.ts
+++ b/packages/alchemy/src/Fly/GetSecretHttp.ts
@@ -37,7 +37,7 @@ export const GetSecretHttp = Layer.effect(
             // that over getSecret — org tokens still cannot read plaintext
             // from outside the App, and the env is already the source of
             // truth once the secret exists.
-            const fromEnv = yield* Config.redacted(name).pipe(
+            const fromEnv = yield* Config.Redacted(name).pipe(
               Effect.map((value) => ({
                 name,
                 value: Redacted.value(value),

--- a/packages/alchemy/src/Fly/RedisBinding.ts
+++ b/packages/alchemy/src/Fly/RedisBinding.ts
@@ -13,7 +13,7 @@ import { REDIS_URL_ENV, RedisUrlMissing, type Redis } from "./Redis.ts";
  * Each `{Op}Http.ts` is a thin `Layer.effect` over {@link makeRedisBinding}.
  * Deploy-time registers the Redis add-on on the host so Service reconcile
  * writes `REDIS_URL`. Runtime commands use that URL internally — callers
- * never read `Config.redacted`.
+ * never read `Config.Redacted`.
  *
  * The RESP client lives in `alchemy/Redis`. This file only wires the
  * Fly host binding.
@@ -35,7 +35,7 @@ const asPlain = (value: unknown): string | undefined => {
   return undefined;
 };
 
-const redisUrlFromEnv = Config.redacted(REDIS_URL_ENV).pipe(
+const redisUrlFromEnv = Config.Redacted(REDIS_URL_ENV).pipe(
   Effect.map((value) => Redacted.value(value)),
 );
 

--- a/packages/alchemy/src/Fly/Secret.ts
+++ b/packages/alchemy/src/Fly/Secret.ts
@@ -77,14 +77,14 @@ const SecretResource = Resource<Secret>("Fly.Secret");
  * managed in one place by Fly.
  *
  * For a secret only this {@link Service} reads from `.env` at deploy
- * time, yield `Config.redacted` instead. Do not pass `env: { ... }` on
+ * time, yield `Config.Redacted` instead. Do not pass `env: { ... }` on
  * a Service.
  *
  * @see https://fly.io/docs/apps/secrets/
  *
- * ### Config.redacted on a Service
+ * ### Config.Redacted on a Service
  * Most secrets in a Service come from your `.env`. Yield
- * `Config.redacted` in init. Alchemy binds the value onto the Machine.
+ * `Config.Redacted` in init. Alchemy binds the value onto the Machine.
  *
  * **Example:** Bind from .env
  * ```typescript
@@ -95,7 +95,7 @@ const SecretResource = Resource<Secret>("Fly.Secret");
  *   "Api",
  *   { app: Site, main: import.meta.url, port: 3000 },
  *   Effect.gen(function* () {
- *     const apiKey = yield* Config.redacted("API_KEY");
+ *     const apiKey = yield* Config.Redacted("API_KEY");
  *
  *     return {
  *       fetch: Effect.gen(function* () {

--- a/packages/alchemy/src/Fly/SecretHttp.ts
+++ b/packages/alchemy/src/Fly/SecretHttp.ts
@@ -224,7 +224,7 @@ export const makeKmsAuth = (
  * error — keep the client's error channel free of `ConfigError`.
  */
 const envName = (key: string): Effect.Effect<string> =>
-  Config.string(key).pipe(Effect.orDie);
+  Config.String(key).pipe(Effect.orDie);
 
 const toNameEffect = (value: unknown): Effect.Effect<string> => {
   if (typeof value === "string") return Effect.succeed(value);

--- a/packages/alchemy/src/Fly/Service.ts
+++ b/packages/alchemy/src/Fly/Service.ts
@@ -448,14 +448,14 @@ export type ServiceRuntimeContext = FlyHostRuntimeContext;
  * whoever deploys and writes it onto the Machine. Do not pass
  * `env: { ... }` on a Service.
  *
- * `Config.redacted("API_KEY")` is `Redacted<string>`. Unwrap with
+ * `Config.Redacted("API_KEY")` is `Redacted<string>`. Unwrap with
  * `Redacted.value` only where you need the raw string.
  *
  * Alchemy also injects `PORT` (when `port` is set) and stack metadata.
  * For a secret Fly should own and inject into every Machine on the
  * App, use {@link Secret}.
  *
- * **Example:** Config.redacted
+ * **Example:** Config.Redacted
  * ```typescript
  * import * as Config from "effect/Config";
  * import * as Redacted from "effect/Redacted";
@@ -464,7 +464,7 @@ export type ServiceRuntimeContext = FlyHostRuntimeContext;
  *   "Api",
  *   { app: Site, main: import.meta.url, port: 3000 },
  *   Effect.gen(function* () {
- *     const apiKey = yield* Config.redacted("API_KEY");
+ *     const apiKey = yield* Config.Redacted("API_KEY");
  *
  *     return {
  *       fetch: Effect.gen(function* () {

--- a/packages/alchemy/src/Fly/Sprite.ts
+++ b/packages/alchemy/src/Fly/Sprite.ts
@@ -225,7 +225,7 @@ export type SpriteRuntimeContext = FlyHostRuntimeContext;
  *
  * Yield `FileSystem.FileSystem` in init, never inside `fetch`.
  *
- * **Example:** Config.redacted
+ * **Example:** Config.Redacted
  * ```typescript
  * import * as Config from "effect/Config";
  * import * as FileSystem from "effect/FileSystem";
@@ -235,7 +235,7 @@ export type SpriteRuntimeContext = FlyHostRuntimeContext;
  *   "Box",
  *   { main: import.meta.url },
  *   Effect.gen(function* () {
- *     const apiKey = yield* Config.redacted("API_KEY");
+ *     const apiKey = yield* Config.Redacted("API_KEY");
  *     const fs = yield* FileSystem.FileSystem;
  *     yield* fs.makeDirectory("/tmp", { recursive: true });
  *

--- a/packages/alchemy/src/GitHub/Env.ts
+++ b/packages/alchemy/src/GitHub/Env.ts
@@ -23,20 +23,20 @@ export interface GitHubEnv {
  * `GITHUB_SHA`, `GITHUB_REPOSITORY_OWNER`, `GITHUB_REPOSITORY`, and the optional
  * `PULL_REQUEST` variable exported by the Alchemy GitHub Action.
  */
-export const GitHubEnv: Config.Config<GitHubEnv | undefined> = Config.boolean(
+export const GitHubEnv: Config.Config<GitHubEnv | undefined> = Config.Boolean(
   "GITHUB_ACTIONS",
 ).pipe(
   Config.withDefault(false),
   // Config has no flatMap in Effect 4; a Config is itself an Effect, so the
-  // enabled branch returns the inner config for mapOrFail to evaluate.
-  Config.mapOrFail(
+  // enabled branch returns the inner config for mapEffect to evaluate.
+  Config.mapEffect(
     (enabled): Effect.Effect<GitHubEnv | undefined, Config.ConfigError> =>
       enabled
         ? Config.all({
-            sha: Config.string("GITHUB_SHA"),
-            owner: Config.string("GITHUB_REPOSITORY_OWNER"),
-            repository: Config.string("GITHUB_REPOSITORY").pipe(
-              Config.mapOrFail(
+            sha: Config.String("GITHUB_SHA"),
+            owner: Config.String("GITHUB_REPOSITORY_OWNER"),
+            repository: Config.String("GITHUB_REPOSITORY").pipe(
+              Config.mapEffect(
                 flow(
                   String.split("/"),
                   Array.get(1),
@@ -47,7 +47,7 @@ export const GitHubEnv: Config.Config<GitHubEnv | undefined> = Config.boolean(
                 ),
               ),
             ),
-            pr: Config.number("PULL_REQUEST").pipe(
+            pr: Config.Number("PULL_REQUEST").pipe(
               Config.option,
               Config.map(Option.getOrUndefined),
             ),

--- a/packages/alchemy/src/Http.ts
+++ b/packages/alchemy/src/Http.ts
@@ -129,7 +129,7 @@ const logUnreportedCause = (cause: Cause.Cause<unknown>) => {
 export const resolvePort = (options: { port?: number } | undefined) =>
   options?.port !== undefined
     ? Effect.succeed(options.port)
-    : Config.number("PORT").pipe(Config.withDefault(3000));
+    : Config.Number("PORT").pipe(Config.withDefault(3000));
 
 export interface BunHttpServerOptions {
   /**

--- a/packages/alchemy/src/Kubernetes/internal/helm.ts
+++ b/packages/alchemy/src/Kubernetes/internal/helm.ts
@@ -26,7 +26,7 @@ export class HelmError extends Data.TaggedError("HelmError")<{
   readonly cause?: unknown;
 }> {}
 
-const HelmBin = Config.string("HELM_BIN").pipe(
+const HelmBin = Config.String("HELM_BIN").pipe(
   Effect.orElseSucceed(() => "helm"),
 );
 

--- a/packages/alchemy/src/Kubernetes/internal/kubeconfig.ts
+++ b/packages/alchemy/src/Kubernetes/internal/kubeconfig.ts
@@ -100,7 +100,7 @@ export const resolveKubeConfigPath = Effect.fn(function* (
   explicit: string | undefined,
 ) {
   if (explicit) return yield* expandHome(explicit);
-  const fromEnv = yield* Config.string("KUBECONFIG").pipe(
+  const fromEnv = yield* Config.String("KUBECONFIG").pipe(
     Effect.orElseSucceed(() => undefined),
   );
   // $KUBECONFIG may be a path list; use the first entry like kubectl's

--- a/packages/alchemy/src/Kubernetes/internal/workload.ts
+++ b/packages/alchemy/src/Kubernetes/internal/workload.ts
@@ -361,8 +361,8 @@ const program = tag.pipe(
     layer.pipe(Layer.provideMerge(Layer.effect(
       Stack,
       Effect.all([
-        Config.string("ALCHEMY_STACK_NAME"),
-        Config.string("ALCHEMY_STAGE")
+        Config.String("ALCHEMY_STACK_NAME"),
+        Config.String("ALCHEMY_STAGE")
       ]).pipe(
         Effect.map(([name, stage]) => ({
           name,
@@ -441,8 +441,8 @@ const program = tag.pipe(
     layer.pipe(Layer.provideMerge(Layer.effect(
       Stack,
       Effect.all([
-        Config.string("ALCHEMY_STACK_NAME"),
-        Config.string("ALCHEMY_STAGE")
+        Config.String("ALCHEMY_STACK_NAME"),
+        Config.String("ALCHEMY_STAGE")
       ]).pipe(
         Effect.map(([name, stage]) => ({
           name,

--- a/packages/alchemy/src/Local/RpcProviderProxy.ts
+++ b/packages/alchemy/src/Local/RpcProviderProxy.ts
@@ -150,5 +150,5 @@ export const layer = (url: string) => Layer.effect(RpcProviderProxy, make(url));
 export const fromEnv = () =>
   Layer.effect(
     RpcProviderProxy,
-    Config.string(SPAWNER_URL_ENV_KEY).pipe(Effect.flatMap(make)),
+    Config.String(SPAWNER_URL_ENV_KEY).pipe(Effect.flatMap(make)),
   );

--- a/packages/alchemy/src/Local/RpcServerEnvironment.ts
+++ b/packages/alchemy/src/Local/RpcServerEnvironment.ts
@@ -82,7 +82,7 @@ export const RPC_SERVER_ENVIRONMENT_KEY =
 
 /** The spawn-time environment the parent baked into the child's process env. */
 export const fromProcessEnv: Effect.Effect<RpcServerEnvironment, unknown> =
-  Config.string(RPC_SERVER_ENVIRONMENT_KEY).pipe(
+  Config.String(RPC_SERVER_ENVIRONMENT_KEY).pipe(
     Config.map((raw) => JSON.parse(raw) as RpcServerEnvironment),
   );
 

--- a/packages/alchemy/src/Local/RpcSpawner.ts
+++ b/packages/alchemy/src/Local/RpcSpawner.ts
@@ -355,7 +355,7 @@ export const forwardSidecarLogs = (
   /** Mirrors every forwarded line (e.g. into a dev log file). */
   tee?: (line: SidecarLogLine) => void,
 ): Effect.Effect<void, never, HttpClient.HttpClient | Scope.Scope> =>
-  Config.string(SPAWNER_URL_ENV_KEY).pipe(
+  Config.String(SPAWNER_URL_ENV_KEY).pipe(
     Effect.flatMap((spawnerUrl) => {
       const streamOnce = Effect.gen(function* () {
         const client = yield* HttpClient.HttpClient;

--- a/packages/alchemy/src/Output.ts
+++ b/packages/alchemy/src/Output.ts
@@ -703,7 +703,7 @@ export const evaluate: <A, Req = never>(
     }
     if (Config.isConfig(expr)) {
       // Resolve Config against the deploy environment — see resolveInput in
-      // Plan.ts for rationale. `Config.redacted` resolves to a `Redacted`,
+      // Plan.ts for rationale. `Config.Redacted` resolves to a `Redacted`,
       // which stays opaque via the leaf fallthrough below.
       return yield* evaluate(yield* expr, upstream, ancestors);
     } else if (isPlainData(expr)) {

--- a/packages/alchemy/src/Phase.ts
+++ b/packages/alchemy/src/Phase.ts
@@ -19,9 +19,9 @@ declare global {
 
 export type AlchemyPhase = "plan" | "runtime";
 
-export const ALCHEMY_PHASE = Config.string("ALCHEMY_PHASE").pipe(
+export const ALCHEMY_PHASE = Config.String("ALCHEMY_PHASE").pipe(
   Config.withDefault("plan"),
-  Config.mapOrFail((value) => {
+  Config.mapEffect((value) => {
     if (value !== "plan" && value !== "runtime") {
       return Effect.die(new Error(`Invalid ALCHEMY_PHASE: ${value}`));
     }
@@ -51,6 +51,6 @@ export const ALCHEMY_PHASE = Config.string("ALCHEMY_PHASE").pipe(
  * });
  * ```
  */
-export const ALCHEMY_DEV = Config.boolean("ALCHEMY_DEV").pipe(
+export const ALCHEMY_DEV = Config.Boolean("ALCHEMY_DEV").pipe(
   Config.withDefault(false),
 );

--- a/packages/alchemy/src/Plan.ts
+++ b/packages/alchemy/src/Plan.ts
@@ -840,7 +840,7 @@ export const make = <A>(
           // here so the concrete value flows into diffing/hashing (an opaque
           // Config hashes the same regardless of the underlying value) and so
           // providers receive a resolved value instead of a Config object.
-          // `Config.redacted` resolves to a `Redacted`, which stays opaque via
+          // `Config.Redacted` resolves to a `Redacted`, which stays opaque via
           // the branch below.
           return yield* resolveInput(yield* input, ancestors);
         } else if (isResource(input)) {

--- a/packages/alchemy/src/Planetscale/Credentials.ts
+++ b/packages/alchemy/src/Planetscale/Credentials.ts
@@ -68,7 +68,7 @@ export const fromAuthProvider = () =>
   Layer.effect(
     Credentials,
     Effect.gen(function* () {
-      const apiBaseUrl = yield* Config.string("PLANETSCALE_API_BASE_URL").pipe(
+      const apiBaseUrl = yield* Config.String("PLANETSCALE_API_BASE_URL").pipe(
         Config.withDefault(DEFAULT_API_BASE_URL),
       );
       const { profileName, resolve } = yield* resolveProviderConfig<

--- a/packages/alchemy/src/Prisma/ComputeBuild.ts
+++ b/packages/alchemy/src/Prisma/ComputeBuild.ts
@@ -1,3 +1,4 @@
+import * as ByteSize from "effect/ByteSize";
 import * as Effect from "effect/Effect";
 import * as Duration from "effect/Duration";
 import * as FileSystem from "effect/FileSystem";
@@ -1351,8 +1352,8 @@ const accountStagingEntry = (
   return Effect.void;
 };
 
-const safeFileSize = (source: string, rawSize: FileSystem.Size) => {
-  const size = Number(rawSize);
+const safeFileSize = (source: string, rawSize: ByteSize.ByteSize) => {
+  const size = ByteSize.toNumberUnsafe(rawSize);
   return Number.isSafeInteger(size) && size >= 0
     ? Effect.succeed(size)
     : Effect.fail(

--- a/packages/alchemy/src/Prisma/PrismaEnvironment.ts
+++ b/packages/alchemy/src/Prisma/PrismaEnvironment.ts
@@ -66,8 +66,8 @@ export const fromProfile = () =>
   Layer.effect(
     PrismaEnvironment,
     Effect.gen(function* () {
-      const baseUrl = yield* Config.string(PRISMA_API_URL_ENV).pipe(
-        Config.orElse(() => Config.string(PRISMA_MANAGEMENT_API_URL_ENV)),
+      const baseUrl = yield* Config.String(PRISMA_API_URL_ENV).pipe(
+        Config.orElse(() => Config.String(PRISMA_MANAGEMENT_API_URL_ENV)),
         Config.withDefault(DEFAULT_BASE_URL),
         Effect.flatMap(normalizeBaseUrl),
       );

--- a/packages/alchemy/src/Railway/BucketBinding.ts
+++ b/packages/alchemy/src/Railway/BucketBinding.ts
@@ -86,15 +86,15 @@ const scopeFromResource = (bucket: Bucket) =>
   });
 
 const scopeFromEnv = Effect.gen(function* () {
-  const bucketName = yield* Config.string("BUCKET_NAME").pipe(
-    Config.orElse(() => Config.string("AWS_S3_BUCKET_NAME")),
+  const bucketName = yield* Config.String("BUCKET_NAME").pipe(
+    Config.orElse(() => Config.String("AWS_S3_BUCKET_NAME")),
   );
-  const accessKeyId = yield* Config.string("AWS_ACCESS_KEY_ID");
-  const secretAccessKey = yield* Config.redacted("AWS_SECRET_ACCESS_KEY");
-  const endpoint = yield* Config.string("AWS_ENDPOINT_URL_S3").pipe(
-    Config.orElse(() => Config.string("AWS_ENDPOINT_URL")),
+  const accessKeyId = yield* Config.String("AWS_ACCESS_KEY_ID");
+  const secretAccessKey = yield* Config.Redacted("AWS_SECRET_ACCESS_KEY");
+  const endpoint = yield* Config.String("AWS_ENDPOINT_URL_S3").pipe(
+    Config.orElse(() => Config.String("AWS_ENDPOINT_URL")),
   );
-  const region = yield* Config.string("AWS_REGION").pipe(
+  const region = yield* Config.String("AWS_REGION").pipe(
     Config.withDefault("auto"),
   );
   return {

--- a/packages/alchemy/src/Railway/RedisBinding.ts
+++ b/packages/alchemy/src/Railway/RedisBinding.ts
@@ -16,7 +16,7 @@ export const REDIS_URL_ENV = "REDIS_URL";
  * Each `{Op}Http.ts` is a thin `Layer.effect` over {@link makeRedisBinding}.
  * Deploy-time writes `REDIS_URL` onto the host Service as a Railway
  * reference (`${{RedisName.REDIS_URL}}`). Runtime commands use that URL
- * internally — callers never read `Config.redacted`.
+ * internally — callers never read `Config.Redacted`.
  *
  * The RESP client lives in `alchemy/Redis`. This file only wires the
  * Railway host binding.
@@ -45,7 +45,7 @@ const resolveName = (redis: Redis) =>
     return redis.LogicalId;
   });
 
-const redisUrlFromEnv = Config.redacted(REDIS_URL_ENV).pipe(
+const redisUrlFromEnv = Config.Redacted(REDIS_URL_ENV).pipe(
   Effect.map((value) => Redacted.value(value)),
 );
 

--- a/packages/alchemy/src/Railway/hosted.ts
+++ b/packages/alchemy/src/Railway/hosted.ts
@@ -208,8 +208,8 @@ const platform = FetchHttpClient.layer;
 const stack = Layer.effect(
   Stack,
   Effect.all([
-    Config.string("ALCHEMY_STACK_NAME"),
-    Config.string("ALCHEMY_STAGE")
+    Config.String("ALCHEMY_STACK_NAME"),
+    Config.String("ALCHEMY_STAGE")
   ]).pipe(
     Effect.map(([name, stage]) => ({
       name,

--- a/packages/alchemy/src/Runtime.ts
+++ b/packages/alchemy/src/Runtime.ts
@@ -92,7 +92,7 @@ const reifyEnvString = (raw: string): string => {
  * marker. The interceptor's runtime branch reifies those markers for reads
  * during Init, but effects that run later (request handlers, nested
  * layers) resolve `Config` against the raw env-backed provider — without
- * this wrapper, `Config.number("PORT")` inside a handler sees the marker
+ * this wrapper, `Config.Number("PORT")` inside a handler sees the marker
  * JSON instead of the source value and fails with a schema error.
  *
  * Two behaviors:

--- a/packages/alchemy/src/Runtime/Bootstrap/Process.ts
+++ b/packages/alchemy/src/Runtime/Bootstrap/Process.ts
@@ -49,8 +49,8 @@ export const stackFromEnv: Layer.Layer<Stack, Config.ConfigError> =
   Layer.effect(
     Stack,
     Effect.all([
-      Config.string("ALCHEMY_STACK_NAME"),
-      Config.string("ALCHEMY_STAGE"),
+      Config.String("ALCHEMY_STACK_NAME"),
+      Config.String("ALCHEMY_STAGE"),
     ]).pipe(
       Effect.map(([name, stage]) => ({
         name,

--- a/packages/alchemy/src/RuntimeContext.ts
+++ b/packages/alchemy/src/RuntimeContext.ts
@@ -136,7 +136,7 @@ export const packEnvValueKeepRedacted = (
  *
  * Runtime `get` accessors MUST feed this from the raw environment
  * (`process.env[key]` / the platform env object) — never through
- * `Config.string`: the ambient runtime `ConfigProvider` reifies bound
+ * `Config.String`: the ambient runtime `ConfigProvider` reifies bound
  * values (unwrapping the marker before it could be detected here), and
  * during init the ambient provider is the interceptor installed in
  * `Platform.ts`, whose runtime branch calls back into `ctx.get(key)` —

--- a/packages/alchemy/src/Server/Process.ts
+++ b/packages/alchemy/src/Server/Process.ts
@@ -84,7 +84,7 @@ export const createHostRuntimeContext =
         }),
       get: <T>(key: string) =>
         // Read straight from `process.env` — see `unpackEnvValue` for why
-        // this must never resolve through `Config.string`.
+        // this must never resolve through `Config.String`.
         Effect.sync(() => unpackEnvValue<T>(process.env[key]) as T),
       run: (effect: Effect.Effect<void, never, any>) =>
         Effect.sync(() => {

--- a/packages/alchemy/src/State/PostgresState.ts
+++ b/packages/alchemy/src/State/PostgresState.ts
@@ -47,7 +47,7 @@ export interface PostgresStateOptions<E = never, R = never> {
   client?: SqlClient.SqlClient;
   /**
    * Postgres connection URL, as a `Redacted` value or an Effect yielding one
-   * — `Config.redacted("STATE_DATABASE_URL")` is itself an Effect, so it can
+   * — `Config.Redacted("STATE_DATABASE_URL")` is itself an Effect, so it can
    * be passed directly. The store creates its own `@effect/sql-pg` pool from
    * the URL and closes that pool when the state layer is released.
    */
@@ -142,7 +142,7 @@ interface Lease {
  *   "my-stack",
  *   {
  *     providers: myProviders(),
- *     state: postgresState({ url: Config.redacted("STATE_DATABASE_URL") }),
+ *     state: postgresState({ url: Config.Redacted("STATE_DATABASE_URL") }),
  *   },
  *   Effect.gen(function* () {
  *     // ...
@@ -158,11 +158,11 @@ interface Lease {
  * // A pool, not `PgClient.makeClient`: the store needs a second connection
  * // to verify the advisory lock held on the reserved one.
  * const sql = yield* PgClient.make({
- *   url: yield* Config.redacted("STATE_DATABASE_URL"),
+ *   url: yield* Config.Redacted("STATE_DATABASE_URL"),
  * });
  * const state = postgresState({
  *   client: sql,
- *   lockKeyPrefix: yield* Config.string("STATE_LOCK_PREFIX"),
+ *   lockKeyPrefix: yield* Config.String("STATE_LOCK_PREFIX"),
  * });
  * ```
  */

--- a/packages/alchemy/src/Telemetry.ts
+++ b/packages/alchemy/src/Telemetry.ts
@@ -80,7 +80,7 @@ export type TelemetryLayer = Layer.Layer<never, any, any>;
  * Redacted marker, and a raw string set directly in the environment).
  */
 const readBoundValue = (key: string): Effect.Effect<unknown> =>
-  Config.string(key).pipe(
+  Config.String(key).pipe(
     Config.withDefault(undefined),
     Effect.orElseSucceed(() => undefined),
     Effect.map((raw) => {

--- a/packages/alchemy/src/Test/Core.ts
+++ b/packages/alchemy/src/Test/Core.ts
@@ -127,7 +127,7 @@ export const sidecarProxy = (options: { profile?: string }) =>
  * in place. Accepts the usual truthy/falsey strings (`true`/`1`/`yes`/`on`,
  * `false`/`0`/`no`/`off`).
  */
-export const ALCHEMY_TEST_DEV = Config.boolean("ALCHEMY_TEST_DEV").pipe(
+export const ALCHEMY_TEST_DEV = Config.Boolean("ALCHEMY_TEST_DEV").pipe(
   Config.option,
 );
 

--- a/packages/alchemy/test/AWS/ECS/fixtures/task.ts
+++ b/packages/alchemy/test/AWS/ECS/fixtures/task.ts
@@ -82,7 +82,7 @@ export default class TestTask extends AWS.ECS.Task<TestTask>()(
     Effect.provide(
       Layer.unwrap(
         Effect.gen(function* () {
-          const url = yield* Config.string("COLLECTOR_URL");
+          const url = yield* Config.String("COLLECTOR_URL");
           return Telemetry.layerOtlp({ url, serviceName: "otel-ecs-e2e" });
         }),
       ),

--- a/packages/alchemy/test/AWS/Lambda/fixtures/otel-handler.ts
+++ b/packages/alchemy/test/AWS/Lambda/fixtures/otel-handler.ts
@@ -45,7 +45,7 @@ export const OtelTestFunctionLive = OtelTestFunction.make(
         // polls this route until it reports 200 before asserting on
         // exported telemetry.
         if (url.pathname === "/probe") {
-          const endpoint = yield* Config.string("COLLECTOR_URL").pipe(
+          const endpoint = yield* Config.String("COLLECTOR_URL").pipe(
             Effect.orDie,
           );
           const result = yield* Effect.tryPromise(() =>
@@ -73,7 +73,7 @@ export const OtelTestFunctionLive = OtelTestFunction.make(
     Effect.provide(
       Layer.unwrap(
         Effect.gen(function* () {
-          const url = yield* Config.string("COLLECTOR_URL");
+          const url = yield* Config.String("COLLECTOR_URL");
           return Telemetry.layerOtlp({ url, serviceName: "otel-lambda-test" });
         }),
       ),

--- a/packages/alchemy/test/AWS/Secret/Secret.test.ts
+++ b/packages/alchemy/test/AWS/Secret/Secret.test.ts
@@ -17,7 +17,7 @@ import SecretsTestFunctionLive, {
 } from "./fixtures/handler.ts";
 
 /**
- * `Config.redacted("CONFIG_SECRET")` resolves against the active
+ * `Config.Redacted("CONFIG_SECRET")` resolves against the active
  * `ConfigProvider` at deploy time. The default provider reads from
  * `process.env`, so populate it before `beforeAll(deploy(Stack))`
  * compiles the stack.
@@ -76,7 +76,7 @@ const getJson = (url: string) =>
   );
 
 test(
-  "Config.redacted with literal default round-trips to Lambda runtime as Redacted<string>",
+  "Config.Redacted with literal default round-trips to Lambda runtime as Redacted<string>",
   Effect.gen(function* () {
     const { url } = yield* stack;
     expect(url).toBeTypeOf("string");
@@ -95,7 +95,7 @@ test(
 );
 
 test(
-  "Config.redacted resolved from env round-trips through Lambda env",
+  "Config.Redacted resolved from env round-trips through Lambda env",
   Effect.gen(function* () {
     const { url } = yield* stack;
     const baseUrl = url.replace(/\/+$/, "");
@@ -113,7 +113,7 @@ test(
 );
 
 test(
-  "Config.string round-trips to Lambda runtime as a string",
+  "Config.String round-trips to Lambda runtime as a string",
   Effect.gen(function* () {
     const { url } = yield* stack;
     const baseUrl = url.replace(/\/+$/, "");
@@ -128,7 +128,7 @@ test(
 );
 
 test(
-  "Config.number round-trips to Lambda runtime preserving the number type",
+  "Config.Number round-trips to Lambda runtime preserving the number type",
   Effect.gen(function* () {
     const { url } = yield* stack;
     const baseUrl = url.replace(/\/+$/, "");
@@ -143,7 +143,7 @@ test(
 );
 
 test(
-  "Config.string with object default round-trips to Lambda runtime preserving nested shape",
+  "Config.String with object default round-trips to Lambda runtime preserving nested shape",
   Effect.gen(function* () {
     const { url } = yield* stack;
     const baseUrl = url.replace(/\/+$/, "");

--- a/packages/alchemy/test/AWS/Secret/fixtures/handler.ts
+++ b/packages/alchemy/test/AWS/Secret/fixtures/handler.ts
@@ -22,7 +22,7 @@ export const OBJECT_VAR_VALUE = {
 
 /**
  * Name of the deploy-time `process.env` variable the test populates
- * before deploying — sourced via `Config.string(...)` inside the
+ * before deploying — sourced via `Config.String(...)` inside the
  * Lambda's init phase.
  */
 export const CONFIG_SECRET_ENV_KEY = "ALCHEMY_AWS_SECRET_TEST_SOURCE";
@@ -40,7 +40,7 @@ export const SecretsTestFunctionLive = SecretsTestFunction.make(
     // Secret from a literal — `Alchemy.Secret` coerces the literal to
     // `Redacted` and the Lambda runtime accessor rebuilds the wrapper
     // from the JSON marker stored in env.
-    const literalSecret = yield* Config.redacted("LITERAL_SECRET").pipe(
+    const literalSecret = yield* Config.Redacted("LITERAL_SECRET").pipe(
       Config.withDefault(Redacted.make(LITERAL_SECRET_VALUE)),
     );
 
@@ -48,22 +48,22 @@ export const SecretsTestFunctionLive = SecretsTestFunction.make(
     // `ConfigProvider` (process.env) at deploy time. The test populates
     // `process.env[CONFIG_SECRET_ENV_KEY]` before deploying, so source
     // from that same key (not a hard-coded literal).
-    const configSecret = yield* Config.redacted(CONFIG_SECRET_ENV_KEY);
+    const configSecret = yield* Config.Redacted(CONFIG_SECRET_ENV_KEY);
 
     // Plain string variable — string round-trip.
-    const stringVar = yield* Config.string("STRING_VAR").pipe(
+    const stringVar = yield* Config.String("STRING_VAR").pipe(
       Config.withDefault(STRING_VAR_VALUE),
     );
 
     // Number variable — non-string values JSON.stringify on `set` and
     // JSON.parse on the runtime accessor, so the accessor returns the
     // original number.
-    const numberVar = yield* Config.number("NUMBER_VAR").pipe(
+    const numberVar = yield* Config.Number("NUMBER_VAR").pipe(
       Config.withDefault(NUMBER_VAR_VALUE),
     );
 
     // Object variable — same JSON round-trip as above for nested data.
-    const objectVar = yield* Config.string("OBJECT_VAR").pipe(
+    const objectVar = yield* Config.String("OBJECT_VAR").pipe(
       Config.withDefault(OBJECT_VAR_VALUE),
     );
 

--- a/packages/alchemy/test/Cloudflare/Secret/Secret.test.ts
+++ b/packages/alchemy/test/Cloudflare/Secret/Secret.test.ts
@@ -15,7 +15,7 @@ import {
   STRING_VAR_VALUE,
 } from "./fixtures/worker.ts";
 /**
- * `Config.redacted("CONFIG_SECRET")` resolves against the active
+ * `Config.Redacted("CONFIG_SECRET")` resolves against the active
  * `ConfigProvider` at deploy time. The default provider reads from
  * `process.env`, so populate it before `beforeAll(deploy(Stack))`
  * compiles the stack.
@@ -67,7 +67,7 @@ const fetchWhenReady = (url: string) =>
   });
 
 test(
-  "Config.redacted with literal default round-trips to runtime as Redacted<string>",
+  "Config.Redacted with literal default round-trips to runtime as Redacted<string>",
   Effect.gen(function* () {
     const { url } = yield* stack;
     expect(url).toBeTypeOf("string");
@@ -85,7 +85,7 @@ test(
 );
 
 test(
-  "Config.redacted resolved from env deploys as a secret_text and round-trips",
+  "Config.Redacted resolved from env deploys as a secret_text and round-trips",
   Effect.gen(function* () {
     const { url } = yield* stack;
 
@@ -102,7 +102,7 @@ test(
 );
 
 test(
-  "Config.string round-trips to runtime as a string",
+  "Config.String round-trips to runtime as a string",
   Effect.gen(function* () {
     const { url } = yield* stack;
 
@@ -116,7 +116,7 @@ test(
 );
 
 test(
-  "Config.number round-trips to runtime preserving the number type",
+  "Config.Number round-trips to runtime preserving the number type",
   Effect.gen(function* () {
     const { url } = yield* stack;
 
@@ -130,7 +130,7 @@ test(
 );
 
 test(
-  "Config.string with object default round-trips to runtime preserving nested shape",
+  "Config.String with object default round-trips to runtime preserving nested shape",
   Effect.gen(function* () {
     const { url } = yield* stack;
 

--- a/packages/alchemy/test/Cloudflare/Secret/fixtures/worker.ts
+++ b/packages/alchemy/test/Cloudflare/Secret/fixtures/worker.ts
@@ -16,7 +16,7 @@ export const OBJECT_VAR_VALUE = { host: "localhost", flags: { beta: true } };
 
 /**
  * Name of the deploy-time `process.env` variable the test populates
- * before deploying — sourced via `Config.string(...)` inside the
+ * before deploying — sourced via `Config.String(...)` inside the
  * worker's init phase.
  */
 
@@ -29,28 +29,28 @@ export default class SecretsTestWorker extends Cloudflare.Worker<SecretsTestWork
   Effect.gen(function* () {
     // Secret from a literal — `Alchemy.Secret` coerces the literal to
     // `Redacted` and the Worker provider deploys it as `secret_text`.
-    const literalSecret = yield* Config.redacted("LITERAL_SECRET").pipe(
+    const literalSecret = yield* Config.Redacted("LITERAL_SECRET").pipe(
       Config.withDefault(Redacted.make(LITERAL_SECRET_VALUE)),
     );
 
     // Secret from a `Config` — resolved against the active
     // `ConfigProvider` (process.env) at deploy time.
-    const configSecret = yield* Config.redacted("CONFIG_SECRET");
+    const configSecret = yield* Config.Redacted("CONFIG_SECRET");
 
     // Plain string variable — `plain_text` binding round-trip.
-    const stringVar = yield* Config.string("STRING_VAR").pipe(
+    const stringVar = yield* Config.String("STRING_VAR").pipe(
       Config.withDefault(STRING_VAR_VALUE),
     );
 
     // Number variable — non-string values JSON.stringify on `set` and
     // JSON.parse on the runtime accessor, so the accessor returns the
     // original number.
-    const numberVar = yield* Config.number("NUMBER_VAR").pipe(
+    const numberVar = yield* Config.Number("NUMBER_VAR").pipe(
       Config.withDefault(NUMBER_VAR_VALUE),
     );
 
     // Object variable — same JSON round-trip as above for nested data.
-    const objectVar = yield* Config.string("OBJECT_VAR").pipe(
+    const objectVar = yield* Config.String("OBJECT_VAR").pipe(
       Config.withDefault(OBJECT_VAR_VALUE),
     );
 

--- a/packages/alchemy/test/Cloudflare/Website/StaticSite.test.ts
+++ b/packages/alchemy/test/Cloudflare/Website/StaticSite.test.ts
@@ -31,7 +31,7 @@ const logLevel = Effect.provideService(
 const fixtureDir = pathe.resolve(import.meta.dirname, "staticsite-fixture");
 const workerEntry = pathe.resolve(import.meta.dirname, "fixtures/worker.ts");
 
-// Read back through `Config.string` by the #796 test below. Set at module
+// Read back through `Config.String` by the #796 test below. Set at module
 // load (collection time): `ConfigProvider.fromEnv` snapshots `process.env`
 // when the test harness constructs the provider — BEFORE a test body runs —
 // so setting this inside the test only ever satisfied the NEXT attempt
@@ -777,7 +777,7 @@ describe.concurrent("StaticSite", () => {
               workersDev: false,
               env: {
                 FROM_STRING: "plain",
-                FROM_CONFIG: Config.string("STATICSITE_ENV_TEST"),
+                FROM_CONFIG: Config.String("STATICSITE_ENV_TEST"),
                 FROM_OUTPUT: dep.outdir,
                 FROM_OUTPUT_OBJECT: Output.map(dep.outdir, (dir) => ({ dir })),
                 // JS callers can pass `null`; it must serialize, not throw.

--- a/packages/alchemy/test/Cloudflare/Workers/WorkerEnv.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/WorkerEnv.test.ts
@@ -16,7 +16,7 @@ const CONFIG_REDACTED_VALUE = (process.env.CONFIG_REDACTED =
   "config-redacted-value");
 const CONFIG_REDACTED_INIT_VALUE = (process.env.CONFIG_REDACTED_INIT =
   "config-redacted-init-value");
-// Read via `Config.string("HOST").pipe(Config.nested("CONFIG_NESTED"))` —
+// Read via `Config.String("HOST").pipe(Config.nested("CONFIG_NESTED"))` —
 // binds under the flattened `CONFIG_NESTED_HOST` key.
 const CONFIG_NESTED_HOST_VALUE = (process.env.CONFIG_NESTED_HOST =
   "config-nested-host-value");

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/email-catchall-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/email-catchall-worker.ts
@@ -3,7 +3,7 @@ import * as Config from "effect/Config";
 import * as Effect from "effect/Effect";
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
 
-const ZoneConfig = Config.string("CLOUDFLARE_TEST_DNS_ZONE_NAME").pipe(
+const ZoneConfig = Config.String("CLOUDFLARE_TEST_DNS_ZONE_NAME").pipe(
   Config.withDefault("alchemy-test-2.us"),
 );
 

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/email-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/email-worker.ts
@@ -16,13 +16,13 @@ import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
  * the send→receive round trip needs a verified destination, which not every
  * account has.
  */
-const ZoneConfig = Config.string("CLOUDFLARE_TEST_DNS_ZONE_NAME").pipe(
+const ZoneConfig = Config.String("CLOUDFLARE_TEST_DNS_ZONE_NAME").pipe(
   Config.withDefault("alchemy-test-2.us"),
 );
-const InboxConfig = Config.string("CLOUDFLARE_TEST_EMAIL_INBOX").pipe(
+const InboxConfig = Config.String("CLOUDFLARE_TEST_EMAIL_INBOX").pipe(
   Config.withDefault(""),
 );
-const SenderConfig = Config.string("CLOUDFLARE_TEST_EMAIL_FROM").pipe(
+const SenderConfig = Config.String("CLOUDFLARE_TEST_EMAIL_FROM").pipe(
   Config.withDefault(""),
 );
 

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/env/effect.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/env/effect.ts
@@ -34,28 +34,28 @@ export default class EnvEffectWorker extends Cloudflare.Worker<EnvEffectWorker>(
       SECRET_JSON: Redacted.make({ token: "abc", scopes: ["read", "write"] }),
       // Config declared statically on `env` — Alchemy resolves at deploy
       // time and binds it as `secret_text` on the Worker.
-      CONFIG_REDACTED: Config.redacted("CONFIG_REDACTED"),
+      CONFIG_REDACTED: Config.Redacted("CONFIG_REDACTED"),
     },
   },
   Effect.gen(function* () {
     // Captured during Init — Alchemy binds these onto the Worker and the
     // runtime ConfigProvider (backed by `env`) re-resolves them here.
-    const configStr = yield* Config.string("CONFIG_STR");
-    const configNum = yield* Config.number("CONFIG_NUM");
-    const configRedactedInit = yield* Config.redacted("CONFIG_REDACTED_INIT");
+    const configStr = yield* Config.String("CONFIG_STR");
+    const configNum = yield* Config.Number("CONFIG_NUM");
+    const configRedactedInit = yield* Config.Redacted("CONFIG_REDACTED_INIT");
     // Composite forms — each member is bound individually, so the whole
     // shape must survive the deploy → runtime round-trip.
     const configAllObj = yield* Config.all({
-      str: Config.string("CONFIG_STR"),
-      num: Config.number("CONFIG_NUM"),
-      redacted: Config.redacted("CONFIG_REDACTED_INIT"),
+      str: Config.String("CONFIG_STR"),
+      num: Config.Number("CONFIG_NUM"),
+      redacted: Config.Redacted("CONFIG_REDACTED_INIT"),
     });
     const configAllTuple = yield* Config.all([
-      Config.string("CONFIG_STR"),
-      Config.number("CONFIG_NUM"),
+      Config.String("CONFIG_STR"),
+      Config.Number("CONFIG_NUM"),
     ]);
     // Nested prefix — bound under the flattened `CONFIG_NESTED_HOST` key.
-    const configNested = yield* Config.string("HOST").pipe(
+    const configNested = yield* Config.String("HOST").pipe(
       Config.nested("CONFIG_NESTED"),
     );
 
@@ -116,23 +116,23 @@ export default class EnvEffectWorker extends Cloudflare.Worker<EnvEffectWorker>(
           // runtime ConfigProvider (not the Init interceptor) answers the
           // read. The bound values arrive in `env` as
           // `{"_tag":"Redacted","value":...}` markers and must be reified
-          // transparently: `Config.number` must decode the raw source value,
+          // transparently: `Config.Number` must decode the raw source value,
           // not the marker JSON.
           const nested = yield* Effect.gen(function* () {
             const allObj = yield* Config.all({
-              str: Config.string("CONFIG_STR"),
-              num: Config.number("CONFIG_NUM"),
-              redacted: Config.redacted("CONFIG_REDACTED_INIT"),
+              str: Config.String("CONFIG_STR"),
+              num: Config.Number("CONFIG_NUM"),
+              redacted: Config.Redacted("CONFIG_REDACTED_INIT"),
             });
             return {
-              CONFIG_STR: yield* Config.string("CONFIG_STR"),
-              CONFIG_NUM: yield* Config.number("CONFIG_NUM"),
+              CONFIG_STR: yield* Config.String("CONFIG_STR"),
+              CONFIG_NUM: yield* Config.Number("CONFIG_NUM"),
               // Combinators re-apply at runtime against the bound source.
-              CONFIG_NUM_WITH_DEFAULT: yield* Config.number("CONFIG_NUM").pipe(
+              CONFIG_NUM_WITH_DEFAULT: yield* Config.Number("CONFIG_NUM").pipe(
                 Config.withDefault(999),
               ),
               // Never read during Init, so never bound — the default applies.
-              CONFIG_UNSET_WITH_DEFAULT: yield* Config.number(
+              CONFIG_UNSET_WITH_DEFAULT: yield* Config.Number(
                 "CONFIG_UNSET",
               ).pipe(Config.withDefault(3000)),
               CONFIG_ALL_OBJ: {
@@ -142,15 +142,15 @@ export default class EnvEffectWorker extends Cloudflare.Worker<EnvEffectWorker>(
                 redactedIsRedacted: Redacted.isRedacted(allObj.redacted),
               },
               CONFIG_ALL_TUPLE: yield* Config.all([
-                Config.string("CONFIG_STR"),
-                Config.number("CONFIG_NUM"),
+                Config.String("CONFIG_STR"),
+                Config.Number("CONFIG_NUM"),
               ]),
-              CONFIG_NESTED_HOST: yield* Config.string("HOST").pipe(
+              CONFIG_NESTED_HOST: yield* Config.String("HOST").pipe(
                 Config.nested("CONFIG_NESTED"),
               ),
             };
           });
-          const redactedAtRuntime = yield* Config.redacted(
+          const redactedAtRuntime = yield* Config.Redacted(
             "CONFIG_REDACTED_INIT",
           );
           return yield* HttpServerResponse.json({

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/env/stack.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/env/stack.ts
@@ -26,9 +26,9 @@ export const AsyncWorker = Cloudflare.Worker("EnvAsyncWorker", {
       token: "abc",
       scopes: ["read", "write"],
     }),
-    CONFIG_STR: Config.string("CONFIG_STR"),
-    CONFIG_NUM: Config.number("CONFIG_NUM"),
-    CONFIG_REDACTED: Config.redacted("CONFIG_REDACTED"),
+    CONFIG_STR: Config.String("CONFIG_STR"),
+    CONFIG_NUM: Config.Number("CONFIG_NUM"),
+    CONFIG_REDACTED: Config.Redacted("CONFIG_REDACTED"),
     CF_VERSION_METADATA: Cloudflare.Workers.VersionMetadata(),
   },
 });

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/native-tracing/worker.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/native-tracing/worker.ts
@@ -200,13 +200,13 @@ export const tracedWorkerImpl = Effect.gen(function* () {
   Effect.provide(
     Layer.unwrap(
       Effect.gen(function* () {
-        const collectorUrl = yield* Config.string("COLLECTOR_URL").pipe(
+        const collectorUrl = yield* Config.String("COLLECTOR_URL").pipe(
           Effect.orElseSucceed(() => undefined),
         );
-        const composeOrder = yield* Config.string("COMPOSE_ORDER").pipe(
+        const composeOrder = yield* Config.String("COMPOSE_ORDER").pipe(
           Effect.orElseSucceed(() => "cf-last"),
         );
-        const headSamplingRate = yield* Config.number(
+        const headSamplingRate = yield* Config.Number(
           "HEAD_SAMPLING_RATE",
         ).pipe(Effect.orElseSucceed(() => 1));
         const native = Layer.mergeAll(

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/otel-custom-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/otel-custom-worker.ts
@@ -21,7 +21,7 @@ export default class OtelCustomWorker extends Cloudflare.Worker<OtelCustomWorker
     env: {
       // Config key must equal the env key — the props re-execute inside
       // the deployed isolate and re-read the Config from the bound var.
-      COLLECTOR_URL: Config.string("COLLECTOR_URL"),
+      COLLECTOR_URL: Config.String("COLLECTOR_URL"),
     },
   },
   Effect.gen(function* () {
@@ -43,7 +43,7 @@ export default class OtelCustomWorker extends Cloudflare.Worker<OtelCustomWorker
       Telemetry.layer(
         Layer.unwrap(
           Effect.gen(function* () {
-            const baseUrl = yield* Config.string("COLLECTOR_URL");
+            const baseUrl = yield* Config.String("COLLECTOR_URL");
             return Otlp.layerJson({
               baseUrl,
               resource: { serviceName: "otel-custom-test" },

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/otel-event-flush-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/otel-event-flush-worker.ts
@@ -55,7 +55,7 @@ export default class OtelEventFlushWorker extends Cloudflare.Worker<OtelEventFlu
   }).pipe(
     Effect.provide(
       Layer.unwrap(
-        Config.string("OTLP_EVENT_FLUSH_URL").pipe(
+        Config.String("OTLP_EVENT_FLUSH_URL").pipe(
           Effect.map((url) =>
             Telemetry.layerOtlp({
               traces: { url },

--- a/packages/alchemy/test/Cloudflare/Workers/fixtures/otel-traced-worker.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/fixtures/otel-traced-worker.ts
@@ -40,7 +40,7 @@ export default class OtelTracedWorker extends Cloudflare.Worker<OtelTracedWorker
         // polls this route until it reports 200 before asserting on
         // exported telemetry.
         if (url.pathname === "/probe") {
-          const endpoint = yield* Config.string("COLLECTOR_URL").pipe(
+          const endpoint = yield* Config.String("COLLECTOR_URL").pipe(
             Effect.orDie,
           );
           const result = yield* Effect.tryPromise(() =>
@@ -71,7 +71,7 @@ export default class OtelTracedWorker extends Cloudflare.Worker<OtelTracedWorker
     Effect.provide(
       Layer.unwrap(
         Effect.gen(function* () {
-          const url = yield* Config.string("COLLECTOR_URL");
+          const url = yield* Config.String("COLLECTOR_URL");
           return Layer.mergeAll(
             Telemetry.layerOtlp({ url, serviceName: "otel-traced-test" }),
             Telemetry.layerOtlp({ traces: { url: `${url}/v1/second-traces` } }),

--- a/packages/alchemy/test/Diff.test.ts
+++ b/packages/alchemy/test/Diff.test.ts
@@ -16,7 +16,7 @@ import * as Redacted from "effect/Redacted";
 describe("Diff", () => {
   describe("havePropsChanged with Redacted values", () => {
     // Config values yielded in a Worker's init phase (e.g.
-    // `yield* Config.string("MY_VARIABLE")`) land in `props.env`
+    // `yield* Config.String("MY_VARIABLE")`) land in `props.env`
     // as `Redacted<string>`. Before unwrapping, every Redacted serialized
     // to the constant mask `"<redacted>"`, so a changed secret was
     // invisible to the diff and the Worker never redeployed.

--- a/packages/alchemy/test/Output.test.ts
+++ b/packages/alchemy/test/Output.test.ts
@@ -139,7 +139,7 @@ describe("Output.evaluate", () => {
       provideState(
         Effect.gen(function* () {
           const result = yield* Output.evaluate(
-            { port: Config.number("PORT").pipe(Config.withDefault(1337)) },
+            { port: Config.Number("PORT").pipe(Config.withDefault(1337)) },
             {},
           ).pipe(
             Effect.provide(

--- a/packages/alchemy/test/Stack.test.ts
+++ b/packages/alchemy/test/Stack.test.ts
@@ -20,7 +20,7 @@ describe("Alchemy.Stack error channel", () => {
         state: Layer.empty as any,
       },
       Effect.gen(function* () {
-        const value = yield* Config.string("SOME_CONFIG");
+        const value = yield* Config.String("SOME_CONFIG");
         return { value };
       }),
     );

--- a/packages/alchemy/test/State/PostgresState.test.ts
+++ b/packages/alchemy/test/State/PostgresState.test.ts
@@ -335,10 +335,10 @@ describe("Postgres state store", () => {
 
   it.effect("reports an unresolvable url config as a state store error", () => {
     // `url` accepts any Effect of a Redacted string, so
-    // `Config.redacted(...)` can be passed straight through; a missing
+    // `Config.Redacted(...)` can be passed straight through; a missing
     // variable surfaces as a StateStoreError like any other failure.
     return withoutClient(
-      { url: Config.redacted("ALCHEMY_TEST_MISSING_STATE_DATABASE_URL") },
+      { url: Config.Redacted("ALCHEMY_TEST_MISSING_STATE_DATABASE_URL") },
       (store) => store.get(request),
     ).pipe(
       Effect.flip,

--- a/packages/alchemy/test/types/Sandbox.ts
+++ b/packages/alchemy/test/types/Sandbox.ts
@@ -33,14 +33,14 @@ export const SandboxLive = Sandbox.make(
         const request = yield* HttpServerRequest;
         // upgrade to web socket
         const socket = yield* request.upgrade;
-        const writeMessage = yield* socket.writer;
+        const writer = yield* socket.writer;
         const cmd = yield* cp.spawn(ChildProcess.make("ffmpeg", ["-version"]));
         const [exitCode] = yield* Effect.all(
           [
             cmd.exitCode,
             // pipe stdout to the websocket
             cmd.stdout.pipe(
-              Stream.tap(writeMessage),
+              Stream.tap((chunk) => writer.write(chunk)),
               Stream.decodeText,
               Stream.mkString,
             ),

--- a/packages/cloudflare-runtime/src/core/Docker.ts
+++ b/packages/cloudflare-runtime/src/core/Docker.ts
@@ -84,11 +84,11 @@ const DEFAULT_DOCKER_HOST =
     : "unix:///var/run/docker.sock";
 const DEV_CONTAINER_PREFIX = "alchemy-dev";
 
-const DockerHost = Config.string("DOCKER_HOST");
-const DockerBin = Config.string("DOCKER_BIN").pipe(
+const DockerHost = Config.String("DOCKER_HOST");
+const DockerBin = Config.String("DOCKER_BIN").pipe(
   Config.orElse(() => Config.succeed("docker")),
 );
-const ContainerEgressInterceptorImage = Config.string(
+const ContainerEgressInterceptorImage = Config.String(
   "CONTAINER_EGRESS_INTERCEPTOR_IMAGE",
 ).pipe(
   Config.orElse(() =>

--- a/packages/cloudflare-runtime/src/core/internal/Paths.ts
+++ b/packages/cloudflare-runtime/src/core/internal/Paths.ts
@@ -35,7 +35,7 @@ export const PathsLive = Layer.effect(
     const makeWith =
       (options: { env: string; fallback: Array<string> }) =>
       (...prefix: Array<string>) =>
-        Config.string(options.env).pipe(
+        Config.String(options.env).pipe(
           Effect.orElseSucceed(() => path.join(home, ...options.fallback)),
           Effect.map((root) => path.join(root, ...prefix)),
           Effect.tap((path) =>

--- a/packages/cloudflare-runtime/src/core/internal/System.ts
+++ b/packages/cloudflare-runtime/src/core/internal/System.ts
@@ -2,10 +2,10 @@ import * as Config from "effect/Config";
 import * as Effect from "effect/Effect";
 import * as NodeOs from "node:os";
 
-export const home = Config.string("CLOUDFLARE_RUNTIME_HOME").pipe(
+export const home = Config.String("CLOUDFLARE_RUNTIME_HOME").pipe(
   Effect.orElseSucceed(() => NodeOs.homedir()),
 );
 
-export const fileSystemSupportsWatcher = Config.boolean(
+export const fileSystemSupportsWatcher = Config.Boolean(
   "CLOUDFLARE_RUNTIME_FILE_SYSTEM_SUPPORTS_WATCHER",
 ).pipe(Effect.orElseSucceed(() => NodeOs.platform() !== "win32"));

--- a/packages/cloudflare-runtime/src/core/remote-bindings/Access.ts
+++ b/packages/cloudflare-runtime/src/core/remote-bindings/Access.ts
@@ -75,7 +75,7 @@ export const layer = Layer.effect(
       );
 
     const getEnv = (name: string) =>
-      Config.string(name).pipe(
+      Config.String(name).pipe(
         Effect.catchTag("ConfigError", () => Effect.succeed(undefined)),
       );
 

--- a/packages/cloudflare-test-tools/src/e2e/Cli.ts
+++ b/packages/cloudflare-test-tools/src/e2e/Cli.ts
@@ -21,7 +21,7 @@ const build = Command.make(
 const dev = Command.make(
   "dev",
   {
-    port: Flag.integer("port").pipe(Flag.optional),
+    port: Flag.Int("port").pipe(Flag.optional),
   },
   Effect.fn(function* ({ port }) {
     const framework = yield* Framework;

--- a/packages/pr-package/src/PackageStore.ts
+++ b/packages/pr-package/src/PackageStore.ts
@@ -34,7 +34,7 @@ const WEEK_MS = 7 * 24 * 60 * 60 * 1000;
  * Optional GitHub token for PR state lookups on TTL expiry. Bound as a
  * Worker secret when `GITHUB_TOKEN` is set at deploy time.
  */
-export const GitHubToken = Config.redacted("GITHUB_TOKEN").pipe(Config.option);
+export const GitHubToken = Config.Redacted("GITHUB_TOKEN").pipe(Config.option);
 
 export default class PackageStore extends Cloudflare.DurableObject<PackageStore>()(
   "PackageStore",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,9 +109,6 @@ catalogs:
     miniflare:
       specifier: ^4.20260701.0
       version: 4.20260722.0
-    mysql2:
-      specifier: ^3.24.2
-      version: 3.24.2
     postal-mime:
       specifier: ^2.4.3
       version: 2.7.5
@@ -149,37 +146,34 @@ catalogs:
     mongodb:
       specifier: ^6.10.0
       version: 6.21.0
-    mysql2:
-      specifier: ^3.24.2
-      version: 3.24.2
     pg:
       specifier: ^8.22.0
       version: 8.23.0
   effect:
     '@effect/atom-react':
-      specifier: '>=4.0.0-rc.112 || >=4.0.0'
-      version: 4.0.0-rc.112
+      specifier: '>=4.0.0-rc.113 || >=4.0.0'
+      version: 4.0.0-rc.113
     '@effect/platform-bun':
-      specifier: '>=4.0.0-rc.112 || >=4.0.0'
-      version: 4.0.0-rc.112
+      specifier: '>=4.0.0-rc.113 || >=4.0.0'
+      version: 4.0.0-rc.113
     '@effect/platform-node':
-      specifier: '>=4.0.0-rc.112 || >=4.0.0'
-      version: 4.0.0-rc.112
+      specifier: '>=4.0.0-rc.113 || >=4.0.0'
+      version: 4.0.0-rc.113
     '@effect/sql-d1':
-      specifier: '>=4.0.0-rc.112 || >=4.0.0'
-      version: 4.0.0-rc.112
+      specifier: '>=4.0.0-rc.113 || >=4.0.0'
+      version: 4.0.0-rc.113
     '@effect/sql-mysql2':
-      specifier: '>=4.0.0-rc.112 || >=4.0.0'
-      version: 4.0.0-rc.112
+      specifier: '>=4.0.0-rc.113 || >=4.0.0'
+      version: 4.0.0-rc.113
     '@effect/sql-pg':
-      specifier: '>=4.0.0-rc.112 || >=4.0.0'
-      version: 4.0.0-rc.112
+      specifier: '>=4.0.0-rc.113 || >=4.0.0'
+      version: 4.0.0-rc.113
     '@effect/sql-sqlite-do':
-      specifier: '>=4.0.0-rc.112 || >=4.0.0'
-      version: 4.0.0-rc.112
+      specifier: '>=4.0.0-rc.113 || >=4.0.0'
+      version: 4.0.0-rc.113
     '@effect/vitest':
-      specifier: '>=4.0.0-rc.112 || >=4.0.0'
-      version: 4.0.0-rc.112
+      specifier: '>=4.0.0-rc.113 || >=4.0.0'
+      version: 4.0.0-rc.113
   frontend:
     '@astrojs/internal-helpers':
       specifier: 0.10.1
@@ -379,10 +373,12 @@ catalogs:
 overrides:
   '@cloudflare/workers-types': 5.20260901.1
   workerd: 1.20260901.1
-  effect: 4.0.0-rc.112
-  '@effect/platform-browser': 4.0.0-rc.112
+  effect: 4.0.0-rc.113
+  '@effect/platform-browser': 4.0.0-rc.113
   drizzle-kit: 1.0.0-rc.5-ab785fc
   drizzle-orm: 1.0.0-rc.5-ab785fc
+  mysql2: 3.24.2
+  zod: 4.4.3
   rolldown: 1.2.5
 
 pnpmfileChecksum: sha256-elTHWproOlNxhpfqxI523wQRI4DQEVcmXXl5vhr4xWU=
@@ -406,10 +402,10 @@ importers:
         version: 0.87.2
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       '@effect/tsgo':
         specifier: 0.36.4
         version: 0.36.4
@@ -426,8 +422,8 @@ importers:
         specifier: ^13.16.1
         version: 13.16.1(magicast@0.5.4)
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       husky:
         specifier: catalog:tooling
         version: 9.1.7
@@ -454,16 +450,16 @@ importers:
         version: link:../../submodules/distilled/packages/aws
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       alchemy:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@cloudflare/containers':
         specifier: catalog:cloudflare
@@ -479,16 +475,16 @@ importers:
     dependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       alchemy:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
 
   examples/aws-bedrock-ai:
     dependencies:
@@ -497,25 +493,25 @@ importers:
         version: link:../../submodules/distilled/packages/aws
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       alchemy:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
 
   examples/aws-dev:
     dependencies:
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       alchemy:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       alchemy-test:
         specifier: workspace:*
@@ -528,13 +524,13 @@ importers:
         version: link:../../submodules/distilled/packages/aws
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       alchemy:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
 
   examples/aws-ecs:
     dependencies:
@@ -543,13 +539,13 @@ importers:
         version: link:../../submodules/distilled/packages/aws
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       alchemy:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       alchemy-test:
         specifier: workspace:*
@@ -562,13 +558,13 @@ importers:
         version: link:../../submodules/distilled/packages/aws
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       alchemy:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
 
   examples/aws-hyperpod:
     dependencies:
@@ -577,13 +573,13 @@ importers:
         version: link:../../submodules/distilled/packages/aws
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       alchemy:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
 
   examples/aws-lambda:
     dependencies:
@@ -592,13 +588,13 @@ importers:
         version: link:../../submodules/distilled/packages/aws
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       alchemy:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       alchemy-test:
         specifier: workspace:*
@@ -611,13 +607,13 @@ importers:
         version: link:../../submodules/distilled/packages/aws
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       alchemy:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
 
   examples/aws-lambda-rpc:
     dependencies:
@@ -626,13 +622,13 @@ importers:
         version: link:../../submodules/distilled/packages/aws
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       alchemy:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
 
   examples/aws-rds:
     dependencies:
@@ -641,7 +637,7 @@ importers:
         version: link:../../submodules/distilled/packages/aws
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       '@types/pg':
         specifier: catalog:database
         version: 8.20.0
@@ -649,8 +645,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       pg:
         specifier: catalog:database
         version: 8.23.0
@@ -664,8 +660,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
 
   examples/aws-router:
     dependencies:
@@ -677,13 +673,13 @@ importers:
         version: link:../../submodules/distilled/packages/aws
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       alchemy:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       react:
         specifier: catalog:frontend
         version: 19.2.8
@@ -720,19 +716,19 @@ importers:
         version: link:../../submodules/distilled/packages/aws
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       alchemy:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
 
   examples/aws-website-astro:
     dependencies:
       astro:
         specifier: catalog:frontend
-        version: 7.3.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
+        version: 7.3.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
     devDependencies:
       '@alchemy.run/frontend-frameworks':
         specifier: workspace:*
@@ -742,7 +738,7 @@ importers:
         version: link:../../submodules/distilled/packages/aws
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       '@tailwindcss/vite':
         specifier: catalog:frontend
         version: 4.3.3(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
@@ -753,8 +749,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/alchemy-test
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       tailwindcss:
         specifier: catalog:frontend
         version: 4.3.3
@@ -765,11 +761,11 @@ importers:
   examples/aws-website-foldkit:
     dependencies:
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       foldkit:
         specifier: catalog:frontend
-        version: 0.148.2(effect@4.0.0-rc.112)
+        version: 0.148.2(effect@4.0.0-rc.113)
     devDependencies:
       '@alchemy.run/frontend-frameworks':
         specifier: workspace:*
@@ -779,10 +775,10 @@ importers:
         version: link:../../submodules/distilled/packages/aws
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       '@foldkit/vite-plugin':
         specifier: catalog:frontend
-        version: 0.16.1(effect@4.0.0-rc.112)(foldkit@0.148.2(effect@4.0.0-rc.112))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+        version: 0.16.1(effect@4.0.0-rc.113)(foldkit@0.148.2(effect@4.0.0-rc.113))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
       '@tailwindcss/vite':
         specifier: catalog:frontend
         version: 4.3.3(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
@@ -819,7 +815,7 @@ importers:
         version: link:../../submodules/distilled/packages/aws
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       '@opennextjs/aws':
         specifier: catalog:frontend
         version: 4.1.0(next@16.2.10(@babel/core@7.29.7(supports-color@10.2.2))(@playwright/test@1.62.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@10.2.2)
@@ -839,8 +835,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/alchemy-test
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       tailwindcss:
         specifier: catalog:frontend
         version: 4.3.3
@@ -854,8 +850,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@alchemy.run/frontend-frameworks':
         specifier: workspace:*
@@ -865,7 +861,7 @@ importers:
         version: link:../../submodules/distilled/packages/aws
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       '@tailwindcss/vite':
         specifier: catalog:frontend
         version: 4.3.3(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
@@ -877,10 +873,10 @@ importers:
         version: link:../../packages/alchemy-test
       nitropack:
         specifier: catalog:frontend
-        version: 2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@24.13.3)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@24.13.3))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4))(mysql2@3.24.2(@types/node@24.13.3))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
+        version: 2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@24.13.3)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@24.13.3))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@24.13.3))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
       nuxt:
         specifier: catalog:frontend
-        version: 4.5.1(64eb09726475984998fb56e43114116a)
+        version: 4.5.1(867099590d63db02e3731b2415c98ffd)
       tailwindcss:
         specifier: catalog:frontend
         version: 4.3.3
@@ -914,7 +910,7 @@ importers:
         version: link:../../submodules/distilled/packages/aws
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       '@react-router/dev':
         specifier: catalog:frontend
         version: 7.16.0(@types/node@26.2.0)(@vitejs/plugin-rsc@0.5.34(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(react@19.2.8)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))(jiti@2.7.0)(lightningcss@1.33.0)(react-router@7.16.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(supports-color@10.2.2)(terser@5.50.0)(tsx@4.23.12)(typescript@7.0.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(wrangler@4.127.1(@cloudflare/workers-types@5.20260901.1))(yaml@2.9.0)
@@ -928,8 +924,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       tailwindcss:
         specifier: catalog:frontend
         version: 4.3.3
@@ -950,7 +946,7 @@ importers:
         version: 2.0.4(@solidjs/router@0.16.3(solid-js@1.9.15))(crossws@0.4.10(srvx@0.12.5))(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
       '@solidjs/vite-plugin-nitro-2':
         specifier: catalog:frontend
-        version: 0.3.2(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+        version: 0.3.2(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
       solid-js:
         specifier: catalog:frontend
         version: 1.9.15
@@ -963,7 +959,7 @@ importers:
         version: link:../../submodules/distilled/packages/aws
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       '@tailwindcss/vite':
         specifier: catalog:frontend
         version: 4.3.3(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
@@ -971,8 +967,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       tailwindcss:
         specifier: catalog:frontend
         version: 4.3.3
@@ -989,8 +985,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@alchemy.run/frontend-frameworks':
         specifier: workspace:*
@@ -1000,7 +996,7 @@ importers:
         version: link:../../submodules/distilled/packages/aws
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       '@sveltejs/kit':
         specifier: catalog:frontend
         version: 3.0.0-next.9(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.8)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))(svelte@5.56.8)(typescript@7.0.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
@@ -1052,7 +1048,7 @@ importers:
         version: link:../../submodules/distilled/packages/aws
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       '@tailwindcss/vite':
         specifier: catalog:frontend
         version: 4.3.3(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
@@ -1069,8 +1065,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       tailwindcss:
         specifier: catalog:frontend
         version: 4.3.3
@@ -1098,7 +1094,7 @@ importers:
         version: link:../../submodules/distilled/packages/aws
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       '@tailwindcss/vite':
         specifier: catalog:frontend
         version: 4.3.3(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
@@ -1115,8 +1111,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       tailwindcss:
         specifier: catalog:frontend
         version: 4.3.3
@@ -1133,8 +1129,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       hono:
         specifier: catalog:frontend
         version: 4.12.33
@@ -1159,7 +1155,7 @@ importers:
         version: link:../../submodules/distilled/packages/aws
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       '@tailwindcss/vite':
         specifier: catalog:frontend
         version: 4.3.3(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
@@ -1189,16 +1185,16 @@ importers:
     dependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       alchemy:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
 
   examples/cloudflare-d1-drizzle:
     dependencies:
@@ -1207,19 +1203,19 @@ importers:
         version: 5.20260901.1
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       alchemy:
         specifier: workspace:*
         version: link:../../packages/alchemy
       drizzle-orm:
         specifier: 1.0.0-rc.5-ab785fc
-        version: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3)
+        version: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3)
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       drizzle-kit:
         specifier: 1.0.0-rc.5-ab785fc
@@ -1235,16 +1231,16 @@ importers:
         version: 5.20260901.1
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       alchemy:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       alchemy-test:
         specifier: workspace:*
@@ -1257,16 +1253,16 @@ importers:
         version: 5.20260901.1
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       alchemy:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
 
   examples/cloudflare-email:
     dependencies:
@@ -1275,29 +1271,29 @@ importers:
         version: 5.20260901.1
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       alchemy:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
 
   examples/cloudflare-foldkit:
     dependencies:
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       foldkit:
         specifier: catalog:frontend
-        version: 0.148.2(effect@4.0.0-rc.112)
+        version: 0.148.2(effect@4.0.0-rc.113)
     devDependencies:
       '@foldkit/vite-plugin':
         specifier: catalog:frontend
-        version: 0.16.1(effect@4.0.0-rc.112)(foldkit@0.148.2(effect@4.0.0-rc.112))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+        version: 0.16.1(effect@4.0.0-rc.113)(foldkit@0.148.2(effect@4.0.0-rc.113))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
       '@tailwindcss/vite':
         specifier: catalog:frontend
         version: 4.3.3(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
@@ -1320,15 +1316,15 @@ importers:
   examples/cloudflare-foldkit-ssr:
     dependencies:
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       foldkit:
         specifier: catalog:frontend
-        version: 0.148.2(effect@4.0.0-rc.112)
+        version: 0.148.2(effect@4.0.0-rc.113)
     devDependencies:
       '@foldkit/vite-plugin':
         specifier: catalog:frontend
-        version: 0.16.1(effect@4.0.0-rc.112)(foldkit@0.148.2(effect@4.0.0-rc.112))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+        version: 0.16.1(effect@4.0.0-rc.113)(foldkit@0.148.2(effect@4.0.0-rc.113))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
       '@types/node':
         specifier: catalog:node24
         version: 24.13.3
@@ -1346,16 +1342,16 @@ importers:
     dependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       alchemy:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
 
   examples/cloudflare-microvm-shell:
     dependencies:
@@ -1364,13 +1360,13 @@ importers:
         version: link:../../submodules/distilled/packages/aws
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       alchemy:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       typescript:
         specifier: catalog:build
@@ -1383,22 +1379,22 @@ importers:
         version: 5.20260901.1
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       '@effect/sql-pg':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       alchemy:
         specifier: workspace:*
         version: link:../../packages/alchemy
       drizzle-orm:
         specifier: 1.0.0-rc.5-ab785fc
-        version: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3)
+        version: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3)
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       pg:
         specifier: catalog:database
         version: 8.23.0
@@ -1425,8 +1421,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       octane:
         specifier: catalog:frontend
         version: 0.1.22(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
@@ -1448,24 +1444,24 @@ importers:
         version: 5.20260901.1
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       '@effect/sql-mysql2':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113)
       alchemy:
         specifier: workspace:*
         version: link:../../packages/alchemy
       drizzle-orm:
         specifier: 1.0.0-rc.5-ab785fc
-        version: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3)
+        version: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3)
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       mysql2:
-        specifier: catalog:database
+        specifier: 3.24.2
         version: 3.24.2(@types/node@26.2.0)
     devDependencies:
       drizzle-kit:
@@ -1479,22 +1475,22 @@ importers:
         version: 5.20260901.1
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       '@effect/sql-pg':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       alchemy:
         specifier: workspace:*
         version: link:../../packages/alchemy
       drizzle-orm:
         specifier: 1.0.0-rc.5-ab785fc
-        version: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3)
+        version: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3)
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       pg:
         specifier: catalog:database
         version: 8.23.0
@@ -1516,16 +1512,16 @@ importers:
         version: 5.20260901.1
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       alchemy:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
 
   examples/cloudflare-secrets-store:
     dependencies:
@@ -1534,16 +1530,16 @@ importers:
         version: 5.20260901.1
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       alchemy:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
 
   examples/cloudflare-solidjs-ssr:
     dependencies:
@@ -1561,8 +1557,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       postcss:
         specifier: catalog:frontend
         version: 8.5.26
@@ -1586,13 +1582,13 @@ importers:
         version: link:../../submodules/distilled/packages/cloudflare
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       alchemy:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       typescript:
         specifier: catalog:build
@@ -1602,16 +1598,16 @@ importers:
     dependencies:
       '@effect/atom-react':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(react@19.2.8)(scheduler@0.27.0)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(react@19.2.8)(scheduler@0.27.0)
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       '@effect/sql-pg':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@tanstack/react-router':
         specifier: catalog:frontend
         version: 1.170.27(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -1623,10 +1619,10 @@ importers:
         version: link:../../packages/alchemy
       drizzle-orm:
         specifier: 1.0.0-rc.5-ab785fc
-        version: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3)
+        version: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3)
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       pg:
         specifier: catalog:database
         version: 8.23.0
@@ -1674,8 +1670,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       solid-js:
         specifier: catalog:frontend
         version: 1.9.15
@@ -1724,8 +1720,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       npm-run-all2:
         specifier: ^8.0.4
         version: 8.0.4
@@ -1743,7 +1739,7 @@ importers:
         version: 8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
       vite-plugin-vue-devtools:
         specifier: ^8.1.1
-        version: 8.2.1(@nuxt/kit@4.5.1(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))))(supports-color@10.2.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(vue@3.6.0-beta.17(typescript@7.0.2))
+        version: 8.2.1(@nuxt/kit@4.5.1(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(vue@3.6.0-beta.17(typescript@7.0.2))
       vue-tsc:
         specifier: ^3.2.6
         version: 3.3.9(typescript@7.0.2)
@@ -1752,7 +1748,7 @@ importers:
     dependencies:
       astro:
         specifier: catalog:frontend
-        version: 7.3.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
+        version: 7.3.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
     devDependencies:
       '@alchemy.run/frontend-frameworks':
         specifier: workspace:*
@@ -1764,8 +1760,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       tailwindcss:
         specifier: catalog:frontend
         version: 4.3.3
@@ -1776,15 +1772,15 @@ importers:
   examples/cloudflare-website-foldkit:
     dependencies:
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       foldkit:
         specifier: catalog:frontend
-        version: 0.148.2(effect@4.0.0-rc.112)
+        version: 0.148.2(effect@4.0.0-rc.113)
     devDependencies:
       '@foldkit/vite-plugin':
         specifier: catalog:frontend
-        version: 0.16.1(effect@4.0.0-rc.112)(foldkit@0.148.2(effect@4.0.0-rc.112))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+        version: 0.16.1(effect@4.0.0-rc.113)(foldkit@0.148.2(effect@4.0.0-rc.113))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
       '@tailwindcss/vite':
         specifier: catalog:frontend
         version: 4.3.3(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
@@ -1832,8 +1828,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       tailwindcss:
         specifier: catalog:frontend
         version: 4.3.3
@@ -1847,8 +1843,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@alchemy.run/frontend-frameworks':
         specifier: workspace:*
@@ -1861,10 +1857,10 @@ importers:
         version: 24.13.3
       nitropack:
         specifier: catalog:frontend
-        version: 2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@24.13.3)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@24.13.3))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4))(mysql2@3.24.2(@types/node@24.13.3))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
+        version: 2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@24.13.3)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@24.13.3))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@24.13.3))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
       nuxt:
         specifier: catalog:frontend
-        version: 4.5.1(64eb09726475984998fb56e43114116a)
+        version: 4.5.1(867099590d63db02e3731b2415c98ffd)
       tailwindcss:
         specifier: catalog:frontend
         version: 4.3.3
@@ -1900,8 +1896,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       tailwindcss:
         specifier: catalog:frontend
         version: 4.3.3
@@ -1930,8 +1926,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       solid-js:
         specifier: catalog:frontend
         version: 1.9.15
@@ -1952,8 +1948,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@alchemy.run/frontend-frameworks':
         specifier: workspace:*
@@ -1995,8 +1991,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       react:
         specifier: catalog:frontend
         version: 19.2.8
@@ -2054,8 +2050,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       tailwindcss:
         specifier: catalog:frontend
         version: 4.3.3
@@ -2072,8 +2068,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       react:
         specifier: catalog:frontend-rsc
         version: 19.2.8
@@ -2127,8 +2123,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       hono:
         specifier: catalog:frontend
         version: 4.12.33
@@ -2177,19 +2173,19 @@ importers:
         version: link:../../packages/better-auth
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       alchemy:
         specifier: workspace:*
         version: link:../../packages/alchemy
       better-auth:
         specifier: catalog:auth
-        version: 1.6.25(e20f5e9f480a52fe3a4e9438c63ccf5e)
+        version: 1.6.25(3f55a70ed1274cd9feb933c6021ba76f)
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
 
   examples/cloudflare-worker-async:
     dependencies:
@@ -2201,19 +2197,19 @@ importers:
         version: 5.20260901.1
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       alchemy:
         specifier: workspace:*
         version: link:../../packages/alchemy
       better-auth:
         specifier: catalog:auth
-        version: 1.6.25(04166073f4f545899d491cc413622642)
+        version: 1.6.25(3f55a70ed1274cd9feb933c6021ba76f)
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
 
   examples/dev-stress:
     dependencies:
@@ -2222,13 +2218,13 @@ importers:
         version: 5.20260901.1
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       alchemy:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
 
   examples/docker-postgres:
     dependencies:
@@ -2236,8 +2232,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
 
   examples/fly-app:
     dependencies:
@@ -2246,13 +2242,13 @@ importers:
         version: link:../../submodules/distilled/packages/fly-io
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       alchemy:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
 
   examples/fly-bucket:
     dependencies:
@@ -2261,13 +2257,13 @@ importers:
         version: link:../../submodules/distilled/packages/fly-io
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       alchemy:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
 
   examples/fly-postgres:
     dependencies:
@@ -2276,19 +2272,19 @@ importers:
         version: link:../../submodules/distilled/packages/fly-io
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       '@effect/sql-pg':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       alchemy:
         specifier: workspace:*
         version: link:../../packages/alchemy
       drizzle-orm:
         specifier: 1.0.0-rc.5-ab785fc
-        version: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3)
+        version: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3)
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       pg:
         specifier: catalog:database
         version: 8.23.0
@@ -2307,13 +2303,13 @@ importers:
         version: link:../../submodules/distilled/packages/fly-io
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       alchemy:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
 
   examples/fly-service:
     dependencies:
@@ -2322,13 +2318,13 @@ importers:
         version: link:../../submodules/distilled/packages/fly-io
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       alchemy:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
 
   examples/fly-sprite:
     dependencies:
@@ -2337,19 +2333,19 @@ importers:
         version: link:../../submodules/distilled/packages/fly-io
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       alchemy:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
 
   examples/fly-website-astro:
     dependencies:
       astro:
         specifier: catalog:frontend
-        version: 7.3.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
+        version: 7.3.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
     devDependencies:
       '@alchemy.run/frontend-frameworks':
         specifier: workspace:*
@@ -2359,7 +2355,7 @@ importers:
         version: link:../../submodules/distilled/packages/fly-io
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       '@tailwindcss/vite':
         specifier: catalog:frontend
         version: 4.3.3(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
@@ -2367,8 +2363,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       tailwindcss:
         specifier: catalog:frontend
         version: 4.3.3
@@ -2379,11 +2375,11 @@ importers:
   examples/fly-website-foldkit:
     dependencies:
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       foldkit:
         specifier: catalog:frontend
-        version: 0.148.2(effect@4.0.0-rc.112)
+        version: 0.148.2(effect@4.0.0-rc.113)
     devDependencies:
       '@alchemy.run/frontend-frameworks':
         specifier: workspace:*
@@ -2393,10 +2389,10 @@ importers:
         version: link:../../submodules/distilled/packages/fly-io
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       '@foldkit/vite-plugin':
         specifier: catalog:frontend
-        version: 0.16.1(effect@4.0.0-rc.112)(foldkit@0.148.2(effect@4.0.0-rc.112))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+        version: 0.16.1(effect@4.0.0-rc.113)(foldkit@0.148.2(effect@4.0.0-rc.113))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
       '@tailwindcss/vite':
         specifier: catalog:frontend
         version: 4.3.3(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
@@ -2433,7 +2429,7 @@ importers:
         version: link:../../submodules/distilled/packages/fly-io
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       '@tailwindcss/postcss':
         specifier: catalog:frontend
         version: 4.3.3
@@ -2447,8 +2443,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       tailwindcss:
         specifier: catalog:frontend
         version: 4.3.3
@@ -2462,8 +2458,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@alchemy.run/frontend-frameworks':
         specifier: workspace:*
@@ -2473,7 +2469,7 @@ importers:
         version: link:../../submodules/distilled/packages/fly-io
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       '@tailwindcss/vite':
         specifier: catalog:frontend
         version: 4.3.3(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
@@ -2482,10 +2478,10 @@ importers:
         version: 24.13.3
       nitropack:
         specifier: catalog:frontend
-        version: 2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@24.13.3)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@24.13.3))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4))(mysql2@3.24.2(@types/node@24.13.3))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
+        version: 2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@24.13.3)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@24.13.3))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@24.13.3))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
       nuxt:
         specifier: catalog:frontend
-        version: 4.5.1(64eb09726475984998fb56e43114116a)
+        version: 4.5.1(867099590d63db02e3731b2415c98ffd)
       tailwindcss:
         specifier: catalog:frontend
         version: 4.3.3
@@ -2502,8 +2498,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       isbot:
         specifier: catalog:frontend
         version: 5.2.1
@@ -2525,7 +2521,7 @@ importers:
         version: link:../../submodules/distilled/packages/fly-io
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       '@react-router/dev':
         specifier: catalog:frontend
         version: 7.16.0(@types/node@26.2.0)(@vitejs/plugin-rsc@0.5.34(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(react@19.2.8)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))(jiti@2.7.0)(lightningcss@1.33.0)(react-router@7.16.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(supports-color@10.2.2)(terser@5.50.0)(tsx@4.23.12)(typescript@7.0.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(wrangler@4.127.1(@cloudflare/workers-types@5.20260901.1))(yaml@2.9.0)
@@ -2555,13 +2551,13 @@ importers:
         version: 2.0.4(@solidjs/router@0.16.3(solid-js@1.9.15))(crossws@0.4.10(srvx@0.12.5))(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
       '@solidjs/vite-plugin-nitro-2':
         specifier: catalog:frontend
-        version: 0.3.2(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+        version: 0.3.2(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
       alchemy:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       solid-js:
         specifier: catalog:frontend
         version: 1.9.15
@@ -2574,7 +2570,7 @@ importers:
         version: link:../../submodules/distilled/packages/fly-io
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       '@tailwindcss/vite':
         specifier: catalog:frontend
         version: 4.3.3(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
@@ -2594,8 +2590,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@alchemy.run/frontend-frameworks':
         specifier: workspace:*
@@ -2605,7 +2601,7 @@ importers:
         version: link:../../submodules/distilled/packages/fly-io
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       '@sveltejs/kit':
         specifier: catalog:frontend
         version: 3.0.0-next.9(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.8)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))(svelte@5.56.8)(typescript@7.0.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
@@ -2643,8 +2639,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       react:
         specifier: catalog:frontend
         version: 19.2.8
@@ -2660,7 +2656,7 @@ importers:
         version: link:../../submodules/distilled/packages/fly-io
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       '@tailwindcss/vite':
         specifier: catalog:frontend
         version: 4.3.3(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
@@ -2693,19 +2689,19 @@ importers:
         version: link:../../submodules/distilled/packages/fly-io
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       '@effect/sql-pg':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       alchemy:
         specifier: workspace:*
         version: link:../../packages/alchemy
       drizzle-orm:
         specifier: 1.0.0-rc.5-ab785fc
-        version: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3)
+        version: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3)
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       pg:
         specifier: catalog:database
         version: 8.23.0
@@ -2747,8 +2743,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       react:
         specifier: catalog:frontend-rsc
         version: 19.2.8
@@ -2773,7 +2769,7 @@ importers:
         version: link:../../submodules/distilled/packages/fly-io
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       '@types/node':
         specifier: catalog:node24
         version: 24.13.3
@@ -2802,8 +2798,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       hono:
         specifier: catalog:frontend
         version: 4.12.33
@@ -2828,7 +2824,7 @@ importers:
         version: link:../../submodules/distilled/packages/fly-io
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       '@tailwindcss/vite':
         specifier: catalog:frontend
         version: 4.3.3(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
@@ -2858,13 +2854,13 @@ importers:
         version: link:../../submodules/distilled/packages/hetzner
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       alchemy:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
 
   examples/hetzner-server:
     dependencies:
@@ -2873,19 +2869,19 @@ importers:
         version: link:../../submodules/distilled/packages/hetzner
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       alchemy:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
 
   examples/hetzner-website-astro:
     dependencies:
       astro:
         specifier: catalog:frontend
-        version: 7.3.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
+        version: 7.3.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
     devDependencies:
       '@alchemy.run/frontend-frameworks':
         specifier: workspace:*
@@ -2895,7 +2891,7 @@ importers:
         version: link:../../submodules/distilled/packages/hetzner
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       '@tailwindcss/vite':
         specifier: catalog:frontend
         version: 4.3.3(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
@@ -2903,8 +2899,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       tailwindcss:
         specifier: catalog:frontend
         version: 4.3.3
@@ -2915,11 +2911,11 @@ importers:
   examples/hetzner-website-foldkit:
     dependencies:
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       foldkit:
         specifier: catalog:frontend
-        version: 0.148.2(effect@4.0.0-rc.112)
+        version: 0.148.2(effect@4.0.0-rc.113)
     devDependencies:
       '@alchemy.run/frontend-frameworks':
         specifier: workspace:*
@@ -2929,10 +2925,10 @@ importers:
         version: link:../../submodules/distilled/packages/hetzner
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       '@foldkit/vite-plugin':
         specifier: catalog:frontend
-        version: 0.16.1(effect@4.0.0-rc.112)(foldkit@0.148.2(effect@4.0.0-rc.112))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+        version: 0.16.1(effect@4.0.0-rc.113)(foldkit@0.148.2(effect@4.0.0-rc.113))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
       '@tailwindcss/vite':
         specifier: catalog:frontend
         version: 4.3.3(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
@@ -2969,7 +2965,7 @@ importers:
         version: link:../../submodules/distilled/packages/hetzner
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       '@tailwindcss/postcss':
         specifier: catalog:frontend
         version: 4.3.3
@@ -2983,8 +2979,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       tailwindcss:
         specifier: catalog:frontend
         version: 4.3.3
@@ -2998,8 +2994,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@alchemy.run/frontend-frameworks':
         specifier: workspace:*
@@ -3009,7 +3005,7 @@ importers:
         version: link:../../submodules/distilled/packages/hetzner
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       '@tailwindcss/vite':
         specifier: catalog:frontend
         version: 4.3.3(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
@@ -3018,10 +3014,10 @@ importers:
         version: 24.13.3
       nitropack:
         specifier: catalog:frontend
-        version: 2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@24.13.3)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@24.13.3))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4))(mysql2@3.24.2(@types/node@24.13.3))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
+        version: 2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@24.13.3)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@24.13.3))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@24.13.3))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
       nuxt:
         specifier: catalog:frontend
-        version: 4.5.1(64eb09726475984998fb56e43114116a)
+        version: 4.5.1(867099590d63db02e3731b2415c98ffd)
       tailwindcss:
         specifier: catalog:frontend
         version: 4.3.3
@@ -3055,7 +3051,7 @@ importers:
         version: link:../../submodules/distilled/packages/hetzner
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       '@react-router/dev':
         specifier: catalog:frontend
         version: 7.16.0(@types/node@26.2.0)(@vitejs/plugin-rsc@0.5.34(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(react@19.2.8)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))(jiti@2.7.0)(lightningcss@1.33.0)(react-router@7.16.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(supports-color@10.2.2)(terser@5.50.0)(tsx@4.23.12)(typescript@7.0.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(wrangler@4.127.1(@cloudflare/workers-types@5.20260901.1))(yaml@2.9.0)
@@ -3069,8 +3065,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       tailwindcss:
         specifier: catalog:frontend
         version: 4.3.3
@@ -3091,7 +3087,7 @@ importers:
         version: 2.0.4(@solidjs/router@0.16.3(solid-js@1.9.15))(crossws@0.4.10(srvx@0.12.5))(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
       '@solidjs/vite-plugin-nitro-2':
         specifier: catalog:frontend
-        version: 0.3.2(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+        version: 0.3.2(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
       solid-js:
         specifier: catalog:frontend
         version: 1.9.15
@@ -3104,7 +3100,7 @@ importers:
         version: link:../../submodules/distilled/packages/hetzner
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       '@tailwindcss/vite':
         specifier: catalog:frontend
         version: 4.3.3(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
@@ -3112,8 +3108,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       tailwindcss:
         specifier: catalog:frontend
         version: 4.3.3
@@ -3130,8 +3126,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@alchemy.run/frontend-frameworks':
         specifier: workspace:*
@@ -3141,7 +3137,7 @@ importers:
         version: link:../../submodules/distilled/packages/hetzner
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       '@sveltejs/kit':
         specifier: catalog:frontend
         version: 3.0.0-next.9(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.8)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))(svelte@5.56.8)(typescript@7.0.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
@@ -3190,7 +3186,7 @@ importers:
         version: link:../../submodules/distilled/packages/hetzner
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       '@tailwindcss/vite':
         specifier: catalog:frontend
         version: 4.3.3(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
@@ -3207,8 +3203,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       tailwindcss:
         specifier: catalog:frontend
         version: 4.3.3
@@ -3229,19 +3225,19 @@ importers:
         version: link:../../submodules/distilled/packages/hetzner
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       '@effect/sql-pg':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       alchemy:
         specifier: workspace:*
         version: link:../../packages/alchemy
       drizzle-orm:
         specifier: 1.0.0-rc.5-ab785fc
-        version: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3)
+        version: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3)
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       pg:
         specifier: catalog:database
         version: 8.23.0
@@ -3283,8 +3279,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       react:
         specifier: catalog:frontend-rsc
         version: 19.2.8
@@ -3309,7 +3305,7 @@ importers:
         version: link:../../submodules/distilled/packages/hetzner
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       '@types/node':
         specifier: catalog:node24
         version: 24.13.3
@@ -3338,8 +3334,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       hono:
         specifier: catalog:frontend
         version: 4.12.33
@@ -3364,7 +3360,7 @@ importers:
         version: link:../../submodules/distilled/packages/hetzner
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       '@tailwindcss/vite':
         specifier: catalog:frontend
         version: 4.3.3(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
@@ -3391,25 +3387,25 @@ importers:
     dependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       alchemy:
         specifier: workspace:*
         version: link:../../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
 
   examples/monorepo-multi-stack/frontend:
     dependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       '@monorepo-multi-stack/backend':
         specifier: workspace:*
         version: link:../backend
@@ -3423,8 +3419,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       react:
         specifier: catalog:frontend
         version: 19.2.8
@@ -3439,16 +3435,16 @@ importers:
     dependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       alchemy:
         specifier: workspace:*
         version: link:../../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
 
   examples/monorepo-single-stack/frontend:
     dependencies:
@@ -3465,8 +3461,8 @@ importers:
         specifier: workspace:*
         version: link:../../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       react:
         specifier: catalog:frontend
         version: 19.2.8
@@ -3481,13 +3477,13 @@ importers:
     dependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       alchemy:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@types/node':
         specifier: catalog:tooling
@@ -3511,11 +3507,11 @@ importers:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       nitro:
         specifier: ^3.0.260415-beta
-        version: 3.0.260415-beta(dde441ba7809e60dabce322e719b3d54)
+        version: 3.0.260415-beta(2572a4db108bb714489ad9ba04d6002b)
       pg:
         specifier: catalog:database
         version: 8.23.0
@@ -3570,13 +3566,13 @@ importers:
         version: link:../../submodules/distilled/packages/railway
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       alchemy:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
 
   examples/railway-service:
     dependencies:
@@ -3585,19 +3581,19 @@ importers:
         version: link:../../submodules/distilled/packages/railway
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       '@effect/sql-pg':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       alchemy:
         specifier: workspace:*
         version: link:../../packages/alchemy
       drizzle-orm:
         specifier: 1.0.0-rc.5-ab785fc
-        version: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3)
+        version: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3)
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       pg:
         specifier: catalog:database
         version: 8.23.0
@@ -3610,7 +3606,7 @@ importers:
     dependencies:
       astro:
         specifier: catalog:frontend
-        version: 7.3.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
+        version: 7.3.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
     devDependencies:
       '@alchemy.run/frontend-frameworks':
         specifier: workspace:*
@@ -3620,7 +3616,7 @@ importers:
         version: link:../../submodules/distilled/packages/railway
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       '@tailwindcss/vite':
         specifier: catalog:frontend
         version: 4.3.3(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
@@ -3628,8 +3624,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       tailwindcss:
         specifier: catalog:frontend
         version: 4.3.3
@@ -3640,11 +3636,11 @@ importers:
   examples/railway-website-foldkit:
     dependencies:
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       foldkit:
         specifier: catalog:frontend
-        version: 0.148.2(effect@4.0.0-rc.112)
+        version: 0.148.2(effect@4.0.0-rc.113)
     devDependencies:
       '@alchemy.run/frontend-frameworks':
         specifier: workspace:*
@@ -3654,10 +3650,10 @@ importers:
         version: link:../../submodules/distilled/packages/railway
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       '@foldkit/vite-plugin':
         specifier: catalog:frontend
-        version: 0.16.1(effect@4.0.0-rc.112)(foldkit@0.148.2(effect@4.0.0-rc.112))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+        version: 0.16.1(effect@4.0.0-rc.113)(foldkit@0.148.2(effect@4.0.0-rc.113))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
       '@tailwindcss/vite':
         specifier: catalog:frontend
         version: 4.3.3(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
@@ -3694,7 +3690,7 @@ importers:
         version: link:../../submodules/distilled/packages/railway
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       '@tailwindcss/postcss':
         specifier: catalog:frontend
         version: 4.3.3
@@ -3708,8 +3704,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       tailwindcss:
         specifier: catalog:frontend
         version: 4.3.3
@@ -3723,8 +3719,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@alchemy.run/frontend-frameworks':
         specifier: workspace:*
@@ -3734,7 +3730,7 @@ importers:
         version: link:../../submodules/distilled/packages/railway
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       '@tailwindcss/vite':
         specifier: catalog:frontend
         version: 4.3.3(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
@@ -3743,10 +3739,10 @@ importers:
         version: 24.13.3
       nitropack:
         specifier: catalog:frontend
-        version: 2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@24.13.3)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@24.13.3))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4))(mysql2@3.24.2(@types/node@24.13.3))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
+        version: 2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@24.13.3)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@24.13.3))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@24.13.3))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
       nuxt:
         specifier: catalog:frontend
-        version: 4.5.1(64eb09726475984998fb56e43114116a)
+        version: 4.5.1(867099590d63db02e3731b2415c98ffd)
       tailwindcss:
         specifier: catalog:frontend
         version: 4.3.3
@@ -3763,8 +3759,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       isbot:
         specifier: catalog:frontend
         version: 5.2.1
@@ -3786,7 +3782,7 @@ importers:
         version: link:../../submodules/distilled/packages/railway
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       '@react-router/dev':
         specifier: catalog:frontend
         version: 7.16.0(@types/node@26.2.0)(@vitejs/plugin-rsc@0.5.34(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(react@19.2.8)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))(jiti@2.7.0)(lightningcss@1.33.0)(react-router@7.16.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(supports-color@10.2.2)(terser@5.50.0)(tsx@4.23.12)(typescript@7.0.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(wrangler@4.127.1(@cloudflare/workers-types@5.20260901.1))(yaml@2.9.0)
@@ -3816,13 +3812,13 @@ importers:
         version: 2.0.4(@solidjs/router@0.16.3(solid-js@1.9.15))(crossws@0.4.10(srvx@0.12.5))(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
       '@solidjs/vite-plugin-nitro-2':
         specifier: catalog:frontend
-        version: 0.3.2(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+        version: 0.3.2(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
       alchemy:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       solid-js:
         specifier: catalog:frontend
         version: 1.9.15
@@ -3835,7 +3831,7 @@ importers:
         version: link:../../submodules/distilled/packages/railway
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       '@tailwindcss/vite':
         specifier: catalog:frontend
         version: 4.3.3(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
@@ -3855,8 +3851,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@alchemy.run/frontend-frameworks':
         specifier: workspace:*
@@ -3866,7 +3862,7 @@ importers:
         version: link:../../submodules/distilled/packages/railway
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       '@sveltejs/kit':
         specifier: catalog:frontend
         version: 3.0.0-next.9(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.8)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))(svelte@5.56.8)(typescript@7.0.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
@@ -3904,8 +3900,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       react:
         specifier: catalog:frontend
         version: 19.2.8
@@ -3921,7 +3917,7 @@ importers:
         version: link:../../submodules/distilled/packages/railway
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       '@tailwindcss/vite':
         specifier: catalog:frontend
         version: 4.3.3(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
@@ -3954,19 +3950,19 @@ importers:
         version: link:../../submodules/distilled/packages/railway
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       '@effect/sql-pg':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       alchemy:
         specifier: workspace:*
         version: link:../../packages/alchemy
       drizzle-orm:
         specifier: 1.0.0-rc.5-ab785fc
-        version: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3)
+        version: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3)
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       pg:
         specifier: catalog:database
         version: 8.23.0
@@ -4008,8 +4004,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       react:
         specifier: catalog:frontend-rsc
         version: 19.2.8
@@ -4034,7 +4030,7 @@ importers:
         version: link:../../submodules/distilled/packages/railway
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       '@types/node':
         specifier: catalog:node24
         version: 24.13.3
@@ -4063,8 +4059,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       hono:
         specifier: catalog:frontend
         version: 4.12.33
@@ -4089,7 +4085,7 @@ importers:
         version: link:../../submodules/distilled/packages/railway
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       '@tailwindcss/vite':
         specifier: catalog:frontend
         version: 4.3.3(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
@@ -4116,7 +4112,7 @@ importers:
     dependencies:
       astro:
         specifier: catalog:frontend
-        version: 7.3.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
+        version: 7.3.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
     devDependencies:
       '@alchemy.run/cloudflare-runtime':
         specifier: workspace:*
@@ -4132,13 +4128,13 @@ importers:
         version: 5.20260901.1
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       '@playwright/test':
         specifier: catalog:testing
         version: 1.62.0
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       vite:
         specifier: catalog:build
         version: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
@@ -4147,7 +4143,7 @@ importers:
     dependencies:
       astro:
         specifier: catalog:frontend
-        version: 7.3.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
+        version: 7.3.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
     devDependencies:
       '@alchemy.run/cloudflare-runtime':
         specifier: workspace:*
@@ -4163,13 +4159,13 @@ importers:
         version: 5.20260901.1
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       '@playwright/test':
         specifier: catalog:testing
         version: 1.62.0
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       vite:
         specifier: catalog:build
         version: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
@@ -4178,7 +4174,7 @@ importers:
     dependencies:
       astro:
         specifier: catalog:frontend
-        version: 7.3.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
+        version: 7.3.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
     devDependencies:
       '@alchemy.run/cloudflare-runtime':
         specifier: workspace:*
@@ -4194,13 +4190,13 @@ importers:
         version: 5.20260901.1
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       '@playwright/test':
         specifier: catalog:testing
         version: 1.62.0
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       vite:
         specifier: catalog:build
         version: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
@@ -4220,8 +4216,8 @@ importers:
         specifier: catalog:testing
         version: 1.62.0
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       vite:
         specifier: catalog:build
         version: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
@@ -4249,7 +4245,7 @@ importers:
         version: link:../../packages/frontend-frameworks
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       '@opennextjs/cloudflare':
         specifier: catalog:frontend
         version: 1.20.1(next@16.2.10(@babel/core@7.29.7(supports-color@10.2.2))(@playwright/test@1.62.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@10.2.2)(wrangler@file:packages/frontend-frameworks/src/nextjs/wrangler-stub)
@@ -4257,8 +4253,8 @@ importers:
         specifier: catalog:testing
         version: 1.62.0
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       miniflare:
         specifier: catalog:cloudflare-runtime
         version: 4.20260722.0
@@ -4289,7 +4285,7 @@ importers:
         version: link:../../packages/frontend-frameworks
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       '@opennextjs/cloudflare':
         specifier: catalog:frontend
         version: 1.20.1(next@16.2.10(@babel/core@7.29.7(supports-color@10.2.2))(@playwright/test@1.62.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(supports-color@10.2.2)(wrangler@file:packages/frontend-frameworks/src/nextjs/wrangler-stub)
@@ -4297,8 +4293,8 @@ importers:
         specifier: catalog:testing
         version: 1.62.0
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       miniflare:
         specifier: catalog:cloudflare-runtime
         version: 4.20260722.0
@@ -4310,10 +4306,10 @@ importers:
     dependencies:
       nitropack:
         specifier: catalog:frontend
-        version: 2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@24.13.3)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@24.13.3))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4))(mysql2@3.24.2(@types/node@24.13.3))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
+        version: 2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@24.13.3)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@24.13.3))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@24.13.3))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
       nuxt:
         specifier: catalog:frontend
-        version: 4.5.1(64eb09726475984998fb56e43114116a)
+        version: 4.5.1(867099590d63db02e3731b2415c98ffd)
     devDependencies:
       '@alchemy.run/cloudflare-runtime':
         specifier: workspace:*
@@ -4334,8 +4330,8 @@ importers:
         specifier: catalog:node24
         version: 24.13.3
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
 
   fixtures/octane:
     dependencies:
@@ -4455,7 +4451,7 @@ importers:
         version: 2.0.4(@solidjs/router@0.16.3(solid-js@1.9.15))(crossws@0.4.10(srvx@0.12.5))(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
       '@solidjs/vite-plugin-nitro-2':
         specifier: catalog:frontend
-        version: 0.3.2(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+        version: 0.3.2(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
       solid-js:
         specifier: catalog:frontend
         version: 1.9.15
@@ -4516,8 +4512,8 @@ importers:
         specifier: catalog:node24
         version: 24.13.3
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       svelte:
         specifier: catalog:frontend
         version: 5.56.8
@@ -4549,8 +4545,8 @@ importers:
         specifier: catalog:node24
         version: 24.13.3
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       svelte:
         specifier: catalog:frontend
         version: 5.56.8
@@ -4562,7 +4558,7 @@ importers:
     dependencies:
       '@effect/sql-pg':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@tailwindcss/vite':
         specifier: catalog:frontend
         version: 4.3.3(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
@@ -4599,7 +4595,7 @@ importers:
         version: 5.20260901.1
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       '@playwright/test':
         specifier: catalog:testing
         version: 1.62.0
@@ -4622,8 +4618,8 @@ importers:
         specifier: ^5.1.4
         version: 5.2.0(supports-color@10.2.2)(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       vite:
         specifier: catalog:build
         version: 8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
@@ -4695,8 +4691,8 @@ importers:
         specifier: catalog:frontend
         version: 0.5.34(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(react@19.2.8)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       unenv:
         specifier: catalog:cloudflare-runtime
         version: 2.0.0-rc.24
@@ -4842,13 +4838,13 @@ importers:
         version: link:../../submodules/distilled/packages/railway
       '@effect/sql-d1':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@effect/sql-sqlite-do':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@effect/vitest':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(vitest@4.1.10(@types/node@26.2.0)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(vitest@4.1.10(@types/node@26.2.0)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))
       '@libsql/client':
         specifier: catalog:database
         version: 0.17.4
@@ -4875,7 +4871,7 @@ importers:
         version: 1.0.0-rc.5-ab785fc
       drizzle-orm:
         specifier: 1.0.0-rc.5-ab785fc
-        version: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3)
+        version: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3)
       fast-glob:
         specifier: catalog:cloudflare-runtime
         version: 3.3.3
@@ -4930,19 +4926,19 @@ importers:
         version: 0.87.2
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       '@effect/sql-mysql2':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113)
       '@effect/sql-pg':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@foldkit/vite-plugin':
         specifier: catalog:frontend
-        version: 0.16.1(effect@4.0.0-rc.112)(foldkit@0.148.2(effect@4.0.0-rc.112))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+        version: 0.16.1(effect@4.0.0-rc.113)(foldkit@0.148.2(effect@4.0.0-rc.113))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
       '@octanejs/adapter-cloudflare':
         specifier: catalog:frontend
         version: 0.0.12(@octanejs/app-core@0.0.18(octane@0.1.22(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))))
@@ -4972,7 +4968,7 @@ importers:
         version: 2.0.4(@solidjs/router@0.16.3(solid-js@1.9.15))(crossws@0.4.10(srvx@0.12.5))(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
       '@solidjs/vite-plugin-nitro-2':
         specifier: catalog:frontend
-        version: 0.3.2(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
+        version: 0.3.2(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
       '@sveltejs/kit':
         specifier: catalog:frontend
         version: 3.0.0-next.9(@sveltejs/vite-plugin-svelte@7.2.0(svelte@5.56.8)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))(svelte@5.56.8)(typescript@7.0.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
@@ -5020,13 +5016,13 @@ importers:
         version: link:../alchemy-test
       astro:
         specifier: catalog:frontend
-        version: 7.3.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
+        version: 7.3.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       foldkit:
         specifier: catalog:frontend
-        version: 0.148.2(effect@4.0.0-rc.112)
+        version: 0.148.2(effect@4.0.0-rc.113)
       hono:
         specifier: catalog:frontend
         version: 4.12.33
@@ -5040,17 +5036,17 @@ importers:
         specifier: catalog:database
         version: 6.21.0(@aws-sdk/credential-providers@3.1095.0)(socks@2.8.9)
       mysql2:
-        specifier: catalog:database
+        specifier: 3.24.2
         version: 3.24.2(@types/node@26.2.0)
       next:
         specifier: catalog:frontend
         version: 16.2.10(@babel/core@7.29.7(supports-color@10.2.2))(@playwright/test@1.62.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       nitropack:
         specifier: catalog:frontend
-        version: 2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
+        version: 2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
       nuxt:
         specifier: catalog:frontend
-        version: 4.5.1(b8f7e2370c0c7cb4e95babfd663ba2fb)
+        version: 4.5.1(7fe16a31c4082a23bec7caccdcc17327)
       octane:
         specifier: catalog:frontend
         version: 0.1.22(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
@@ -5113,13 +5109,13 @@ importers:
     dependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@opentui/core':
         specifier: catalog:shared
         version: 0.5.11(typescript@7.0.2)(web-tree-sitter@0.25.10)
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@types/bun':
         specifier: catalog:tooling
@@ -5138,7 +5134,7 @@ importers:
         version: link:../../submodules/distilled/packages/aws
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@neondatabase/serverless':
         specifier: catalog:database
         version: 1.1.0
@@ -5156,18 +5152,18 @@ importers:
         version: link:../alchemy-test
       better-auth:
         specifier: catalog:auth
-        version: 1.6.25(e20f5e9f480a52fe3a4e9438c63ccf5e)
+        version: 1.6.25(3f55a70ed1274cd9feb933c6021ba76f)
       drizzle-orm:
         specifier: 1.0.0-rc.5-ab785fc
-        version: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3)
+        version: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3)
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       kysely:
         specifier: catalog:database
         version: 0.29.5
       mysql2:
-        specifier: catalog:database
+        specifier: 3.24.2
         version: 3.24.2(@types/node@26.2.0)
       pathe:
         specifier: catalog:tooling
@@ -5197,8 +5193,8 @@ importers:
         specifier: catalog:cloudflare-runtime
         version: 0.0.16(typescript@7.0.2)
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       magic-string:
         specifier: catalog:cloudflare-runtime
         version: 0.30.21
@@ -5223,13 +5219,13 @@ importers:
         version: 5.20260901.1
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       '@effect/vitest':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(vitest@4.1.10(@types/node@26.2.0)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(vitest@4.1.10(@types/node@26.2.0)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -5258,7 +5254,7 @@ importers:
         specifier: catalog:cloudflare-runtime
         version: 4.1.0
       mysql2:
-        specifier: catalog:cloudflare-runtime
+        specifier: 3.24.2
         version: 3.24.2(@types/node@26.2.0)
       postal-mime:
         specifier: catalog:cloudflare-runtime
@@ -5295,10 +5291,10 @@ importers:
         version: link:../frontend-frameworks
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       miniflare:
         specifier: catalog:cloudflare-runtime
         version: 4.20260722.0
@@ -5325,8 +5321,8 @@ importers:
         specifier: catalog:tooling
         version: 26.2.0
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       typescript:
         specifier: catalog:build
         version: 7.0.2
@@ -5341,7 +5337,7 @@ importers:
         version: link:../../submodules/distilled/packages/cloudflare
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       esbuild:
         specifier: catalog:cloudflare-runtime
         version: 0.28.2
@@ -5363,7 +5359,7 @@ importers:
         version: 5.20260901.1
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@octanejs/vite-plugin':
         specifier: catalog:frontend
         version: 0.1.22(octane@0.1.22(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
@@ -5381,19 +5377,19 @@ importers:
         version: 6.0.5(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
       astro:
         specifier: catalog:frontend
-        version: 7.3.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
+        version: 7.3.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       hono:
         specifier: catalog:frontend
         version: 4.12.33
       nitropack:
         specifier: catalog:frontend
-        version: 2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4))(mysql2@3.24.2(@types/node@26.2.0))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
+        version: 2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
       nuxt:
         specifier: catalog:frontend
-        version: 4.5.1(7234cbbd18b9a21040d15b51f4bb3989)
+        version: 4.5.1(df1693d43dd7d6545462287ea122e04b)
       tsdown:
         specifier: catalog:build
         version: 0.22.14(@volar/typescript@2.4.28(typescript@7.0.2))(tsx@4.23.12)(typescript@7.0.2)(vue-tsc@3.3.9(typescript@7.0.2))
@@ -5435,8 +5431,8 @@ importers:
         specifier: workspace:*
         version: link:../alchemy
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       typescript:
         specifier: catalog:build
@@ -5448,12 +5444,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -5467,12 +5463,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -5486,12 +5482,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -5505,12 +5501,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -5524,12 +5520,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -5567,15 +5563,15 @@ importers:
         specifier: catalog:aws
         version: 1.0.20
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       fast-xml-parser:
         specifier: catalog:shared
         version: 5.10.1
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -5595,12 +5591,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -5614,12 +5610,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -5633,12 +5629,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -5652,12 +5648,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -5671,12 +5667,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -5690,12 +5686,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -5709,12 +5705,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -5726,7 +5722,7 @@ importers:
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -5734,8 +5730,8 @@ importers:
         specifier: catalog:tooling
         version: 26.2.0
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
 
   submodules/distilled/packages/customerio:
     dependencies:
@@ -5743,12 +5739,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -5762,12 +5758,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -5781,12 +5777,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -5800,12 +5796,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -5819,12 +5815,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -5838,12 +5834,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -5857,12 +5853,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -5876,12 +5872,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -5895,12 +5891,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -5914,12 +5910,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -5933,12 +5929,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -5952,12 +5948,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -5971,12 +5967,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -5990,12 +5986,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -6009,12 +6005,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -6028,12 +6024,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -6047,12 +6043,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -6066,12 +6062,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -6085,12 +6081,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -6104,12 +6100,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -6123,12 +6119,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -6142,12 +6138,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -6161,12 +6157,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -6180,12 +6176,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -6199,12 +6195,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -6218,12 +6214,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -6237,12 +6233,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -6256,12 +6252,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -6275,12 +6271,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -6294,12 +6290,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -6313,12 +6309,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -6332,12 +6328,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -6351,12 +6347,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -6370,12 +6366,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -6389,12 +6385,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -6408,12 +6404,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -6427,12 +6423,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -6446,12 +6442,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -6465,12 +6461,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -6484,12 +6480,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -6503,12 +6499,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -6522,12 +6518,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -6541,12 +6537,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -6560,12 +6556,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -6579,12 +6575,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -6598,12 +6594,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -6617,12 +6613,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -6636,12 +6632,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -6655,12 +6651,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -6674,12 +6670,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -6693,12 +6689,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -6712,12 +6708,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -6731,12 +6727,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -6750,12 +6746,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -6769,12 +6765,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -6788,12 +6784,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -6807,12 +6803,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -6826,12 +6822,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -6845,12 +6841,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -6864,12 +6860,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -6883,12 +6879,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -6902,12 +6898,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -6921,12 +6917,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -6940,12 +6936,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -6959,12 +6955,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -6978,12 +6974,12 @@ importers:
         specifier: workspace:*
         version: link:../core
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
     devDependencies:
       '@effect/platform-bun':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@types/bun':
         specifier: catalog:tooling
         version: 1.3.14
@@ -6998,7 +6994,7 @@ importers:
         version: 0.9.10(prettier@3.9.6)(typescript@7.0.2)
       '@astrojs/mdx':
         specifier: 8.0.0
-        version: 8.0.0(@astrojs/markdown-satteri@0.4.0)(astro@7.3.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+        version: 8.0.0(@astrojs/markdown-satteri@0.4.0)(astro@7.3.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
       '@astrojs/react':
         specifier: 6.0.5
         version: 6.0.5(@types/node@26.2.0)(@types/react-dom@19.2.7(@types/react@19.2.18))(@types/react@19.2.18)(esbuild@0.28.2)(jiti@2.7.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@10.2.2)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
@@ -7007,13 +7003,13 @@ importers:
         version: 3.7.4
       '@astrojs/starlight':
         specifier: 0.42.0
-        version: 0.42.0(patch_hash=3ea8686c3055e8d097b5afa93dcf9e16ebfbebbf006e7493ad5df38e6edbfd19)(astro@7.3.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(supports-color@10.2.2)(typescript@7.0.2)
+        version: 0.42.0(patch_hash=3ea8686c3055e8d097b5afa93dcf9e16ebfbebbf006e7493ad5df38e6edbfd19)(astro@7.3.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(supports-color@10.2.2)(typescript@7.0.2)
       '@astrojs/starlight-tailwind':
         specifier: ^5.0.0
-        version: 5.0.0(@astrojs/starlight@0.42.0(patch_hash=3ea8686c3055e8d097b5afa93dcf9e16ebfbebbf006e7493ad5df38e6edbfd19)(astro@7.3.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(supports-color@10.2.2)(typescript@7.0.2))(tailwindcss@4.3.3)
+        version: 5.0.0(@astrojs/starlight@0.42.0(patch_hash=3ea8686c3055e8d097b5afa93dcf9e16ebfbebbf006e7493ad5df38e6edbfd19)(astro@7.3.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(supports-color@10.2.2)(typescript@7.0.2))(tailwindcss@4.3.3)
       '@effect/platform-node':
         specifier: catalog:effect
-        version: 4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)
+        version: 4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)
       '@fontsource-variable/caveat':
         specifier: ^5.3.0
         version: 5.3.0
@@ -7040,10 +7036,10 @@ importers:
         version: link:../packages/alchemy
       astro:
         specifier: catalog:frontend
-        version: 7.3.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
+        version: 7.3.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
       effect:
-        specifier: 4.0.0-rc.112
-        version: 4.0.0-rc.112
+        specifier: 4.0.0-rc.113
+        version: 4.0.0-rc.113
       react:
         specifier: catalog:frontend
         version: 19.2.8
@@ -7055,7 +7051,7 @@ importers:
         version: 0.10.5
       starlight-blog:
         specifier: ^0.29.0
-        version: 0.29.0(patch_hash=7b6e57367fab3517e0cfd5e4d0da3459ac1430bf4b6036cf03002c978602c23b)(a153ef7c4b126f946ad8fea5f283bda5)
+        version: 0.29.0(patch_hash=7b6e57367fab3517e0cfd5e4d0da3459ac1430bf4b6036cf03002c978602c23b)(9d7f649d32a49ea7fe732f9e37e1226e)
       tailwindcss:
         specifier: catalog:frontend
         version: 4.3.3
@@ -8125,10 +8121,10 @@ packages:
     peerDependencies:
       '@noble/ciphers': ^1.0.0
 
-  '@effect/atom-react@4.0.0-rc.112':
-    resolution: {integrity: sha512-Ksf90KQa6D4UDnMj4M84arlVKNIuwxxF2GvgXBzuaYi2LsgririsUhKQ5SYaK1euf8oIYeamEuthoZSbUQmIhw==}
+  '@effect/atom-react@4.0.0-rc.113':
+    resolution: {integrity: sha512-P5MA9czW1Lgl6IC0xkCKZop/h6Rh0yxTOu/9ZEX2dzJ01Ff6PklTkx2/70TqQcVRhj6yvJu9cqDz4Xde/FyijA==}
     peerDependencies:
-      effect: 4.0.0-rc.112
+      effect: 4.0.0-rc.113
       react: '>=19.0.0 <20.0.0'
       scheduler: '>=0.25.0 <0.28.0'
 
@@ -8136,43 +8132,43 @@ packages:
     resolution: {integrity: sha512-CfiSoaVQO8pZgaMZGw5VvMvRGybsJ2LaSDoLYaqiVGvo/YYPYVR2GzUKY0h1NtIweq/+SQ5XLrvtzPIttWQ0GQ==}
     hasBin: true
 
-  '@effect/platform-bun@4.0.0-rc.112':
-    resolution: {integrity: sha512-Y5n2HhV/vsbrJls9ukX42RL7zqXQxISHegWFsP9njsCyDmGTnq7QYSO82rglwrLPwtTrv5dkSRTuGw4+oXxgMg==}
+  '@effect/platform-bun@4.0.0-rc.113':
+    resolution: {integrity: sha512-EOn8doDVaiizfTpdmtRS0SZLAAt19yyHFKg+aV8YXJreNDYqXQLEt+/ThiEOurDimApVYhn2NZW52OJrZlybQw==}
     peerDependencies:
-      effect: 4.0.0-rc.112
+      effect: 4.0.0-rc.113
 
-  '@effect/platform-node-shared@4.0.0-rc.112':
-    resolution: {integrity: sha512-ttjz0xKamFN7vL8pNDYVwddJLjZvqKePc05djlz2VcdaKbLsnYbtMnL1rbOfHgEnIUSHGh7FkjaN4DM1Ov81sQ==}
+  '@effect/platform-node-shared@4.0.0-rc.113':
+    resolution: {integrity: sha512-EPCfjvKlHmNDgqIlT85P1OcgNUNvRxNtBpTFOz1UGHwNJe6Ap7rP93Rue7kzFUeplQMy6EfoZEH4CJR4N0nJ1g==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      effect: 4.0.0-rc.112
+      effect: 4.0.0-rc.113
 
-  '@effect/platform-node@4.0.0-rc.112':
-    resolution: {integrity: sha512-/BMAcdNGQQskLmI0Zoa95KfTZkr9HV9N4NSxaSrusG6GeW6Ulp9KvZ+Rlaiw8lnOt43CXjFLdfll5/k5rxL4hQ==}
+  '@effect/platform-node@4.0.0-rc.113':
+    resolution: {integrity: sha512-8luSE2JcGVsALQ6cZOWh5jdZu+VgcUKIKPfhN/MjX+ZzIuK/krm3jZBHYZdhqkXjM9s8aYGBxNMHGF0WzF+Gpg==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      effect: 4.0.0-rc.112
+      effect: 4.0.0-rc.113
       redis: '>=5.0.0 <7.0.0'
 
-  '@effect/sql-d1@4.0.0-rc.112':
-    resolution: {integrity: sha512-Wxdr6aU3pBHqhyBiybzbHmEK7qZ2w4iy0IxBgJHe9BLleYzCxObOaBQI9qq/VZSqEvc0IaOBMpbk2zh3dlPNSQ==}
+  '@effect/sql-d1@4.0.0-rc.113':
+    resolution: {integrity: sha512-5TqTaT/XjbBgZeiUlyhfApGPFwcI9bx/MTMQwLzihV0dU+HquojkU/vGx5uXIGjcbZOCqy5oG7Y+r2i0I3dTog==}
     peerDependencies:
-      effect: 4.0.0-rc.112
+      effect: 4.0.0-rc.113
 
-  '@effect/sql-mysql2@4.0.0-rc.112':
-    resolution: {integrity: sha512-2tInSVhOGCfuWiBD+RF2QBmadr5L7woA7Hz+Z9d21AZQftw5IACo30hdm8wKE4QIzffSjAy8qaJIC7NcCqZ9hQ==}
+  '@effect/sql-mysql2@4.0.0-rc.113':
+    resolution: {integrity: sha512-df5d5fQD/clIHHRi8oYFeJDL4KfFeCUdzrc0Bgx/hScN5eK9fwPjk5B4TAkgGmzqXHdV8U4n8h/Gb5FBWh7uUg==}
     peerDependencies:
-      effect: 4.0.0-rc.112
+      effect: 4.0.0-rc.113
 
-  '@effect/sql-pg@4.0.0-rc.112':
-    resolution: {integrity: sha512-UYUA3LAGH1Pg88Yau7eTlTLHRrIb/uTdxdPGxVcRdIjjrTzxtA7iKHR4hcmUeq5lQEcGLCopN7E4ffsAKF8vEQ==}
+  '@effect/sql-pg@4.0.0-rc.113':
+    resolution: {integrity: sha512-xsAbmxsR5sC6Pc/38nB4/rBi1co4aCC7e4T95sVy8EhWA9NRheimtiN05EyhTKZwX1C0T2gquainQwCuQYuKuA==}
     peerDependencies:
-      effect: 4.0.0-rc.112
+      effect: 4.0.0-rc.113
 
-  '@effect/sql-sqlite-do@4.0.0-rc.112':
-    resolution: {integrity: sha512-PewNVasimmhrdxYbNU91O0YlCcalIHOoF0H5XAWXrmzcEQrKM7kVCyb5h0gmJAZjBM4ZgWRvPY0PUOfbNmWchQ==}
+  '@effect/sql-sqlite-do@4.0.0-rc.113':
+    resolution: {integrity: sha512-l38VSaq+J8UVMNRsoxdn5XcKh4icp+wXbeXtTukfzr5gSPMgvzxnXj57OUxcC3cGvq03E0E54NYPX5kvh/JyPQ==}
     peerDependencies:
-      effect: 4.0.0-rc.112
+      effect: 4.0.0-rc.113
 
   '@effect/tsgo-darwin-arm64@0.36.4':
     resolution: {integrity: sha512-oOcWdKQucNch6G4CvidHEzmfgeKEPMvFcz+DXuKGonBLwVHX+i1VYGbZwccEOoiitOg7eWVl4e8S0qKMXg3/gg==}
@@ -8213,11 +8209,11 @@ packages:
     resolution: {integrity: sha512-fNmdUV6FgXnvIcG18AVS1SRXt7z9jsyBh5CKuJYmTsE+DgbLaWF0CevKHx7hQPcidDWRVmdJYfU66Jvc/ZEt6w==}
     hasBin: true
 
-  '@effect/vitest@4.0.0-rc.112':
-    resolution: {integrity: sha512-mEKh/FI64mt8JK1/v9mpOrJYdnp+UFZdRUBMEdZMiKz7klg6NPqVgg/oeAGH6wOOQc2iAPcfc2H9BbAv1KyzMQ==}
+  '@effect/vitest@4.0.0-rc.113':
+    resolution: {integrity: sha512-ebuPhtZmumq1967n0vgF0sgAx/8tRHMmNGOdH1Oya1jKzV2Yoqhlv8WCGT0N//PuaV/Pc/zky3mmDvxmW81FiQ==}
     peerDependencies:
-      effect: 4.0.0-rc.112
-      vitest: '>=4.1.0 <5.0.0'
+      effect: 4.0.0-rc.113
+      vitest: '>=5.0.0 <6.0.0'
 
   '@electric-sql/pglite-socket@0.0.20':
     resolution: {integrity: sha512-J5nLGsicnD9wJHnno9r+DGxfcZWh+YJMCe0q/aCgtG6XOm9Z7fKeite8IZSNXgZeGltSigM9U/vAWZQWdgcSFg==}
@@ -8930,7 +8926,7 @@ packages:
     resolution: {integrity: sha512-zYbiQbYPRh32jSeocJEKVwsbrL1xD3IKZDBPbE1Dvq4s6LOMWbqbJmON781SVwVJ9cFp0Wh6AITNGsH8GLvccA==}
     engines: {node: '>=20.19.0'}
     peerDependencies:
-      effect: 4.0.0-rc.112
+      effect: 4.0.0-rc.113
       foldkit: '>=0.148.0'
       vite: ^7.0.0 || ^8.0.0
 
@@ -9796,7 +9792,7 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
-      zod: ^3.25 || ^4.0
+      zod: 4.4.3
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
@@ -9807,36 +9803,6 @@ packages:
   '@mrleebo/prisma-ast@0.13.1':
     resolution: {integrity: sha512-XyroGQXcHrZdvmrGJvsA9KNeOOgGMg1Vg9OlheUsBOSKznLMDl+YChxbkboRHvtFYJEMRYmlV3uoo/njCw05iw==}
     engines: {node: '>=16'}
-
-  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4':
-    resolution: {integrity: sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.4':
-    resolution: {integrity: sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.4':
-    resolution: {integrity: sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw==}
-    cpu: [arm64]
-    os: [linux]
-
-  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.4':
-    resolution: {integrity: sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw==}
-    cpu: [arm]
-    os: [linux]
-
-  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.4':
-    resolution: {integrity: sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ==}
-    cpu: [x64]
-    os: [linux]
-
-  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4':
-    resolution: {integrity: sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ==}
-    cpu: [x64]
-    os: [win32]
 
   '@napi-rs/lzma-linux-x64-gnu@1.5.1':
     resolution: {integrity: sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==}
@@ -13965,7 +13931,7 @@ packages:
       drizzle-kit: 1.0.0-rc.5-ab785fc
       drizzle-orm: 1.0.0-rc.5-ab785fc
       mongodb: ^6.0.0 || ^7.0.0
-      mysql2: ^3.0.0
+      mysql2: 3.24.2
       next: ^14.0.0 || ^15.0.0 || ^16.0.0
       pg: ^8.0.0
       prisma: ^5.0.0 || ^6.0.0 || ^7.0.0
@@ -14018,7 +13984,7 @@ packages:
   better-call@1.3.7:
     resolution: {integrity: sha512-Al51/hjp2SSp6CRTa3F2ptcx4yQVS1xWKoY6jcVXqNYOap6mHFP2jUBn5EwIL4iIed1/Sq4hlQ+Umm6EflZG+w==}
     peerDependencies:
-      zod: ^4.0.0
+      zod: 4.4.3
     peerDependenciesMeta:
       zod:
         optional: true
@@ -14505,7 +14471,7 @@ packages:
       '@libsql/client': '*'
       better-sqlite3: '*'
       drizzle-orm: 1.0.0-rc.5-ab785fc
-      mysql2: '*'
+      mysql2: 3.24.2
       sqlite3: '*'
     peerDependenciesMeta:
       '@electric-sql/pglite':
@@ -14686,18 +14652,18 @@ packages:
       arktype: '>=2.0.0'
       better-sqlite3: '>=9.3.0'
       bun-types: '*'
-      effect: 4.0.0-rc.112
+      effect: 4.0.0-rc.113
       expo-sqlite: '>=14.0.0'
       minipg: '>=0.2.0'
       mssql: ^11.0.1
-      mysql2: '>=2'
+      mysql2: 3.24.2
       pg: '>=8'
       postgres: '>=3'
       sql.js: '>=1'
       sqlite3: '>=5'
       typebox: '>=1.2.0'
       valibot: '>=1.0.0-beta.7'
-      zod: ^3.25.0 || ^4.0.0
+      zod: 4.4.3
     peerDependenciesMeta:
       '@aws-sdk/client-rds-data':
         optional: true
@@ -14835,8 +14801,8 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
-  effect@4.0.0-rc.112:
-    resolution: {integrity: sha512-wXxwuh1Ywnv4cPRM3Wfa0vDwuOHnZ1TsTgHJkG9XgzND6inhBH9n1vBxhg3iIXOia/OrpmvVmd3lrD4vq6bF3A==}
+  effect@4.0.0-rc.113:
+    resolution: {integrity: sha512-uZ4Bh7KSlw2sdVdNDHPLSNjLGH+MWap7cheIHZoB/1T/ZJ3pvI4KiN3kUp50MpFKXhygOMmReJJOwWMQPwpPAg==}
 
   electron-to-chromium@1.5.405:
     resolution: {integrity: sha512-bNglH7lPH5l+yHOes7Zr4VqxhOy4BQ9ZBUX4VdoFgxMpzJk7W1ZoO3Vgd9Pxa9PyjQ76sfm2aKH/nzEcCNRlew==}
@@ -15145,10 +15111,6 @@ packages:
     engines: {node: '>= 10.17.0'}
     hasBin: true
 
-  fast-check@4.9.0:
-    resolution: {integrity: sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==}
-    engines: {node: '>=12.17.0'}
-
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -15239,7 +15201,7 @@ packages:
     resolution: {integrity: sha512-Bf735uDqbKU1jSUAMgkV1aMUEf5X+4ljsfQFkylgowOSKqTSEY0NYgrsAKiFSFkW3G2ReF1qyX61lBdbItYxnQ==}
     engines: {node: '>=20.19.0'}
     peerDependencies:
-      effect: 4.0.0-rc.112
+      effect: 4.0.0-rc.113
 
   fontace@0.4.1:
     resolution: {integrity: sha512-lDMvbAzSnHmbYMTEld5qdtvNH2/pWpICOqpean9IgC7vUbUJc3k+k5Dokp85CegamqQpFbXf0rAVkbzpyTA8aw==}
@@ -16651,13 +16613,6 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  msgpackr-extract@3.0.4:
-    resolution: {integrity: sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw==}
-    hasBin: true
-
-  msgpackr@2.0.5:
-    resolution: {integrity: sha512-cef05H/dSYpLpqp3sj/qyZh5vhUYCalnaLO7j1yOmpsR0y/XwLVtK7r5gn+U/F7CTEfMowcGhlUQJDLcLf7jcA==}
-
   muggle-string@0.4.1:
     resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
 
@@ -16801,10 +16756,6 @@ packages:
     resolution: {integrity: sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==}
     engines: {node: '>= 6.13.0'}
 
-  node-gyp-build-optional-packages@5.2.2:
-    resolution: {integrity: sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==}
-    hasBin: true
-
   node-gyp-build@4.8.4:
     resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
     hasBin: true
@@ -16913,9 +16864,6 @@ packages:
 
   obliterator@1.6.1:
     resolution: {integrity: sha512-9WXswnqINnnhOG/5SLimUlzuU1hFJUc8zkwyD59Sd+dPOMf05PmnYG/d6Q7HZ+KmgkZJa1PxRso6QdM3sTNHig==}
-
-  obuf@1.1.2:
-    resolution: {integrity: sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==}
 
   obug@2.1.4:
     resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
@@ -17182,10 +17130,6 @@ packages:
     resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
     engines: {node: '>=4.0.0'}
 
-  pg-numeric@1.0.2:
-    resolution: {integrity: sha512-BM/Thnrw5jm2kKLE5uJkXqqExRUY/toLHda65XgFTBTFYZyopbKjBe29Ii3RbkvlsMoFwD+tHeGaCjjv0gHlyw==}
-    engines: {node: '>=4'}
-
   pg-pool@3.14.0:
     resolution: {integrity: sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==}
     peerDependencies:
@@ -17197,10 +17141,6 @@ packages:
   pg-types@2.2.0:
     resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
     engines: {node: '>=4'}
-
-  pg-types@4.1.0:
-    resolution: {integrity: sha512-o2XFanIMy/3+mThw69O8d4n1E5zsLhdO+OPqswezu7Z5ekP4hYDqlDjlmOpYMbzY2Br0ufCwJLdDIXeNVwcWFg==}
-    engines: {node: '>=10'}
 
   pg@8.20.0:
     resolution: {integrity: sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==}
@@ -17464,36 +17404,17 @@ packages:
     resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
     engines: {node: '>=4'}
 
-  postgres-array@3.0.4:
-    resolution: {integrity: sha512-nAUSGfSDGOaOAEGwqsRY27GPOea7CNipJPOA7lPbdEpx5Kg3qzdP0AaWC5MlhTWV9s4hFX39nomVZ+C4tnGOJQ==}
-    engines: {node: '>=12'}
-
   postgres-bytea@1.0.1:
     resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
     engines: {node: '>=0.10.0'}
-
-  postgres-bytea@3.0.0:
-    resolution: {integrity: sha512-CNd4jim9RFPkObHSjVHlVrxoVQXz7quwNFpz7RY1okNNme49+sVyiTvTRobiLV548Hx/hb1BG+iE7h9493WzFw==}
-    engines: {node: '>= 6'}
 
   postgres-date@1.0.7:
     resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
     engines: {node: '>=0.10.0'}
 
-  postgres-date@2.1.0:
-    resolution: {integrity: sha512-K7Juri8gtgXVcDfZttFKVmhglp7epKb1K4pgrkLxehjqkrgPhfG6OO8LHLkfaqkbpjNRnra018XwAr1yQFWGcA==}
-    engines: {node: '>=12'}
-
   postgres-interval@1.2.0:
     resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
     engines: {node: '>=0.10.0'}
-
-  postgres-interval@3.0.0:
-    resolution: {integrity: sha512-BSNDnbyZCXSxgA+1f5UU2GmwhoI0aU5yMxRGO8CdFEcY2BQF9xm/7MqKnYoM1nJDk8nONNWDk9WeSmePFhQdlw==}
-    engines: {node: '>=12'}
-
-  postgres-range@1.1.4:
-    resolution: {integrity: sha512-i/hbxIE9803Alj/6ytL7UHQxRvZkI9O4Sy+J3HGc4F4oo/2eQAjTSNJ0bfxyse3bH0nuVesCk+3IRLaMtG3H6w==}
 
   powershell-utils@0.1.0:
     resolution: {integrity: sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==}
@@ -17557,9 +17478,6 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
-
-  pure-rand@8.4.2:
-    resolution: {integrity: sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==}
 
   qs@6.15.3:
     resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
@@ -18711,6 +18629,10 @@ packages:
     resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
     engines: {node: '>=22.19.0'}
 
+  undici@8.10.2:
+    resolution: {integrity: sha512-/y4/bH9YNU5hi9NIrpOuvGXFcxrj3CMrV+/AYpowAYTpHn8gX/XPFjNy766FPoYY0miQhdW977JFWKGNhBdwyQ==}
+    engines: {node: '>=22.19.0'}
+
   unenv@2.0.0-rc.24:
     resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
 
@@ -19772,13 +19694,10 @@ packages:
   zod-to-json-schema@3.25.2:
     resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
     peerDependencies:
-      zod: ^3.25.28 || ^4
+      zod: 4.4.3
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
-
-  zod@4.5.4:
-    resolution: {integrity: sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -20000,13 +19919,13 @@ snapshots:
       github-slugger: 2.0.0
       satteri: 0.10.5
 
-  '@astrojs/mdx@7.0.5(@astrojs/markdown-satteri@0.4.0)(astro@7.3.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(supports-color@10.2.2)':
+  '@astrojs/mdx@7.0.5(@astrojs/markdown-satteri@0.4.0)(astro@7.3.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(supports-color@10.2.2)':
     dependencies:
       '@astrojs/internal-helpers': 0.10.2
       '@astrojs/markdown-remark': 7.2.2(supports-color@10.2.2)
       '@mdx-js/mdx': 3.1.1(supports-color@10.2.2)
       acorn: 8.18.0
-      astro: 7.3.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
+      astro: 7.3.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
       es-module-lexer: 2.3.1
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
@@ -20022,11 +19941,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/mdx@8.0.0(@astrojs/markdown-satteri@0.4.0)(astro@7.3.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))':
+  '@astrojs/mdx@8.0.0(@astrojs/markdown-satteri@0.4.0)(astro@7.3.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))':
     dependencies:
       '@astrojs/internal-helpers': 0.11.0
       '@astrojs/markdown-satteri': 0.4.0
-      astro: 7.3.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
+      astro: 7.3.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
       es-module-lexer: 2.3.1
 
   '@astrojs/prism@4.0.2':
@@ -20063,35 +19982,35 @@ snapshots:
     dependencies:
       fast-xml-parser: 5.10.1
       piccolore: 0.1.3
-      zod: 4.5.4
+      zod: 4.4.3
 
   '@astrojs/sitemap@3.7.3':
     dependencies:
       sitemap: 9.0.1
       stream-replace-string: 2.0.0
-      zod: 4.5.4
+      zod: 4.4.3
 
   '@astrojs/sitemap@3.7.4':
     dependencies:
       sitemap: 9.0.1
-      zod: 4.5.4
+      zod: 4.4.3
 
-  ? '@astrojs/starlight-tailwind@5.0.0(@astrojs/starlight@0.42.0(patch_hash=3ea8686c3055e8d097b5afa93dcf9e16ebfbebbf006e7493ad5df38e6edbfd19)(astro@7.3.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(supports-color@10.2.2)(typescript@7.0.2))(tailwindcss@4.3.3)'
+  ? '@astrojs/starlight-tailwind@5.0.0(@astrojs/starlight@0.42.0(patch_hash=3ea8686c3055e8d097b5afa93dcf9e16ebfbebbf006e7493ad5df38e6edbfd19)(astro@7.3.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(supports-color@10.2.2)(typescript@7.0.2))(tailwindcss@4.3.3)'
   : dependencies:
-      '@astrojs/starlight': 0.42.0(patch_hash=3ea8686c3055e8d097b5afa93dcf9e16ebfbebbf006e7493ad5df38e6edbfd19)(astro@7.3.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(supports-color@10.2.2)(typescript@7.0.2)
+      '@astrojs/starlight': 0.42.0(patch_hash=3ea8686c3055e8d097b5afa93dcf9e16ebfbebbf006e7493ad5df38e6edbfd19)(astro@7.3.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(supports-color@10.2.2)(typescript@7.0.2)
       tailwindcss: 4.3.3
 
-  '@astrojs/starlight@0.42.0(patch_hash=3ea8686c3055e8d097b5afa93dcf9e16ebfbebbf006e7493ad5df38e6edbfd19)(astro@7.3.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(supports-color@10.2.2)(typescript@7.0.2)':
+  '@astrojs/starlight@0.42.0(patch_hash=3ea8686c3055e8d097b5afa93dcf9e16ebfbebbf006e7493ad5df38e6edbfd19)(astro@7.3.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(supports-color@10.2.2)(typescript@7.0.2)':
     dependencies:
       '@astrojs/markdown-satteri': 0.4.0
-      '@astrojs/mdx': 8.0.0(@astrojs/markdown-satteri@0.4.0)(astro@7.3.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+      '@astrojs/mdx': 8.0.0(@astrojs/markdown-satteri@0.4.0)(astro@7.3.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
       '@astrojs/sitemap': 3.7.3
       '@pagefind/default-ui': 1.5.2
       '@types/hast': 3.0.5
       '@types/js-yaml': 4.0.9
       '@types/mdast': 4.0.4
-      astro: 7.3.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
-      astro-expressive-code: 0.44.1(astro@7.3.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+      astro: 7.3.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
+      astro-expressive-code: 0.44.1(astro@7.3.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
       bcp-47: 2.1.1
       hast-util-format: 1.1.0
       hast-util-select: 6.0.4
@@ -20805,6 +20724,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-create-class-features-plugin@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-annotate-as-pure': 7.29.7
+      '@babel/helper-member-expression-to-functions': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-optimise-call-expression': 7.29.7
+      '@babel/helper-replace-supers': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7(supports-color@10.2.2)
+      '@babel/traverse': 7.29.8(supports-color@10.2.2)
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-globals@7.29.7': {}
 
   '@babel/helper-member-expression-to-functions@7.29.7(supports-color@10.2.2)':
@@ -20858,6 +20790,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/helper-replace-supers@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-member-expression-to-functions': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-optimise-call-expression': 7.29.7
+      '@babel/traverse': 7.29.8(supports-color@10.2.2)
+    transitivePeerDependencies:
+      - supports-color
+
   '@babel/helper-skip-transparent-expression-wrappers@7.29.7(supports-color@10.2.2)':
     dependencies:
       '@babel/traverse': 7.29.8(supports-color@10.2.2)
@@ -20896,20 +20837,36 @@ snapshots:
       '@babel/plugin-syntax-decorators': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
     transitivePeerDependencies:
       - supports-color
+    optional: true
+
+  '@babel/plugin-proposal-decorators@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/plugin-syntax-decorators': 7.29.7(@babel/core@7.29.7)
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/plugin-syntax-decorators@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
+    optional: true
 
-  '@babel/plugin-syntax-import-attributes@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
+  '@babel/plugin-syntax-decorators@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
-  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.29.7(supports-color@10.2.2))':
+  '@babel/plugin-syntax-import-attributes@7.29.7(@babel/core@7.29.7)':
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
@@ -20921,11 +20878,15 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
-    optional: true
 
   '@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))':
     dependencies:
       '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
       '@babel/helper-plugin-utils': 7.29.7
 
   '@babel/plugin-transform-modules-commonjs@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
@@ -20954,6 +20915,17 @@ snapshots:
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/helper-skip-transparent-expression-wrappers': 7.29.7(supports-color@10.2.2)
       '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-annotate-as-pure': 7.29.7
+      '@babel/helper-create-class-features-plugin': 7.29.7(@babel/core@7.29.7)
+      '@babel/helper-plugin-utils': 7.29.7
+      '@babel/helper-skip-transparent-expression-wrappers': 7.29.7(supports-color@10.2.2)
+      '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.7)
     transitivePeerDependencies:
       - supports-color
 
@@ -21031,23 +21003,16 @@ snapshots:
       jose: 6.2.8
       kysely: 0.29.5
       nanostores: 1.4.2
-      zod: 4.5.4
+      zod: 4.4.3
     optionalDependencies:
       '@cloudflare/workers-types': 5.20260901.1
 
-  '@better-auth/drizzle-adapter@1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260901.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))':
+  '@better-auth/drizzle-adapter@1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260901.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))':
     dependencies:
       '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260901.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2)
       '@better-auth/utils': 0.4.2
     optionalDependencies:
-      drizzle-orm: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3)
-
-  '@better-auth/drizzle-adapter@1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260901.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4))':
-    dependencies:
-      '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260901.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2)
-      '@better-auth/utils': 0.4.2
-    optionalDependencies:
-      drizzle-orm: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4)
+      drizzle-orm: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3)
 
   '@better-auth/kysely-adapter@1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260901.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(kysely@0.29.5)':
     dependencies:
@@ -21456,76 +21421,68 @@ snapshots:
     dependencies:
       '@noble/ciphers': 1.3.0
 
-  '@effect/atom-react@4.0.0-rc.112(effect@4.0.0-rc.112)(react@19.2.8)(scheduler@0.27.0)':
+  '@effect/atom-react@4.0.0-rc.113(effect@4.0.0-rc.113)(react@19.2.8)(scheduler@0.27.0)':
     dependencies:
-      effect: 4.0.0-rc.112
+      effect: 4.0.0-rc.113
       react: 19.2.8
       scheduler: 0.27.0
 
   '@effect/language-service@0.87.2': {}
 
-  '@effect/platform-bun@4.0.0-rc.112(effect@4.0.0-rc.112)':
+  '@effect/platform-bun@4.0.0-rc.113(effect@4.0.0-rc.113)':
     dependencies:
-      '@effect/platform-node-shared': 4.0.0-rc.112(effect@4.0.0-rc.112)
-      effect: 4.0.0-rc.112
+      '@effect/platform-node-shared': 4.0.0-rc.113(effect@4.0.0-rc.113)
+      effect: 4.0.0-rc.113
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@effect/platform-node-shared@4.0.0-rc.112(effect@4.0.0-rc.112)':
+  '@effect/platform-node-shared@4.0.0-rc.113(effect@4.0.0-rc.113)':
     dependencies:
       '@types/ws': 8.18.1
-      effect: 4.0.0-rc.112
+      effect: 4.0.0-rc.113
       ws: 8.21.3
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@effect/platform-node@4.0.0-rc.112(effect@4.0.0-rc.112)(redis@6.2.1)':
+  '@effect/platform-node@4.0.0-rc.113(effect@4.0.0-rc.113)(redis@6.2.1)':
     dependencies:
-      '@effect/platform-node-shared': 4.0.0-rc.112(effect@4.0.0-rc.112)
-      effect: 4.0.0-rc.112
-      mime: 4.1.0
+      '@effect/platform-node-shared': 4.0.0-rc.113(effect@4.0.0-rc.113)
+      effect: 4.0.0-rc.113
       redis: 6.2.1
-      undici: 8.10.0
+      undici: 8.10.2
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  '@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112)':
+  '@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113)':
     dependencies:
       '@cloudflare/workers-types': 5.20260901.1
-      effect: 4.0.0-rc.112
+      effect: 4.0.0-rc.113
 
-  '@effect/sql-mysql2@4.0.0-rc.112(@types/node@24.13.3)(effect@4.0.0-rc.112)':
+  '@effect/sql-mysql2@4.0.0-rc.113(@types/node@24.13.3)(effect@4.0.0-rc.113)':
     dependencies:
-      effect: 4.0.0-rc.112
+      effect: 4.0.0-rc.113
       mysql2: 3.24.2(@types/node@24.13.3)
     transitivePeerDependencies:
       - '@types/node'
     optional: true
 
-  '@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112)':
+  '@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113)':
     dependencies:
-      effect: 4.0.0-rc.112
+      effect: 4.0.0-rc.113
       mysql2: 3.24.2(@types/node@26.2.0)
     transitivePeerDependencies:
       - '@types/node'
 
-  '@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112)':
+  '@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113)':
     dependencies:
-      effect: 4.0.0-rc.112
-      pg: 8.23.0
-      pg-connection-string: 2.14.0
-      pg-cursor: 2.22.0(pg@8.23.0)
-      pg-pool: 3.14.0(pg@8.23.0)
-      pg-types: 4.1.0
-    transitivePeerDependencies:
-      - pg-native
+      effect: 4.0.0-rc.113
 
-  '@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112)':
+  '@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113)':
     dependencies:
-      effect: 4.0.0-rc.112
+      effect: 4.0.0-rc.113
 
   '@effect/tsgo-darwin-arm64@0.36.4':
     optional: true
@@ -21558,9 +21515,9 @@ snapshots:
       '@effect/tsgo-win32-arm64': 0.36.4
       '@effect/tsgo-win32-x64': 0.36.4
 
-  '@effect/vitest@4.0.0-rc.112(effect@4.0.0-rc.112)(vitest@4.1.10(@types/node@26.2.0)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))':
+  '@effect/vitest@4.0.0-rc.113(effect@4.0.0-rc.113)(vitest@4.1.10(@types/node@26.2.0)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))':
     dependencies:
-      effect: 4.0.0-rc.112
+      effect: 4.0.0-rc.113
       vitest: 4.1.10(@types/node@26.2.0)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
 
   '@electric-sql/pglite-socket@0.0.20(@electric-sql/pglite@0.3.15)':
@@ -21999,10 +21956,10 @@ snapshots:
       - '@vue/composition-api'
       - vue
 
-  '@foldkit/vite-plugin@0.16.1(effect@4.0.0-rc.112)(foldkit@0.148.2(effect@4.0.0-rc.112))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))':
+  '@foldkit/vite-plugin@0.16.1(effect@4.0.0-rc.113)(foldkit@0.148.2(effect@4.0.0-rc.113))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))':
     dependencies:
-      effect: 4.0.0-rc.112
-      foldkit: 0.148.2(effect@4.0.0-rc.112)
+      effect: 4.0.0-rc.113
+      foldkit: 0.148.2(effect@4.0.0-rc.113)
       magic-string: 0.30.21
       vite: 8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
       ws: 8.21.3
@@ -22010,10 +21967,10 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@foldkit/vite-plugin@0.16.1(effect@4.0.0-rc.112)(foldkit@0.148.2(effect@4.0.0-rc.112))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))':
+  '@foldkit/vite-plugin@0.16.1(effect@4.0.0-rc.113)(foldkit@0.148.2(effect@4.0.0-rc.113))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))':
     dependencies:
-      effect: 4.0.0-rc.112
-      foldkit: 0.148.2(effect@4.0.0-rc.112)
+      effect: 4.0.0-rc.113
+      foldkit: 0.148.2(effect@4.0.0-rc.113)
       magic-string: 0.30.21
       vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
       ws: 8.21.3
@@ -22757,24 +22714,6 @@ snapshots:
       chevrotain: 10.5.0
       lilconfig: 2.1.0
 
-  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4':
-    optional: true
-
-  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.4':
-    optional: true
-
-  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.4':
-    optional: true
-
-  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.4':
-    optional: true
-
-  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.4':
-    optional: true
-
-  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4':
-    optional: true
-
   '@napi-rs/lzma-linux-x64-gnu@1.5.1':
     optional: true
 
@@ -22955,72 +22894,7 @@ snapshots:
       pkg-types: 2.3.1
       semver: 7.8.5
 
-  '@nuxt/devtools@3.4.1(43838925e6dd8e4c5211d688814ddf88)':
-    dependencies:
-      '@nuxt/devtools-kit': 3.4.1(magic-string@1.1.1)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
-      '@nuxt/devtools-wizard': 3.4.1
-      '@nuxt/kit': 4.5.1(magic-string@1.1.1)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))
-      '@vue/devtools-core': 8.2.1(vue@3.5.41(typescript@7.0.2))
-      '@vue/devtools-kit': 8.2.1
-      birpc: 4.1.0
-      consola: 3.4.2
-      destr: 2.0.5
-      error-stack-parser-es: 2.0.1
-      execa: 8.0.1
-      fast-npm-meta: 2.2.0
-      get-port-please: 3.2.0
-      hookable: 6.1.1
-      image-meta: 0.2.2
-      is-installed-globally: 1.0.0
-      launch-editor: 2.14.1
-      local-pkg: 1.2.1
-      magicast: 0.5.4
-      nypm: 0.6.9
-      ohash: 2.0.11
-      pathe: 2.0.3
-      perfect-debounce: 2.1.0
-      pkg-types: 2.3.1
-      semver: 7.8.5
-      simple-git: 3.36.0(supports-color@10.2.2)
-      sirv: 3.0.2
-      structured-clone-es: 2.0.1
-      tinyglobby: 0.2.17
-      unstorage: 1.17.5(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))
-      vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
-      vite-plugin-inspect: 11.4.1(@nuxt/kit@4.5.1(magic-string@1.1.1)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
-      vite-plugin-vue-tracer: 1.5.0(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(vue@3.5.41(typescript@7.0.2))
-      which: 6.0.1
-      ws: 8.21.3
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bufferutil
-      - db0
-      - idb-keyval
-      - ioredis
-      - magic-string
-      - oxc-parser
-      - rolldown
-      - supports-color
-      - unplugin
-      - uploadthing
-      - utf-8-validate
-      - vue
-
-  '@nuxt/devtools@3.4.1(6005cdf8de4f0e458074d9bb92d5f425)':
+  '@nuxt/devtools@3.4.1(42eff27e1b9a45d570b2cdedacd8db41)':
     dependencies:
       '@nuxt/devtools-kit': 3.4.1(magic-string@1.1.1)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
       '@nuxt/devtools-wizard': 3.4.1
@@ -23050,7 +22924,7 @@ snapshots:
       sirv: 3.0.2
       structured-clone-es: 2.0.1
       tinyglobby: 0.2.17
-      unstorage: 1.17.5(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@24.13.3)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@24.13.3))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4))(mysql2@3.24.2(@types/node@24.13.3)))(ioredis@5.11.1(supports-color@10.2.2))
+      unstorage: 1.17.5(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@24.13.3)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@24.13.3))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@24.13.3)))(ioredis@5.11.1(supports-color@10.2.2))
       vite: 8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
       vite-plugin-inspect: 11.4.1(@nuxt/kit@4.5.1(magic-string@1.1.1)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
       vite-plugin-vue-tracer: 1.5.0(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(vue@3.5.41(typescript@7.0.2))
@@ -23085,7 +22959,7 @@ snapshots:
       - utf-8-validate
       - vue
 
-  '@nuxt/devtools@3.4.1(68770fa0c397238e9aed70d45d97d0b7)':
+  '@nuxt/devtools@3.4.1(6068b5ad1d0b1ba9f9227fcb07baf80f)':
     dependencies:
       '@nuxt/devtools-kit': 3.4.1(magic-string@1.1.1)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
       '@nuxt/devtools-wizard': 3.4.1
@@ -23115,7 +22989,7 @@ snapshots:
       sirv: 3.0.2
       structured-clone-es: 2.0.1
       tinyglobby: 0.2.17
-      unstorage: 1.17.5(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))
+      unstorage: 1.17.5(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))
       vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
       vite-plugin-inspect: 11.4.1(@nuxt/kit@4.5.1(magic-string@1.1.1)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
       vite-plugin-vue-tracer: 1.5.0(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(vue@3.5.41(typescript@7.0.2))
@@ -23241,7 +23115,94 @@ snapshots:
       - unplugin
     optional: true
 
-  '@nuxt/nitro-server@4.5.1(69b87bb0a1ee217202dcfcb775749e8a)':
+  '@nuxt/nitro-server@4.5.1(419e31df70c861b79b43f043f657c53c)':
+    dependencies:
+      '@nuxt/devalue': 2.0.2
+      '@nuxt/kit': 4.5.1(magic-string@1.1.1)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))
+      '@unhead/vue': 3.3.1(@oxc-project/types@0.146.0)(esbuild@0.28.2)(lightningcss@1.33.0)(oxc-parser@0.141.0)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(vue@3.5.41(typescript@7.0.2))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
+      '@vue/shared': 3.5.41
+      consola: 3.4.2
+      defu: 6.1.7
+      destr: 2.0.5
+      devalue: 5.9.0
+      errx: 0.1.2
+      escape-string-regexp: 5.0.0
+      exsolve: 1.1.1
+      h3: 1.15.11
+      impound: 1.1.6(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
+      klona: 2.0.6
+      mocked-exports: 0.1.1
+      nitropack: 2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
+      nostics: 1.2.0
+      nuxt: 4.5.1(df1693d43dd7d6545462287ea122e04b)
+      nypm: 0.6.9
+      ohash: 2.0.11
+      pathe: 2.0.3
+      rou3: 0.9.2
+      std-env: 4.2.0
+      ufo: 1.6.4
+      unctx: 3.0.0(magic-string@1.1.1)(oxc-parser@0.141.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))
+      unstorage: 1.17.5(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))
+      vue: 3.5.41(typescript@7.0.2)
+      vue-bundle-renderer: 2.3.2
+      vue-devtools-stub: 0.1.0
+    optionalDependencies:
+      '@babel/plugin-proposal-decorators': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@electric-sql/pglite'
+      - '@farmfe/core'
+      - '@libsql/client'
+      - '@netlify/blobs'
+      - '@oxc-project/types'
+      - '@parcel/watcher'
+      - '@planetscale/database'
+      - '@rspack/core'
+      - '@unhead/cli'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - '@vitejs/devtools-kit'
+      - aws4fetch
+      - bare-abort-controller
+      - bare-buffer
+      - better-sqlite3
+      - bun-types-no-globals
+      - db0
+      - drizzle-orm
+      - encoding
+      - esbuild
+      - idb-keyval
+      - ioredis
+      - lightningcss
+      - magic-string
+      - magicast
+      - mysql2
+      - oxc-parser
+      - react-native-b4a
+      - rolldown
+      - rollup
+      - sqlite3
+      - srvx
+      - supports-color
+      - typescript
+      - unloader
+      - unplugin
+      - uploadthing
+      - vite
+      - webpack
+      - xml2js
+
+  '@nuxt/nitro-server@4.5.1(50165601727411fc4f6553cdc5712e27)':
     dependencies:
       '@nuxt/devalue': 2.0.2
       '@nuxt/kit': 4.5.1(magic-string@1.1.1)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))
@@ -23258,9 +23219,9 @@ snapshots:
       impound: 1.1.6(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
       klona: 2.0.6
       mocked-exports: 0.1.1
-      nitropack: 2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@24.13.3)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@24.13.3))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4))(mysql2@3.24.2(@types/node@24.13.3))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
+      nitropack: 2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@24.13.3)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@24.13.3))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@24.13.3))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
       nostics: 1.2.0
-      nuxt: 4.5.1(64eb09726475984998fb56e43114116a)
+      nuxt: 4.5.1(867099590d63db02e3731b2415c98ffd)
       nypm: 0.6.9
       ohash: 2.0.11
       pathe: 2.0.3
@@ -23268,7 +23229,7 @@ snapshots:
       std-env: 4.2.0
       ufo: 1.6.4
       unctx: 3.0.0(magic-string@1.1.1)(oxc-parser@0.141.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))
-      unstorage: 1.17.5(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@24.13.3)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@24.13.3))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4))(mysql2@3.24.2(@types/node@24.13.3)))(ioredis@5.11.1(supports-color@10.2.2))
+      unstorage: 1.17.5(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@24.13.3)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@24.13.3))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@24.13.3)))(ioredis@5.11.1(supports-color@10.2.2))
       vue: 3.5.41(typescript@7.0.2)
       vue-bundle-renderer: 2.3.2
       vue-devtools-stub: 0.1.0
@@ -23328,7 +23289,7 @@ snapshots:
       - webpack
       - xml2js
 
-  '@nuxt/nitro-server@4.5.1(c3f5ec8db84c3b5b73511d8dc32cb3a5)':
+  '@nuxt/nitro-server@4.5.1(602eb0a9c0dd6902d8c3c66fadbcd198)':
     dependencies:
       '@nuxt/devalue': 2.0.2
       '@nuxt/kit': 4.5.1(magic-string@1.1.1)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))
@@ -23345,9 +23306,9 @@ snapshots:
       impound: 1.1.6(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
       klona: 2.0.6
       mocked-exports: 0.1.1
-      nitropack: 2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
+      nitropack: 2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
       nostics: 1.2.0
-      nuxt: 4.5.1(b8f7e2370c0c7cb4e95babfd663ba2fb)
+      nuxt: 4.5.1(7fe16a31c4082a23bec7caccdcc17327)
       nypm: 0.6.9
       ohash: 2.0.11
       pathe: 2.0.3
@@ -23355,94 +23316,7 @@ snapshots:
       std-env: 4.2.0
       ufo: 1.6.4
       unctx: 3.0.0(magic-string@1.1.1)(oxc-parser@0.141.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))
-      unstorage: 1.17.5(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))
-      vue: 3.5.41(typescript@7.0.2)
-      vue-bundle-renderer: 2.3.2
-      vue-devtools-stub: 0.1.0
-    optionalDependencies:
-      '@babel/plugin-proposal-decorators': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-syntax-typescript': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@electric-sql/pglite'
-      - '@farmfe/core'
-      - '@libsql/client'
-      - '@netlify/blobs'
-      - '@oxc-project/types'
-      - '@parcel/watcher'
-      - '@planetscale/database'
-      - '@rspack/core'
-      - '@unhead/cli'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - '@vitejs/devtools-kit'
-      - aws4fetch
-      - bare-abort-controller
-      - bare-buffer
-      - better-sqlite3
-      - bun-types-no-globals
-      - db0
-      - drizzle-orm
-      - encoding
-      - esbuild
-      - idb-keyval
-      - ioredis
-      - lightningcss
-      - magic-string
-      - magicast
-      - mysql2
-      - oxc-parser
-      - react-native-b4a
-      - rolldown
-      - rollup
-      - sqlite3
-      - srvx
-      - supports-color
-      - typescript
-      - unloader
-      - unplugin
-      - uploadthing
-      - vite
-      - webpack
-      - xml2js
-
-  '@nuxt/nitro-server@4.5.1(c7b1827fb70a2cfe9ce6c6b724e2b172)':
-    dependencies:
-      '@nuxt/devalue': 2.0.2
-      '@nuxt/kit': 4.5.1(magic-string@1.1.1)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))
-      '@unhead/vue': 3.3.1(@oxc-project/types@0.146.0)(esbuild@0.28.2)(lightningcss@1.33.0)(oxc-parser@0.141.0)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(vue@3.5.41(typescript@7.0.2))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
-      '@vue/shared': 3.5.41
-      consola: 3.4.2
-      defu: 6.1.7
-      destr: 2.0.5
-      devalue: 5.9.0
-      errx: 0.1.2
-      escape-string-regexp: 5.0.0
-      exsolve: 1.1.1
-      h3: 1.15.11
-      impound: 1.1.6(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
-      klona: 2.0.6
-      mocked-exports: 0.1.1
-      nitropack: 2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4))(mysql2@3.24.2(@types/node@26.2.0))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
-      nostics: 1.2.0
-      nuxt: 4.5.1(7234cbbd18b9a21040d15b51f4bb3989)
-      nypm: 0.6.9
-      ohash: 2.0.11
-      pathe: 2.0.3
-      rou3: 0.9.2
-      std-env: 4.2.0
-      ufo: 1.6.4
-      unctx: 3.0.0(magic-string@1.1.1)(oxc-parser@0.141.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))
-      unstorage: 1.17.5(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))
+      unstorage: 1.17.5(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))
       vue: 3.5.41(typescript@7.0.2)
       vue-bundle-renderer: 2.3.2
       vue-devtools-stub: 0.1.0
@@ -23529,7 +23403,7 @@ snapshots:
       rc9: 3.0.1
       std-env: 4.2.0
 
-  '@nuxt/vite-builder@4.5.1(@babel/plugin-proposal-decorators@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@types/node@24.13.3)(esbuild@0.28.2)(magic-string@1.1.1)(magicast@0.5.4)(nuxt@4.5.1(64eb09726475984998fb56e43114116a))(oxc-parser@0.141.0)(oxlint@1.81.0)(rolldown@1.2.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.5)(rollup@4.62.4))(rollup@4.62.4)(supports-color@10.2.2)(terser@5.50.0)(tsx@4.23.12)(typescript@7.0.2)(vue-tsc@3.3.9(typescript@7.0.2))(vue@3.5.41(typescript@7.0.2))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))(yaml@2.9.0)':
+  '@nuxt/vite-builder@4.5.1(@babel/plugin-proposal-decorators@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@types/node@24.13.3)(esbuild@0.28.2)(magic-string@1.1.1)(magicast@0.5.4)(nuxt@4.5.1(867099590d63db02e3731b2415c98ffd))(oxc-parser@0.141.0)(oxlint@1.81.0)(rolldown@1.2.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.5)(rollup@4.62.4))(rollup@4.62.4)(supports-color@10.2.2)(terser@5.50.0)(tsx@4.23.12)(typescript@7.0.2)(vue-tsc@3.3.9(typescript@7.0.2))(vue@3.5.41(typescript@7.0.2))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))(yaml@2.9.0)':
     dependencies:
       '@nuxt/kit': 4.5.1(magic-string@1.1.1)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))
       '@vitejs/plugin-vue': 6.0.8(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(vue@3.5.41(typescript@7.0.2))
@@ -23547,7 +23421,7 @@ snapshots:
       knitwork: 1.3.0
       mlly: 1.8.2
       mocked-exports: 0.1.1
-      nuxt: 4.5.1(64eb09726475984998fb56e43114116a)
+      nuxt: 4.5.1(867099590d63db02e3731b2415c98ffd)
       nypm: 0.6.9
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -23599,7 +23473,7 @@ snapshots:
       - webpack
       - yaml
 
-  '@nuxt/vite-builder@4.5.1(@babel/plugin-proposal-decorators@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@types/node@26.2.0)(esbuild@0.28.2)(magic-string@1.1.1)(magicast@0.5.4)(nuxt@4.5.1(7234cbbd18b9a21040d15b51f4bb3989))(oxc-parser@0.141.0)(oxlint@1.81.0)(rolldown@1.2.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.5)(rollup@4.62.4))(rollup@4.62.4)(supports-color@10.2.2)(terser@5.50.0)(tsx@4.23.12)(typescript@7.0.2)(vue-tsc@3.3.9(typescript@7.0.2))(vue@3.5.41(typescript@7.0.2))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))(yaml@2.9.0)':
+  '@nuxt/vite-builder@4.5.1(@babel/plugin-proposal-decorators@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@types/node@26.2.0)(esbuild@0.28.2)(magic-string@1.1.1)(magicast@0.5.4)(nuxt@4.5.1(7fe16a31c4082a23bec7caccdcc17327))(oxc-parser@0.141.0)(oxlint@1.81.0)(rolldown@1.2.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.5)(rollup@4.62.4))(rollup@4.62.4)(supports-color@10.2.2)(terser@5.50.0)(tsx@4.23.12)(typescript@7.0.2)(vue@3.5.41(typescript@7.0.2))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))(yaml@2.9.0)':
     dependencies:
       '@nuxt/kit': 4.5.1(magic-string@1.1.1)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))
       '@vitejs/plugin-vue': 6.0.8(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(vue@3.5.41(typescript@7.0.2))
@@ -23617,7 +23491,7 @@ snapshots:
       knitwork: 1.3.0
       mlly: 1.8.2
       mocked-exports: 0.1.1
-      nuxt: 4.5.1(7234cbbd18b9a21040d15b51f4bb3989)
+      nuxt: 4.5.1(7fe16a31c4082a23bec7caccdcc17327)
       nypm: 0.6.9
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -23669,7 +23543,7 @@ snapshots:
       - webpack
       - yaml
 
-  '@nuxt/vite-builder@4.5.1(@babel/plugin-proposal-decorators@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@types/node@26.2.0)(esbuild@0.28.2)(magic-string@1.1.1)(magicast@0.5.4)(nuxt@4.5.1(b8f7e2370c0c7cb4e95babfd663ba2fb))(oxc-parser@0.141.0)(oxlint@1.81.0)(rolldown@1.2.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.5)(rollup@4.62.4))(rollup@4.62.4)(supports-color@10.2.2)(terser@5.50.0)(tsx@4.23.12)(typescript@7.0.2)(vue@3.5.41(typescript@7.0.2))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))(yaml@2.9.0)':
+  '@nuxt/vite-builder@4.5.1(@babel/plugin-proposal-decorators@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@types/node@26.2.0)(esbuild@0.28.2)(magic-string@1.1.1)(magicast@0.5.4)(nuxt@4.5.1(df1693d43dd7d6545462287ea122e04b))(oxc-parser@0.141.0)(oxlint@1.81.0)(rolldown@1.2.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.5)(rollup@4.62.4))(rollup@4.62.4)(supports-color@10.2.2)(terser@5.50.0)(tsx@4.23.12)(typescript@7.0.2)(vue-tsc@3.3.9(typescript@7.0.2))(vue@3.5.41(typescript@7.0.2))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))(yaml@2.9.0)':
     dependencies:
       '@nuxt/kit': 4.5.1(magic-string@1.1.1)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))
       '@vitejs/plugin-vue': 6.0.8(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(vue@3.5.41(typescript@7.0.2))
@@ -23687,7 +23561,7 @@ snapshots:
       knitwork: 1.3.0
       mlly: 1.8.2
       mocked-exports: 0.1.1
-      nuxt: 4.5.1(b8f7e2370c0c7cb4e95babfd663ba2fb)
+      nuxt: 4.5.1(df1693d43dd7d6545462287ea122e04b)
       nypm: 0.6.9
       pathe: 2.0.3
       pkg-types: 2.3.1
@@ -25107,7 +24981,7 @@ snapshots:
       set-cookie-parser: 3.1.0
       vue: 3.5.41(typescript@7.0.2)
       yaml: 2.9.0
-      zod: 4.5.4
+      zod: 4.4.3
     transitivePeerDependencies:
       - '@vue/composition-api'
       - async-validator
@@ -25300,14 +25174,14 @@ snapshots:
       '@scalar/helpers': 0.8.2
       nanoid: 5.1.16
       type-fest: 5.8.0
-      zod: 4.5.4
+      zod: 4.4.3
 
   '@scalar/types@0.17.1':
     dependencies:
       '@scalar/helpers': 0.10.0
       nanoid: 5.1.16
       type-fest: 5.8.0
-      zod: 4.5.4
+      zod: 4.4.3
 
   '@scalar/use-codemirror@0.14.14(typescript@7.0.2)':
     dependencies:
@@ -25907,9 +25781,9 @@ snapshots:
       - crossws
       - supports-color
 
-  '@solidjs/vite-plugin-nitro-2@0.3.2(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))':
+  '@solidjs/vite-plugin-nitro-2@0.3.2(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))':
     dependencies:
-      nitropack: 2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
+      nitropack: 2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
       vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@azure/app-configuration'
@@ -25955,50 +25829,6 @@ snapshots:
     dependencies:
       nitropack: 2.13.4(srvx@0.12.5)(supports-color@10.2.2)(vite@7.3.6(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
       vite: 7.3.6(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@electric-sql/pglite'
-      - '@farmfe/core'
-      - '@libsql/client'
-      - '@netlify/blobs'
-      - '@parcel/watcher'
-      - '@planetscale/database'
-      - '@rspack/core'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bare-abort-controller
-      - bare-buffer
-      - better-sqlite3
-      - bun-types-no-globals
-      - drizzle-orm
-      - encoding
-      - idb-keyval
-      - mysql2
-      - oxc-parser
-      - react-native-b4a
-      - rolldown
-      - sqlite3
-      - srvx
-      - supports-color
-      - unloader
-      - uploadthing
-      - webpack
-      - xml2js
-
-  '@solidjs/vite-plugin-nitro-2@0.3.2(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))':
-    dependencies:
-      nitropack: 2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4))(mysql2@3.24.2(@types/node@26.2.0))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
-      vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -26885,7 +26715,7 @@ snapshots:
       jiti: 2.7.0
       magic-string: 0.30.21
       prettier: 3.9.6
-      zod: 4.5.4
+      zod: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -26898,7 +26728,7 @@ snapshots:
       jiti: 2.7.0
       magic-string: 0.30.21
       prettier: 3.9.6
-      zod: 4.5.4
+      zod: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -26911,7 +26741,7 @@ snapshots:
       jiti: 2.7.0
       magic-string: 0.30.21
       prettier: 3.9.6
-      zod: 4.5.4
+      zod: 4.4.3
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -26926,7 +26756,7 @@ snapshots:
       '@tanstack/router-utils': 1.162.2(supports-color@10.2.2)
       chokidar: 5.0.0
       unplugin: 3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
-      zod: 4.5.4
+      zod: 4.4.3
     optionalDependencies:
       '@tanstack/react-router': 1.170.27(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       vite: 8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
@@ -26952,7 +26782,7 @@ snapshots:
       '@tanstack/router-utils': 1.162.2(supports-color@10.2.2)
       chokidar: 5.0.0
       unplugin: 3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
-      zod: 4.5.4
+      zod: 4.4.3
     optionalDependencies:
       '@tanstack/react-router': 1.170.27(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
@@ -26978,7 +26808,7 @@ snapshots:
       '@tanstack/router-utils': 1.162.2
       chokidar: 5.0.0
       unplugin: 3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
-      zod: 4.5.4
+      zod: 4.4.3
     optionalDependencies:
       '@tanstack/react-router': 1.170.27(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
@@ -27004,7 +26834,7 @@ snapshots:
       '@tanstack/router-utils': 1.162.2(supports-color@10.2.2)
       chokidar: 5.0.0
       unplugin: 3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
-      zod: 4.5.4
+      zod: 4.4.3
     optionalDependencies:
       '@tanstack/react-router': 1.170.32(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
@@ -27030,7 +26860,7 @@ snapshots:
       '@tanstack/router-utils': 1.162.2(supports-color@10.2.2)
       chokidar: 5.0.0
       unplugin: 3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
-      zod: 4.5.4
+      zod: 4.4.3
     optionalDependencies:
       '@tanstack/react-router': 1.170.32(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
@@ -27191,7 +27021,7 @@ snapshots:
       ufo: 1.6.4
       vitefu: 1.1.3(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
       xmlbuilder2: 4.0.3
-      zod: 4.5.4
+      zod: 4.4.3
     optionalDependencies:
       vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
     transitivePeerDependencies:
@@ -27229,7 +27059,7 @@ snapshots:
       ufo: 1.6.4
       vitefu: 1.1.3(vite@8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
       xmlbuilder2: 4.0.3
-      zod: 4.5.4
+      zod: 4.4.3
     optionalDependencies:
       vite: 8.2.1(@types/node@22.20.1)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
     transitivePeerDependencies:
@@ -27267,7 +27097,7 @@ snapshots:
       ufo: 1.6.4
       vitefu: 1.1.3(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
       xmlbuilder2: 4.0.3
-      zod: 4.5.4
+      zod: 4.4.3
     optionalDependencies:
       vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
     transitivePeerDependencies:
@@ -27305,7 +27135,7 @@ snapshots:
       ufo: 1.6.4
       vitefu: 1.1.3(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
       xmlbuilder2: 4.0.3
-      zod: 4.5.4
+      zod: 4.4.3
     optionalDependencies:
       vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
     transitivePeerDependencies:
@@ -27343,7 +27173,7 @@ snapshots:
       ufo: 1.6.4
       vitefu: 1.1.3(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
       xmlbuilder2: 4.0.3
-      zod: 4.5.4
+      zod: 4.4.3
     optionalDependencies:
       vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
     transitivePeerDependencies:
@@ -27381,7 +27211,7 @@ snapshots:
       ufo: 1.6.4
       vitefu: 1.1.3(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
       xmlbuilder2: 4.0.3
-      zod: 4.5.4
+      zod: 4.4.3
     optionalDependencies:
       vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
     transitivePeerDependencies:
@@ -28099,19 +27929,19 @@ snapshots:
 
   '@vue/babel-helper-vue-transform-on@2.0.1': {}
 
-  '@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@vue/babel-plugin-jsx@1.5.0(@babel/core@7.29.7)':
     dependencies:
       '@babel/helper-module-imports': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
-      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
+      '@babel/plugin-syntax-jsx': 7.29.7(@babel/core@7.29.7)
       '@babel/template': 7.29.7
       '@babel/traverse': 7.29.8(supports-color@10.2.2)
       '@babel/types': 7.29.8
       '@vue/babel-helper-vue-transform-on': 1.5.0
-      '@vue/babel-plugin-resolve-type': 1.5.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@vue/babel-plugin-resolve-type': 1.5.0(@babel/core@7.29.7)
       '@vue/shared': 3.5.41
     optionalDependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -28131,10 +27961,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vue/babel-plugin-resolve-type@1.5.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)':
+  '@vue/babel-plugin-resolve-type@1.5.0(@babel/core@7.29.7)':
     dependencies:
       '@babel/code-frame': 7.29.7
-      '@babel/core': 7.29.7(supports-color@10.2.2)
+      '@babel/core': 7.29.7
       '@babel/helper-module-imports': 7.29.7(supports-color@10.2.2)
       '@babel/helper-plugin-utils': 7.29.7
       '@babel/parser': 7.29.8
@@ -28670,13 +28500,13 @@ snapshots:
 
   astring@1.9.0: {}
 
-  astro-expressive-code@0.44.1(astro@7.3.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)):
+  astro-expressive-code@0.44.1(astro@7.3.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)):
     dependencies:
-      astro: 7.3.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
+      astro: 7.3.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
       rehype-expressive-code: 0.44.1
       url-extras: 0.1.0
 
-  astro@7.3.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0):
+  astro@7.3.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0):
     dependencies:
       '@astrojs/compiler-rs': 0.4.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)
       '@astrojs/internal-helpers': 0.11.0
@@ -28725,103 +28555,12 @@ snapshots:
       tinyglobby: 0.2.17
       ultrahtml: 1.7.0
       unifont: 0.7.5
-      unstorage: 1.17.5(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))
+      unstorage: 1.17.5(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))
       vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
       vitefu: 1.1.3(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
       xxhash-wasm: 1.1.0
       yargs-parser: 22.0.0
-      zod: 4.5.4
-    optionalDependencies:
-      sharp: 0.35.4(@types/node@26.2.0)
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@emnapi/core'
-      - '@emnapi/runtime'
-      - '@netlify/blobs'
-      - '@planetscale/database'
-      - '@types/node'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - '@vitejs/devtools'
-      - aws4fetch
-      - db0
-      - idb-keyval
-      - ioredis
-      - jiti
-      - less
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - terser
-      - tsx
-      - uploadthing
-      - yaml
-
-  astro@7.3.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0):
-    dependencies:
-      '@astrojs/compiler-rs': 0.4.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)
-      '@astrojs/internal-helpers': 0.11.0
-      '@astrojs/markdown-satteri': 0.4.0
-      '@astrojs/telemetry': 3.3.3
-      '@capsizecss/unpack': 4.0.1
-      '@clack/prompts': 1.7.0
-      '@oslojs/encoding': 1.1.0
-      am-i-vibing: 0.4.0
-      aria-query: 5.3.2
-      axobject-query: 4.1.0
-      ci-info: 4.4.0
-      clsx: 2.1.1
-      common-ancestor-path: 2.0.0
-      cookie: 2.0.1
-      devalue: 5.8.1
-      diff: 9.0.0
-      dset: 3.1.4
-      es-module-lexer: 2.3.1
-      esbuild: 0.28.2
-      find-proc: 0.1.0
-      flattie: 1.1.1
-      fontace: 0.4.1
-      get-tsconfig: 5.0.0-beta.4
-      github-slugger: 2.0.0
-      html-escaper: 3.0.3
-      http-cache-semantics: 4.2.0
-      js-yaml: 4.3.1
-      jsonc-parser: 3.3.1
-      magic-string: 1.1.1
-      magicast: 0.5.4
-      mrmime: 2.0.1
-      neotraverse: 1.0.1
-      obug: 2.1.4
-      p-limit: 7.3.1
-      p-queue: 9.3.3
-      package-manager-detector: 1.8.0
-      piccolore: 0.1.3
-      picomatch: 4.0.5
-      semver: 7.8.5
-      shiki: 4.4.3
-      smol-toml: 1.8.0
-      svgo: 4.0.2
-      tinyclip: 0.1.15
-      tinyexec: 1.3.0
-      tinyglobby: 0.2.17
-      ultrahtml: 1.7.0
-      unifont: 0.7.5
-      unstorage: 1.17.5(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))
-      vite: 8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
-      vitefu: 1.1.3(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
-      xxhash-wasm: 1.1.0
-      yargs-parser: 22.0.0
-      zod: 4.5.4
+      zod: 4.4.3
     optionalDependencies:
       sharp: 0.35.4(@types/node@26.2.0)
     transitivePeerDependencies:
@@ -28984,10 +28723,10 @@ snapshots:
 
   before-after-hook@4.0.0: {}
 
-  better-auth@1.6.25(04166073f4f545899d491cc413622642):
+  better-auth@1.6.25(3f55a70ed1274cd9feb933c6021ba76f):
     dependencies:
       '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260901.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2)
-      '@better-auth/drizzle-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260901.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4))
+      '@better-auth/drizzle-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260901.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))
       '@better-auth/kysely-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260901.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(kysely@0.29.5)
       '@better-auth/memory-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260901.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)
       '@better-auth/mongo-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260901.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(mongodb@6.21.0(@aws-sdk/credential-providers@3.1095.0)(socks@2.8.9))
@@ -29007,45 +28746,7 @@ snapshots:
       '@tanstack/react-start': 1.168.49(@vitejs/plugin-rsc@0.5.34(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(react@19.2.8)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))(crossws@0.4.10(srvx@0.12.5))(esbuild@0.28.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.5)(rollup@4.62.4)(supports-color@10.2.2)(vite-plugin-solid@2.11.14(solid-js@1.9.15)(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
       '@tanstack/solid-start': 1.168.42(@tanstack/react-router@1.170.32(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(crossws@0.4.10(srvx@0.12.5))(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(solid-js@1.9.15)(supports-color@10.2.2)(vite-plugin-solid@2.11.14(solid-js@1.9.15)(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
       drizzle-kit: 1.0.0-rc.5-ab785fc
-      drizzle-orm: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4)
-      mongodb: 6.21.0(@aws-sdk/credential-providers@3.1095.0)(socks@2.8.9)
-      mysql2: 3.24.2(@types/node@26.2.0)
-      next: 16.2.10(@babel/core@7.29.7(supports-color@10.2.2))(@playwright/test@1.62.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
-      pg: 8.23.0
-      react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
-      solid-js: 1.9.15
-      svelte: 5.56.8
-      vitest: 4.1.10(@types/node@26.2.0)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
-      vue: 3.5.41(typescript@7.0.2)
-    transitivePeerDependencies:
-      - '@cloudflare/workers-types'
-      - '@opentelemetry/api'
-
-  better-auth@1.6.25(e20f5e9f480a52fe3a4e9438c63ccf5e):
-    dependencies:
-      '@better-auth/core': 1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260901.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2)
-      '@better-auth/drizzle-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260901.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))
-      '@better-auth/kysely-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260901.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(kysely@0.29.5)
-      '@better-auth/memory-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260901.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)
-      '@better-auth/mongo-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260901.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(mongodb@6.21.0(@aws-sdk/credential-providers@3.1095.0)(socks@2.8.9))
-      '@better-auth/prisma-adapter': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260901.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)
-      '@better-auth/telemetry': 1.6.25(@better-auth/core@1.6.25(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@cloudflare/workers-types@5.20260901.1)(better-call@1.3.7(zod@4.4.3))(jose@6.2.8)(kysely@0.29.5)(nanostores@1.4.2))(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)
-      '@better-auth/utils': 0.4.2
-      '@better-fetch/fetch': 1.3.1
-      '@noble/ciphers': 2.3.0
-      '@noble/hashes': 2.3.0
-      better-call: 1.3.7(zod@4.4.3)
-      defu: 6.1.7
-      jose: 6.2.8
-      kysely: 0.29.5
-      nanostores: 1.4.2
-      zod: 4.4.3
-    optionalDependencies:
-      '@tanstack/react-start': 1.168.49(@vitejs/plugin-rsc@0.5.34(react-dom@19.2.8(react@19.2.8))(react-server-dom-webpack@19.2.8(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))(react@19.2.8)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))(crossws@0.4.10(srvx@0.12.5))(esbuild@0.28.2)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(rolldown@1.2.5)(rollup@4.62.4)(supports-color@10.2.2)(vite-plugin-solid@2.11.14(solid-js@1.9.15)(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
-      '@tanstack/solid-start': 1.168.42(@tanstack/react-router@1.170.32(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(crossws@0.4.10(srvx@0.12.5))(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(solid-js@1.9.15)(supports-color@10.2.2)(vite-plugin-solid@2.11.14(solid-js@1.9.15)(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)))(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
-      drizzle-kit: 1.0.0-rc.5-ab785fc
-      drizzle-orm: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3)
+      drizzle-orm: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3)
       mongodb: 6.21.0(@aws-sdk/credential-providers@3.1095.0)(socks@2.8.9)
       mysql2: 3.24.2(@types/node@26.2.0)
       next: 16.2.10(@babel/core@7.29.7(supports-color@10.2.2))(@playwright/test@1.62.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
@@ -29560,25 +29261,18 @@ snapshots:
 
   dayjs@1.11.21: {}
 
-  db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@24.13.3)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@24.13.3))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4))(mysql2@3.24.2(@types/node@24.13.3)):
+  db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@24.13.3)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@24.13.3))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@24.13.3)):
     optionalDependencies:
       '@electric-sql/pglite': 0.3.15
       '@libsql/client': 0.17.4
-      drizzle-orm: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@24.13.3)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@24.13.3))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4)
+      drizzle-orm: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@24.13.3)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@24.13.3))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3)
       mysql2: 3.24.2(@types/node@24.13.3)
 
-  db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)):
+  db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)):
     optionalDependencies:
       '@electric-sql/pglite': 0.3.15
       '@libsql/client': 0.17.4
-      drizzle-orm: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3)
-      mysql2: 3.24.2(@types/node@26.2.0)
-
-  db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4))(mysql2@3.24.2(@types/node@26.2.0)):
-    optionalDependencies:
-      '@electric-sql/pglite': 0.3.15
-      '@libsql/client': 0.17.4
-      drizzle-orm: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4)
+      drizzle-orm: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3)
       mysql2: 3.24.2(@types/node@26.2.0)
 
   debug@4.4.3(supports-color@10.2.2):
@@ -29681,64 +29375,44 @@ snapshots:
       get-tsconfig: 4.14.2
       jiti: 2.7.0
 
-  drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@24.13.3)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@24.13.3))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4):
+  drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@24.13.3)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@24.13.3))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3):
     optionalDependencies:
       '@cloudflare/workers-types': 5.20260901.1
-      '@effect/sql-d1': 4.0.0-rc.112(effect@4.0.0-rc.112)
-      '@effect/sql-mysql2': 4.0.0-rc.112(@types/node@24.13.3)(effect@4.0.0-rc.112)
-      '@effect/sql-pg': 4.0.0-rc.112(effect@4.0.0-rc.112)
-      '@effect/sql-sqlite-do': 4.0.0-rc.112(effect@4.0.0-rc.112)
+      '@effect/sql-d1': 4.0.0-rc.113(effect@4.0.0-rc.113)
+      '@effect/sql-mysql2': 4.0.0-rc.113(@types/node@24.13.3)(effect@4.0.0-rc.113)
+      '@effect/sql-pg': 4.0.0-rc.113(effect@4.0.0-rc.113)
+      '@effect/sql-sqlite-do': 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@electric-sql/pglite': 0.3.15
       '@libsql/client': 0.17.4
       '@neondatabase/serverless': 1.1.0
       '@types/pg': 8.20.0
       arktype: 2.2.3
       bun-types: 1.3.14
-      effect: 4.0.0-rc.112
+      effect: 4.0.0-rc.113
       mysql2: 3.24.2(@types/node@24.13.3)
       pg: 8.23.0
       valibot: 1.2.0(typescript@7.0.2)
-      zod: 4.5.4
+      zod: 4.4.3
     optional: true
 
-  drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3):
+  drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3):
     optionalDependencies:
       '@cloudflare/workers-types': 5.20260901.1
-      '@effect/sql-d1': 4.0.0-rc.112(effect@4.0.0-rc.112)
-      '@effect/sql-mysql2': 4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112)
-      '@effect/sql-pg': 4.0.0-rc.112(effect@4.0.0-rc.112)
-      '@effect/sql-sqlite-do': 4.0.0-rc.112(effect@4.0.0-rc.112)
+      '@effect/sql-d1': 4.0.0-rc.113(effect@4.0.0-rc.113)
+      '@effect/sql-mysql2': 4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113)
+      '@effect/sql-pg': 4.0.0-rc.113(effect@4.0.0-rc.113)
+      '@effect/sql-sqlite-do': 4.0.0-rc.113(effect@4.0.0-rc.113)
       '@electric-sql/pglite': 0.3.15
       '@libsql/client': 0.17.4
       '@neondatabase/serverless': 1.1.0
       '@types/pg': 8.20.0
       arktype: 2.2.3
       bun-types: 1.3.14
-      effect: 4.0.0-rc.112
+      effect: 4.0.0-rc.113
       mysql2: 3.24.2(@types/node@26.2.0)
       pg: 8.23.0
       valibot: 1.2.0(typescript@7.0.2)
       zod: 4.4.3
-
-  drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4):
-    optionalDependencies:
-      '@cloudflare/workers-types': 5.20260901.1
-      '@effect/sql-d1': 4.0.0-rc.112(effect@4.0.0-rc.112)
-      '@effect/sql-mysql2': 4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112)
-      '@effect/sql-pg': 4.0.0-rc.112(effect@4.0.0-rc.112)
-      '@effect/sql-sqlite-do': 4.0.0-rc.112(effect@4.0.0-rc.112)
-      '@electric-sql/pglite': 0.3.15
-      '@libsql/client': 0.17.4
-      '@neondatabase/serverless': 1.1.0
-      '@types/pg': 8.20.0
-      arktype: 2.2.3
-      bun-types: 1.3.14
-      effect: 4.0.0-rc.112
-      mysql2: 3.24.2(@types/node@26.2.0)
-      pg: 8.23.0
-      valibot: 1.2.0(typescript@7.0.2)
-      zod: 4.5.4
-    optional: true
 
   dset@3.1.4: {}
 
@@ -29765,10 +29439,7 @@ snapshots:
 
   ee-first@1.1.1: {}
 
-  effect@4.0.0-rc.112:
-    dependencies:
-      fast-check: 4.9.0
-      msgpackr: 2.0.5
+  effect@4.0.0-rc.113: {}
 
   electron-to-chromium@1.5.405: {}
 
@@ -30220,10 +29891,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  fast-check@4.9.0:
-    dependencies:
-      pure-rand: 8.4.2
-
   fast-deep-equal@3.1.3: {}
 
   fast-fifo@1.3.2: {}
@@ -30317,9 +29984,9 @@ snapshots:
     dependencies:
       tabbable: 6.5.0
 
-  foldkit@0.148.2(effect@4.0.0-rc.112):
+  foldkit@0.148.2(effect@4.0.0-rc.113):
     dependencies:
-      effect: 4.0.0-rc.112
+      effect: 4.0.0-rc.113
       parse5: 8.0.1
 
   fontace@0.4.1:
@@ -32034,22 +31701,6 @@ snapshots:
 
   ms@2.1.3: {}
 
-  msgpackr-extract@3.0.4:
-    dependencies:
-      node-gyp-build-optional-packages: 5.2.2
-    optionalDependencies:
-      '@msgpackr-extract/msgpackr-extract-darwin-arm64': 3.0.4
-      '@msgpackr-extract/msgpackr-extract-darwin-x64': 3.0.4
-      '@msgpackr-extract/msgpackr-extract-linux-arm': 3.0.4
-      '@msgpackr-extract/msgpackr-extract-linux-arm64': 3.0.4
-      '@msgpackr-extract/msgpackr-extract-linux-x64': 3.0.4
-      '@msgpackr-extract/msgpackr-extract-win32-x64': 3.0.4
-    optional: true
-
-  msgpackr@2.0.5:
-    optionalDependencies:
-      msgpackr-extract: 3.0.4
-
   muggle-string@0.4.1: {}
 
   mysql2@3.24.2(@types/node@24.13.3):
@@ -32130,11 +31781,11 @@ snapshots:
 
   nf3@0.3.23: {}
 
-  nitro@3.0.260415-beta(dde441ba7809e60dabce322e719b3d54):
+  nitro@3.0.260415-beta(2572a4db108bb714489ad9ba04d6002b):
     dependencies:
       consola: 3.4.2
       crossws: 0.4.10(srvx@0.11.22)
-      db0: 0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4))(mysql2@3.24.2(@types/node@26.2.0))
+      db0: 0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0))
       env-runner: 0.1.16(miniflare@4.20260722.0)(wrangler@4.127.1(@cloudflare/workers-types@5.20260901.1))
       h3: 2.0.1-rc.26(crossws@0.4.10(srvx@0.11.22))
       hookable: 6.1.1
@@ -32145,7 +31796,7 @@ snapshots:
       rolldown: 1.2.5
       srvx: 0.11.22
       unenv: 2.0.0-rc.24
-      unstorage: 2.0.0-alpha.7(aws4fetch@1.0.20)(chokidar@5.0.0)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(lru-cache@11.5.2)(mongodb@6.21.0(@aws-sdk/credential-providers@3.1095.0)(socks@2.8.9))(ofetch@2.0.0-alpha.3)
+      unstorage: 2.0.0-alpha.7(aws4fetch@1.0.20)(chokidar@5.0.0)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(lru-cache@11.5.2)(mongodb@6.21.0(@aws-sdk/credential-providers@3.1095.0)(socks@2.8.9))(ofetch@2.0.0-alpha.3)
     optionalDependencies:
       dotenv: 17.4.2
       giget: 3.3.1
@@ -32184,7 +31835,7 @@ snapshots:
       - uploadthing
       - wrangler
 
-  nitropack@2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@24.13.3)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@24.13.3))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4))(mysql2@3.24.2(@types/node@24.13.3))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)):
+  nitropack@2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@24.13.3)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@24.13.3))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@24.13.3))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.2
       '@rollup/plugin-alias': 6.0.0(rollup@4.62.4)
@@ -32205,7 +31856,7 @@ snapshots:
       cookie-es: 2.0.1
       croner: 10.0.1
       crossws: 0.3.5
-      db0: 0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@24.13.3)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@24.13.3))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4))(mysql2@3.24.2(@types/node@24.13.3))
+      db0: 0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@24.13.3)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@24.13.3))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@24.13.3))
       defu: 6.1.7
       destr: 2.0.5
       dot-prop: 10.2.0
@@ -32251,7 +31902,7 @@ snapshots:
       unenv: 2.0.0-rc.24
       unimport: 6.4.0(esbuild@0.28.2)(oxc-parser@0.141.0)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
       unplugin-utils: 0.3.2
-      unstorage: 1.17.5(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@24.13.3)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@24.13.3))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4))(mysql2@3.24.2(@types/node@24.13.3)))(ioredis@5.11.1(supports-color@10.2.2))
+      unstorage: 1.17.5(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@24.13.3)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@24.13.3))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@24.13.3)))(ioredis@5.11.1(supports-color@10.2.2))
       untyped: 2.0.0
       unwasm: 0.5.3
       youch: 4.1.1
@@ -32296,7 +31947,7 @@ snapshots:
       - vite
       - webpack
 
-  nitropack@2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)):
+  nitropack@2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.2
       '@rollup/plugin-alias': 6.0.0(rollup@4.62.4)
@@ -32317,7 +31968,7 @@ snapshots:
       cookie-es: 2.0.1
       croner: 10.0.1
       crossws: 0.3.5
-      db0: 0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0))
+      db0: 0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0))
       defu: 6.1.7
       destr: 2.0.5
       dot-prop: 10.2.0
@@ -32363,119 +32014,7 @@ snapshots:
       unenv: 2.0.0-rc.24
       unimport: 6.4.0(esbuild@0.28.2)(oxc-parser@0.141.0)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
       unplugin-utils: 0.3.2
-      unstorage: 1.17.5(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))
-      untyped: 2.0.0
-      unwasm: 0.5.3
-      youch: 4.1.1
-      youch-core: 0.3.3
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@electric-sql/pglite'
-      - '@farmfe/core'
-      - '@libsql/client'
-      - '@netlify/blobs'
-      - '@parcel/watcher'
-      - '@planetscale/database'
-      - '@rspack/core'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - aws4fetch
-      - bare-abort-controller
-      - bare-buffer
-      - better-sqlite3
-      - bun-types-no-globals
-      - drizzle-orm
-      - encoding
-      - idb-keyval
-      - mysql2
-      - oxc-parser
-      - react-native-b4a
-      - rolldown
-      - sqlite3
-      - srvx
-      - supports-color
-      - unloader
-      - uploadthing
-      - vite
-      - webpack
-
-  nitropack@2.13.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(aws4fetch@1.0.20)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4))(mysql2@3.24.2(@types/node@26.2.0))(oxc-parser@0.141.0)(rolldown@1.2.5)(srvx@0.12.5)(supports-color@10.2.2)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)):
-    dependencies:
-      '@cloudflare/kv-asset-handler': 0.4.2
-      '@rollup/plugin-alias': 6.0.0(rollup@4.62.4)
-      '@rollup/plugin-commonjs': 29.0.3(rollup@4.62.4)
-      '@rollup/plugin-inject': 5.0.5(rollup@4.62.4)
-      '@rollup/plugin-json': 6.1.0(rollup@4.62.4)
-      '@rollup/plugin-node-resolve': 16.0.3(rollup@4.62.4)
-      '@rollup/plugin-replace': 6.0.3(rollup@4.62.4)
-      '@rollup/plugin-terser': 1.0.0(rollup@4.62.4)
-      '@vercel/nft': 1.10.2(rollup@4.62.4)(supports-color@10.2.2)
-      archiver: 7.0.1
-      c12: 3.3.4(magicast@0.5.4)
-      chokidar: 5.0.0
-      citty: 0.2.2
-      compatx: 0.2.0
-      confbox: 0.2.4
-      consola: 3.4.2
-      cookie-es: 2.0.1
-      croner: 10.0.1
-      crossws: 0.3.5
-      db0: 0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4))(mysql2@3.24.2(@types/node@26.2.0))
-      defu: 6.1.7
-      destr: 2.0.5
-      dot-prop: 10.2.0
-      esbuild: 0.28.2
-      escape-string-regexp: 5.0.0
-      etag: 1.8.1
-      exsolve: 1.1.1
-      globby: 16.2.3
-      gzip-size: 7.0.0
-      h3: 1.15.11
-      hookable: 5.5.3
-      httpxy: 0.5.5
-      ioredis: 5.11.1(supports-color@10.2.2)
-      jiti: 2.7.0
-      klona: 2.0.6
-      knitwork: 1.3.0
-      listhen: 1.10.1(srvx@0.12.5)
-      magic-string: 0.30.21
-      magicast: 0.5.4
-      mime: 4.1.0
-      mlly: 1.8.2
-      node-fetch-native: 1.6.7
-      node-mock-http: 1.0.5
-      ofetch: 1.5.1
-      ohash: 2.0.11
-      pathe: 2.0.3
-      perfect-debounce: 2.1.0
-      pkg-types: 2.3.1
-      pretty-bytes: 7.1.1
-      radix3: 1.1.2
-      rollup: 4.62.4
-      rollup-plugin-visualizer: 7.0.1(rolldown@1.2.5)(rollup@4.62.4)
-      scule: 1.3.0
-      semver: 7.8.5
-      serve-placeholder: 2.0.2
-      serve-static: 2.2.1(supports-color@10.2.2)
-      source-map: 0.7.6
-      std-env: 4.2.0
-      ufo: 1.6.4
-      ultrahtml: 1.7.0
-      uncrypto: 0.1.3
-      unctx: 2.5.0
-      unenv: 2.0.0-rc.24
-      unimport: 6.4.0(esbuild@0.28.2)(oxc-parser@0.141.0)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
-      unplugin-utils: 0.3.2
-      unstorage: 1.17.5(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))
+      unstorage: 1.17.5(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))
       untyped: 2.0.0
       unwasm: 0.5.3
       youch: 4.1.1
@@ -32541,7 +32080,7 @@ snapshots:
       cookie-es: 2.0.1
       croner: 10.0.1
       crossws: 0.3.5
-      db0: 0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4))(mysql2@3.24.2(@types/node@26.2.0))
+      db0: 0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0))
       defu: 6.1.7
       destr: 2.0.5
       dot-prop: 10.2.0
@@ -32587,7 +32126,7 @@ snapshots:
       unenv: 2.0.0-rc.24
       unimport: 6.4.0(esbuild@0.28.2)(rollup@4.62.4)(vite@7.3.6(@types/node@26.2.0)(jiti@2.7.0)(lightningcss@1.33.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
       unplugin-utils: 0.3.2
-      unstorage: 1.17.5(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))
+      unstorage: 1.17.5(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))
       untyped: 2.0.0
       unwasm: 0.5.3
       youch: 4.1.1
@@ -32651,11 +32190,6 @@ snapshots:
 
   node-forge@1.4.0: {}
 
-  node-gyp-build-optional-packages@5.2.2:
-    dependencies:
-      detect-libc: 2.1.2
-    optional: true
-
   node-gyp-build@4.8.4: {}
 
   node-mock-http@1.0.5: {}
@@ -32718,156 +32252,16 @@ snapshots:
       next: 16.2.10(@babel/core@7.29.7(supports-color@10.2.2))(@playwright/test@1.62.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react-router: 7.16.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
 
-  nuxt@4.5.1(64eb09726475984998fb56e43114116a):
-    dependencies:
-      '@dxup/nuxt': 0.5.6(esbuild@0.28.2)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
-      '@nuxt/cli': 3.37.0(@nuxt/schema@4.5.1)(cac@6.7.14)(commander@14.0.3)(magicast@0.5.4)(supports-color@10.2.2)
-      '@nuxt/devtools': 3.4.1(6005cdf8de4f0e458074d9bb92d5f425)
-      '@nuxt/kit': 4.5.1(magic-string@1.1.1)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))
-      '@nuxt/nitro-server': 4.5.1(69b87bb0a1ee217202dcfcb775749e8a)
-      '@nuxt/schema': 4.5.1
-      '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.5.1(magic-string@1.1.1)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))))
-      '@nuxt/vite-builder': 4.5.1(@babel/plugin-proposal-decorators@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@types/node@24.13.3)(esbuild@0.28.2)(magic-string@1.1.1)(magicast@0.5.4)(nuxt@4.5.1(64eb09726475984998fb56e43114116a))(oxc-parser@0.141.0)(oxlint@1.81.0)(rolldown@1.2.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.5)(rollup@4.62.4))(rollup@4.62.4)(supports-color@10.2.2)(terser@5.50.0)(tsx@4.23.12)(typescript@7.0.2)(vue-tsc@3.3.9(typescript@7.0.2))(vue@3.5.41(typescript@7.0.2))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))(yaml@2.9.0)
-      '@unhead/vue': 3.3.1(@oxc-project/types@0.146.0)(esbuild@0.28.2)(lightningcss@1.33.0)(oxc-parser@0.141.0)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(vue@3.5.41(typescript@7.0.2))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
-      '@vue/shared': 3.5.41
-      chokidar: 5.0.0
-      compatx: 0.2.0
-      consola: 3.4.2
-      cookie-es: 3.1.1
-      defu: 6.1.7
-      devalue: 5.9.0
-      errx: 0.1.2
-      escape-string-regexp: 5.0.0
-      exsolve: 1.1.1
-      fnv1a-64: 0.1.2
-      hookable: 6.1.1
-      ignore: 7.0.6
-      impound: 1.1.6(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
-      jiti: 2.7.0
-      klona: 2.0.6
-      knitwork: 1.3.0
-      magic-string: 1.1.1
-      mlly: 1.8.2
-      nanotar: 0.3.0
-      nostics: 1.2.0
-      nypm: 0.6.9
-      object-identity: 0.2.3
-      ofetch: 1.5.1
-      ohash: 2.0.11
-      on-change: 6.0.2
-      oxc-walker: 1.1.1(@oxc-project/types@0.146.0)(oxc-parser@0.141.0)(rolldown@1.2.5)
-      pathe: 2.0.3
-      perfect-debounce: 2.1.0
-      picomatch: 4.0.5
-      pkg-types: 2.3.1
-      rolldown: 1.2.5
-      rolldown-string: 0.3.1(rolldown@1.2.5)
-      rou3: 0.9.2
-      scule: 1.3.0
-      std-env: 4.2.0
-      tinyglobby: 0.2.17
-      ufo: 1.6.4
-      ultrahtml: 1.7.0
-      uncrypto: 0.1.3
-      unctx: 3.0.0(magic-string@1.1.1)(oxc-parser@0.141.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))
-      undici: 8.10.0
-      unhead: 3.3.1(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
-      unimport: 6.4.0(esbuild@0.28.2)(oxc-parser@0.141.0)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
-      unplugin: 3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
-      unrouting: 0.2.3
-      untyped: 2.0.0
-      verkit: 0.2.0
-      vue: 3.5.41(typescript@7.0.2)
-      vue-router: 5.2.0(@vue/compiler-sfc@3.5.41)(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(vue@3.5.41(typescript@7.0.2))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
-    optionalDependencies:
-      '@types/node': 24.13.3
-    transitivePeerDependencies:
-      - '@azure/app-configuration'
-      - '@azure/cosmos'
-      - '@azure/data-tables'
-      - '@azure/identity'
-      - '@azure/keyvault-secrets'
-      - '@azure/storage-blob'
-      - '@babel/plugin-proposal-decorators'
-      - '@babel/plugin-syntax-jsx'
-      - '@babel/plugin-syntax-typescript'
-      - '@biomejs/biome'
-      - '@capacitor/preferences'
-      - '@deno/kv'
-      - '@electric-sql/pglite'
-      - '@farmfe/core'
-      - '@libsql/client'
-      - '@netlify/blobs'
-      - '@oxc-project/types'
-      - '@pinia/colada'
-      - '@planetscale/database'
-      - '@rollup/plugin-babel'
-      - '@rspack/core'
-      - '@unhead/cli'
-      - '@upstash/redis'
-      - '@vercel/blob'
-      - '@vercel/functions'
-      - '@vercel/kv'
-      - '@vitejs/devtools'
-      - '@vitejs/devtools-kit'
-      - '@vue/compiler-sfc'
-      - aws4fetch
-      - bare-abort-controller
-      - bare-buffer
-      - better-sqlite3
-      - bufferutil
-      - bun-types-no-globals
-      - cac
-      - commander
-      - db0
-      - drizzle-orm
-      - encoding
-      - esbuild
-      - eslint
-      - idb-keyval
-      - ioredis
-      - less
-      - lightningcss
-      - magicast
-      - meow
-      - mysql2
-      - optionator
-      - oxc-parser
-      - oxlint
-      - pinia
-      - react-native-b4a
-      - rollup
-      - rollup-plugin-visualizer
-      - sass
-      - sass-embedded
-      - sqlite3
-      - srvx
-      - stylelint
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - typescript
-      - unloader
-      - uploadthing
-      - utf-8-validate
-      - vite
-      - vue-tsc
-      - webpack
-      - xml2js
-      - yaml
-
-  nuxt@4.5.1(7234cbbd18b9a21040d15b51f4bb3989):
+  nuxt@4.5.1(7fe16a31c4082a23bec7caccdcc17327):
     dependencies:
       '@dxup/nuxt': 0.5.6(esbuild@0.28.2)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
       '@nuxt/cli': 3.37.0(@nuxt/schema@4.5.1)(cac@6.7.14)(commander@14.0.3)(magicast@0.5.4)(supports-color@10.2.2)
-      '@nuxt/devtools': 3.4.1(68770fa0c397238e9aed70d45d97d0b7)
+      '@nuxt/devtools': 3.4.1(6068b5ad1d0b1ba9f9227fcb07baf80f)
       '@nuxt/kit': 4.5.1(magic-string@1.1.1)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))
-      '@nuxt/nitro-server': 4.5.1(c7b1827fb70a2cfe9ce6c6b724e2b172)
+      '@nuxt/nitro-server': 4.5.1(602eb0a9c0dd6902d8c3c66fadbcd198)
       '@nuxt/schema': 4.5.1
       '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.5.1(magic-string@1.1.1)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))))
-      '@nuxt/vite-builder': 4.5.1(@babel/plugin-proposal-decorators@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@types/node@26.2.0)(esbuild@0.28.2)(magic-string@1.1.1)(magicast@0.5.4)(nuxt@4.5.1(7234cbbd18b9a21040d15b51f4bb3989))(oxc-parser@0.141.0)(oxlint@1.81.0)(rolldown@1.2.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.5)(rollup@4.62.4))(rollup@4.62.4)(supports-color@10.2.2)(terser@5.50.0)(tsx@4.23.12)(typescript@7.0.2)(vue-tsc@3.3.9(typescript@7.0.2))(vue@3.5.41(typescript@7.0.2))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))(yaml@2.9.0)
+      '@nuxt/vite-builder': 4.5.1(@babel/plugin-proposal-decorators@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@types/node@26.2.0)(esbuild@0.28.2)(magic-string@1.1.1)(magicast@0.5.4)(nuxt@4.5.1(7fe16a31c4082a23bec7caccdcc17327))(oxc-parser@0.141.0)(oxlint@1.81.0)(rolldown@1.2.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.5)(rollup@4.62.4))(rollup@4.62.4)(supports-color@10.2.2)(terser@5.50.0)(tsx@4.23.12)(typescript@7.0.2)(vue@3.5.41(typescript@7.0.2))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))(yaml@2.9.0)
       '@unhead/vue': 3.3.1(@oxc-project/types@0.146.0)(esbuild@0.28.2)(lightningcss@1.33.0)(oxc-parser@0.141.0)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(vue@3.5.41(typescript@7.0.2))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
       '@vue/shared': 3.5.41
       chokidar: 5.0.0
@@ -32998,16 +32392,156 @@ snapshots:
       - xml2js
       - yaml
 
-  nuxt@4.5.1(b8f7e2370c0c7cb4e95babfd663ba2fb):
+  nuxt@4.5.1(867099590d63db02e3731b2415c98ffd):
+    dependencies:
+      '@dxup/nuxt': 0.5.6(esbuild@0.28.2)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
+      '@nuxt/cli': 3.37.0(@nuxt/schema@4.5.1)(cac@6.7.14)(commander@14.0.3)(magicast@0.5.4)(supports-color@10.2.2)
+      '@nuxt/devtools': 3.4.1(42eff27e1b9a45d570b2cdedacd8db41)
+      '@nuxt/kit': 4.5.1(magic-string@1.1.1)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))
+      '@nuxt/nitro-server': 4.5.1(50165601727411fc4f6553cdc5712e27)
+      '@nuxt/schema': 4.5.1
+      '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.5.1(magic-string@1.1.1)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))))
+      '@nuxt/vite-builder': 4.5.1(@babel/plugin-proposal-decorators@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@types/node@24.13.3)(esbuild@0.28.2)(magic-string@1.1.1)(magicast@0.5.4)(nuxt@4.5.1(867099590d63db02e3731b2415c98ffd))(oxc-parser@0.141.0)(oxlint@1.81.0)(rolldown@1.2.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.5)(rollup@4.62.4))(rollup@4.62.4)(supports-color@10.2.2)(terser@5.50.0)(tsx@4.23.12)(typescript@7.0.2)(vue-tsc@3.3.9(typescript@7.0.2))(vue@3.5.41(typescript@7.0.2))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))(yaml@2.9.0)
+      '@unhead/vue': 3.3.1(@oxc-project/types@0.146.0)(esbuild@0.28.2)(lightningcss@1.33.0)(oxc-parser@0.141.0)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(vue@3.5.41(typescript@7.0.2))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
+      '@vue/shared': 3.5.41
+      chokidar: 5.0.0
+      compatx: 0.2.0
+      consola: 3.4.2
+      cookie-es: 3.1.1
+      defu: 6.1.7
+      devalue: 5.9.0
+      errx: 0.1.2
+      escape-string-regexp: 5.0.0
+      exsolve: 1.1.1
+      fnv1a-64: 0.1.2
+      hookable: 6.1.1
+      ignore: 7.0.6
+      impound: 1.1.6(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
+      jiti: 2.7.0
+      klona: 2.0.6
+      knitwork: 1.3.0
+      magic-string: 1.1.1
+      mlly: 1.8.2
+      nanotar: 0.3.0
+      nostics: 1.2.0
+      nypm: 0.6.9
+      object-identity: 0.2.3
+      ofetch: 1.5.1
+      ohash: 2.0.11
+      on-change: 6.0.2
+      oxc-walker: 1.1.1(@oxc-project/types@0.146.0)(oxc-parser@0.141.0)(rolldown@1.2.5)
+      pathe: 2.0.3
+      perfect-debounce: 2.1.0
+      picomatch: 4.0.5
+      pkg-types: 2.3.1
+      rolldown: 1.2.5
+      rolldown-string: 0.3.1(rolldown@1.2.5)
+      rou3: 0.9.2
+      scule: 1.3.0
+      std-env: 4.2.0
+      tinyglobby: 0.2.17
+      ufo: 1.6.4
+      ultrahtml: 1.7.0
+      uncrypto: 0.1.3
+      unctx: 3.0.0(magic-string@1.1.1)(oxc-parser@0.141.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))
+      undici: 8.10.0
+      unhead: 3.3.1(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
+      unimport: 6.4.0(esbuild@0.28.2)(oxc-parser@0.141.0)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
+      unplugin: 3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
+      unrouting: 0.2.3
+      untyped: 2.0.0
+      verkit: 0.2.0
+      vue: 3.5.41(typescript@7.0.2)
+      vue-router: 5.2.0(@vue/compiler-sfc@3.5.41)(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(vue@3.5.41(typescript@7.0.2))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
+    optionalDependencies:
+      '@types/node': 24.13.3
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@babel/plugin-proposal-decorators'
+      - '@babel/plugin-syntax-jsx'
+      - '@babel/plugin-syntax-typescript'
+      - '@biomejs/biome'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@electric-sql/pglite'
+      - '@farmfe/core'
+      - '@libsql/client'
+      - '@netlify/blobs'
+      - '@oxc-project/types'
+      - '@pinia/colada'
+      - '@planetscale/database'
+      - '@rollup/plugin-babel'
+      - '@rspack/core'
+      - '@unhead/cli'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - '@vitejs/devtools'
+      - '@vitejs/devtools-kit'
+      - '@vue/compiler-sfc'
+      - aws4fetch
+      - bare-abort-controller
+      - bare-buffer
+      - better-sqlite3
+      - bufferutil
+      - bun-types-no-globals
+      - cac
+      - commander
+      - db0
+      - drizzle-orm
+      - encoding
+      - esbuild
+      - eslint
+      - idb-keyval
+      - ioredis
+      - less
+      - lightningcss
+      - magicast
+      - meow
+      - mysql2
+      - optionator
+      - oxc-parser
+      - oxlint
+      - pinia
+      - react-native-b4a
+      - rollup
+      - rollup-plugin-visualizer
+      - sass
+      - sass-embedded
+      - sqlite3
+      - srvx
+      - stylelint
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - typescript
+      - unloader
+      - uploadthing
+      - utf-8-validate
+      - vite
+      - vue-tsc
+      - webpack
+      - xml2js
+      - yaml
+
+  nuxt@4.5.1(df1693d43dd7d6545462287ea122e04b):
     dependencies:
       '@dxup/nuxt': 0.5.6(esbuild@0.28.2)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
       '@nuxt/cli': 3.37.0(@nuxt/schema@4.5.1)(cac@6.7.14)(commander@14.0.3)(magicast@0.5.4)(supports-color@10.2.2)
-      '@nuxt/devtools': 3.4.1(43838925e6dd8e4c5211d688814ddf88)
+      '@nuxt/devtools': 3.4.1(6068b5ad1d0b1ba9f9227fcb07baf80f)
       '@nuxt/kit': 4.5.1(magic-string@1.1.1)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26)))
-      '@nuxt/nitro-server': 4.5.1(c3f5ec8db84c3b5b73511d8dc32cb3a5)
+      '@nuxt/nitro-server': 4.5.1(419e31df70c861b79b43f043f657c53c)
       '@nuxt/schema': 4.5.1
       '@nuxt/telemetry': 2.8.0(@nuxt/kit@4.5.1(magic-string@1.1.1)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))))
-      '@nuxt/vite-builder': 4.5.1(@babel/plugin-proposal-decorators@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@types/node@26.2.0)(esbuild@0.28.2)(magic-string@1.1.1)(magicast@0.5.4)(nuxt@4.5.1(b8f7e2370c0c7cb4e95babfd663ba2fb))(oxc-parser@0.141.0)(oxlint@1.81.0)(rolldown@1.2.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.5)(rollup@4.62.4))(rollup@4.62.4)(supports-color@10.2.2)(terser@5.50.0)(tsx@4.23.12)(typescript@7.0.2)(vue@3.5.41(typescript@7.0.2))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))(yaml@2.9.0)
+      '@nuxt/vite-builder': 4.5.1(@babel/plugin-proposal-decorators@7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2))(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@10.2.2)))(@types/node@26.2.0)(esbuild@0.28.2)(magic-string@1.1.1)(magicast@0.5.4)(nuxt@4.5.1(df1693d43dd7d6545462287ea122e04b))(oxc-parser@0.141.0)(oxlint@1.81.0)(rolldown@1.2.5)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.5)(rollup@4.62.4))(rollup@4.62.4)(supports-color@10.2.2)(terser@5.50.0)(tsx@4.23.12)(typescript@7.0.2)(vue-tsc@3.3.9(typescript@7.0.2))(vue@3.5.41(typescript@7.0.2))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))(yaml@2.9.0)
       '@unhead/vue': 3.3.1(@oxc-project/types@0.146.0)(esbuild@0.28.2)(lightningcss@1.33.0)(oxc-parser@0.141.0)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@26.2.0)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(vue@3.5.41(typescript@7.0.2))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))
       '@vue/shared': 3.5.41
       chokidar: 5.0.0
@@ -33162,8 +32696,6 @@ snapshots:
   object-treeify@1.1.33: {}
 
   obliterator@1.6.1: {}
-
-  obuf@1.1.2: {}
 
   obug@2.1.4: {}
 
@@ -33529,13 +33061,7 @@ snapshots:
     dependencies:
       pg: 8.20.0
 
-  pg-cursor@2.22.0(pg@8.23.0):
-    dependencies:
-      pg: 8.23.0
-
   pg-int8@1.0.1: {}
-
-  pg-numeric@1.0.2: {}
 
   pg-pool@3.14.0(pg@8.20.0):
     dependencies:
@@ -33554,16 +33080,6 @@ snapshots:
       postgres-bytea: 1.0.1
       postgres-date: 1.0.7
       postgres-interval: 1.2.0
-
-  pg-types@4.1.0:
-    dependencies:
-      pg-int8: 1.0.1
-      pg-numeric: 1.0.2
-      postgres-array: 3.0.4
-      postgres-bytea: 3.0.0
-      postgres-date: 2.1.0
-      postgres-interval: 3.0.0
-      postgres-range: 1.1.4
 
   pg@8.20.0:
     dependencies:
@@ -33812,25 +33328,13 @@ snapshots:
 
   postgres-array@2.0.0: {}
 
-  postgres-array@3.0.4: {}
-
   postgres-bytea@1.0.1: {}
 
-  postgres-bytea@3.0.0:
-    dependencies:
-      obuf: 1.1.2
-
   postgres-date@1.0.7: {}
-
-  postgres-date@2.1.0: {}
 
   postgres-interval@1.2.0:
     dependencies:
       xtend: 4.0.2
-
-  postgres-interval@3.0.0: {}
-
-  postgres-range@1.1.4: {}
 
   powershell-utils@0.1.0: {}
 
@@ -33888,8 +33392,6 @@ snapshots:
       once: 1.4.0
 
   punycode@2.3.1: {}
-
-  pure-rand@8.4.2: {}
 
   qs@6.15.3:
     dependencies:
@@ -34858,12 +34360,12 @@ snapshots:
 
   standard-as-callback@2.1.0: {}
 
-  starlight-blog@0.29.0(patch_hash=7b6e57367fab3517e0cfd5e4d0da3459ac1430bf4b6036cf03002c978602c23b)(a153ef7c4b126f946ad8fea5f283bda5):
+  starlight-blog@0.29.0(patch_hash=7b6e57367fab3517e0cfd5e4d0da3459ac1430bf4b6036cf03002c978602c23b)(9d7f649d32a49ea7fe732f9e37e1226e):
     dependencies:
       '@astrojs/markdown-remark': 7.2.2(supports-color@10.2.2)
-      '@astrojs/mdx': 7.0.5(@astrojs/markdown-satteri@0.4.0)(astro@7.3.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(supports-color@10.2.2)
+      '@astrojs/mdx': 7.0.5(@astrojs/markdown-satteri@0.4.0)(astro@7.3.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(supports-color@10.2.2)
       '@astrojs/rss': 4.0.19
-      '@astrojs/starlight': 0.42.0(patch_hash=3ea8686c3055e8d097b5afa93dcf9e16ebfbebbf006e7493ad5df38e6edbfd19)(astro@7.3.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(supports-color@10.2.2)(typescript@7.0.2)
+      '@astrojs/starlight': 0.42.0(patch_hash=3ea8686c3055e8d097b5afa93dcf9e16ebfbebbf006e7493ad5df38e6edbfd19)(astro@7.3.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.3)(@types/node@26.2.0)(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(supports-color@10.2.2)(typescript@7.0.2)
       github-slugger: 2.0.0
       hast-util-from-html: 2.0.3
       hast-util-to-html: 9.0.5
@@ -35430,6 +34932,8 @@ snapshots:
 
   undici@8.10.0: {}
 
+  undici@8.10.2: {}
+
   unenv@2.0.0-rc.24:
     dependencies:
       pathe: 2.0.3
@@ -35717,7 +35221,7 @@ snapshots:
       escape-string-regexp: 5.0.0
       ufo: 1.6.4
 
-  unstorage@1.17.5(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@24.13.3)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@24.13.3))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4))(mysql2@3.24.2(@types/node@24.13.3)))(ioredis@5.11.1(supports-color@10.2.2)):
+  unstorage@1.17.5(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@24.13.3)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@24.13.3))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@24.13.3)))(ioredis@5.11.1(supports-color@10.2.2)):
     dependencies:
       anymatch: 3.1.3
       chokidar: 5.0.0
@@ -35729,10 +35233,10 @@ snapshots:
       ufo: 1.6.4
     optionalDependencies:
       aws4fetch: 1.0.20
-      db0: 0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@24.13.3)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@24.13.3))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4))(mysql2@3.24.2(@types/node@24.13.3))
+      db0: 0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@24.13.3)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@24.13.3))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@24.13.3))
       ioredis: 5.11.1(supports-color@10.2.2)
 
-  unstorage@1.17.5(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2)):
+  unstorage@1.17.5(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2)):
     dependencies:
       anymatch: 3.1.3
       chokidar: 5.0.0
@@ -35744,29 +35248,14 @@ snapshots:
       ufo: 1.6.4
     optionalDependencies:
       aws4fetch: 1.0.20
-      db0: 0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0))
+      db0: 0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0))
       ioredis: 5.11.1(supports-color@10.2.2)
 
-  unstorage@1.17.5(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2)):
-    dependencies:
-      anymatch: 3.1.3
-      chokidar: 5.0.0
-      destr: 2.0.5
-      h3: 1.15.11
-      lru-cache: 11.5.2
-      node-fetch-native: 1.6.7
-      ofetch: 1.5.1
-      ufo: 1.6.4
-    optionalDependencies:
-      aws4fetch: 1.0.20
-      db0: 0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4))(mysql2@3.24.2(@types/node@26.2.0))
-      ioredis: 5.11.1(supports-color@10.2.2)
-
-  unstorage@2.0.0-alpha.7(aws4fetch@1.0.20)(chokidar@5.0.0)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(lru-cache@11.5.2)(mongodb@6.21.0(@aws-sdk/credential-providers@3.1095.0)(socks@2.8.9))(ofetch@2.0.0-alpha.3):
+  unstorage@2.0.0-alpha.7(aws4fetch@1.0.20)(chokidar@5.0.0)(db0@0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0)))(ioredis@5.11.1(supports-color@10.2.2))(lru-cache@11.5.2)(mongodb@6.21.0(@aws-sdk/credential-providers@3.1095.0)(socks@2.8.9))(ofetch@2.0.0-alpha.3):
     optionalDependencies:
       aws4fetch: 1.0.20
       chokidar: 5.0.0
-      db0: 0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-mysql2@4.0.0-rc.112(@types/node@26.2.0)(effect@4.0.0-rc.112))(@effect/sql-pg@4.0.0-rc.112(effect@4.0.0-rc.112))(@effect/sql-sqlite-do@4.0.0-rc.112(effect@4.0.0-rc.112))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.112)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.5.4))(mysql2@3.24.2(@types/node@26.2.0))
+      db0: 0.3.4(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(drizzle-orm@1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-mysql2@4.0.0-rc.113(@types/node@26.2.0)(effect@4.0.0-rc.113))(@effect/sql-pg@4.0.0-rc.113(effect@4.0.0-rc.113))(@effect/sql-sqlite-do@4.0.0-rc.113(effect@4.0.0-rc.113))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.113)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3))(mysql2@3.24.2(@types/node@26.2.0))
       ioredis: 5.11.1(supports-color@10.2.2)
       lru-cache: 11.5.2
       mongodb: 6.21.0(@aws-sdk/credential-providers@3.1095.0)(socks@2.8.9)
@@ -36050,7 +35539,7 @@ snapshots:
       - supports-color
     optional: true
 
-  vite-plugin-vue-devtools@8.2.1(@nuxt/kit@4.5.1(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))))(supports-color@10.2.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(vue@3.6.0-beta.17(typescript@7.0.2)):
+  vite-plugin-vue-devtools@8.2.1(@nuxt/kit@4.5.1(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(vue@3.6.0-beta.17(typescript@7.0.2)):
     dependencies:
       '@vue/devtools-core': 8.2.1(vue@3.6.0-beta.17(typescript@7.0.2))
       '@vue/devtools-kit': 8.2.1
@@ -36058,20 +35547,20 @@ snapshots:
       sirv: 3.0.2
       vite: 8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)
       vite-plugin-inspect: 11.4.1(@nuxt/kit@4.5.1(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.141.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.5)(rollup@4.62.4)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))(webpack@5.109.2(cssnano@8.0.5(postcss@8.5.26))(csso@5.0.5)(esbuild@0.28.2)(lightningcss@1.33.0)(postcss@8.5.26))))(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
-      vite-plugin-vue-inspector: 6.0.0(supports-color@10.2.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
+      vite-plugin-vue-inspector: 6.0.0(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0))
       vue: 3.6.0-beta.17(typescript@7.0.2)
     transitivePeerDependencies:
       - '@nuxt/kit'
       - supports-color
 
-  vite-plugin-vue-inspector@6.0.0(supports-color@10.2.2)(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)):
+  vite-plugin-vue-inspector@6.0.0(vite@8.2.1(@types/node@24.13.3)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(tsx@4.23.12)(yaml@2.9.0)):
     dependencies:
-      '@babel/core': 7.29.7(supports-color@10.2.2)
-      '@babel/plugin-proposal-decorators': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      '@babel/plugin-syntax-import-attributes': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.29.7(supports-color@10.2.2))
-      '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
-      '@vue/babel-plugin-jsx': 1.5.0(@babel/core@7.29.7(supports-color@10.2.2))(supports-color@10.2.2)
+      '@babel/core': 7.29.7
+      '@babel/plugin-proposal-decorators': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-syntax-import-attributes': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-syntax-import-meta': 7.10.4(@babel/core@7.29.7)
+      '@babel/plugin-transform-typescript': 7.29.7(@babel/core@7.29.7)
+      '@vue/babel-plugin-jsx': 1.5.0(@babel/core@7.29.7)
       '@vue/compiler-dom': 3.5.41
       kolorist: 1.8.0
       magic-string: 0.30.21
@@ -37237,7 +36726,5 @@ snapshots:
       zod: 4.4.3
 
   zod@4.4.3: {}
-
-  zod@4.5.4: {}
 
   zwitch@2.0.4: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -88,15 +88,15 @@ catalogs:
     mongodb: ^6.10.0
     pg: ^8.22.0
   effect:
-    "@effect/atom-react": ">=4.0.0-rc.112 || >=4.0.0"
-    "@effect/platform-bun": ">=4.0.0-rc.112 || >=4.0.0"
-    "@effect/platform-node": ">=4.0.0-rc.112 || >=4.0.0"
-    "@effect/sql-d1": ">=4.0.0-rc.112 || >=4.0.0"
-    "@effect/sql-mysql2": ">=4.0.0-rc.112 || >=4.0.0"
-    "@effect/sql-pg": ">=4.0.0-rc.112 || >=4.0.0"
-    "@effect/sql-sqlite-do": ">=4.0.0-rc.112 || >=4.0.0"
-    "@effect/vitest": ">=4.0.0-rc.112 || >=4.0.0"
-    effect: ">=4.0.0-rc.112 || >=4.0.0"
+    "@effect/atom-react": ">=4.0.0-rc.113 || >=4.0.0"
+    "@effect/platform-bun": ">=4.0.0-rc.113 || >=4.0.0"
+    "@effect/platform-node": ">=4.0.0-rc.113 || >=4.0.0"
+    "@effect/sql-d1": ">=4.0.0-rc.113 || >=4.0.0"
+    "@effect/sql-mysql2": ">=4.0.0-rc.113 || >=4.0.0"
+    "@effect/sql-pg": ">=4.0.0-rc.113 || >=4.0.0"
+    "@effect/sql-sqlite-do": ">=4.0.0-rc.113 || >=4.0.0"
+    "@effect/vitest": ">=4.0.0-rc.113 || >=4.0.0"
+    effect: ">=4.0.0-rc.113 || >=4.0.0"
   frontend:
     "@astrojs/internal-helpers": 0.10.1
     "@astrojs/underscore-redirects": 1.0.3
@@ -173,27 +173,31 @@ catalogs:
 overrides:
   "@cloudflare/workers-types": 5.20260901.1
   workerd: 1.20260901.1
-  effect: 4.0.0-rc.112
-  "@effect/platform-browser": 4.0.0-rc.112
+  effect: 4.0.0-rc.113
+  "@effect/platform-browser": 4.0.0-rc.113
   drizzle-kit: 1.0.0-rc.5-ab785fc
   drizzle-orm: 1.0.0-rc.5-ab785fc
+  # Keep drizzle-orm's optional peer graph identical across workspace
+  # packages so TypeScript sees one drizzle-orm identity.
+  mysql2: 3.24.2
+  zod: 4.4.3
   rolldown: 1.2.5
 patchedDependencies:
   "@astrojs/starlight@0.42.0": patches/@astrojs%2Fstarlight@0.42.0.patch
   starlight-blog@0.29.0: patches/starlight-blog@0.29.0.patch
 minimumReleaseAgeExclude:
   - "@alchemy.run/sigil@0.0.0-alpha.10"
-  - "@effect/atom-react@4.0.0-rc.112"
-  - "@effect/platform-bun@4.0.0-rc.112"
-  - "@effect/platform-node-shared@4.0.0-rc.112"
-  - "@effect/platform-node@4.0.0-rc.112"
-  - "@effect/sql-d1@4.0.0-rc.112"
-  - "@effect/sql-mysql2@4.0.0-rc.112"
-  - "@effect/sql-pg@4.0.0-rc.112"
-  - "@effect/sql-sqlite-do@4.0.0-rc.112"
-  - "@effect/vitest@4.0.0-rc.112"
+  - "@effect/atom-react@4.0.0-rc.113"
+  - "@effect/platform-bun@4.0.0-rc.113"
+  - "@effect/platform-node-shared@4.0.0-rc.113"
+  - "@effect/platform-node@4.0.0-rc.113"
+  - "@effect/sql-d1@4.0.0-rc.113"
+  - "@effect/sql-mysql2@4.0.0-rc.113"
+  - "@effect/sql-pg@4.0.0-rc.113"
+  - "@effect/sql-sqlite-do@4.0.0-rc.113"
+  - "@effect/vitest@4.0.0-rc.113"
   - "@foldkit/vite-plugin@0.16.1"
-  - effect@4.0.0-rc.112
+  - effect@4.0.0-rc.113
   - foldkit@0.148.2
   - "@solidjs/start@2.0.4"
   - "@cloudflare/workers-types@5.20260901.1"

--- a/processes/Railway.md
+++ b/processes/Railway.md
@@ -114,7 +114,7 @@ export default class Api extends Fly.Service<Api>()(
 Flat `Fly.*` namespace. Resource-valued props accept the resource or
 an Effect producing it (module-scope `const Site = Fly.App("Site")`).
 No `Input<T>` in Props. No `export * as Services`. No Attach API.
-No `Config.redacted` as the postgres binding.
+No `Config.Redacted` as the postgres binding.
 
 Distilled (Railway):
 
@@ -243,7 +243,7 @@ groups, and volumes.
 | `ReadRedis` / `WriteRedis` / `ReadWriteRedis` | implemented | Service | RESP over `REDIS_URL`, same shape as Fly. |
 | `PutObject` / `GetObject` / `DeleteObject` / `HeadObject` / `ListObjectsV2` | implemented | Service | S3 against bucket credentials. |
 | `MountVolume` | implemented | Service | `{ path, volumeId }` into `ServiceBinding.mounts`; reconcile attaches via `volumeCreate`/`volumeInstanceUpdate`. |
-| `GetVariable` (optional) | missing | Service | Read a Variable by name from env. Prefer `Config.redacted` for `.env`. |
+| `GetVariable` (optional) | missing | Service | Read a Variable by name from env. Prefer `Config.Redacted` for `.env`. |
 
 Shared scaffolding (`RedisBinding.ts`, `RedisHttp.ts`, `BucketBinding.ts`)
 is **not** exported from `index.ts`. Keep it that way.

--- a/stacks/github.ts
+++ b/stacks/github.ts
@@ -24,15 +24,15 @@ export default Alchemy.Stack(
   },
   Effect.gen(function* () {
     const AWS_REGION = yield* yield* AWS.Region;
-    const DOPPLER_TOKEN = yield* Config.redacted("DOPPLER_TOKEN");
-    const CLOUDFLARE_API_TOKEN = yield* Config.redacted("CLOUDFLARE_API_TOKEN");
-    const TEST_CLOUDFLARE_ACCOUNT_ID = yield* Config.string(
+    const DOPPLER_TOKEN = yield* Config.Redacted("DOPPLER_TOKEN");
+    const CLOUDFLARE_API_TOKEN = yield* Config.Redacted("CLOUDFLARE_API_TOKEN");
+    const TEST_CLOUDFLARE_ACCOUNT_ID = yield* Config.String(
       "TEST_CLOUDFLARE_ACCOUNT_ID",
     );
-    const PROD_CLOUDFLARE_ACCOUNT_ID = yield* Config.string(
+    const PROD_CLOUDFLARE_ACCOUNT_ID = yield* Config.String(
       "PROD_CLOUDFLARE_ACCOUNT_ID",
     );
-    const PR_PACKAGE_TOKEN = yield* Config.string("PR_PACKAGE_TOKEN");
+    const PR_PACKAGE_TOKEN = yield* Config.String("PR_PACKAGE_TOKEN");
 
     const PROD_CLOUDFLARE_API_TOKEN = yield* AccountApiToken("ProdApiToken", {
       accountId: PROD_CLOUDFLARE_ACCOUNT_ID,

--- a/stacks/otel.ts
+++ b/stacks/otel.ts
@@ -51,7 +51,7 @@ export default Alchemy.Stack(
     // proxies PostHog Cloud for first-party browser analytics.
     const relay = yield* Ingester;
 
-    // const posthogProjectKey = yield* Config.string("POSTHOG_PROJECT_KEY")
+    // const posthogProjectKey = yield* Config.String("POSTHOG_PROJECT_KEY")
     //   .pipe(Config.option)
     //
     //   .pipe(Effect.orDie);

--- a/website/src/content/docs/aws/security/secrets-env.mdx
+++ b/website/src/content/docs/aws/security/secrets-env.mdx
@@ -13,7 +13,7 @@ shared, generated, or rotated → Secrets Manager.
 
 ## Bind a secret from .env
 
-`yield* Config.redacted(...)` in the function's Construction phase reads
+`yield* Config.Redacted(...)` in the function's Construction phase reads
 your `.env` at deploy time and binds the value as a Lambda
 environment variable:
 
@@ -28,7 +28,7 @@ export default class Api extends AWS.Lambda.Function<Api>()(
   "Api",
   { main: import.meta.url, functionUrl: true },
   Effect.gen(function* () {
-    const apiKey = yield* Config.redacted("OPENAI_API_KEY");
+    const apiKey = yield* Config.Redacted("OPENAI_API_KEY");
 
     return {
       fetch: Effect.gen(function* () {
@@ -58,12 +58,12 @@ the literal text `<redacted>`, not the value — that's the point.
 
 ## Plain vars and defaults
 
-Non-secret config uses the same mechanism with `Config.string` and
-`Config.number`:
+Non-secret config uses the same mechanism with `Config.String` and
+`Config.Number`:
 
 ```typescript
-const host = yield* Config.string("HOST");
-const port = yield* Config.number("PORT").pipe(Config.withDefault(3000));
+const host = yield* Config.String("HOST");
+const port = yield* Config.Number("PORT").pipe(Config.withDefault(3000));
 ```
 
 Values JSON round-trip through the environment, so `port` comes
@@ -84,7 +84,7 @@ export default class Api extends AWS.Lambda.Function<Api>()(
     return {
       fetch: Effect.gen(function* () {
         // 🚫 never bound — API_KEY won't exist at runtime
-        const apiKey = yield* Config.redacted("API_KEY");
+        const apiKey = yield* Config.Redacted("API_KEY");
       }),
     };
   }),

--- a/website/src/content/docs/cloudflare/ai/effect-ai.mdx
+++ b/website/src/content/docs/cloudflare/ai/effect-ai.mdx
@@ -53,11 +53,11 @@ Effect.gen(function* () {
 pattern works in a Lambda handler, an HTTP API endpoint, an RPC
 procedure, a Workflow, or any other Effect.
 
-## Read the API key with `Config.redacted`
+## Read the API key with `Config.Redacted`
 
 Every upstream provider's client Layer (`OpenAiClient.layer`,
 `AnthropicClient.layer`, …) takes an `apiKey: Redacted<string>`.
-[`Config.redacted`](/environments/secrets) resolved in the Runtime's
+[`Config.Redacted`](/environments/secrets) resolved in the Runtime's
 Construction phase gives you exactly that `Redacted<string>` — and Alchemy
 automatically binds the value as a `secret_text` binding
 (Cloudflare) or environment variable (Lambda) at deploy time:
@@ -66,10 +66,10 @@ automatically binds the value as a `secret_text` binding
 import * as Config from "effect/Config";
 
 // constructor — resolves the value AND records the binding
-const apiKey = yield* Config.redacted("OPENAI_API_KEY");
+const apiKey = yield* Config.Redacted("OPENAI_API_KEY");
 ```
 
-`Config.redacted("OPENAI_API_KEY")` reads `OPENAI_API_KEY` from your
+`Config.Redacted("OPENAI_API_KEY")` reads `OPENAI_API_KEY` from your
 `ConfigProvider` (e.g. `.env`) at deploy time, records the binding,
 and resolves from that binding again at runtime — one line, both
 phases. See [Concepts › Secrets and Config](/environments/secrets) for
@@ -109,7 +109,7 @@ export default Cloudflare.Worker(
   "Worker",
   { main: import.meta.url },
   Effect.gen(function* () {
-    const apiKey = yield* Config.redacted("OPENAI_API_KEY");
+    const apiKey = yield* Config.Redacted("OPENAI_API_KEY");
 
     const languageModel = OpenAiLanguageModel.layer({
       model: "gpt-4o-mini",
@@ -269,5 +269,5 @@ model })` — is the same.
 - [Add an AI Gateway](/cloudflare/ai/ai-gateway) — wire
   Workers AI behind a Cloudflare AI Gateway with caching and
   streaming.
-- [Secrets & env](/cloudflare/security/secrets-env) — how `Config.redacted`
+- [Secrets & env](/cloudflare/security/secrets-env) — how `Config.Redacted`
   feeds the upstream providers' API keys at deploy and runtime.

--- a/website/src/content/docs/cloudflare/compute/add-a-workflow.mdx
+++ b/website/src/content/docs/cloudflare/compute/add-a-workflow.mdx
@@ -247,7 +247,7 @@ sleep → broadcast → return — is durable end to end.
 ## Bind a secret
 
 Most real workflows need credentials — an upstream API key, a
-signing token, etc. `Config.redacted` registers a `secret_text`
+signing token, etc. `Config.Redacted` registers a `secret_text`
 binding on the workflow at plantime and hands back a
 `Redacted<string>` for use inside steps:
 
@@ -261,10 +261,10 @@ binding on the workflow at plantime and hands back a
    "Notifier",
    Effect.gen(function* () {
      const rooms = yield* Room;
-+    const apiKey = yield* Config.redacted("API_KEY");
++    const apiKey = yield* Config.Redacted("API_KEY");
 ```
 
-`Config.redacted("API_KEY")` reads `API_KEY` from the active
+`Config.Redacted("API_KEY")` reads `API_KEY` from the active
 `Config` provider (env vars, `.env`, …) at plantime and binds it
 into the workflow as `secret_text`. Set it in your local `.env`:
 
@@ -291,7 +291,7 @@ site that needs it (here, an `Authorization` header):
    "Notifier",
    Effect.gen(function* () {
      const rooms = yield* Room;
-     const apiKey = yield* Config.redacted("API_KEY");
+     const apiKey = yield* Config.Redacted("API_KEY");
 
      return Effect.gen(function* () {
        const env = yield* Cloudflare.Workers.WorkerEnvironment;

--- a/website/src/content/docs/cloudflare/frontend/astro.mdx
+++ b/website/src/content/docs/cloudflare/frontend/astro.mdx
@@ -118,13 +118,13 @@ secrets:
 export const Website = Cloudflare.Website.Astro("Website", {
 +  env: {
 +    CACHE: Cache,
-+    API_KEY: Config.redacted("API_KEY"),
++    API_KEY: Config.Redacted("API_KEY"),
 +  },
 });
 ```
 
 `Cache` is a description, not a deploy — Alchemy provisions the real
-namespace because the Website binds it. `Config.redacted` reads
+namespace because the Website binds it. `Config.Redacted` reads
 `API_KEY` from your environment at deploy time and binds it as a
 Worker secret — see [Secrets & env](/cloudflare/security/secrets-env).
 

--- a/website/src/content/docs/cloudflare/frontend/nextjs.mdx
+++ b/website/src/content/docs/cloudflare/frontend/nextjs.mdx
@@ -125,13 +125,13 @@ secrets:
 export const Website = Cloudflare.Website.Nextjs("Website", {
 +  env: {
 +    UPLOADS: Uploads,
-+    API_KEY: Config.redacted("API_KEY"),
++    API_KEY: Config.Redacted("API_KEY"),
 +  },
 });
 ```
 
 `Uploads` is a description, not a deploy — Alchemy provisions the
-real bucket because the Website binds it. `Config.redacted` reads
+real bucket because the Website binds it. `Config.Redacted` reads
 `API_KEY` from your environment at deploy time and binds it as a
 Worker secret — see [Secrets & env](/cloudflare/security/secrets-env).
 

--- a/website/src/content/docs/cloudflare/frontend/nuxt.mdx
+++ b/website/src/content/docs/cloudflare/frontend/nuxt.mdx
@@ -142,13 +142,13 @@ secrets:
 export const Website = Cloudflare.Website.Nuxt("Website", {
 +  env: {
 +    UPLOADS: Uploads,
-+    API_KEY: Config.redacted("API_KEY"),
++    API_KEY: Config.Redacted("API_KEY"),
 +  },
 });
 ```
 
 `Uploads` is a description, not a deploy — Alchemy provisions the
-real bucket because the Website binds it. `Config.redacted` reads
+real bucket because the Website binds it. `Config.Redacted` reads
 `API_KEY` from your environment at deploy time and binds it as a
 Worker secret — see [Secrets & env](/cloudflare/security/secrets-env).
 

--- a/website/src/content/docs/cloudflare/frontend/octane.mdx
+++ b/website/src/content/docs/cloudflare/frontend/octane.mdx
@@ -123,13 +123,13 @@ vocabulary — KV namespaces, R2 buckets, secrets:
 export const Website = Cloudflare.Website.Octane("Website", {
 +  env: {
 +    CACHE: Cache,
-+    API_KEY: Config.redacted("API_KEY"),
++    API_KEY: Config.Redacted("API_KEY"),
 +  },
 });
 ```
 
 `Cache` is a description, not a deploy — Alchemy provisions the real
-namespace because the Website binds it. `Config.redacted` reads
+namespace because the Website binds it. `Config.Redacted` reads
 `API_KEY` from your environment at deploy time and binds it as a
 Worker secret — see [Secrets & env](/cloudflare/security/secrets-env).
 

--- a/website/src/content/docs/cloudflare/frontend/react-router.mdx
+++ b/website/src/content/docs/cloudflare/frontend/react-router.mdx
@@ -197,7 +197,7 @@ secrets:
 export const Website = Cloudflare.Website.Vite("Website", {
 +  env: {
 +    UPLOADS: Uploads,
-+    API_KEY: Config.redacted("API_KEY"),
++    API_KEY: Config.Redacted("API_KEY"),
 +  },
   viteEnvironments: {
     entry: "rsc",
@@ -207,7 +207,7 @@ export const Website = Cloudflare.Website.Vite("Website", {
 ```
 
 `Uploads` is a description, not a deploy — Alchemy provisions the
-real bucket because the Website binds it. `Config.redacted` reads
+real bucket because the Website binds it. `Config.Redacted` reads
 `API_KEY` from your environment at deploy time and binds it as a
 Worker secret — see [Secrets & env](/cloudflare/security/secrets-env).
 

--- a/website/src/content/docs/cloudflare/frontend/solidstart.mdx
+++ b/website/src/content/docs/cloudflare/frontend/solidstart.mdx
@@ -104,13 +104,13 @@ to the SSR Worker as runtime bindings:
 export const Website = Cloudflare.Website.Vite("Website", {
 +  env: {
 +    UPLOADS: Uploads,
-+    API_KEY: Config.redacted("API_KEY"),
++    API_KEY: Config.Redacted("API_KEY"),
 +  },
 });
 ```
 
 `Uploads` is a description, not a deploy — Alchemy provisions the
-real bucket because the Website binds it. `Config.redacted` reads
+real bucket because the Website binds it. `Config.Redacted` reads
 `API_KEY` from your environment at deploy time and binds it as a
 Worker secret — see [Secrets & env](/cloudflare/security/secrets-env).
 

--- a/website/src/content/docs/cloudflare/frontend/sveltekit.mdx
+++ b/website/src/content/docs/cloudflare/frontend/sveltekit.mdx
@@ -116,13 +116,13 @@ secrets:
 export const Website = Cloudflare.Website.SvelteKit("Website", {
 +  env: {
 +    CACHE: Cache,
-+    API_KEY: Config.redacted("API_KEY"),
++    API_KEY: Config.Redacted("API_KEY"),
 +  },
 });
 ```
 
 `Cache` is a description, not a deploy — Alchemy provisions the real
-namespace because the Website binds it. `Config.redacted` reads
+namespace because the Website binds it. `Config.Redacted` reads
 `API_KEY` from your environment at deploy time and binds it as a
 Worker secret — see [Secrets & env](/cloudflare/security/secrets-env).
 

--- a/website/src/content/docs/cloudflare/frontend/waku.mdx
+++ b/website/src/content/docs/cloudflare/frontend/waku.mdx
@@ -147,13 +147,13 @@ secrets:
 export const Website = Cloudflare.Website.Waku("Website", {
 +  env: {
 +    UPLOADS: Uploads,
-+    API_KEY: Config.redacted("API_KEY"),
++    API_KEY: Config.Redacted("API_KEY"),
 +  },
 });
 ```
 
 `Uploads` is a description, not a deploy — Alchemy provisions the
-real bucket because the Website binds it. `Config.redacted` reads
+real bucket because the Website binds it. `Config.Redacted` reads
 `API_KEY` from your environment at deploy time and binds it as a
 Worker secret — see [Secrets & env](/cloudflare/security/secrets-env).
 

--- a/website/src/content/docs/cloudflare/messaging/github-events.mdx
+++ b/website/src/content/docs/cloudflare/messaging/github-events.mdx
@@ -119,7 +119,7 @@ events. Pass one and alchemy rejects any delivery whose
 +import * as Config from "effect/Config";
 
    Effect.gen(function* () {
-+    const secret = yield* Config.redacted("GITHUB_WEBHOOK_SECRET");
++    const secret = yield* Config.Redacted("GITHUB_WEBHOOK_SECRET");
 +
      yield* GitHub.consumeRepositoryEvents(
        {
@@ -135,7 +135,7 @@ events. Pass one and alchemy rejects any delivery whose
 The webhook is provisioned with the secret, so GitHub signs every
 delivery with `HMAC-SHA256`; the Worker recomputes the signature over
 the raw body and compares in constant time, answering `401` on a
-mismatch. `Config.redacted` reads the value from your `.env` at
+mismatch. `Config.Redacted` reads the value from your `.env` at
 deploy time and binds it as a Worker secret — see
 [Secrets & env](/cloudflare/security/secrets-env).
 

--- a/website/src/content/docs/cloudflare/security/secrets-env.mdx
+++ b/website/src/content/docs/cloudflare/security/secrets-env.mdx
@@ -5,7 +5,7 @@ description: Bind env vars and secrets to Workers with effect/Config, generate s
 
 Three ways to get a secret into a Worker, by where the value lives.
 A value from your `.env` that belongs to one Worker —
-`Config.redacted`. A token your infrastructure mints —
+`Config.Redacted`. A token your infrastructure mints —
 `Alchemy.Random`. A secret shared across Workers that must rotate
 without a redeploy — [Secrets Store](#graduate-to-secrets-store).
 
@@ -25,7 +25,7 @@ export default Cloudflare.Worker(
   "Worker",
   { main: import.meta.url },
   Effect.gen(function* () {
-    const apiKey = yield* Config.redacted("API_KEY");
+    const apiKey = yield* Config.Redacted("API_KEY");
 
     return {
       fetch: Effect.gen(function* () {
@@ -60,11 +60,11 @@ string `"<redacted>"` — `` `Bearer ${apiKey}` `` sends
 
 ## Plain vars and defaults
 
-Non-secret config uses `Config.string` / `Config.number`, and any
+Non-secret config uses `Config.String` / `Config.Number`, and any
 combinator works:
 
 ```typescript
-const port = yield* Config.number("PORT").pipe(
+const port = yield* Config.Number("PORT").pipe(
   Config.withDefault(3000),
 );
 ```
@@ -83,7 +83,7 @@ is never discovered or bound:
 Effect.gen(function* () {
   return {
     fetch: Effect.gen(function* () {
-      const apiKey = yield* Config.redacted("API_KEY");
+      const apiKey = yield* Config.Redacted("API_KEY");
       // ...
     }),
   };
@@ -96,7 +96,7 @@ the handler:
 ```typescript
 // ✅ bound in Construction, used in Runtime
 Effect.gen(function* () {
-  const apiKey = yield* Config.redacted("API_KEY");
+  const apiKey = yield* Config.Redacted("API_KEY");
   return {
     fetch: Effect.gen(function* () {
       return new Response(Redacted.value(apiKey));
@@ -118,8 +118,8 @@ import * as Config from "effect/Config";
 export const Worker = Cloudflare.Worker("Worker", {
   main: "./src/worker.ts",
   env: {
-    API_KEY: Config.redacted("API_KEY"),
-    HOST: Config.string("HOST"),
+    API_KEY: Config.Redacted("API_KEY"),
+    HOST: Config.String("HOST"),
     Bucket, // resource references work the same
   },
 });

--- a/website/src/content/docs/cloudflare/security/secrets-store.mdx
+++ b/website/src/content/docs/cloudflare/security/secrets-store.mdx
@@ -217,7 +217,7 @@ export default class Api extends Cloudflare.Worker<Api>()(
 Both end up as bindings on the Worker — pick based on where the value
 lives and who shares it:
 
-- **Env vars** ([`Config.redacted`](/environments/secrets)) — the value
+- **Env vars** ([`Config.Redacted`](/environments/secrets)) — the value
   comes from *your* environment (`.env`, CI secrets) at deploy time
   and is baked into that one Worker. Right for third-party API keys
   and per-app config. See [Secrets & env](/cloudflare/security/secrets-env)

--- a/website/src/content/docs/cloudflare/tutorial/part-5.mdx
+++ b/website/src/content/docs/cloudflare/tutorial/part-5.mdx
@@ -416,8 +416,8 @@ export default Alchemy.Stack(
     state: Cloudflare.state(),
   },
   Effect.gen(function* () {
-    const testAccountId = yield* Config.string("TEST_CLOUDFLARE_ACCOUNT_ID");
-    const prodAccountId = yield* Config.string("PROD_CLOUDFLARE_ACCOUNT_ID");
+    const testAccountId = yield* Config.String("TEST_CLOUDFLARE_ACCOUNT_ID");
+    const prodAccountId = yield* Config.String("PROD_CLOUDFLARE_ACCOUNT_ID");
 
     const testToken = yield* Cloudflare.ApiToken.AccountApiToken("TestApiToken", {
       accountId: testAccountId,

--- a/website/src/content/docs/docker/build-and-push.mdx
+++ b/website/src/content/docs/docker/build-and-push.mdx
@@ -70,7 +70,7 @@ const image = yield* Docker.Image("app", {
   registry: {
     server: "ghcr.io",
     username: "octocat",
-    password: Config.redacted("GITHUB_TOKEN"),
+    password: Config.Redacted("GITHUB_TOKEN"),
   },
 });
 ```
@@ -94,7 +94,7 @@ const mirrored = yield* Docker.RemoteImage("nginx-mirror", {
   registry: {
     server: "ghcr.io",
     username: "octocat",
-    password: Config.redacted("GITHUB_TOKEN"),
+    password: Config.Redacted("GITHUB_TOKEN"),
   },
 });
 ```

--- a/website/src/content/docs/docker/local-services.mdx
+++ b/website/src/content/docs/docker/local-services.mdx
@@ -68,7 +68,7 @@ fixed once it holds data you care about.
 import * as Config from "effect/Config";
 import * as Option from "effect/Option";
 
-const configuredPassword = yield* Config.redacted("POSTGRES_PASSWORD").pipe(
+const configuredPassword = yield* Config.Redacted("POSTGRES_PASSWORD").pipe(
   Config.option,
 );
 const password = yield* Option.match(configuredPassword, {

--- a/website/src/content/docs/docker/setup.mdx
+++ b/website/src/content/docs/docker/setup.mdx
@@ -50,7 +50,7 @@ const image = yield* Docker.Image("app", {
   registry: {
     server: "ghcr.io",
     username: "octocat",
-    password: Config.redacted("GITHUB_TOKEN"),
+    password: Config.Redacted("GITHUB_TOKEN"),
   },
 });
 ```

--- a/website/src/content/docs/environments/ci.mdx
+++ b/website/src/content/docs/environments/ci.mdx
@@ -523,8 +523,8 @@ export default Alchemy.Stack(
     state: Cloudflare.state(),
   },
   Effect.gen(function* () {
-    const testAccountId = yield* Config.string("TEST_CLOUDFLARE_ACCOUNT_ID");
-    const prodAccountId = yield* Config.string("PROD_CLOUDFLARE_ACCOUNT_ID");
+    const testAccountId = yield* Config.String("TEST_CLOUDFLARE_ACCOUNT_ID");
+    const prodAccountId = yield* Config.String("PROD_CLOUDFLARE_ACCOUNT_ID");
 
     const policies = (accountId: string) => [
       {
@@ -753,8 +753,8 @@ export default Alchemy.Stack(
     providers: GitHub.providers(),
   },
   Effect.gen(function* () {
-    const accessKeyId = yield* Config.string("AWS_ACCESS_KEY_ID");
-    const secretAccessKey = yield* Config.redacted("AWS_SECRET_ACCESS_KEY");
+    const accessKeyId = yield* Config.String("AWS_ACCESS_KEY_ID");
+    const secretAccessKey = yield* Config.Redacted("AWS_SECRET_ACCESS_KEY");
 
     yield* GitHub.Secret("aws-access-key-id", {
       owner: "your-org",

--- a/website/src/content/docs/environments/secrets.mdx
+++ b/website/src/content/docs/environments/secrets.mdx
@@ -25,7 +25,7 @@ export default Cloudflare.Worker(
   "Worker",
   { main: import.meta.url },
   Effect.gen(function* () {
-    const apiKey = yield* Config.redacted("API_KEY"); 
+    const apiKey = yield* Config.Redacted("API_KEY"); 
     // apiKey is Redacted<string> — usable here in Construction AND captured as a binding
 
     return {
@@ -51,7 +51,7 @@ export default Cloudflare.Worker(
   "Worker",
   { main: import.meta.url },
   Effect.gen(function* () {
-    const apiKey = yield* Config.redacted("OPENAI_API_KEY");
+    const apiKey = yield* Config.Redacted("OPENAI_API_KEY");
     const client = createOpenAI(Redacted.value(apiKey));
 
     return {
@@ -67,18 +67,18 @@ export default Cloudflare.Worker(
 
 ## Transformations
 
-Any combinator works — `withDefault`, `orElse`, `mapAttempt`, and so
+Any combinator works — `withDefault`, `orElse`, `mapEffect`, and so
 on. What gets bound is the *source* value (the raw env var), not the
 transformed result; the combinators run again at runtime against that
 source.
 
 ```typescript
-const port = yield* Config.number("PORT").pipe(
+const port = yield* Config.Number("PORT").pipe(
   Config.withDefault(3000),
 );
 ```
 
-- If `PORT` is set, its raw value is bound. At runtime `Config.number("PORT")`
+- If `PORT` is set, its raw value is bound. At runtime `Config.Number("PORT")`
   reads it from the binding and the combinators re-apply.
 - If `PORT` is not set, nothing is bound. At runtime the source is
   still empty and `Config.withDefault(3000)` produces `3000` again.
@@ -99,7 +99,7 @@ export default Cloudflare.Worker(
     return {
       fetch: Effect.gen(function* () {
         // 🚫 nothing is bound to the Worker — API_KEY won't exist at runtime
-        const apiKey = yield* Config.redacted("API_KEY");
+        const apiKey = yield* Config.Redacted("API_KEY");
         // ...
       }),
     };
@@ -114,7 +114,7 @@ and reference that `const` from the runtime body:
 ```typescript
 // ✅ bound in Construction, used in Runtime
 Effect.gen(function* () {
-  const apiKey = yield* Config.redacted("API_KEY");
+  const apiKey = yield* Config.Redacted("API_KEY");
   return {
     fetch: Effect.gen(function* () {
       return new Response(Redacted.value(apiKey));
@@ -144,8 +144,8 @@ import * as Config from "effect/Config";
 export const Worker = Cloudflare.Worker("Worker", {
   main: "./src/worker.ts",
   env: {
-    API_KEY: Config.redacted("API_KEY"),
-    HOST:    Config.string("HOST"),
+    API_KEY: Config.Redacted("API_KEY"),
+    HOST:    Config.String("HOST"),
     Bucket, // resource references work the same
   },
 });

--- a/website/src/content/docs/fly/compute/regions.mdx
+++ b/website/src/content/docs/fly/compute/regions.mdx
@@ -104,7 +104,7 @@ Fly sets `FLY_REGION` on the Machine. Read it in a Service with
 ```typescript
 import * as Config from "effect/Config";
 
-const region = yield* Config.string("FLY_REGION");
+const region = yield* Config.String("FLY_REGION");
 ```
 
 ## Region codes

--- a/website/src/content/docs/fly/compute/services.mdx
+++ b/website/src/content/docs/fly/compute/services.mdx
@@ -192,7 +192,7 @@ export default class Api extends Fly.Service<Api>()(
   "Api",
   { app: Site, main: import.meta.url, port: 3000 },
   Effect.gen(function* () {
-    const apiKey = yield* Config.redacted("API_KEY");
+    const apiKey = yield* Config.Redacted("API_KEY");
 
     return {
       fetch: Effect.gen(function* () {
@@ -204,7 +204,7 @@ export default class Api extends Fly.Service<Api>()(
 ) {}
 ```
 
-`Config.redacted("API_KEY")` is `Redacted<string>`. Unwrap with
+`Config.Redacted("API_KEY")` is `Redacted<string>`. Unwrap with
 `Redacted.value` only where you need the raw string.
 
 Alchemy also injects `PORT` (when `port` is set) and stack metadata.
@@ -277,5 +277,5 @@ hibernate — no parent App, no Docker image.
 [Postgres](/fly/data/postgres) binds with `ConnectPostgres`.
 [Redis](/fly/data/redis) binds with `ReadWriteRedis`.
 [Tigris](/fly/data/tigris) binds with `PutObject` / `GetObject`.
-[Secrets](/fly/data/secrets) covers `Config.redacted` and `Fly.Secret`.
+[Secrets](/fly/data/secrets) covers `Config.Redacted` and `Fly.Secret`.
 The [`Service` reference](/providers/fly/service) lists every prop.

--- a/website/src/content/docs/fly/compute/sprites.mdx
+++ b/website/src/content/docs/fly/compute/sprites.mdx
@@ -110,7 +110,7 @@ export default class Box extends Fly.Sprite<Box>()(
   "Box",
   { main: import.meta.url },
   Effect.gen(function* () {
-    const apiKey = yield* Config.redacted("API_KEY");
+    const apiKey = yield* Config.Redacted("API_KEY");
     const fs = yield* FileSystem.FileSystem;
     yield* fs.makeDirectory("/tmp", { recursive: true });
 
@@ -182,5 +182,5 @@ deletes the old one.
 ## Where next
 
 [Services](/fly/compute/services) are always-on Machines on an App.
-[Secrets](/fly/data/secrets) covers `Config.redacted`.
+[Secrets](/fly/data/secrets) covers `Config.Redacted`.
 The [`Sprite` reference](/providers/fly/sprite) lists every prop.

--- a/website/src/content/docs/fly/data/postgres.mdx
+++ b/website/src/content/docs/fly/data/postgres.mdx
@@ -64,7 +64,7 @@ export default class Api extends Fly.Service<Api>()(
 
 `connectionString` is the cluster's pooled PgBouncer URI Output.
 `directConnectionString` is the direct URI. Both come from
-`Fly.Postgres`, packed into the Service env — not `Config.redacted`.
+`Fly.Postgres`, packed into the Service env — not `Config.Redacted`.
 
 ## Migrations
 
@@ -148,7 +148,7 @@ Flipping `postgis` later is ignored.
 binds the cluster.
 [Drizzle on Postgres](/sql/drizzle/postgres) is the schema-to-query
 flow.
-[Secrets](/fly/data/secrets) covers `Config.redacted` for values
+[Secrets](/fly/data/secrets) covers `Config.Redacted` for values
 from `.env`.
 The [`Postgres` reference](/providers/fly/postgres) lists every
 prop.

--- a/website/src/content/docs/fly/data/secrets.mdx
+++ b/website/src/content/docs/fly/data/secrets.mdx
@@ -1,10 +1,10 @@
 ---
 title: Secrets
-description: Config.redacted on a Service, Fly.Secret when Fly should own the value, and KMS keys.
+description: Config.Redacted on a Service, Fly.Secret when Fly should own the value, and KMS keys.
 ---
 
 Most secrets in a [`Service`](/fly/compute/services) come from your
-`.env`. Yield `Config.redacted` in the constructor. Alchemy binds the value
+`.env`. Yield `Config.Redacted` in the constructor. Alchemy binds the value
 onto the Machine.
 
 Use [`Fly.Secret`](/providers/fly/secret) when the value should be
@@ -21,7 +21,7 @@ export default class Api extends Fly.Service<Api>()(
   "Api",
   { app: Site, main: import.meta.url, port: 3000 },
   Effect.gen(function* () {
-    const apiKey = yield* Config.redacted("API_KEY");
+    const apiKey = yield* Config.Redacted("API_KEY");
 
     return {
       fetch: Effect.gen(function* () {
@@ -33,7 +33,7 @@ export default class Api extends Fly.Service<Api>()(
 ) {}
 ```
 
-`Config.redacted("API_KEY")` reads `API_KEY` from the env of whoever
+`Config.Redacted("API_KEY")` reads `API_KEY` from the env of whoever
 runs the deploy and writes it onto the Machine. At runtime the same
 line resolves from that env var.
 
@@ -175,7 +175,7 @@ a Service, not a laptop Action.
 
 The [tutorial](/fly/tutorial/part-4) stores an App secret and reads
 it from a Service. [Services](/fly/compute/services) covers
-`Config.redacted` for values from `.env`. [Postgres](/fly/data/postgres),
+`Config.Redacted` for values from `.env`. [Postgres](/fly/data/postgres),
 [Redis](/fly/data/redis), and [Tigris](/fly/data/tigris) bind
 typed clients (`ConnectPostgres`, `ReadWriteRedis`, `PutObject`)
 that use Fly-owned secrets internally. See the

--- a/website/src/content/docs/fly/index.mdx
+++ b/website/src/content/docs/fly/index.mdx
@@ -68,7 +68,7 @@ the same TypeScript program.
 
 ## Secrets
 
-- **[Secrets](/fly/data/secrets)** — `Config.redacted` in a Service
+- **[Secrets](/fly/data/secrets)** — `Config.Redacted` in a Service
   for values from `.env`. `Fly.Secret` when Fly should own a value
   shared across Machines. KMS keys are `SecretKey` plus `Encrypt` /
   `Decrypt` / `Sign` / `Verify`.
@@ -95,7 +95,7 @@ the same TypeScript program.
 | Object storage               | [Tigris](/fly/data/tigris) + `PutObject` / `GetObject`                     |
 | N replicas behind fly.dev    | Service `count`, or more [Machine](/fly/compute/machines) resources       |
 | Restore a disk               | [VolumeSnapshot](/fly/data/volumes#snapshots) + mount `snapshotId`        |
-| Config / API tokens          | [`Config.redacted`](/fly/data/secrets). [`Fly.Secret`](/fly/data/secrets) when Fly should own it |
+| Config / API tokens          | [`Config.Redacted`](/fly/data/secrets). [`Fly.Secret`](/fly/data/secrets) when Fly should own it |
 | Sign / encrypt in-app        | [SecretKey](/fly/data/secrets#kms-keys) + `Encrypt` / `Sign`              |
 | `{app}.fly.dev` over IPv4    | [IpAssignment](/fly/networking) `type: "shared_v4"`                       |
 | Your own domain              | [Certificate](/fly/networking#certificates) (ACME)                        |

--- a/website/src/content/docs/fly/tutorial/part-4.mdx
+++ b/website/src/content/docs/fly/tutorial/part-4.mdx
@@ -9,7 +9,7 @@ import Terminal from "../../../../components/Terminal.astro";
 import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
 
 A secret only this Service needs from `.env` is
-`Config.redacted`. See [Secrets](/fly/data/secrets).
+`Config.Redacted`. See [Secrets](/fly/data/secrets).
 
 This part is for a value Fly should own: an App **Secret** Fly
 injects into every Machine. You will read it with `GetSecret`, then

--- a/website/src/content/docs/github/events.mdx
+++ b/website/src/content/docs/github/events.mdx
@@ -31,7 +31,7 @@ yield* GitHub.Webhook("ci-webhook", {
 
 `events` defaults to `["push"]`; pass `["*"]` to receive every event
 GitHub emits. The `secret` (a `Redacted` string, e.g. from
-`Config.redacted` — see [Secrets & env](/cloudflare/security/secrets-env))
+`Config.Redacted` — see [Secrets & env](/cloudflare/security/secrets-env))
 makes GitHub sign each delivery with `HMAC-SHA256` in the
 `X-Hub-Signature-256` header so your receiver can verify the payload
 came from GitHub.

--- a/website/src/content/docs/hetzner/compute/services.mdx
+++ b/website/src/content/docs/hetzner/compute/services.mdx
@@ -112,7 +112,7 @@ export default class Api extends Hetzner.Service<Api>()(
     env: { GREETING: "hello" },
   },
   Effect.gen(function* () {
-    const greeting = yield* Config.string("GREETING");
+    const greeting = yield* Config.String("GREETING");
     // ...
   }),
 ) {}

--- a/website/src/content/docs/infrastructure-as-effects/telemetry.mdx
+++ b/website/src/content/docs/infrastructure-as-effects/telemetry.mdx
@@ -85,7 +85,7 @@ The `Config` read binds the value at deploy time, and because it is
 ```typescript
 const Honeycomb = Layer.unwrap(
   Effect.gen(function* () {
-    const key = yield* Config.redacted("HONEYCOMB_API_KEY");
+    const key = yield* Config.Redacted("HONEYCOMB_API_KEY");
     return Alchemy.Telemetry.layerOtlp({
       url: "https://api.honeycomb.io",
       headers: { "x-honeycomb-team": key },

--- a/website/src/content/docs/railway/compute/services.mdx
+++ b/website/src/content/docs/railway/compute/services.mdx
@@ -263,7 +263,7 @@ export default class Api extends Railway.Service<Api>()(
     port: 3000,
   },
   Effect.gen(function* () {
-    const apiKey = yield* Config.redacted("API_KEY");
+    const apiKey = yield* Config.Redacted("API_KEY");
 
     return {
       fetch: Effect.gen(function* () {
@@ -275,7 +275,7 @@ export default class Api extends Railway.Service<Api>()(
 ) {}
 ```
 
-`Config.redacted("API_KEY")` is `Redacted<string>`. Unwrap with
+`Config.Redacted("API_KEY")` is `Redacted<string>`. Unwrap with
 `Redacted.value` only where you need the raw string.
 
 Alchemy also injects `PORT` (when `port` is set) and stack metadata.
@@ -352,7 +352,7 @@ and canvas Functions, including [schemaless RPC](/railway/compute/functions#sche
 same shape.
 [Redis](/railway/data/redis) binds with `ReadWriteRedis`.
 [Buckets](/railway/data/buckets) bind with `PutObject` / `GetObject`.
-[Variables](/railway/data/variables) covers `Config.redacted`,
+[Variables](/railway/data/variables) covers `Config.Redacted`,
 `Railway.Variable`, and `Railway.ref`.
 The [`Service` reference](/providers/railway/service) lists every
 prop.

--- a/website/src/content/docs/railway/data/mysql.mdx
+++ b/website/src/content/docs/railway/data/mysql.mdx
@@ -59,7 +59,7 @@ export default class Api extends Railway.Service<Api>()(
 
 `connectionString` is the private URI
 (`{name}.railway.internal:3306`). Packed into the Service env — not
-`Config.redacted`.
+`Config.Redacted`.
 
 To store Railway's `${{Db.MYSQL_URL}}` template instead of a
 resolved URI, pass [`Railway.ref`](/providers/railway/ref)

--- a/website/src/content/docs/railway/data/postgres.mdx
+++ b/website/src/content/docs/railway/data/postgres.mdx
@@ -61,7 +61,7 @@ export default class Api extends Railway.Service<Api>()(
 
 `connectionString` is the private URI
 (`{name}.railway.internal:5432`). Both come from `Railway.Postgres`,
-packed into the Service env — not `Config.redacted`.
+packed into the Service env — not `Config.Redacted`.
 
 To store Railway's `${{Db.DATABASE_URL}}` template instead of a
 resolved URI, pass [`Railway.ref`](/providers/railway/ref)
@@ -138,7 +138,7 @@ the cluster.
 same shape for those engines.
 [Drizzle on Postgres](/sql/drizzle/postgres) is the schema-to-query
 flow.
-[Variables](/railway/data/variables) covers `Config.redacted` and
+[Variables](/railway/data/variables) covers `Config.Redacted` and
 `Railway.ref`.
 The [`Postgres` reference](/providers/railway/postgres) lists every
 prop.

--- a/website/src/content/docs/railway/data/variables.mdx
+++ b/website/src/content/docs/railway/data/variables.mdx
@@ -1,10 +1,10 @@
 ---
 title: Variables
-description: Config.redacted on a Service, Railway.Variable when Railway should own the value.
+description: Config.Redacted on a Service, Railway.Variable when Railway should own the value.
 ---
 
 Most secrets in a [`Service`](/railway/compute/services) come from
-your `.env`. Yield `Config.redacted` in the constructor. Alchemy binds the
+your `.env`. Yield `Config.Redacted` in the constructor. Alchemy binds the
 value onto the Service.
 
 Use [`Railway.Variable`](/providers/railway/variable) when the value
@@ -25,7 +25,7 @@ export default class Api extends Railway.Service<Api>()(
     port: 3000,
   },
   Effect.gen(function* () {
-    const apiKey = yield* Config.redacted("API_KEY");
+    const apiKey = yield* Config.Redacted("API_KEY");
 
     return {
       fetch: Effect.gen(function* () {
@@ -37,7 +37,7 @@ export default class Api extends Railway.Service<Api>()(
 ) {}
 ```
 
-`Config.redacted("API_KEY")` reads `API_KEY` from the env of whoever
+`Config.Redacted("API_KEY")` reads `API_KEY` from the env of whoever
 runs the deploy and writes it onto the Service. At runtime the same
 line resolves from that env var.
 
@@ -101,7 +101,7 @@ export default class Api extends Railway.Service<Api>()(
   },
   Effect.gen(function* () {
     yield* ApiToken;
-    const name = yield* Config.string("API_TOKEN").pipe(
+    const name = yield* Config.String("API_TOKEN").pipe(
       Effect.orElseSucceed(() => ""),
     );
 
@@ -173,7 +173,7 @@ const token = yield* Railway.Variable("StagingToken", {
 
 The [tutorial](/railway/tutorial/part-4) stores a Variable and reads
 it from a Service. [Services](/railway/compute/services) covers
-`Config.redacted` for values from `.env`. [Postgres](/railway/data/postgres),
+`Config.Redacted` for values from `.env`. [Postgres](/railway/data/postgres),
 [MySQL](/railway/data/mysql), [Mongo](/railway/data/mongo),
 [Redis](/railway/data/redis), and [Buckets](/railway/data/buckets)
 bind typed clients (`ConnectPostgres`, `ConnectMySQL`,

--- a/website/src/content/docs/railway/index.mdx
+++ b/website/src/content/docs/railway/index.mdx
@@ -77,7 +77,7 @@ a resource — Alchemy uses `me.workspace ?? me.workspaces[0]`.
 
 ## Variables
 
-- **[Variables](/railway/data/variables)** — `Config.redacted` in a
+- **[Variables](/railway/data/variables)** — `Config.Redacted` in a
   Service for values from `.env`. `Railway.Variable` when Railway
   should own a value shared across services. `Railway.ref(Db,
   "DATABASE_URL")` emits `${{Db.DATABASE_URL}}` (IaC
@@ -111,7 +111,7 @@ a resource — Alchemy uses `me.workspace ?? me.workspaces[0]`.
 | Redis                        | [Redis](/railway/data/redis) + `ReadRedis` / `WriteRedis` / `ReadWriteRedis` |
 | Object storage               | [Bucket](/railway/data/buckets) + `PutObject` / `GetObject`               |
 | Staging next to production   | [Environment](/railway/compute/environments)                              |
-| Config / API tokens          | [`Config.redacted`](/railway/data/variables). [`Railway.Variable`](/railway/data/variables) when Railway should own it |
+| Config / API tokens          | [`Config.Redacted`](/railway/data/variables). [`Railway.Variable`](/railway/data/variables) when Railway should own it |
 | Cross-service env            | [`Railway.ref`](/railway/data/variables#variable-references)              |
 | Your own domain              | [CustomDomain](/railway/networking#custom-domains)                        |
 | Laptop access to Postgres    | [TcpProxy](/railway/networking#tcp-proxies) (or Postgres `public: true`)  |

--- a/website/src/content/docs/railway/tutorial/part-4.mdx
+++ b/website/src/content/docs/railway/tutorial/part-4.mdx
@@ -9,7 +9,7 @@ import Terminal from "../../../../components/Terminal.astro";
 import { Code, Tabs, TabItem } from "@astrojs/starlight/components";
 
 A secret only this Service needs from `.env` is
-`Config.redacted`. See [Variables](/railway/data/variables).
+`Config.Redacted`. See [Variables](/railway/data/variables).
 
 This part is for a value Railway should own: a **Variable** Railway
 injects into services. You will read it with `Config`, then tear
@@ -56,7 +56,7 @@ plaintext:
     const fs = yield* FileSystem.FileSystem;
 +    yield* ApiToken;
 +    const tokenName = "API_TOKEN";
-+    const token = yield* Config.string(tokenName).pipe(
++    const token = yield* Config.String(tokenName).pipe(
 +      Effect.orElseSucceed(() => ""),
 +    );
 
@@ -179,7 +179,7 @@ Over four parts you built a complete Railway deployment:
   multiple Services per Project, image-based Services.
 - [Volumes](/railway/data/volumes) — attach at create time, region
   rules.
-- [Variables](/railway/data/variables) — `Config.redacted` vs
+- [Variables](/railway/data/variables) — `Config.Redacted` vs
   `Railway.Variable`.
 - [Postgres](/railway/data/postgres) — bind `ConnectPostgres` and
   query with Drizzle.

--- a/website/src/content/docs/state-store/index.mdx
+++ b/website/src/content/docs/state-store/index.mdx
@@ -130,7 +130,7 @@ Alchemy.Stack(
   "MyApp",
   {
     providers: Prisma.providers(),
-    state: postgresState({ url: Config.redacted("STATE_DATABASE_URL") }),
+    state: postgresState({ url: Config.Redacted("STATE_DATABASE_URL") }),
   },
   Effect.gen(function* () {
     // ...


### PR DESCRIPTION
Bump Effect from `4.0.0-rc.112` to `4.0.0-rc.113` (catalog, overrides, lockfile, and the remaining hard pins).

```yaml
effect: ">=4.0.0-rc.113 || >=4.0.0"
```

RC 113 PascalCase constructors:

```ts
Config.string("HOST")     // before
Config.String("HOST")     // after

Config.mapOrFail(...)     // before
Config.mapEffect(...)     // after

Flag.boolean("yes")       // before
Flag.Boolean("yes")       // after
Flag.integer("limit")     // before
Flag.Int("limit")         // after
Flag.choice("backend", …) // before
Flag.Literals("backend", …)
```

Also:

- `fiber.currentSpan` → `fiber.cache.span`
- Socket `run`/`runRaw` → reader/writer (`fromTransformStream`, `toStream`)
- `LanguageModel.Service` → `LanguageModel.LanguageModel`
- thunk `Effect.tryPromise` now fails with `UnknownError`; Durable Object storage uses `Effect.promise`
- `FileSystem.Size` → `ByteSize.ByteSize`

Pin `mysql2` and `zod` in workspace overrides so drizzle-orm does not split into two TypeScript identities after the lockfile refresh.

Also points `distilled` at the matching bump: [alchemy-run/distilled#575](https://github.com/alchemy-run/distilled/pull/575)
