### PR TITLE
feat(cloudflare/workers): Worker Previews

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -407,6 +407,20 @@ export interface WorkerDomainConfig {
    * Alternative to {@link zoneId} / {@link zoneName}.
    */
   zone?: ZoneReference;
+  /**
+   * Serve Worker Previews on this custom domain as
+   * `<preview-name>.<name>` (and a pinned
+   * `<deployment-id>-<preview-name>.<name>` per deploy). Cloudflare
+   * provisions a wildcard DNS record and certificate. Equivalent to
+   * Wrangler's `previews_enabled` on a custom-domain route.
+   *
+   * This is a **parent** setting — enable it on the production Worker,
+   * not on the Preview Worker. A dedicated Preview hostname
+   * (`previews.example.com`) avoids colliding with existing subdomains.
+   *
+   * @default false
+   */
+  previews?: boolean;
 }
 
 export interface WorkerRouteConfig {
@@ -611,6 +625,62 @@ export interface WorkerVersionOptions {
   tag?: string;
 }
 
+/**
+ * Worker Preview configuration — uploads this Worker as a first-class
+ * [Preview](https://developers.cloudflare.com/workers/previews/) of
+ * another Worker's script instead of creating a script of its own.
+ *
+ * Distinct from {@link WorkerVersionOptions}: a version is an immutable
+ * upload onto the parent script (gradual rollouts, canaries, Version
+ * URLs). A Preview is a named copy with its own variables, secrets,
+ * bindings, and isolated same-Worker Durable Object / Container state.
+ * Cloudflare recommends Previews for branch and pull-request testing.
+ *
+ * Mutually exclusive with {@link WorkerVersionOptions.parent}.
+ */
+export interface WorkerPreviewOptions {
+  /**
+   * The Worker this Preview belongs to. Accepts a Worker reference —
+   * typically `yield* Cloudflare.Worker.ref(id, { stage, stack })` for
+   * a Worker deployed in another stage/stack, or a locally-declared
+   * Worker — or a literal script name as an escape hatch.
+   *
+   * When set, this resource does not create a script of its own: it
+   * creates (or updates) a Preview of the parent's script and deploys
+   * this Worker's code, assets, and bindings to it. Script-level
+   * settings that belong to the parent — `name`, `namespace`, `crons`,
+   * `domain`, `routes`, `workersDev`, `access` — cannot be set on a
+   * Preview Worker. Locally-hosted Durable Object and Workflow classes
+   * *are* allowed: each Preview gets its own isolated namespace.
+   *
+   * Changing the parent replaces the resource (a Preview belongs to
+   * exactly one script).
+   */
+  of: string | Worker;
+  /**
+   * Preview name. Defaults to a DNS-safe form of the stack stage
+   * (`pr-123`, `feat-login`). Appears in Preview URLs:
+   * `https://<name>-<worker>.<subdomain>.workers.dev` and, when the
+   * parent has {@link WorkerDomainConfig.previews} enabled,
+   * `https://<name>.<domain>`.
+   *
+   * Must start with a lowercase letter, contain only lowercase letters,
+   * digits, and dashes, and `<name>-<worker-name>` must fit in 63
+   * characters (a DNS label).
+   */
+  name?: string;
+  /**
+   * Human-readable annotation attached to the Preview deployment,
+   * shown in the Cloudflare dashboard.
+   */
+  message?: string;
+  /**
+   * Machine-readable tag annotation attached to the Preview deployment
+   * (e.g. a git commit SHA or PR number).
+   */
+  tag?: string;
+}
+
 export interface WorkerProps<
   // PERF: unconstrained for the same reason as `Worker<Bindings>` above —
   // the `extends WorkerBindingProps` proof is expensive for generic mapped
@@ -648,12 +718,23 @@ export interface WorkerProps<
   namespace?: string | DispatchNamespace;
   /**
    * Worker versions & gradual deployments. Set `version.parent` to upload
-   * this Worker as a preview/canary *version* of another Worker's script
+   * this Worker as a canary *version* of another Worker's script
    * instead of creating its own; set `version.traffic` below 100 to
-   * gradually roll out a deploy of this Worker's own script. See
+   * gradually roll out a deploy of this Worker's own script. For branch
+   * and pull-request testing, use {@link preview} instead. See
    * {@link WorkerVersionOptions}.
    */
   version?: WorkerVersionOptions;
+  /**
+   * Deploy this Worker as a [Preview](https://developers.cloudflare.com/workers/previews/)
+   * of another Worker's script. Set `preview.of` to the parent Worker
+   * (typically `yield* Cloudflare.Worker.ref(id, { stage })`). The
+   * Preview gets its own URL, bindings, and isolated Durable Object
+   * state; the parent's live deployment is untouched. Mutually
+   * exclusive with {@link version.parent}. See
+   * {@link WorkerPreviewOptions}.
+   */
+  preview?: WorkerPreviewOptions;
   /**
    * Controls the Worker's `workers.dev` surface.
    *
@@ -1219,6 +1300,7 @@ export type Worker<Bindings = any> = Resource<
           aliases: string[];
           redirects: string[];
           zone?: ZoneReference;
+          previews?: boolean;
         }
       | undefined;
     tags: string[] | undefined;
@@ -1251,6 +1333,34 @@ export type Worker<Bindings = any> = Resource<
      * avoid treating the parent's script as this resource's own.
      */
     versionOf?: string | undefined;
+    /**
+     * The parent script name this Worker is a Preview of, when this
+     * resource is a Preview Worker (`preview.of` set). `undefined` for
+     * a Worker that owns its own script. Discriminator `read`/`delete`
+     * use so they never treat the parent's script as this resource's own.
+     */
+    previewOf?: string | undefined;
+    /**
+     * Cloudflare's immutable Preview id. Set when this resource is a
+     * Preview Worker (`preview.of`).
+     */
+    previewId?: string | undefined;
+    /**
+     * The Preview name as created — the user-provided `preview.name`, or
+     * the auto-derived name from the stack stage.
+     */
+    previewName?: string | undefined;
+    /**
+     * DNS-safe slug Cloudflare assigned to this Preview. Used in Preview
+     * URLs (`<slug>-<worker>.<subdomain>.workers.dev` and
+     * `<slug>.<domain>` when the parent has custom-domain Previews).
+     */
+    previewSlug?: string | undefined;
+    /**
+     * Same-Worker Durable Object class names hosted on the last Preview
+     * deploy — the baseline for the next Preview's class migrations.
+     */
+    previewDoClasses?: string[] | undefined;
     /**
      * The id of the version uploaded by the most recent deploy. Only set
      * when versioning is in play: always for a version worker
@@ -1908,15 +2018,49 @@ export const isSelf = (value: unknown): value is Self =>
  * });
  * ```
  *
+ * ### Worker Previews
+ * The `preview` prop maps Cloudflare's
+ * [Worker Previews](https://developers.cloudflare.com/workers/previews/) —
+ * a named copy of a Worker with its own URL, variables, secrets, bindings,
+ * and isolated same-Worker Durable Object state. Use it for branch and
+ * pull-request testing. Distinct from {@link version}: a version is an
+ * immutable upload onto the parent script (gradual rollouts, canaries);
+ * a Preview does not take production traffic.
+ *
+ * A Preview Worker's `url` is its stable Preview URL
+ * (`<name>-<parent>.<subdomain>.workers.dev`, or
+ * `<name>.<domain>` when the parent has `domain.previews`). The name
+ * defaults to the stack stage (override with `preview.name`). Destroying
+ * the Preview Worker deletes the Preview; the parent is untouched.
+ *
+ * **Example:** PR preview of another stage's Worker
+ * ```typescript
+ * const parent = yield* Cloudflare.Worker.ref("Api", { stage: "prod" });
+ * const preview = yield* Cloudflare.Worker("Api", {
+ *   main: "./src/api.ts",
+ *   preview: { of: parent, message: `PR #${process.env.PR_NUMBER}` },
+ * });
+ * // preview.url -> https://<stage>-<name>.<subdomain>.workers.dev
+ * ```
+ *
+ * **Example:** Custom-domain Preview URLs
+ * ```typescript
+ * // On the production Worker:
+ * yield* Cloudflare.Worker("Api", {
+ *   main: "./src/api.ts",
+ *   domain: { name: "app.example.com", previews: true },
+ * });
+ * // A Preview of that Worker is then at https://<preview-name>.app.example.com
+ * ```
+ *
  * ### Versions & Gradual Deployments
  * The `version` prop maps Cloudflare's
  * [versions and gradual deployments](https://developers.cloudflare.com/workers/configuration/versions-and-deployments/)
  * onto Alchemy stages. A Worker with `version.parent` set uploads an
  * immutable *version* to the parent Worker's script instead of creating its
- * own — by default with no traffic, reachable only at its preview URL
- * (`worker.url`), which is the PR-preview workflow. Give it `traffic` to
- * run it as a canary, or use `version.traffic` on a normal Worker to roll
- * out its own deploys gradually.
+ * own — give it `traffic` to run it as a canary, or use `version.traffic`
+ * on a normal Worker to roll out its own deploys gradually. For branch
+ * and pull-request testing, use {@link preview} instead.
  *
  * A version worker's `url` is its *aliased* preview URL
  * (`<alias>-<name>.<subdomain>.workers.dev`) — the alias is derived from
@@ -1932,20 +2076,14 @@ export const isSelf = (value: unknown): value is Self =>
  * as are locally-hosted Durable Object or Workflow classes. Preview URLs
  * require the parent's workers.dev subdomain to be enabled (the default).
  *
- * **Example:** PR preview: a version of another stage's Worker
+ * **Example:** Upload a version without routing traffic
  * ```typescript
- * // The staging stage deploys the real Worker; a PR stage uploads its
- * // code as a zero-traffic version of staging's script and gets back a
- * // stable preview URL.
- * const parent = yield* Cloudflare.Worker.ref("MyWorker", {
- *   stage: "staging",
- * });
- * const preview = yield* Cloudflare.Worker("MyWorker", {
+ * // Inspect this upload at its Version URL before a gradual rollout.
+ * // For branch/PR testing, use `preview.of` instead.
+ * yield* Cloudflare.Worker("MyWorker", {
  *   main: "./src/worker.ts",
- *   version: { parent, message: `PR #${process.env.PR_NUMBER}` },
+ *   version: { traffic: 0, tag: process.env.GITHUB_SHA },
  * });
- * // preview.url -> https://<alias>-<name>.<subdomain>.workers.dev
- * // (stable across deploys; re-points at each newly uploaded version)
  * ```
  *
  * **Example:** Canary: send 10% of the parent's traffic to a version

--- a/packages/alchemy/src/Cloudflare/Workers/Worker.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Worker.ts
@@ -408,15 +408,17 @@ export interface WorkerDomainConfig {
    */
   zone?: ZoneReference;
   /**
-   * Serve Worker Previews on this custom domain as
-   * `<preview-name>.<name>` (and a pinned
-   * `<deployment-id>-<preview-name>.<name>` per deploy). Cloudflare
+   * Opt into custom-domain Worker Previews (private beta). When `true`,
+   * Previews of this Worker are served at `<preview-name>.<name>` (and a
+   * pinned `<deployment-id>-<preview-name>.<name>` per deploy). Cloudflare
    * provisions a wildcard DNS record and certificate. Equivalent to
    * Wrangler's `previews_enabled` on a custom-domain route.
    *
-   * This is a **parent** setting — enable it on the production Worker,
-   * not on the Preview Worker. A dedicated Preview hostname
-   * (`previews.example.com`) avoids colliding with existing subdomains.
+   * Unset, the field is not sent to Cloudflare — existing custom-domain
+   * attaches are unchanged. This is a **parent** setting: enable it on
+   * the production Worker, not on the Preview Worker. A dedicated Preview
+   * hostname (`previews.example.com`) avoids colliding with existing
+   * subdomains.
    *
    * @default false
    */
@@ -726,12 +728,12 @@ export interface WorkerProps<
    */
   version?: WorkerVersionOptions;
   /**
-   * Deploy this Worker as a [Preview](https://developers.cloudflare.com/workers/previews/)
-   * of another Worker's script. Set `preview.of` to the parent Worker
-   * (typically `yield* Cloudflare.Worker.ref(id, { stage })`). The
-   * Preview gets its own URL, bindings, and isolated Durable Object
-   * state; the parent's live deployment is untouched. Mutually
-   * exclusive with {@link version.parent}. See
+   * Opt into Cloudflare's [Worker Previews](https://developers.cloudflare.com/workers/previews/)
+   * (private beta). Unset, this Worker deploys as a normal script and none
+   * of the Preview APIs are called. Set `preview.of` to upload this Worker
+   * as a Preview of another Worker's script instead: own URL, bindings,
+   * and isolated Durable Object state; the parent's live deployment is
+   * untouched. Mutually exclusive with {@link version.parent}. See
    * {@link WorkerPreviewOptions}.
    */
   preview?: WorkerPreviewOptions;

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
@@ -1541,7 +1541,11 @@ export const LiveWorkerProvider = () =>
                 hostname,
                 service: scriptName,
                 zoneId,
-                previewsEnabled: previewsEnabled === true,
+                // Private-beta field — only send it when the user opted
+                // into custom-domain Previews. Omitting it keeps the
+                // public PUT /workers/domains body unchanged for everyone
+                // else.
+                ...(previewsEnabled === true ? { previewsEnabled: true } : {}),
               })
               .pipe(
                 Effect.retry({

--- a/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/WorkerProvider.ts
@@ -215,6 +215,63 @@ export const resolveVersionParentName = (
 };
 
 /**
+ * A Worker's `preview` configuration is invalid — combined with
+ * `version.parent`, missing `preview.of`, a bad Preview name, or a
+ * script-level setting that belongs to the parent.
+ */
+export class WorkerPreviewConfigError extends Data.TaggedError(
+  "WorkerPreviewConfigError",
+)<{
+  message: string;
+}> {}
+
+/**
+ * Resolve the parent script *name* from a resolved `preview.of` prop.
+ *
+ * @internal
+ */
+export const resolvePreviewParentName = (
+  preview: WorkerProps["preview"],
+): string | undefined => {
+  const parent = preview?.of;
+  if (parent == null) return undefined;
+  if (typeof parent === "string") return parent;
+  const workerName = (parent as { workerName?: unknown }).workerName;
+  return typeof workerName === "string" ? workerName : undefined;
+};
+
+const toPreviewWireKey = (key: string) =>
+  key.replace(/[A-Z]/g, (c) => `_${c.toLowerCase()}`);
+
+const toPreviewWire = (value: unknown): unknown => {
+  if (Array.isArray(value)) return value.map(toPreviewWire);
+  if (value !== null && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([k, v]) => [
+        toPreviewWireKey(k),
+        toPreviewWire(v),
+      ]),
+    );
+  }
+  return value;
+};
+
+/** Convert Alchemy's binding array into wrangler's Preview `env` map. */
+const bindingsToPreviewEnv = (
+  bindings: WorkerBinding[],
+): Record<string, unknown> => {
+  const env: Record<string, unknown> = {};
+  for (const binding of bindings) {
+    const { name, ...rest } = binding as unknown as {
+      name?: unknown;
+    } & Record<string, unknown>;
+    if (typeof name !== "string") continue;
+    env[name] = toPreviewWire(rest);
+  }
+  return env;
+};
+
+/**
  * The traffic percentage a *self-owned* Worker's new version should receive,
  * or `undefined` for the default full cutover. Only a `version` prop without
  * a `parent` participates — version workers handle traffic separately.
@@ -477,6 +534,8 @@ export interface ResolvedWorkerDomain {
   redirects: string[];
   /** Pinned zone from props, when the caller set zoneId / zone / zoneName. */
   zone?: ZoneReference;
+  /** Serve Worker Previews on this custom domain. */
+  previews?: boolean;
 }
 
 const isZoneReference = (value: unknown): value is ZoneReference => {
@@ -574,9 +633,15 @@ export const resolveWorkerDomain = (
       );
     }
     const zone = resolveWorkerDomainZone(config);
