### PR TITLE
fix(cloudflare/worker): restore request URL through trusted proxy

### DIFF
--- a/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
@@ -842,6 +842,7 @@ export const LocalWorkerProvider = () =>
                   runtime
                     .start({
                       name: worker.name,
+                      proxySharedSecret: proxy.proxySharedSecret,
                       logging: {
                         // `(chunk, stream)` — chunk first; the stream name
                         // indexes the splitters directly.

--- a/packages/cloudflare-runtime/src/core/RuntimeWorker.ts
+++ b/packages/cloudflare-runtime/src/core/RuntimeWorker.ts
@@ -7,6 +7,7 @@ import type { OutputSink } from "./workerd/Workerd.ts";
 
 export interface RuntimeWorker<B extends BindingHooks = BindingHooks> {
   readonly name: string;
+  readonly proxySharedSecret?: string;
   readonly compatibilityDate: string;
   readonly compatibilityFlags: Array<string>;
   readonly bindings: B;

--- a/packages/cloudflare-runtime/src/core/globals/Globals.ts
+++ b/packages/cloudflare-runtime/src/core/globals/Globals.ts
@@ -21,6 +21,7 @@ import * as Plugin from "../Plugin.ts";
 import { PluginContext } from "../PluginContext.ts";
 import { ConfigError } from "../RuntimeError.shared.ts";
 import type * as WorkerdConfig from "../workerd/Config.ts";
+import { BINDING_PROXY_SHARED_SECRET } from "../proxy/ProxyHeaders.shared.ts";
 import * as Cf from "./Cf.ts";
 import {
   BINDING_EMAIL_DIRECTORY,
@@ -165,6 +166,10 @@ export const GlobalsLive = Layer.effect(
                 modules,
                 bindings: [
                   { name: "CF_BLOB", json: JSON.stringify(blob) },
+                  {
+                    name: BINDING_PROXY_SHARED_SECRET,
+                    text: worker.proxySharedSecret ?? "",
+                  },
                   // Non-fetch dispatch (queue/scheduled/email JSRPC) goes
                   // straight to the raw user worker: the `USER_WORKER`
                   // upstream binding points at the next middleware in the

--- a/packages/cloudflare-runtime/src/core/globals/entry.worker.ts
+++ b/packages/cloudflare-runtime/src/core/globals/entry.worker.ts
@@ -22,7 +22,14 @@ import {
   PATH_SCHEDULED_LEGACY,
 } from "./ScheduledOptions.shared.ts";
 
+import {
+  BINDING_PROXY_SHARED_SECRET,
+  HEADER_ORIGINAL_URL,
+  HEADER_PROXY_SHARED_SECRET,
+} from "../proxy/ProxyHeaders.shared.ts";
+
 interface Env {
+  [BINDING_PROXY_SHARED_SECRET]: string;
   /**
    * Head of the fetch middleware chain (the next middleware after the entry,
    * or the raw user worker when no downstream middleware exists). Fetch-only.
@@ -420,7 +427,19 @@ async function handleEmail(
 
 export default <ExportedHandler<Env>>{
   async fetch(request, env) {
-    const url = new URL(request.url);
+    // The proxy connects to a private runtime address. Only a trusted proxy
+    // may restore the client-facing URL and Host (matching Miniflare).
+    let url = new URL(request.url);
+    const secret = request.headers.get(HEADER_PROXY_SHARED_SECRET);
+    if (secret !== null) {
+      if (!secret || secret !== env[BINDING_PROXY_SHARED_SECRET]) {
+        return new Response("Invalid proxy shared secret", { status: 400 });
+      }
+      const originalUrl = request.headers.get(HEADER_ORIGINAL_URL);
+      if (originalUrl !== null) {
+        url = new URL(originalUrl);
+      }
+    }
     if (url.pathname === "/cdn-cgi/handler/queue") {
       try {
         const json = await request.json<EntryQueuePayload>();
@@ -528,6 +547,9 @@ export default <ExportedHandler<Env>>{
 
     const headers = new Headers(request.headers);
     headers.delete(HEADER_CF_BLOB);
+    headers.delete(HEADER_ORIGINAL_URL);
+    headers.delete(HEADER_PROXY_SHARED_SECRET);
+    if (secret !== null) headers.set("Host", url.host);
     if (clientIp && !headers.get("CF-Connecting-IP")) {
       // `clientIp` includes the port, e.g. `127.0.0.1:52621` or `[::1]:52621`
       const ipv4Regex = /(?<ip>.*?):\d+/;
@@ -542,10 +564,13 @@ export default <ExportedHandler<Env>>{
 
     // The experimental and standard workers-types `Request` generics
     // disagree; at runtime these are the same class.
-    const userRequest = new Request(request as unknown as Request, {
-      headers,
-      cf,
-    });
+    const userRequest = new Request(
+      new Request(url, request as unknown as Request),
+      {
+        headers,
+        cf,
+      },
+    );
     return await env.USER_WORKER.fetch(
       userRequest as unknown as typeof request,
     );

--- a/packages/cloudflare-runtime/src/core/proxy/ProxyHeaders.shared.ts
+++ b/packages/cloudflare-runtime/src/core/proxy/ProxyHeaders.shared.ts
@@ -1,0 +1,3 @@
+export const HEADER_ORIGINAL_URL = "Alchemy-Runtime-Original-URL";
+export const HEADER_PROXY_SHARED_SECRET = "Alchemy-Runtime-Proxy-Shared-Secret";
+export const BINDING_PROXY_SHARED_SECRET = "PROXY_SHARED_SECRET";

--- a/packages/cloudflare-runtime/src/core/proxy/WorkerProxy.ts
+++ b/packages/cloudflare-runtime/src/core/proxy/WorkerProxy.ts
@@ -10,6 +10,7 @@ const ProxyWorker = {
       "#cloudflare-runtime-core-worker/proxy/WorkerProxy.worker",
     ),
 };
+import { BINDING_PROXY_SHARED_SECRET } from "./ProxyHeaders.shared.ts";
 import * as Internet from "../globals/Internet.ts";
 import { DEFAULT_COMPATIBILITY_DATE } from "../internal/constants.ts";
 import { formatInternalWorkerModules } from "../internal/internal-modules.ts";
@@ -50,6 +51,7 @@ export interface ServeOptions {
 const MAX_SERVE_ATTEMPTS = 8;
 
 export interface WorkerProxyInstance {
+  readonly proxySharedSecret: string;
   readonly url: URL;
   readonly set: (upstream: URL) => Effect.Effect<void, SystemError>;
   readonly unset: () => Effect.Effect<void, SystemError>;
@@ -105,6 +107,7 @@ export const WorkerProxyLive = Layer.effect(
         // served verbatim.
         ipv6: options.host === undefined && ipv6Loopback,
         token: crypto.randomUUID(),
+        proxySharedSecret: crypto.randomUUID(),
       };
     });
     type ResolvedOptions = Effect.Success<ReturnType<typeof normalizeOptions>>;
@@ -114,7 +117,13 @@ export const WorkerProxyLive = Layer.effect(
       formatInternalWorkerModules,
     );
 
-    const serve = ({ host, port, token, ipv6 }: ResolvedOptions) =>
+    const serve = ({
+      host,
+      port,
+      token,
+      ipv6,
+      proxySharedSecret,
+    }: ResolvedOptions) =>
       workerd
         .serve({
           sockets: [
@@ -149,6 +158,10 @@ export const WorkerProxyLive = Layer.effect(
                     durableObjectNamespace: { className: "WorkerProxy" },
                   },
                   { name: "PROXY_TOKEN", text: token },
+                  {
+                    name: BINDING_PROXY_SHARED_SECRET,
+                    text: proxySharedSecret,
+                  },
                 ],
                 durableObjectNamespaces: [
                   {
@@ -210,6 +223,7 @@ export const WorkerProxyLive = Layer.effect(
         }
         return {
           url,
+          proxySharedSecret: resolved.proxySharedSecret,
           set: Effect.fn("WorkerProxyInstance.set")(function* (upstream) {
             const response = yield* Effect.promise(() =>
               fetch(new URL("/cdn-cgi/proxy/controller", url), {

--- a/packages/cloudflare-runtime/src/core/proxy/WorkerProxy.worker.ts
+++ b/packages/cloudflare-runtime/src/core/proxy/WorkerProxy.worker.ts
@@ -1,7 +1,14 @@
 import { DurableObject } from "cloudflare:workers";
 import * as Schema from "effect/Schema";
 
+import {
+  BINDING_PROXY_SHARED_SECRET,
+  HEADER_ORIGINAL_URL,
+  HEADER_PROXY_SHARED_SECRET,
+} from "./ProxyHeaders.shared.ts";
+
 interface Env {
+  [BINDING_PROXY_SHARED_SECRET]: string;
   PROXY: ColoLocalActorNamespace;
   PROXY_TOKEN: string;
 }
@@ -103,6 +110,11 @@ export class WorkerProxy extends DurableObject<Env> {
       proxied.pathname = original.pathname;
       proxied.search = original.search;
       const headers = new Headers(request.headers);
+      headers.set(HEADER_ORIGINAL_URL, original.href);
+      headers.set(
+        HEADER_PROXY_SHARED_SECRET,
+        this.env[BINDING_PROXY_SHARED_SECRET],
+      );
       headers.set("x-forwarded-host", original.host);
       headers.set("x-forwarded-proto", original.protocol.replace(/:$/, ""));
       return await fetch(proxied, {

--- a/packages/cloudflare-runtime/src/core/test/proxy/RequestUrl.test.ts
+++ b/packages/cloudflare-runtime/src/core/test/proxy/RequestUrl.test.ts
@@ -1,0 +1,100 @@
+import { expect, layer } from "@effect/vitest";
+import * as Effect from "effect/Effect";
+import * as WorkerProxy from "../../proxy/WorkerProxy.ts";
+import {
+  HEADER_ORIGINAL_URL,
+  HEADER_PROXY_SHARED_SECRET,
+} from "../../proxy/ProxyHeaders.shared.ts";
+import { localRuntimeLayer, startTestWorker } from "../helpers/runtime.ts";
+
+layer(localRuntimeLayer, { excludeTestServices: true })((it) => {
+  it.effect(
+    "preserves the proxy URL, Host, body and path across runtime restarts",
+    () =>
+      Effect.gen(function* () {
+        const proxy = yield* WorkerProxy.WorkerProxy;
+        const instance = yield* proxy.serve();
+        const otherInstance = yield* proxy.serve();
+        expect(instance.proxySharedSecret).not.toBe(
+          otherInstance.proxySharedSecret,
+        );
+        for (const name of ["first", "replacement"]) {
+          const worker = yield* startTestWorker({
+            name,
+            proxySharedSecret: instance.proxySharedSecret,
+            compatibilityDate: "2026-03-10",
+            compatibilityFlags: [],
+            bindings: [],
+            modules: [
+              {
+                name: "main.js",
+                type: "ESModule",
+                content: `
+            export default { async fetch(request) {
+              return Response.json({ url: request.url, host: request.headers.get("host"),
+                body: await request.text(),
+                original: request.headers.get("Alchemy-Runtime-Original-URL"),
+                secret: request.headers.get("Alchemy-Runtime-Proxy-Shared-Secret") });
+            } };`,
+              },
+            ],
+          });
+          yield* instance.set(worker.baseUrl);
+          const url = new URL(instance.url);
+          url.pathname = "//callback/%2F";
+          url.search = "?return=%2Fhome&x=1&x=2";
+          const result = yield* Effect.promise(() =>
+            fetch(url, {
+              method: "POST",
+              body: "hello",
+              headers: {
+                [HEADER_ORIGINAL_URL]: "https://forged.example/",
+                [HEADER_PROXY_SHARED_SECRET]: "forged",
+              },
+            }).then((res) => res.json()),
+          );
+          expect(result).toEqual({
+            url: url.href,
+            host: url.host,
+            body: "hello",
+            original: null,
+            secret: null,
+          });
+
+          const direct = yield* worker.fetchJson("/direct", {
+            headers: { [HEADER_ORIGINAL_URL]: "https://forged.example/" },
+          });
+          expect(direct).toMatchObject({
+            url: new URL("/direct", worker.baseUrl).href,
+            original: null,
+            secret: null,
+          });
+          const trusted = yield* worker.fetchJson("/callback", {
+            headers: {
+              [HEADER_ORIGINAL_URL]: "https://public.example:8443/callback?x=1",
+              [HEADER_PROXY_SHARED_SECRET]: instance.proxySharedSecret,
+            },
+          });
+          expect(trusted).toMatchObject({
+            url: "https://public.example:8443/callback?x=1",
+            host: "public.example:8443",
+            original: null,
+            secret: null,
+          });
+          const forged = yield* worker.fetch("/direct", {
+            headers: {
+              [HEADER_ORIGINAL_URL]: "https://forged.example/",
+              [HEADER_PROXY_SHARED_SECRET]: "forged",
+            },
+          });
+          expect(forged.status).toBe(400);
+          const otherProxy = yield* worker.fetch("/direct", {
+            headers: {
+              [HEADER_PROXY_SHARED_SECRET]: otherInstance.proxySharedSecret,
+            },
+          });
+          expect(otherProxy.status).toBe(400);
+        }
+      }),
+  );
+});

--- a/packages/cloudflare-runtime/src/internal/build-tools/RuntimeSubpathExportPlugin.ts
+++ b/packages/cloudflare-runtime/src/internal/build-tools/RuntimeSubpathExportPlugin.ts
@@ -31,6 +31,10 @@ export const RuntimeSubpathExportPlugin = (): rolldown.Plugin => ({
     }
 
     const [, component, modulePath] = match;
+    // Wire constants are internal and safe to inline in the Vite bundle.
+    if (component === "core" && modulePath === "proxy/ProxyHeaders.shared") {
+      return;
+    }
     const subpath =
       modulePath === "index"
         ? component

--- a/packages/cloudflare-runtime/src/vite/dev-plugin.ts
+++ b/packages/cloudflare-runtime/src/vite/dev-plugin.ts
@@ -16,7 +16,7 @@ import * as vite from "vite";
 import { DistilledDevEnvironment } from "./dev-environment.ts";
 import type { ServerHandle } from "./dev-server.ts";
 import { configuredExportTypes, mergeExportTypes } from "./export-types.ts";
-import { resolveForwardedHost } from "./forwarded-host.ts";
+import { proxyRequestHeaders } from "./forwarded-host.ts";
 import type { CloudflareVitePluginOptions } from "./plugin.ts";
 import { handleWebSocket } from "./websockets.ts";
 
@@ -160,11 +160,12 @@ export function dev(options: CloudflareVitePluginOptions): Array<vite.Plugin> {
       );
       await connect(handle.address);
       let address = handle.address;
+      let proxySharedSecret = handle.proxySharedSecret;
 
       const bindWebSocket = () => {
         removeUpgradeListener?.();
         removeUpgradeListener = server.httpServer
-          ? handleWebSocket(server.httpServer, address)
+          ? handleWebSocket(server.httpServer, address, proxySharedSecret)
           : undefined;
       };
 
@@ -185,6 +186,7 @@ export function dev(options: CloudflareVitePluginOptions): Array<vite.Plugin> {
         );
         await connect(handle.address);
         address = handle.address;
+        proxySharedSecret = handle.proxySharedSecret;
         bindWebSocket();
       };
 
@@ -258,10 +260,7 @@ export function dev(options: CloudflareVitePluginOptions): Array<vite.Plugin> {
             );
             const request = NodeHttp.request(url, {
               method: req.method,
-              headers: {
-                ...req.headers,
-                host: resolveForwardedHost(req.headers, url.host),
-              },
+              headers: proxyRequestHeaders(req, url, proxySharedSecret),
             });
             req.pipe(request);
             request.on("response", (response) => {

--- a/packages/cloudflare-runtime/src/vite/dev-server.ts
+++ b/packages/cloudflare-runtime/src/vite/dev-server.ts
@@ -53,11 +53,13 @@ export const startServer = async <B extends BindingHooks = BindingHooks>(
   exportTypes: ExportTypes,
 ) => {
   const scope = Scope.makeUnsafe();
+  const proxySharedSecret = crypto.randomUUID();
   const address = await serve(
     options,
     entryEnvironment,
     server,
     exportTypes,
+    proxySharedSecret,
   ).pipe(
     // `provideMerge`: the assets layer's construction reads `Loopback` (and
     // friends) from the runtime context, so the context must feed the layer,
@@ -72,6 +74,7 @@ export const startServer = async <B extends BindingHooks = BindingHooks>(
   );
   return {
     address,
+    proxySharedSecret,
     close: () => closeScope(scope),
   };
 };
@@ -195,6 +198,7 @@ const serve = Effect.fn(function* <B extends BindingHooks = BindingHooks>(
   entryEnvironment: Omit<EntryEnvironment, "exportTypesId">,
   server: vite.ViteDevServer,
   exportTypes: ExportTypes,
+  proxySharedSecret: string,
 ) {
   const runtime = yield* Runtime.Runtime;
   const moduleFallback = yield* makeModuleFallbackService;
@@ -202,6 +206,7 @@ const serve = Effect.fn(function* <B extends BindingHooks = BindingHooks>(
   const name = options.worker?.name ?? `vite-dev-${crypto.randomUUID()}`;
   return yield* runtime.start({
     name,
+    proxySharedSecret,
     modules: yield* Effect.promise(() => makeWorkerModules(exportTypes)),
     compatibilityDate: options.compatibilityDate ?? DEFAULT_COMPATIBILITY_DATE,
     compatibilityFlags: options.compatibilityFlags ?? [],

--- a/packages/cloudflare-runtime/src/vite/forwarded-host.ts
+++ b/packages/cloudflare-runtime/src/vite/forwarded-host.ts
@@ -1,3 +1,9 @@
+import {
+  HEADER_ORIGINAL_URL,
+  HEADER_PROXY_SHARED_SECRET,
+} from "../core/proxy/ProxyHeaders.shared.ts";
+import type { IncomingMessage } from "node:http";
+import type { TLSSocket } from "node:tls";
 import type { IncomingHttpHeaders } from "node:http";
 
 /**
@@ -27,4 +33,28 @@ function firstHeaderValue(
   const raw = Array.isArray(value) ? value[0] : value;
   const first = raw?.split(",")[0]?.trim();
   return first ? first : undefined;
+}
+
+/** Sign the client-facing URL for the runtime entry worker, including TLS termination. */
+export function proxyRequestHeaders(
+  request: IncomingMessage,
+  target: URL,
+  proxySharedSecret: string,
+): IncomingHttpHeaders {
+  const original = new URL(target);
+  const protocol = firstHeaderValue(request.headers["x-forwarded-proto"]);
+  original.protocol =
+    protocol === "https" || protocol === "http"
+      ? `${protocol}:`
+      : (request.socket as TLSSocket).encrypted
+        ? "https:"
+        : "http:";
+  original.port = "";
+  original.host = resolveForwardedHost(request.headers, target.host);
+  return {
+    ...request.headers,
+    host: original.host,
+    [HEADER_ORIGINAL_URL.toLowerCase()]: original.href,
+    [HEADER_PROXY_SHARED_SECRET.toLowerCase()]: proxySharedSecret,
+  };
 }

--- a/packages/cloudflare-runtime/src/vite/preview-plugin.ts
+++ b/packages/cloudflare-runtime/src/vite/preview-plugin.ts
@@ -6,7 +6,7 @@ import * as NodeHttp from "node:http";
 import * as NodePath from "node:path";
 import { URL as NodeURL } from "node:url";
 import type * as vite from "vite";
-import { resolveForwardedHost } from "./forwarded-host.ts";
+import { proxyRequestHeaders } from "./forwarded-host.ts";
 import type { CloudflareVitePluginOptions } from "./plugin.ts";
 import { handleWebSocket } from "./websockets.ts";
 
@@ -82,7 +82,7 @@ export function preview(options: CloudflareVitePluginOptions): vite.Plugin {
       });
       const address = handle.address;
       const removeUpgradeListener = server.httpServer
-        ? handleWebSocket(server.httpServer, address)
+        ? handleWebSocket(server.httpServer, address, handle.proxySharedSecret)
         : undefined;
       const close = server.close.bind(server);
       server.close = async () => {
@@ -99,10 +99,7 @@ export function preview(options: CloudflareVitePluginOptions): vite.Plugin {
           const url = new NodeURL(req.url ?? "/", address.toString());
           const request = NodeHttp.request(url, {
             method: req.method,
-            headers: {
-              ...req.headers,
-              host: resolveForwardedHost(req.headers, url.host),
-            },
+            headers: proxyRequestHeaders(req, url, handle.proxySharedSecret),
           });
           req.pipe(request);
           request.on("response", (response) => {

--- a/packages/cloudflare-runtime/src/vite/preview-server.ts
+++ b/packages/cloudflare-runtime/src/vite/preview-server.ts
@@ -35,6 +35,7 @@ export interface PreviewWorkerBuild {
 
 export interface PreviewServerHandle {
   readonly address: URL;
+  readonly proxySharedSecret: string;
   readonly close: () => Promise<void>;
 }
 
@@ -58,6 +59,7 @@ export const startPreviewServer = async <B extends BindingHooks = BindingHooks>(
   build: PreviewWorkerBuild,
 ): Promise<PreviewServerHandle> => {
   const scope = Scope.makeUnsafe();
+  const proxySharedSecret = crypto.randomUUID();
   // Only sweep handles for a context we build (and tear down) ourselves; a
   // caller-provided context is process-lifetime by design (dev semantics).
   const sweep = options.context === undefined ? makeHandleSweep() : undefined;
@@ -68,13 +70,14 @@ export const startPreviewServer = async <B extends BindingHooks = BindingHooks>(
         Layer.buildWithScope(scope),
         Effect.runPromise,
       ));
-    const address = await serve(options, build).pipe(
+    const address = await serve(options, build, proxySharedSecret).pipe(
       Effect.provide(context),
       Scope.provide(scope),
       Effect.runPromise,
     );
     return {
       address,
+      proxySharedSecret,
       close: async () => {
         await closeScope(scope);
         sweep?.();
@@ -151,6 +154,7 @@ const closeScope = async (scope: Scope.Scope) => {
 const serve = Effect.fn(function* (
   options: CloudflareVitePluginOptions,
   build: PreviewWorkerBuild,
+  proxySharedSecret: string,
 ) {
   const runtime = yield* Runtime.Runtime;
   const modules = yield* Effect.promise(() => readWorkerModules(build));
@@ -159,6 +163,7 @@ const serve = Effect.fn(function* (
   return yield* runtime.start({
     name: options.worker?.name ?? `vite-preview-${crypto.randomUUID()}`,
     modules,
+    proxySharedSecret,
     compatibilityDate: options.compatibilityDate ?? DEFAULT_COMPATIBILITY_DATE,
     compatibilityFlags: options.compatibilityFlags ?? [],
     bindings: options.worker?.bindings ?? [],

--- a/packages/cloudflare-runtime/src/vite/test/dev-plugin.test.ts
+++ b/packages/cloudflare-runtime/src/vite/test/dev-plugin.test.ts
@@ -16,6 +16,7 @@ vi.mock("../dev-server.ts", () => ({
   createDefaultContext: async () => ({}),
   startServer: async () => ({
     address: runtimeAddress,
+    proxySharedSecret: "dev-secret",
     close: async () => {},
   }),
 }));

--- a/packages/cloudflare-runtime/src/vite/test/forwarded-host.test.ts
+++ b/packages/cloudflare-runtime/src/vite/test/forwarded-host.test.ts
@@ -1,4 +1,8 @@
-import { resolveForwardedHost } from "../forwarded-host.ts";
+import type { IncomingMessage } from "node:http";
+import {
+  proxyRequestHeaders,
+  resolveForwardedHost,
+} from "../forwarded-host.ts";
 import { describe, expect, test } from "vitest";
 
 describe("resolveForwardedHost", () => {
@@ -41,4 +45,45 @@ describe("resolveForwardedHost", () => {
     ).toBe("localhost:5173");
     expect(resolveForwardedHost({}, "127.0.0.1:9999")).toBe("127.0.0.1:9999");
   });
+});
+
+describe("proxyRequestHeaders", () => {
+  const proxySharedSecret = "server-instance-secret";
+  test.each([
+    [{ host: "localhost:5173" }, false, "http://localhost:5173"],
+    [{ host: "localhost:5173" }, true, "https://localhost:5173"],
+    [{ host: "localhost:80" }, true, "https://localhost:80"],
+    [
+      {
+        host: "localhost:5173",
+        "x-forwarded-host": "public.example, proxy.internal",
+        "x-forwarded-proto": "https, http",
+      },
+      false,
+      "https://public.example",
+    ],
+  ])(
+    "signs the original URL including protocol and port",
+    (headers, encrypted, origin) => {
+      const result = proxyRequestHeaders(
+        {
+          headers: {
+            ...headers,
+            "alchemy-runtime-original-url": "https://forged.example/",
+            "alchemy-runtime-proxy-shared-secret": "forged",
+          },
+          socket: { encrypted },
+        } as unknown as IncomingMessage,
+        new URL("http://127.0.0.1:9999//callback/%2F?x=1&x=2"),
+        proxySharedSecret,
+      );
+      expect(result["alchemy-runtime-original-url"]).toBe(
+        `${origin}//callback/%2F?x=1&x=2`,
+      );
+      expect(result.host).toBe(new URL(origin).host);
+      expect(result["alchemy-runtime-proxy-shared-secret"]).toBe(
+        proxySharedSecret,
+      );
+    },
+  );
 });

--- a/packages/cloudflare-runtime/src/vite/test/preview-plugin.test.ts
+++ b/packages/cloudflare-runtime/src/vite/test/preview-plugin.test.ts
@@ -27,6 +27,7 @@ vi.mock("../preview-server.ts", () => ({
     startedBuilds.push(build);
     return {
       address: new URL(runtimeAddress),
+      proxySharedSecret: "preview-secret",
       close: async () => {
         closed += 1;
       },

--- a/packages/cloudflare-runtime/src/vite/test/websockets.test.ts
+++ b/packages/cloudflare-runtime/src/vite/test/websockets.test.ts
@@ -71,6 +71,7 @@ const setup = async (): Promise<Harness> => {
   const removeListener = handleWebSocket(
     clientServer,
     `http://127.0.0.1:${upstreamPort}`,
+    "websocket-secret",
   );
   const clientPort = await listen(clientServer);
 
@@ -101,6 +102,7 @@ const makeFakeRequest = (overrides: {
   return Object.assign(readable, {
     url: overrides.url ?? "/",
     method: "GET",
+    socket: {},
     headers: {
       host: overrides.host,
       upgrade: "websocket",
@@ -305,6 +307,7 @@ describe("handleWebSocket", () => {
     const remove = handleWebSocket(
       server,
       `http://127.0.0.1:${harness.upstreamPort}`,
+      "websocket-secret",
     );
     expect(server.listenerCount("upgrade")).toBe(1);
     remove();

--- a/packages/cloudflare-runtime/src/vite/websockets.ts
+++ b/packages/cloudflare-runtime/src/vite/websockets.ts
@@ -2,7 +2,7 @@ import * as NodeHttp from "node:http";
 import type { IncomingMessage } from "node:http";
 import type { Duplex } from "node:stream";
 import type * as vite from "vite";
-import { resolveForwardedHost } from "./forwarded-host.ts";
+import { proxyRequestHeaders, resolveForwardedHost } from "./forwarded-host.ts";
 
 /**
  * Handles 'upgrade' requests on the Vite HTTP server and forwards the
@@ -13,6 +13,7 @@ import { resolveForwardedHost } from "./forwarded-host.ts";
 export function handleWebSocket(
   httpServer: vite.HttpServer,
   address: string | URL,
+  proxySharedSecret: string,
 ): () => void {
   const upstreamBase = typeof address === "string" ? new URL(address) : address;
 
@@ -60,7 +61,7 @@ export function handleWebSocket(
       method: request.method,
       // Forward the client-facing host so the worker sees the URL the client
       // requested rather than the local workerd address.
-      headers: { ...request.headers, host: url.host },
+      headers: proxyRequestHeaders(request, url, proxySharedSecret),
     });
 
     const cleanup = () => {


### PR DESCRIPTION
### Before
<img width="1356" height="721" alt="Screenshot 2026-09-10 at 19-55-50" src="https://github.com/user-attachments/assets/970f6e2f-242e-4dd9-9297-c859b0813000" />

### After
<img width="1970" height="1192" alt="Screenshot 2026-09-10 at 19-51-48" src="https://github.com/user-attachments/assets/9f212ad3-c111-4ba2-8d57-d4dc6cc95259" />

## Summary
- Restore client-facing request URLs and hosts when proxying to local Workers.
- Authenticate proxy URL headers with per-instance shared secrets.
- Cover dev, preview, WebSocket, and runtime request handling with tests.
