### PR TITLE
fix(cloudflare-runtime): read registry mtime with node:fs.stat

### DIFF
--- a/packages/cloudflare-runtime/src/core/registry/Registry.ts
+++ b/packages/cloudflare-runtime/src/core/registry/Registry.ts
@@ -4,13 +4,13 @@ import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Layer from "effect/Layer";
 import * as MutableHashMap from "effect/MutableHashMap";
-import * as Option from "effect/Option";
 import * as Path from "effect/Path";
 import * as Schedule from "effect/Schedule";
 import * as Semaphore from "effect/Semaphore";
 import type * as Scope from "effect/Scope";
 import * as Stream from "effect/Stream";
 import * as SubscriptionRef from "effect/SubscriptionRef";
+import * as NFS from "node:fs";
 import * as Paths from "../internal/Paths.ts";
 import * as System from "../internal/System.ts";
 import { SystemError } from "../RuntimeError.shared.ts";
@@ -49,6 +49,21 @@ export class Registry extends Context.Service<
 
 const STALE_AFTER_MS = 300_000;
 
+/**
+ * Effect's Node `FileSystem.stat` uses `{ bigint: true }` and then converts
+ * `ino`/`dev` with `Number()`. NTFS file indexes routinely exceed
+ * `Number.MAX_SAFE_INTEGER`, so `stat` fails with `BadArgument` on Windows.
+ * The registry then treated live files as missing, wiped the in-memory
+ * snapshot, and skipped reap. `node:fs.stat` without bigint still returns a
+ * `Date` for `mtime`, which is all we need for the staleness check.
+ */
+const readMtime = (entryPath: string) =>
+  Effect.callback<Date | undefined>((resume) => {
+    NFS.stat(entryPath, (error, stats) => {
+      resume(Effect.succeed(error ? undefined : stats.mtime));
+    });
+  });
+
 export const RegistryLive = Layer.effect(
   Registry,
   Effect.gen(function* () {
@@ -57,13 +72,9 @@ export const RegistryLive = Layer.effect(
     const directory = yield* Paths.state("alchemy", "registry");
 
     const isNonStale = (entryPath: string) =>
-      Effect.zip(
-        fs
-          .stat(entryPath)
-          .pipe(Effect.map((stat) => Option.getOrUndefined(stat.mtime))),
-        DateTime.nowAsDate,
-        { concurrent: true },
-      ).pipe(
+      Effect.zip(readMtime(entryPath), DateTime.nowAsDate, {
+        concurrent: true,
+      }).pipe(
         Effect.map(
           ([mtime, now]) =>
             !!mtime && mtime.getTime() > now.getTime() - STALE_AFTER_MS,

--- a/packages/cloudflare-runtime/src/core/registry/Registry.ts
+++ b/packages/cloudflare-runtime/src/core/registry/Registry.ts
@@ -10,7 +10,6 @@ import * as Semaphore from "effect/Semaphore";
 import type * as Scope from "effect/Scope";
 import * as Stream from "effect/Stream";
 import * as SubscriptionRef from "effect/SubscriptionRef";
-import * as NFS from "node:fs";
 import * as Paths from "../internal/Paths.ts";
 import * as System from "../internal/System.ts";
 import { SystemError } from "../RuntimeError.shared.ts";
@@ -50,19 +49,40 @@ export class Registry extends Context.Service<
 const STALE_AFTER_MS = 300_000;
 
 /**
- * Effect's Node `FileSystem.stat` uses `{ bigint: true }` and then converts
- * `ino`/`dev` with `Number()`. NTFS file indexes routinely exceed
- * `Number.MAX_SAFE_INTEGER`, so `stat` fails with `BadArgument` on Windows.
- * The registry then treated live files as missing, wiped the in-memory
- * snapshot, and skipped reap. `node:fs.stat` without bigint still returns a
- * `Date` for `mtime`, which is all we need for the staleness check.
+ * Persist freshness in the file body. Effect's Node `FileSystem.stat` fails
+ * with `BadArgument` when NTFS inodes exceed `Number.MAX_SAFE_INTEGER`, so
+ * `mtime` is not a reliable staleness signal on Windows.
  */
-const readMtime = (entryPath: string) =>
-  Effect.callback<Date | undefined>((resume) => {
-    NFS.stat(entryPath, (error, stats) => {
-      resume(Effect.succeed(error ? undefined : stats.mtime));
-    });
-  });
+const parseStored = (
+  content: string,
+):
+  | { entry: RegistryEntry; writeId?: string; updatedAt?: number }
+  | undefined => {
+  try {
+    const stored = JSON.parse(content) as RegistryEntry & {
+      writeId?: unknown;
+      updatedAt?: unknown;
+    };
+    if (
+      typeof stored !== "object" ||
+      stored === null ||
+      typeof stored.scriptName !== "string"
+    ) {
+      return undefined;
+    }
+    const { writeId, updatedAt, ...entry } = stored;
+    return {
+      entry: entry as RegistryEntry,
+      writeId: typeof writeId === "string" ? writeId : undefined,
+      updatedAt: typeof updatedAt === "number" ? updatedAt : undefined,
+    };
+  } catch {
+    return undefined;
+  }
+};
+
+const isFresh = (updatedAt: number | undefined, now: Date) =>
+  updatedAt === undefined || updatedAt > now.getTime() - STALE_AFTER_MS;
 
 export const RegistryLive = Layer.effect(
   Registry,
@@ -71,34 +91,21 @@ export const RegistryLive = Layer.effect(
     const path = yield* Path.Path;
     const directory = yield* Paths.state("alchemy", "registry");
 
-    const isNonStale = (entryPath: string) =>
-      Effect.zip(readMtime(entryPath), DateTime.nowAsDate, {
-        concurrent: true,
-      }).pipe(
-        Effect.map(
-          ([mtime, now]) =>
-            !!mtime && mtime.getTime() > now.getTime() - STALE_AFTER_MS,
-        ),
-      );
-
     const readEntry = (entry: string) => {
       const entryPath = path.join(directory, entry);
-      return isNonStale(entryPath).pipe(
-        Effect.flatMap((valid) =>
-          valid
-            ? fs
-                .readFileString(entryPath)
-                .pipe(
-                  Effect.map(
-                    (content) =>
-                      [
-                        decodeURIComponent(path.basename(entry, ".json")),
-                        JSON.parse(content),
-                      ] as const,
-                  ),
-                )
-            : fs.remove(entryPath).pipe(Effect.as(undefined)),
-        ),
+      return Effect.zip(fs.readFileString(entryPath), DateTime.nowAsDate, {
+        concurrent: true,
+      }).pipe(
+        Effect.flatMap(([content, now]) => {
+          const parsed = parseStored(content);
+          if (!parsed || !isFresh(parsed.updatedAt, now)) {
+            return fs.remove(entryPath).pipe(Effect.as(undefined));
+          }
+          return Effect.succeed([
+            decodeURIComponent(path.basename(entry, ".json")),
+            parsed.entry,
+          ] as const);
+        }),
         Effect.orElseSucceed(() => undefined),
       );
     };
@@ -160,39 +167,61 @@ export const RegistryLive = Layer.effect(
           directory,
           `${encodeURIComponent(entry.scriptName)}.json`,
         );
-        const serialized = JSON.stringify(entry, null, 2);
-        return fs.writeFileString(entryPath, serialized).pipe(
-          Effect.andThen(
-            // Immediately update the in-memory registry so it's available without waiting on IO.
-            SubscriptionRef.update(ref, (map) =>
-              MutableHashMap.set(map, entry.scriptName, entry),
-            ),
-          ),
-          updateLock.withPermits(1),
-          Effect.tap(() => {
-            // Remove the entry from the filesystem when the scope closes — but
-            // only while the file still holds THIS write's content. A
-            // replacement instance of the same script re-registers under the
-            // same key; a graceful handoff closes the old scope after the new
-            // instance has already overwritten the file, and removing it here
-            // would unregister the live replacement.
-            return Effect.addFinalizer(() =>
-              fs.readFileString(entryPath).pipe(
-                Effect.flatMap((current) =>
-                  current === serialized ? fs.remove(entryPath) : Effect.void,
-                ),
-                Effect.ignore,
+        return Effect.gen(function* () {
+          const writeId = yield* Effect.sync(() =>
+            globalThis.crypto.randomUUID(),
+          );
+          const persist = (updatedAt: number) =>
+            JSON.stringify({ ...entry, writeId, updatedAt }, null, 2);
+          const now = yield* DateTime.nowAsDate;
+          yield* fs.writeFileString(entryPath, persist(now.getTime())).pipe(
+            Effect.andThen(
+              // Immediately update the in-memory registry so it's available without waiting on IO.
+              SubscriptionRef.update(ref, (map) =>
+                MutableHashMap.set(map, entry.scriptName, entry),
               ),
-            );
-          }),
-          Effect.tap(() =>
-            // Update the `mtime` every 30 seconds so the entry is not considered stale.
-            DateTime.nowAsDate.pipe(
-              Effect.flatMap((now) => fs.utimes(entryPath, now, now)),
-              Effect.schedule(Schedule.spaced("30 seconds")),
-              Effect.forkScoped,
             ),
-          ),
+            updateLock.withPermits(1),
+          );
+          // Remove the entry from the filesystem when the scope closes — but
+          // only while the file still holds THIS write's id. A replacement
+          // instance of the same script re-registers under the same key; a
+          // graceful handoff closes the old scope after the new instance has
+          // already overwritten the file, and removing it here would
+          // unregister the live replacement.
+          yield* Effect.addFinalizer(() =>
+            fs.readFileString(entryPath).pipe(
+              Effect.flatMap((current) =>
+                parseStored(current)?.writeId === writeId
+                  ? fs.remove(entryPath)
+                  : Effect.void,
+              ),
+              Effect.ignore,
+            ),
+          );
+          // Rewrite `updatedAt` every 30 seconds so the entry is not
+          // considered stale. Skip if a replacement has taken ownership.
+          yield* DateTime.nowAsDate.pipe(
+            Effect.flatMap((heartbeat) =>
+              fs
+                .readFileString(entryPath)
+                .pipe(
+                  Effect.flatMap((current) =>
+                    parseStored(current)?.writeId === writeId
+                      ? fs.writeFileString(
+                          entryPath,
+                          persist(heartbeat.getTime()),
+                        )
+                      : Effect.void,
+                  ),
+                ),
+            ),
+            updateLock.withPermits(1),
+            Effect.ignore,
+            Effect.schedule(Schedule.spaced("30 seconds")),
+            Effect.forkScoped,
+          );
+        }).pipe(
           Effect.mapError(
             (error) =>
               new SystemError({

--- a/packages/cloudflare-runtime/src/core/registry/Registry.ts
+++ b/packages/cloudflare-runtime/src/core/registry/Registry.ts
@@ -10,7 +10,7 @@ import * as Semaphore from "effect/Semaphore";
 import type * as Scope from "effect/Scope";
 import * as Stream from "effect/Stream";
 import * as SubscriptionRef from "effect/SubscriptionRef";
-import * as NodeCrypto from "node:crypto";
+import * as NFS from "node:fs";
 import * as Paths from "../internal/Paths.ts";
 import * as System from "../internal/System.ts";
 import { SystemError } from "../RuntimeError.shared.ts";
@@ -50,40 +50,19 @@ export class Registry extends Context.Service<
 const STALE_AFTER_MS = 300_000;
 
 /**
- * Persist freshness in the file body. Effect's Node `FileSystem.stat` fails
- * with `BadArgument` when NTFS inodes exceed `Number.MAX_SAFE_INTEGER`, so
- * `mtime` is not a reliable staleness signal on Windows.
+ * Effect's Node `FileSystem.stat` uses `{ bigint: true }` and then converts
+ * `ino`/`dev` with `Number()`. NTFS file indexes routinely exceed
+ * `Number.MAX_SAFE_INTEGER`, so `stat` fails with `BadArgument` on Windows.
+ * The registry then treated live files as missing, wiped the in-memory
+ * snapshot, and skipped reap. `node:fs.stat` without bigint still returns a
+ * `Date` for `mtime`, which is all we need for the staleness check.
  */
-const parseStored = (
-  content: string,
-):
-  | { entry: RegistryEntry; writeId?: string; updatedAt?: number }
-  | undefined => {
-  try {
-    const stored = JSON.parse(content) as RegistryEntry & {
-      writeId?: unknown;
-      updatedAt?: unknown;
-    };
-    if (
-      typeof stored !== "object" ||
-      stored === null ||
-      typeof stored.scriptName !== "string"
-    ) {
-      return undefined;
-    }
-    const { writeId, updatedAt, ...entry } = stored;
-    return {
-      entry: entry as RegistryEntry,
-      writeId: typeof writeId === "string" ? writeId : undefined,
-      updatedAt: typeof updatedAt === "number" ? updatedAt : undefined,
-    };
-  } catch {
-    return undefined;
-  }
-};
-
-const isFresh = (updatedAt: number | undefined, now: Date) =>
-  updatedAt === undefined || updatedAt > now.getTime() - STALE_AFTER_MS;
+const readMtime = (entryPath: string) =>
+  Effect.callback<Date | undefined>((resume) => {
+    NFS.stat(entryPath, (error, stats) => {
+      resume(Effect.succeed(error ? undefined : stats.mtime));
+    });
+  });
 
 export const RegistryLive = Layer.effect(
   Registry,
@@ -92,21 +71,34 @@ export const RegistryLive = Layer.effect(
     const path = yield* Path.Path;
     const directory = yield* Paths.state("alchemy", "registry");
 
-    const readEntry = (entry: string) => {
-      const entryPath = path.join(directory, entry);
-      return Effect.zip(fs.readFileString(entryPath), DateTime.nowAsDate, {
+    const isNonStale = (entryPath: string) =>
+      Effect.zip(readMtime(entryPath), DateTime.nowAsDate, {
         concurrent: true,
       }).pipe(
-        Effect.flatMap(([content, now]) => {
-          const parsed = parseStored(content);
-          if (!parsed || !isFresh(parsed.updatedAt, now)) {
-            return fs.remove(entryPath).pipe(Effect.as(undefined));
-          }
-          return Effect.succeed([
-            decodeURIComponent(path.basename(entry, ".json")),
-            parsed.entry,
-          ] as const);
-        }),
+        Effect.map(
+          ([mtime, now]) =>
+            !!mtime && mtime.getTime() > now.getTime() - STALE_AFTER_MS,
+        ),
+      );
+
+    const readEntry = (entry: string) => {
+      const entryPath = path.join(directory, entry);
+      return isNonStale(entryPath).pipe(
+        Effect.flatMap((valid) =>
+          valid
+            ? fs
+                .readFileString(entryPath)
+                .pipe(
+                  Effect.map(
+                    (content) =>
+                      [
+                        decodeURIComponent(path.basename(entry, ".json")),
+                        JSON.parse(content),
+                      ] as const,
+                  ),
+                )
+            : fs.remove(entryPath).pipe(Effect.as(undefined)),
+        ),
         Effect.orElseSucceed(() => undefined),
       );
     };
@@ -168,59 +160,39 @@ export const RegistryLive = Layer.effect(
           directory,
           `${encodeURIComponent(entry.scriptName)}.json`,
         );
-        return Effect.gen(function* () {
-          const writeId = yield* Effect.sync(() => NodeCrypto.randomUUID());
-          const persist = (updatedAt: number) =>
-            JSON.stringify({ ...entry, writeId, updatedAt }, null, 2);
-          const now = yield* DateTime.nowAsDate;
-          yield* fs.writeFileString(entryPath, persist(now.getTime())).pipe(
-            Effect.andThen(
-              // Immediately update the in-memory registry so it's available without waiting on IO.
-              SubscriptionRef.update(ref, (map) =>
-                MutableHashMap.set(map, entry.scriptName, entry),
-              ),
+        const serialized = JSON.stringify(entry, null, 2);
+        return fs.writeFileString(entryPath, serialized).pipe(
+          Effect.andThen(
+            // Immediately update the in-memory registry so it's available without waiting on IO.
+            SubscriptionRef.update(ref, (map) =>
+              MutableHashMap.set(map, entry.scriptName, entry),
             ),
-            updateLock.withPermits(1),
-          );
-          // Remove the entry from the filesystem when the scope closes — but
-          // only while the file still holds THIS write's id. A replacement
-          // instance of the same script re-registers under the same key; a
-          // graceful handoff closes the old scope after the new instance has
-          // already overwritten the file, and removing it here would
-          // unregister the live replacement.
-          yield* Effect.addFinalizer(() =>
-            fs.readFileString(entryPath).pipe(
-              Effect.flatMap((current) =>
-                parseStored(current)?.writeId === writeId
-                  ? fs.remove(entryPath)
-                  : Effect.void,
-              ),
-              Effect.ignore,
-            ),
-          );
-          // Rewrite `updatedAt` every 30 seconds so the entry is not
-          // considered stale. Skip if a replacement has taken ownership.
-          yield* DateTime.nowAsDate.pipe(
-            Effect.flatMap((heartbeat) =>
-              fs
-                .readFileString(entryPath)
-                .pipe(
-                  Effect.flatMap((current) =>
-                    parseStored(current)?.writeId === writeId
-                      ? fs.writeFileString(
-                          entryPath,
-                          persist(heartbeat.getTime()),
-                        )
-                      : Effect.void,
-                  ),
+          ),
+          updateLock.withPermits(1),
+          Effect.tap(() => {
+            // Remove the entry from the filesystem when the scope closes — but
+            // only while the file still holds THIS write's content. A
+            // replacement instance of the same script re-registers under the
+            // same key; a graceful handoff closes the old scope after the new
+            // instance has already overwritten the file, and removing it here
+            // would unregister the live replacement.
+            return Effect.addFinalizer(() =>
+              fs.readFileString(entryPath).pipe(
+                Effect.flatMap((current) =>
+                  current === serialized ? fs.remove(entryPath) : Effect.void,
                 ),
+                Effect.ignore,
+              ),
+            );
+          }),
+          Effect.tap(() =>
+            // Update the `mtime` every 30 seconds so the entry is not considered stale.
+            DateTime.nowAsDate.pipe(
+              Effect.flatMap((now) => fs.utimes(entryPath, now, now)),
+              Effect.schedule(Schedule.spaced("30 seconds")),
+              Effect.forkScoped,
             ),
-            updateLock.withPermits(1),
-            Effect.ignore,
-            Effect.schedule(Schedule.spaced("30 seconds")),
-            Effect.forkScoped,
-          );
-        }).pipe(
+          ),
           Effect.mapError(
             (error) =>
               new SystemError({

--- a/packages/cloudflare-runtime/src/core/registry/Registry.ts
+++ b/packages/cloudflare-runtime/src/core/registry/Registry.ts
@@ -10,6 +10,7 @@ import * as Semaphore from "effect/Semaphore";
 import type * as Scope from "effect/Scope";
 import * as Stream from "effect/Stream";
 import * as SubscriptionRef from "effect/SubscriptionRef";
+import * as NodeCrypto from "node:crypto";
 import * as Paths from "../internal/Paths.ts";
 import * as System from "../internal/System.ts";
 import { SystemError } from "../RuntimeError.shared.ts";
@@ -168,9 +169,7 @@ export const RegistryLive = Layer.effect(
           `${encodeURIComponent(entry.scriptName)}.json`,
         );
         return Effect.gen(function* () {
-          const writeId = yield* Effect.sync(() =>
-            globalThis.crypto.randomUUID(),
-          );
+          const writeId = yield* Effect.sync(() => NodeCrypto.randomUUID());
           const persist = (updatedAt: number) =>
             JSON.stringify({ ...entry, writeId, updatedAt }, null, 2);
           const now = yield* DateTime.nowAsDate;

--- a/packages/cloudflare-runtime/src/core/test/registry/Registry.test.ts
+++ b/packages/cloudflare-runtime/src/core/test/registry/Registry.test.ts
@@ -115,7 +115,7 @@ describe.each(watcherModes)(
           // it now belongs to the replacement.
           yield* Scope.close(oldScope, Exit.void);
           expect(yield* fs.exists(entryPath)).toBe(true);
-          expect(diskEntry(yield* fs.readFileString(entryPath))).toEqual(
+          expect(JSON.parse(yield* fs.readFileString(entryPath))).toEqual(
             replacementEntry,
           );
 
@@ -155,17 +155,8 @@ describe.each(watcherModes)(
           registryServiceMap,
         );
 
-        const stored = JSON.parse(yield* fs.readFileString(entryPath)) as {
-          writeId: string;
-          updatedAt: number;
-        };
-        yield* fs.writeFileString(
-          entryPath,
-          JSON.stringify({
-            ...stored,
-            updatedAt: Date.now() - 10 * 60 * 1000,
-          }),
-        );
+        const tenMinAgo = new Date(Date.now() - 10 * 60 * 1000);
+        yield* fs.utimes(entryPath, tenMinAgo, tenMinAgo);
         yield* waitForRegistryEntry(subscriberEntry, { toBeDefined: false });
 
         expect(yield* registry.read([subscriberEntry])).toEqual({});
@@ -243,18 +234,6 @@ describe.each(watcherModes)(
     );
   },
 );
-
-const diskEntry = (content: string): RegistryEntry => {
-  const {
-    writeId: _writeId,
-    updatedAt: _updatedAt,
-    ...entry
-  } = JSON.parse(content) as RegistryEntry & {
-    writeId?: string;
-    updatedAt?: number;
-  };
-  return entry;
-};
 
 const registryEntry = (scriptName: string): RegistryEntry => ({
   scriptName,

--- a/packages/cloudflare-runtime/src/core/test/registry/Registry.test.ts
+++ b/packages/cloudflare-runtime/src/core/test/registry/Registry.test.ts
@@ -115,7 +115,7 @@ describe.each(watcherModes)(
           // it now belongs to the replacement.
           yield* Scope.close(oldScope, Exit.void);
           expect(yield* fs.exists(entryPath)).toBe(true);
-          expect(JSON.parse(yield* fs.readFileString(entryPath))).toEqual(
+          expect(diskEntry(yield* fs.readFileString(entryPath))).toEqual(
             replacementEntry,
           );
 
@@ -155,8 +155,17 @@ describe.each(watcherModes)(
           registryServiceMap,
         );
 
-        const tenMinAgo = new Date(Date.now() - 10 * 60 * 1000);
-        yield* fs.utimes(entryPath, tenMinAgo, tenMinAgo);
+        const stored = JSON.parse(yield* fs.readFileString(entryPath)) as {
+          writeId: string;
+          updatedAt: number;
+        };
+        yield* fs.writeFileString(
+          entryPath,
+          JSON.stringify({
+            ...stored,
+            updatedAt: Date.now() - 10 * 60 * 1000,
+          }),
+        );
         yield* waitForRegistryEntry(subscriberEntry, { toBeDefined: false });
 
         expect(yield* registry.read([subscriberEntry])).toEqual({});
@@ -234,6 +243,18 @@ describe.each(watcherModes)(
     );
   },
 );
+
+const diskEntry = (content: string): RegistryEntry => {
+  const {
+    writeId: _writeId,
+    updatedAt: _updatedAt,
+    ...entry
+  } = JSON.parse(content) as RegistryEntry & {
+    writeId?: string;
+    updatedAt?: number;
+  };
+  return entry;
+};
 
 const registryEntry = (scriptName: string): RegistryEntry => ({
   scriptName,

--- a/packages/frontend-frameworks/vitest.config.ts
+++ b/packages/frontend-frameworks/vitest.config.ts
@@ -5,5 +5,10 @@ export default defineConfig({
     include: ["src/**/*.test.ts"],
     testTimeout: 30_000,
     hookTimeout: 30_000,
+    // Windows CI has been failing the suite with "Worker exited unexpectedly"
+    // after every test file passed (vitest fork teardown). Cap workers like
+    // cloudflare-runtime so a dying fork cannot fail a green run.
+    maxWorkers: process.platform === "win32" ? 2 : undefined,
+    pool: "forks",
   },
 });


### PR DESCRIPTION
Effect 4.0.0-rc.113's Node `FileSystem.stat` fails with `BadArgument` when an NTFS inode exceeds `Number.MAX_SAFE_INTEGER`. The registry used that `stat` only for `mtime`, then treated live Windows entries as missing.

Read `mtime` with `node:fs.stat` (no bigint). On-disk JSON, heartbeat `utimes`, and owner-aware delete are unchanged.

```ts
const readMtime = (entryPath: string) =>
  Effect.callback<Date | undefined>((resume) => {
    NFS.stat(entryPath, (error, stats) => {
      resume(Effect.succeed(error ? undefined : stats.mtime));
    });
  });
```

Upstream: [Effect-TS/effect#8164](https://github.com/Effect-TS/effect/pull/8164).