-    return zone === undefined
-      ? { name, aliases, redirects }
-      : { name, aliases, redirects, zone };
+    const previews =
+      "previews" in config && config.previews === true ? true : undefined;
+    return {
+      name,
+      aliases,
+      redirects,
+      ...(zone === undefined ? {} : { zone }),
+      ...(previews === undefined ? {} : { previews }),
+    };
   });
 
 const isWorkersDevHostname = (hostname: string) =>
@@ -635,6 +700,7 @@ export const stateWorkerDomain = (
           zone?: ZoneReference;
           zoneId?: unknown;
           zoneName?: unknown;
+          previews?: unknown;
         } | null;
         domains?: unknown[];
       }
@@ -651,6 +717,7 @@ export const stateWorkerDomain = (
         (h): h is string => typeof h === "string",
       ),
       ...(zone === undefined ? {} : { zone }),
+      ...(domain.previews === true ? { previews: true } : {}),
     };
   }
   const legacy = stateCustomDomains(state?.domains);
@@ -1141,6 +1208,14 @@ const resolveWorkerMetadataHash = ({
           tag: props.version.tag,
         }
       : undefined,
+    preview: props.preview
+      ? {
+          of: resolvePreviewParentName(props.preview),
+          name: props.preview.name,
+          message: props.preview.message,
+          tag: props.preview.tag,
+        }
+      : undefined,
   }).pipe(Effect.flatMap((metadata) => sha256Object({ metadata })));
 
 export const WorkerProvider = () =>
@@ -1339,6 +1414,7 @@ export const LiveWorkerProvider = () =>
         scriptName: string,
         desired: string[],
         zone?: ZoneReference,
+        previewsEnabled?: boolean,
       ) =>
         Effect.gen(function* () {
           const { accountId } = yield* yield* CloudflareEnvironment;
@@ -1363,6 +1439,7 @@ export const LiveWorkerProvider = () =>
                           hostname: d.hostname,
                           zoneId: d.zoneId,
                           service: d.service ?? undefined,
+                          previewsEnabled: d.previewsEnabled === true,
                         },
                       ]
                     : [],
@@ -1403,7 +1480,11 @@ export const LiveWorkerProvider = () =>
                 : yield* inferZoneIdForHostname(hostname, zoneCache, zone);
             if (
               live &&
-              !shouldRecreateWorkerDomainAttachment(live.zoneId, desiredZoneId)
+              !shouldRecreateWorkerDomainAttachment(
+                live.zoneId,
+                desiredZoneId,
+              ) &&
+              live.previewsEnabled === (previewsEnabled === true)
             ) {
               return {
                 hostname: live.hostname,
@@ -1460,6 +1541,7 @@ export const LiveWorkerProvider = () =>
                 hostname,
                 service: scriptName,
                 zoneId,
+                previewsEnabled: previewsEnabled === true,
               })
               .pipe(
                 Effect.retry({
@@ -3079,6 +3161,341 @@ export const LiveWorkerProvider = () =>
         } satisfies Worker["Attributes"];
       });
 
+      /**
+       * Reconcile a *Preview Worker*: create/update a first-class Preview of
+       * the parent script and upload this Worker's code + bindings as a
+       * Preview deployment. Isolated same-Worker Durable Object classes
+       * get their own namespace per Preview.
+       */
+      const putWorkerPreview = Effect.fn(function* (
+        id: string,
+        fqn: string,
+        news: WorkerProps,
+        bindings: ResourceBinding<Worker["Binding"]>[],
+        session: ScopedPlanStatusSession,
+        output: Worker["Attributes"] | undefined,
+      ) {
+        const { accountId } = yield* yield* CloudflareEnvironment;
+        const preview = news.preview!;
+        const parentName = resolvePreviewParentName(preview);
+        if (parentName === undefined) {
+          return yield* Effect.fail(
+            new WorkerPreviewConfigError({
+              message: `preview.of did not resolve to a Worker script name. Pass a Worker (e.g. \`yield* Cloudflare.Worker.ref(id, { stage })\`) or a literal script name.`,
+            }),
+          );
+        }
+        if (news.version !== undefined) {
+          return yield* Effect.fail(
+            new WorkerPreviewConfigError({
+              message: `preview and version cannot be set together. Use preview.of for branch/PR Previews; use version.parent / version.traffic for canaries and gradual rollouts.`,
+            }),
+          );
+        }
+        const forbidden = (
+          [
+            ["name", news.name],
+            ["namespace", news.namespace],
+            ["crons", news.crons],
+            ["tailConsumers", news.tailConsumers],
+            ["streamingTailConsumers", news.streamingTailConsumers],
+            ["domain", news.domain],
+            ["routes", news.routes],
+            ["workersDev", news.workersDev],
+            ["access", news.access],
+          ] as const
+        ).flatMap(([key, value]) => (value !== undefined ? [key] : []));
+        if (forbidden.length > 0) {
+          return yield* Effect.fail(
+            new WorkerPreviewConfigError({
+              message:
+                `preview.of creates a Preview of '${parentName}' — script-level settings belong to the parent Worker and cannot be set here: ${forbidden.join(", ")}. ` +
+                `Remove ${forbidden.length === 1 ? "this prop" : "these props"} or configure ${forbidden.length === 1 ? "it" : "them"} on the parent.`,
+            }),
+          );
+        }
+        const cronBindings = getCronBindings(bindings);
+        if (cronBindings.length > 0) {
+          return yield* Effect.fail(
+            new WorkerPreviewConfigError({
+              message: `Cron Triggers are script-level settings and cannot be registered from a Preview of '${parentName}'. Configure crons on the parent Worker.`,
+            }),
+          );
+        }
+
+        const budget = 63 - parentName.length - 1;
+        const userName = preview.name;
+        let previewName: string;
+        if (userName !== undefined) {
+          if (!/^[a-z][a-z0-9-]*$/.test(userName)) {
+            return yield* Effect.fail(
+              new WorkerPreviewConfigError({
+                message: `preview.name '${userName}' is invalid: names must start with a lowercase letter and contain only lowercase letters, digits, and dashes.`,
+              }),
+            );
+          }
+          if (userName.length > budget) {
+            return yield* Effect.fail(
+              new WorkerPreviewConfigError({
+                message: `preview.name '${userName}' is too long: '<name>-${parentName}' must fit in a 63-character DNS label, leaving ${Math.max(budget, 0)} characters for the name.`,
+              }),
+            );
+          }
+          previewName = userName;
+        } else if (budget < 4) {
+          return yield* Effect.fail(
+            new WorkerPreviewConfigError({
+              message: `Cannot derive a Preview name: '<name>-${parentName}' must fit in a 63-character DNS label. Set preview.name to a short value or shorten the parent's name.`,
+            }),
+          );
+        } else {
+          const readable = stack.stage
+            .toLowerCase()
+            .replace(/[^a-z0-9-]+/g, "-")
+            .replace(/^-+|-+$/g, "");
+          const derived = (readable.length > 0 ? readable : `p${id}`)
+            .slice(0, budget)
+            .replace(/-+$/, "");
+          previewName = /^[a-z]/.test(derived)
+            ? derived
+            : `p${derived}`.slice(0, budget);
+        }
+
+        yield* Effect.logInfo(
+          `Cloudflare Worker Preview: ${previewName} of ${parentName} (from ${id})`,
+        );
+
+        const existingPreview = yield* workers
+          .getPreview({
+            accountId,
+            workerId: parentName,
+            previewId: previewName,
+          })
+          .pipe(
+            Effect.catchTag("PreviewNotFound", () => Effect.succeed(undefined)),
+            Effect.catchTag("WorkerNotFound", () =>
+              Effect.fail(
+                new WorkerPreviewConfigError({
+                  message: `preview.of script '${parentName}' does not exist. Deploy the parent Worker first (or check the referenced stage/stack).`,
+                }),
+              ),
+            ),
+          );
+
+        const previewResource =
+          existingPreview ??
+          (yield* workers
+            .createPreview({
+              accountId,
+              workerId: parentName,
+              name: previewName,
+              ignoreBaseConfig: true,
+            })
+            .pipe(
+              Effect.catchTag("WorkerNotFound", () =>
+                Effect.fail(
+                  new WorkerPreviewConfigError({
+                    message: `preview.of script '${parentName}' does not exist. Deploy the parent Worker first (or check the referenced stage/stack).`,
+                  }),
+                ),
+              ),
+            ));
+
+        const accountSubdomain = yield* getAccountSubdomain(accountId);
+        const parentAttrs =
+          typeof preview.of === "object" && preview.of !== null
+            ? (preview.of as unknown as Partial<Worker["Attributes"]>)
+            : undefined;
+        const parentDomainName = parentAttrs?.domain?.name;
+        const parentDomainPreviews = parentAttrs?.domain?.previews === true;
+        const constructedUrls = [
+          ...(parentDomainPreviews && parentDomainName
+            ? [`https://${previewResource.slug}.${parentDomainName}`]
+            : []),
+          `https://${previewResource.slug}-${parentName}.${accountSubdomain}.workers.dev`,
+        ];
+        const stableUrl = previewResource.urls?.[0] ?? constructedUrls[0];
+        const selfUrl = hasSelfUrlBinding(bindings) ? stableUrl : undefined;
+
+        yield* Effect.logInfo(
+          `Cloudflare Worker Preview: preparing bundle for ${parentName} (preview ${previewName})`,
+        );
+        const {
+          assets,
+          bundle,
+          hash: preparedHash,
+        } = yield* prepareAssetsAndBundle(id, fqn, parentName, news, {
+          skipAssetsRead: false,
+        });
+        const metadataHash = yield* resolveWorkerMetadataHash({
+          props: news,
+          bindings,
+          accountId,
+          stack: { name: stack.name, stage: stack.stage },
+          selfUrl,
+        });
+        const hash = {
+          ...preparedHash,
+          metadata: metadataHash,
+        } satisfies Worker["Attributes"]["hash"];
+
+        const metadataBindings = bindings.flatMap((b) =>
+          (b.data.bindings ?? []).map((item) =>
+            item.type === "self_url"
+              ? { type: "plain_text" as const, name: item.name, text: selfUrl! }
+              : item.type === "self_service"
+                ? {
+                    type: "service" as const,
+                    name: item.name,
+                    service: parentName,
+                  }
+                : item,
+          ),
+        );
+        let metadataAssets:
+          | workers.CreatePreviewDeploymentMetadata["assets"]
+          | undefined;
+        if (assets) {
+          yield* Effect.logInfo(
+            `Cloudflare Worker Preview: uploading assets for ${parentName}`,
+          );
+          const { jwt } = yield* uploadAssets(
+            accountId,
+            parentName,
+            assets,
+            session,
+          );
+          metadataAssets = {
+            jwt,
+            config: mergeAssetsConfigFiles(assets.config, assets),
+          };
+          metadataBindings.push({ type: "assets", name: "ASSETS" });
+        }
+        appendAlchemyAndEnvBindings(
+          metadataBindings,
+          news,
+          accountId,
+          parentName,
+        );
+
+        const hostedClasses = getDurableObjectBindings(bindings, parentName);
+        const classNames = [...new Set(hostedClasses.map((c) => c.className))];
+        let migrations: unknown = undefined;
+        if (classNames.length > 0) {
+          const latest = yield* workers
+            .getPreviewDeployment({
+              accountId,
+              workerId: parentName,
+              previewId: previewResource.id,
+              deploymentId: "latest",
+            })
+            .pipe(
+              Effect.catchTag(
+                ["PreviewNotFound", "PreviewDeploymentNotFound"],
+                () => Effect.succeed(undefined),
+              ),
+            );
+          const oldTag = latest?.migrationTag ?? undefined;
+          const previous = output?.previewDoClasses ?? [];
+          if (oldTag === undefined) {
+            migrations = {
+              new_tag: "alchemy:v1",
+              new_sqlite_classes: classNames,
+            };
+          } else {
+            const added = classNames.filter((c) => !previous.includes(c));
+            const deleted = previous.filter((c) => !classNames.includes(c));
+            if (added.length > 0 || deleted.length > 0) {
+              migrations = {
+                old_tag: oldTag,
+                new_tag: bumpMigrationTagVersion(oldTag) ?? "alchemy:v1",
+                ...(added.length > 0 ? { new_sqlite_classes: added } : {}),
+                ...(deleted.length > 0 ? { deleted_classes: deleted } : {}),
+              };
+            }
+          }
+        }
+
+        const compatibility = getCompatibility(news);
+        const annotations =
+          preview.message !== undefined || preview.tag !== undefined
+            ? {
+                ...(preview.message !== undefined
+                  ? { "workers/message": preview.message }
+                  : {}),
+                ...(preview.tag !== undefined
+                  ? { "workers/tag": preview.tag }
+                  : {}),
+              }
+            : undefined;
+
+        yield* session.note(
+          `Uploading Preview ${previewName} of ${parentName} ...`,
+          {
+            kind: "status",
+          },
+        );
+        const deployment = yield* workers.createPreviewDeployment({
+          accountId,
+          workerId: parentName,
+          previewId: previewResource.id,
+          metadata: {
+            mainModule: bundle.main!,
+            assets: metadataAssets,
+            compatibilityDate: compatibility.date,
+            compatibilityFlags: compatibility.flags,
+            cacheOptions: news.cache ?? getCacheBinding(bindings),
+            annotations,
+            migrations,
+            env: bindingsToPreviewEnv(metadataBindings),
+          },
+          files: bundle.files,
+        });
+
+        const refreshed = yield* workers
+          .getPreview({
+            accountId,
+            workerId: parentName,
+            previewId: previewResource.id,
+          })
+          .pipe(
+            Effect.catchTag("PreviewNotFound", () =>
+              Effect.succeed(previewResource),
+            ),
+          );
+
+        const urls = [
+          ...new Set([
+            ...(refreshed.urls ?? []),
+            ...constructedUrls,
+            ...(deployment.urls ?? []),
+          ]),
+        ];
+        return {
+          workerId:
+            cachedWorkerId(output?.workerId, parentName) ??
+            (yield* findWorkerId(accountId, parentName)),
+          workerName: parentName,
+          namespace: undefined,
+          logpush: undefined,
+          url: urls[0],
+          urls,
+          domain: undefined,
+          tags: undefined,
+          durableObjectNamespaces: {},
+          accountId,
+          routes: [],
+          crons: [],
+          previewOf: parentName,
+          previewId: previewResource.id,
+          previewName,
+          previewSlug: previewResource.slug,
+          previewDoClasses: classNames.length > 0 ? classNames : undefined,
+          deploymentId: deployment.id,
+          hash,
+        } satisfies Worker["Attributes"];
+      });
+
       const putWorker = Effect.fn(function* (
         id: string,
         fqn: string,
@@ -3926,6 +4343,7 @@ export const LiveWorkerProvider = () =>
             name,
             desiredHostnames,
             domainConfig?.zone,
+            domainConfig?.previews,
           );
           const zoneIdByHostname = new Map([
             ...liveBeforeReconcile,
@@ -4143,19 +4561,25 @@ export const LiveWorkerProvider = () =>
             props.version?.parent != null
               ? (resolveVersionParentName(props.version) ?? output.versionOf)
               : undefined;
+          const previewParent =
+            props.preview?.of != null
+              ? (resolvePreviewParentName(props.preview) ?? output.previewOf)
+              : undefined;
           const selfUrl = hasSelfUrlBinding(bindings)
-            ? versionParent !== undefined
-              ? yield* Effect.gen(function* () {
-                  const alias = yield* resolveVersionAlias(
-                    id,
-                    props,
-                    versionParent,
-                  );
-                  return alias !== undefined
-                    ? `https://${alias}-${versionParent}.${yield* getAccountSubdomain(accountId)}.workers.dev`
-                    : undefined;
-                })
-              : yield* resolveSelfUrl(output.workerName, props, accountId)
+            ? previewParent !== undefined
+              ? output.url
+              : versionParent !== undefined
+                ? yield* Effect.gen(function* () {
+                    const alias = yield* resolveVersionAlias(
+                      id,
+                      props,
+                      versionParent,
+                    );
+                    return alias !== undefined
+                      ? `https://${alias}-${versionParent}.${yield* getAccountSubdomain(accountId)}.workers.dev`
+                      : undefined;
+                  })
+                : yield* resolveSelfUrl(output.workerName, props, accountId)
             : undefined;
           const metadataHash = yield* resolveWorkerMetadataHash({
             props,
@@ -4336,9 +4760,9 @@ export const LiveWorkerProvider = () =>
           if (newNamespace !== oldNamespace) {
             return { action: "replace" };
           }
-          // A version worker (version.parent) and a script-owning Worker are
-          // distinct cloud resources, and a version belongs to exactly one
-          // parent script — switching mode or parent is a replacement.
+          // A version worker (version.parent), a Preview Worker
+          // (preview.of), and a script-owning Worker are distinct cloud
+          // resources — switching mode or parent is a replacement.
           const newIsVersion = news.version?.parent != null;
           const oldIsVersion =
             output?.versionOf !== undefined || olds?.version?.parent != null;
@@ -4349,6 +4773,24 @@ export const LiveWorkerProvider = () =>
             const newParent = resolveVersionParentName(news.version);
             const oldParent =
               output?.versionOf ?? resolveVersionParentName(olds?.version);
+            if (
+              newParent !== undefined &&
+              oldParent !== undefined &&
+              newParent !== oldParent
+            ) {
+              return { action: "replace" };
+            }
+          }
+          const newIsPreview = news.preview?.of != null;
+          const oldIsPreview =
+            output?.previewOf !== undefined || olds?.preview?.of != null;
+          if (newIsPreview !== oldIsPreview) {
+            return { action: "replace" };
+          }
+          if (newIsPreview) {
+            const newParent = resolvePreviewParentName(news.preview);
+            const oldParent =
+              output?.previewOf ?? resolvePreviewParentName(olds?.preview);
             if (
               newParent !== undefined &&
               oldParent !== undefined &&
@@ -4384,6 +4826,7 @@ export const LiveWorkerProvider = () =>
                   d.aliases,
                   [...d.redirects].sort(),
                   d.zone ?? null,
+                  d.previews === true,
                 ]);
           // An omitted `domain` unmanages the surface (#942): reconcile
           // carries previously-observed custom domains forward in state, so
@@ -4562,9 +5005,9 @@ export const LiveWorkerProvider = () =>
           // no placeholder is needed for circular bindings either. (`news`
           // is raw here — `version.parent` may be an unresolved ref, but its
           // *presence* is statically known.)
-          if (news.version?.parent != null) {
+          if (news.version?.parent != null || news.preview?.of != null) {
             yield* Effect.logInfo(
-              `Cloudflare Worker precreate: skipping stub for version worker ${id}`,
+              `Cloudflare Worker precreate: skipping stub for ${news.preview?.of != null ? "Preview" : "version"} worker ${id}`,
             );
             return {
               // Provisional: a version worker resolves its parent's
@@ -4841,6 +5284,23 @@ export const LiveWorkerProvider = () =>
                   ),
                 );
             }
+            if (output?.previewOf !== undefined || olds?.preview?.of != null) {
+              if (output?.previewOf === undefined || !output.previewId) {
+                return undefined;
+              }
+              return yield* workers
+                .getPreview({
+                  accountId,
+                  workerId: output.previewOf,
+                  previewId: output.previewId,
+                })
+                .pipe(
+                  Effect.map(() => output),
+                  Effect.catchTag(["WorkerNotFound", "PreviewNotFound"], () =>
+                    Effect.succeed(undefined),
+                  ),
+                );
+            }
             const workerName =
               output?.workerName ?? (yield* createWorkerName(id, olds?.name));
             const dispatchNamespace =
@@ -5088,11 +5548,28 @@ export const LiveWorkerProvider = () =>
           session,
         }) {
           yield* assertCloudflareTelemetryCompatibility(news, bindings);
+          if (news.preview?.of != null && news.version?.parent != null) {
+            return yield* Effect.fail(
+              new WorkerPreviewConfigError({
+                message: `preview and version cannot be set together. Use preview.of for branch/PR Previews; use version.parent / version.traffic for canaries and gradual rollouts.`,
+              }),
+            );
+          }
           // A version worker uploads an immutable version to its parent's
           // script instead of owning a script of its own — none of the
           // script-level observation below applies.
           if (news.version?.parent != null) {
             return yield* putWorkerVersion(
+              id,
+              fqn,
+              news,
+              bindings,
+              session,
+              output,
+            );
+          }
+          if (news.preview?.of != null) {
+            return yield* putWorkerPreview(
               id,
               fqn,
               news,
@@ -5232,6 +5709,26 @@ export const LiveWorkerProvider = () =>
                 versions: [{ versionId: stable.versionId, percentage: 100 }],
               })
               .pipe(Effect.catchTag("WorkerNotFound", () => Effect.void));
+            return;
+          }
+          if (output.previewOf !== undefined) {
+            const previewId = output.previewId ?? output.previewName;
+            if (!previewId) return;
+            yield* Effect.logInfo(
+              `Cloudflare Worker delete: deleting Preview ${previewId} of ${output.previewOf}`,
+            );
+            yield* workers
+              .deletePreview({
+                accountId: output.accountId,
+                workerId: output.previewOf,
+                previewId,
+              })
+              .pipe(
+                Effect.catchTag(
+                  ["PreviewNotFound", "WorkerNotFound"],
+                  () => Effect.void,
+                ),
+              );
             return;
           }
           yield* Effect.logInfo(

--- a/packages/alchemy/test/Cloudflare/Workers/WorkerPreview.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/WorkerPreview.test.ts
@@ -122,8 +122,8 @@ describe.concurrent("Cloudflare.Worker preview", () => {
               });
               return yield* Cloudflare.Worker("ComboPreview", {
                 script: script("combo-preview"),
-                preview: { of: parent },
-                version: { parent },
+                preview: { of: parent.workerName },
+                version: { parent: parent.workerName },
               });
             }),
           )

--- a/packages/alchemy/test/Cloudflare/Workers/WorkerPreview.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/WorkerPreview.test.ts
@@ -1,0 +1,177 @@
+import { CloudflareEnvironment } from "@/Cloudflare/CloudflareEnvironment";
+import * as Cloudflare from "@/Cloudflare/index.ts";
+import { WorkerPreviewConfigError } from "@/Cloudflare/Workers/WorkerProvider.ts";
+import * as Test from "@/Test/Alchemy";
+import * as workers from "@distilled.cloud/cloudflare/workers";
+import { describe, expect } from "alchemy-test";
+import * as Effect from "effect/Effect";
+import { MinimumLogLevel } from "effect/References";
+import { expectUrlContains } from "../Utils/Http.ts";
+
+const { test } = Test.make({ providers: Cloudflare.providers() });
+
+const logLevel = Effect.provideService(
+  MinimumLogLevel,
+  process.env.DEBUG ? "Debug" : "Info",
+);
+
+const script = (marker: string) =>
+  `export default { fetch() { return new Response("${marker}"); } };`;
+
+describe.concurrent("Cloudflare.Worker preview", () => {
+  test.provider(
+    "preview of a parent worker, updated, then deleted",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const v1 = yield* stack.deploy(
+          Effect.gen(function* () {
+            const parent = yield* Cloudflare.Worker("PreviewParent", {
+              script: script("parent-marker-v1"),
+            });
+            const preview = yield* Cloudflare.Worker("PreviewChild", {
+              script: script("preview-marker-v1"),
+              preview: { of: parent, message: "alchemy preview test" },
+            });
+            return { parent, preview };
+          }),
+        );
+
+        expect(v1.preview.previewOf).toEqual(v1.parent.workerName);
+        expect(v1.preview.workerName).toEqual(v1.parent.workerName);
+        expect(v1.preview.previewId).toBeDefined();
+        expect(v1.preview.previewName).toBeDefined();
+        expect(v1.preview.previewSlug).toBeDefined();
+        expect(v1.preview.deploymentId).toBeDefined();
+        expect(v1.preview.url).toBeDefined();
+        expect(v1.preview.url).toContain(
+          `${v1.preview.previewSlug}-${v1.parent.workerName}.`,
+        );
+        expect(v1.preview.versionOf).toBeUndefined();
+
+        yield* expectUrlContains(v1.parent.url!, "parent-marker-v1", {
+          label: "parent serves its own code",
+        });
+        yield* expectUrlContains(v1.preview.url!, "preview-marker-v1", {
+          label: "Preview URL serves the Preview's code",
+        });
+
+        const v2 = yield* stack.deploy(
+          Effect.gen(function* () {
+            const parent = yield* Cloudflare.Worker("PreviewParent", {
+              script: script("parent-marker-v1"),
+            });
+            const preview = yield* Cloudflare.Worker("PreviewChild", {
+              script: script("preview-marker-v2"),
+              preview: { of: parent },
+            });
+            return { parent, preview };
+          }),
+        );
+
+        expect(v2.preview.previewId).toEqual(v1.preview.previewId);
+        expect(v2.preview.previewName).toEqual(v1.preview.previewName);
+        expect(v2.preview.url).toEqual(v1.preview.url);
+        yield* expectUrlContains(v2.preview.url!, "preview-marker-v2", {
+          label: "updated Preview serves new code at the same URL",
+        });
+        yield* expectUrlContains(v2.parent.url!, "parent-marker-v1", {
+          label: "parent is untouched by the Preview update",
+        });
+
+        yield* stack.destroy();
+
+        const { accountId } = yield* yield* CloudflareEnvironment;
+        const gone = yield* workers
+          .getPreview({
+            accountId,
+            workerId: v1.parent.workerName,
+            previewId: v1.preview.previewId!,
+          })
+          .pipe(
+            Effect.map(() => false),
+            Effect.catchTag("PreviewNotFound", () => Effect.succeed(true)),
+            Effect.catchTag("WorkerNotFound", () => Effect.succeed(true)),
+          );
+        expect(gone).toBe(true);
+      }).pipe(logLevel),
+    { timeout: 240_000 },
+  );
+
+  test.provider(
+    "rejects preview combined with version.parent",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const { parent } = yield* stack.deploy(
+          Effect.gen(function* () {
+            const parent = yield* Cloudflare.Worker("ComboParent", {
+              script: script("combo-parent"),
+            });
+            return { parent };
+          }),
+        );
+
+        const error = yield* stack
+          .deploy(
+            Effect.gen(function* () {
+              yield* Cloudflare.Worker("ComboParent", {
+                script: script("combo-parent"),
+              });
+              return yield* Cloudflare.Worker("ComboPreview", {
+                script: script("combo-preview"),
+                preview: { of: parent },
+                version: { parent },
+              });
+            }),
+          )
+          .pipe(Effect.flip);
+
+        expect(error).toBeInstanceOf(WorkerPreviewConfigError);
+        expect(String(error)).toContain("preview and version cannot be set");
+
+        yield* stack.destroy();
+      }).pipe(logLevel),
+    { timeout: 180_000 },
+  );
+
+  test.provider(
+    "rejects script-level settings on a Preview worker",
+    (stack) =>
+      Effect.gen(function* () {
+        yield* stack.destroy();
+
+        const { parent } = yield* stack.deploy(
+          Effect.gen(function* () {
+            const parent = yield* Cloudflare.Worker("SettingsParent", {
+              script: script("settings-parent"),
+            });
+            return { parent };
+          }),
+        );
+
+        const error = yield* stack
+          .deploy(
+            Effect.gen(function* () {
+              yield* Cloudflare.Worker("SettingsParent", {
+                script: script("settings-parent"),
+              });
+              return yield* Cloudflare.Worker("SettingsPreview", {
+                script: script("settings-preview"),
+                preview: { of: parent.workerName },
+                crons: ["*/5 * * * *"],
+              });
+            }),
+          )
+          .pipe(Effect.flip);
+
+        expect(error).toBeInstanceOf(WorkerPreviewConfigError);
+        expect(String(error)).toContain("script-level settings");
+
+        yield* stack.destroy();
+      }).pipe(logLevel),
+    { timeout: 180_000 },
+  );
+});

--- a/packages/alchemy/test/Cloudflare/Workers/WorkerProvider.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/WorkerProvider.test.ts
@@ -100,6 +100,15 @@ describe("WorkerProvider", () => {
       });
     });
 
+    test("previews: true is preserved", () => {
+      expect(resolve({ name: "app.example.com", previews: true })).toEqual({
+        name: "app.example.com",
+        aliases: [],
+        redirects: [],
+        previews: true,
+      });
+    });
+
     test("object form dedupes and punycodes hostnames", () => {
       expect(
         resolve({

--- a/website/alchemy.run.ts
+++ b/website/alchemy.run.ts
@@ -29,10 +29,10 @@ const Website = Cloudflare.Website.StaticSite(
       command: "bun run build",
       main: "./src/worker.ts",
       outdir: "dist",
-      version: previewParent
+      preview: previewParent
         ? {
-            parent: previewParent,
-            alias: stack.stage,
+            of: previewParent,
+            name: stack.stage,
             message: process.env.PULL_REQUEST
               ? `PR #${process.env.PULL_REQUEST}`
               : undefined,
@@ -41,7 +41,11 @@ const Website = Cloudflare.Website.StaticSite(
       workersDev: stack.stage === "prod" ? false : undefined,
       domain:
         stack.stage === "prod"
-          ? { name: "alchemy.run", redirects: ["v2.alchemy.run"] }
+          ? {
+              name: "alchemy.run",
+              redirects: ["v2.alchemy.run"],
+              previews: true,
+            }
           : stack.stage === "main"
             ? { name: "main.alchemy.run" }
             : undefined,

--- a/website/src/content/docs/cloudflare/compute/gradual-deployments.mdx
+++ b/website/src/content/docs/cloudflare/compute/gradual-deployments.mdx
@@ -9,7 +9,9 @@ a snapshot of code, bindings, and compatibility settings. A
 *deployment* routes traffic across up to two versions by percentage.
 By default alchemy deploys each new version at 100%. The `version`
 prop unlocks the other shapes: gradual rollouts, canaries, and
-traffic-free previews.
+traffic-free version uploads. For branch and pull-request testing,
+use [Worker Previews](/cloudflare/compute/previews) (`preview.of`)
+instead of a zero-traffic version.
 
 ## Roll out a deploy gradually
 
@@ -116,39 +118,34 @@ yield* Cloudflare.Worker("ApiCanary", {
 
 Destroying the canary restores 100% of traffic to the live version.
 
-## Preview versions
+## Upload a version without routing traffic
 
-With `parent` set and no `traffic`, the version receives no traffic.
-It is reachable only at its preview URL. This is the PR-preview
-workflow:
+With `traffic: 0` the version is uploaded and reachable at its Version
+URL, but it is not in the live deployment. Use this to inspect a
+specific upload before a gradual rollout. For branch and pull-request
+testing — isolated Durable Objects, Preview-specific bindings, custom
+domain Preview URLs — use
+[Worker Previews](/cloudflare/compute/previews) (`preview.of`) instead.
 
 ```typescript
-const parent = yield* Cloudflare.Worker.ref("Api", { stage: "staging" });
-
-const preview = yield* Cloudflare.Worker("Api", {
+yield* Cloudflare.Worker("Api", {
   main: "./src/api.ts",
-  version: { parent, message: `PR #${process.env.PR_NUMBER}` },
+  version: { traffic: 0, tag: process.env.GITHUB_SHA },
 });
-
-// https://<alias>-<name>.<subdomain>.workers.dev — stable across
-// re-deploys, always serving the latest uploaded version
-preview.url;
 ```
 
-Alchemy derives the alias from the stack, stage, and logical id
-(override with `version.alias`). The version carries its own bindings,
-so a PR can bind its own KV namespaces, D1 databases, and secrets.
-Preview URLs require the parent's workers.dev subdomain (on by
-default); `workersDev: { enabled: false, previewsEnabled: true }`
-keeps previews working with the stable URL off.
+`version.parent` with no `traffic` still uploads a Version URL of
+another stage's Worker (the previous PR-preview path). Prefer
+`preview.of` for that job going forward.
 
-### Preview version or preview stage?
+### Version, Preview, or stage?
 
-Deploying the stack to its own stage is also a preview, a fully
-independent one, with its own script and its own copies of every
-resource. A preview *version* rides the parent's script, settings, and
-version history, and adds no scripts to the account. Use a stage to
-preview infrastructure changes; use a version to preview code.
+A Preview is a named copy of a Worker with isolated Durable Object
+state. A version rides the parent's script and version history. A
+stage is a fully independent stack. Use a stage to preview
+infrastructure changes; use a Preview to preview code; use a version
+to canary or inspect an upload. See
+[Worker Previews](/cloudflare/compute/previews).
 
 ## Smoke test before shifting traffic
 

--- a/website/src/content/docs/cloudflare/compute/previews.mdx
+++ b/website/src/content/docs/cloudflare/compute/previews.mdx
@@ -1,0 +1,86 @@
+---
+title: Worker Previews
+description: Deploy a branch or pull request as a first-class Preview of another Worker — its own URL, bindings, and isolated Durable Object state, without touching production traffic.
+sidebar:
+  order: 2
+---
+
+A [Worker Preview](https://developers.cloudflare.com/workers/previews/) is
+a named copy of a Worker: own URL, own variables, secrets, and
+bindings, and isolated same-Worker Durable Object (and Container)
+state. The parent's live deployment is untouched.
+
+This is the branch and pull-request path. It is **not** a Worker
+version. Versions are for gradual rollouts and canaries — see
+[Gradual deployments](/cloudflare/compute/gradual-deployments).
+
+## Preview another stage's Worker
+
+```typescript
+const parent = yield* Cloudflare.Worker.ref("Api", { stage: "prod" });
+
+const api = yield* Cloudflare.Worker("Api", {
+  main: "./src/api.ts",
+  preview: {
+    of: parent,
+    message: `PR #${process.env.PR_NUMBER}`,
+  },
+});
+
+// https://<stage>-<worker>.<account>.workers.dev
+api.url;
+```
+
+The Preview name defaults to a DNS-safe form of the stack stage
+(`pr-123`, `feat-login`). Override with `preview.name`. Destroying
+the Preview Worker deletes the Preview; the parent stays up.
+
+Bindings are whatever *this* Worker declares. Point them at staging
+resources, or let a PR stage create its own KV / D1 / R2. Same-Worker
+[Durable Object](/cloudflare/compute/durable-objects) classes are
+isolated automatically — each Preview gets its own namespace, deleted
+with the Preview. Version workers (`version.parent`) cannot host
+Durable Object classes; Previews can.
+
+## Custom-domain Preview URLs
+
+Enable Previews on the **parent** Worker's custom domain:
+
+```typescript
+yield* Cloudflare.Worker("Api", {
+  main: "./src/api.ts",
+  domain: {
+    name: "app.example.com",
+    previews: true,
+  },
+});
+```
+
+A Preview of that Worker is then at
+`https://<preview-name>.app.example.com`, plus a pinned
+`https://<deployment-id>-<preview-name>.app.example.com` per deploy.
+
+Use a dedicated Preview hostname (`previews.example.com`) when
+production already has subdomains, so the wildcard does not collide
+with `docs.example.com`.
+
+## Preview, version, or stage?
+
+| What you want | Use |
+|---|---|
+| Branch / PR with its own URL and isolated DOs | `preview.of` |
+| Canary a percentage of live traffic | `version.parent` + `version.traffic` |
+| Gradual rollout of this Worker | `version.traffic` |
+| Inspect one upload without routing | `version.traffic: 0` |
+| Persistent env, or infra that must be fully isolated (new table, matching service bindings) | A separate Alchemy **stage** |
+
+`preview` and `version.parent` cannot be set together.
+
+Service bindings from a Preview currently resolve to the bound
+Worker's **production** deployment. Crons, queue consumers, and
+production routes stay on production. For an end-to-end multi-Worker
+PR, deploy a full stage instead.
+
+Preview URLs are public. Protect them with
+[Cloudflare Access](/cloudflare/security/access) on the parent
+Worker (`access.previews` stays on by default).

--- a/website/src/content/docs/cloudflare/compute/workers.mdx
+++ b/website/src/content/docs/cloudflare/compute/workers.mdx
@@ -541,10 +541,13 @@ yield* Cloudflare.Worker("Api", {
 });
 ```
 
-Set `version.parent` to upload the code as a preview version or
-canary of another stage's Worker instead. Ramping, rollback, smoke
-testing with version overrides, and pinning users to a version are
-covered in [Gradual deployments](/cloudflare/compute/gradual-deployments).
+Set `preview.of` to deploy this Worker as a
+[Preview](/cloudflare/compute/previews) of another stage's Worker
+(branch and pull-request testing, isolated Durable Objects). Set
+`version.parent` to upload a canary version of another stage's
+Worker. Ramping, rollback, smoke testing with version overrides, and
+pinning users to a version are covered in
+[Gradual deployments](/cloudflare/compute/gradual-deployments).
 
 The `version_metadata` binding tells a running Worker which version
 it is, so responses and logs can say exactly which deploy produced

--- a/website/src/content/docs/cloudflare/networking/custom-domains.mdx
+++ b/website/src/content/docs/cloudflare/networking/custom-domains.mdx
@@ -112,6 +112,12 @@ redirect hostnames never appear there — they serve no content. Their
 redirect rules live in the zone's `http_request_dynamic_redirect`
 phase, which runs before Workers.
 
+Set `previews: true` so [Worker Previews](/cloudflare/compute/previews)
+of this Worker are served at `<preview-name>.api.example.com`. That is
+a parent setting — enable it on the production Worker, not on the
+Preview Worker. Use a dedicated hostname (`previews.example.com`) if
+production already has subdomains, so the wildcard does not collide.
+
 ## Route a hostname pattern to a Worker
 
 Routes are the classic alternative: a zone-level mapping from a URL


### PR DESCRIPTION
Worker Previews as a sibling of `version` — a named copy of another Worker with its own URL, bindings, and isolated Durable Objects. Production traffic is untouched.

```ts
const parent = yield* Cloudflare.Worker.ref("Api", { stage: "prod" });

const api = yield* Cloudflare.Worker("Api", {
  main: "./src/api.ts",
  preview: { of: parent },
});
// api.url → https://<stage>-<worker>.<account>.workers.dev
```

`preview.name` defaults to the stack stage (`pr-123`). Destroying the Preview Worker deletes the Preview; the parent stays up.

Custom-domain Preview URLs are a parent setting:

```ts
domain: { name: "app.example.com", previews: true }
// Preview → https://<preview-name>.app.example.com
```

Same-Worker Durable Object classes are isolated per Preview. Version workers (`version.parent`) still cannot host them.

```ts
preview.of          // branch / PR
version.parent      // canary of another stage
version.traffic     // gradual rollout
version.traffic: 0  // upload without routing
```

`preview` and `version.parent` cannot be set together. Website composites inherit both props via `WorkerProps`.
