### PR TITLE
chore(test): forward interrupts to example CLI children

### DIFF
--- a/packages/alchemy-test/src/DevCli.ts
+++ b/packages/alchemy-test/src/DevCli.ts
@@ -1,4 +1,4 @@
-import { spawn, spawnSync } from "node:child_process";
+import { spawn, spawnSync, type ChildProcess } from "node:child_process";
 import * as path from "node:path";
 
 export type PollOptions = {
@@ -143,6 +143,7 @@ export class DevCli {
       },
     );
     this.#process = child;
+    forwardSignals(child);
     const capture = (chunk: Buffer) => {
       const text = chunk.toString();
       this.#output += text;
@@ -236,3 +237,28 @@ export class DevCli {
     }
   }
 }
+
+/** Forward Ctrl-C to a detached CLI and let it finish its own cleanup. */
+export const forwardSignals = (child: ChildProcess): void => {
+  let interrupted: NodeJS.Signals | undefined;
+  const forward = (signal: NodeJS.Signals) => {
+    if (interrupted !== undefined) return;
+    interrupted = signal;
+    child.kill(signal);
+  };
+  const removeListeners = () => {
+    process.off("SIGINT", forward);
+    process.off("SIGTERM", forward);
+  };
+  process.on("SIGINT", forward);
+  process.on("SIGTERM", forward);
+  child.once("error", removeListeners);
+  child.once("exit", () => {
+    removeListeners();
+    // Bun skips afterAll on Ctrl-C. Exit only after the CLI has shut down,
+    // without resuming the interrupted tests or starting the next command.
+    if (interrupted !== undefined) {
+      process.exit(interrupted === "SIGINT" ? 130 : 143);
+    }
+  });
+};

--- a/packages/alchemy-test/test/forwardSignals.test.ts
+++ b/packages/alchemy-test/test/forwardSignals.test.ts
@@ -1,0 +1,80 @@
+import { expect, test } from "bun:test";
+import { spawn } from "node:child_process";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { pollUntil } from "../src/DevCli.ts";
+
+for (const signal of ["SIGINT", "SIGTERM"] as const) {
+  test(`forwards ${signal} to DevCli and waits for cleanup`, async () => {
+    const root = mkdtempSync(join(tmpdir(), "alchemy-forward-signals-"));
+    const devCli = resolve(import.meta.dirname, "../src/DevCli.ts");
+    writeFileSync(
+      join(root, "cli.ts"),
+      `
+      import { writeFileSync } from "node:fs";
+      process.on(${JSON.stringify(signal)}, () => {
+        setTimeout(() => { writeFileSync("cleaned", "yes"); process.exit(0); }, 200);
+      });
+      writeFileSync("child.pid", String(process.pid));
+      setInterval(() => {}, 1000);
+    `,
+    );
+    writeFileSync(
+      join(root, "owner.test.ts"),
+      `
+      import { afterAll, test } from "bun:test";
+      import { writeFileSync } from "node:fs";
+      import { DevCli } from ${JSON.stringify(devCli)};
+      const cli = new DevCli({ root: process.cwd(), alchemyBin: process.cwd() + "/cli.ts" });
+      afterAll(async () => { writeFileSync("afterAll", "yes"); await cli.stop(); });
+      test("running", async () => { cli.start(); await Bun.sleep(60000); }, 65000);
+    `,
+    );
+    const runner = spawn(process.execPath, ["test", "owner.test.ts"], {
+      cwd: root,
+      detached: true,
+      stdio: "ignore",
+      env: { ...process.env, ALCHEMY_PROFILE: "alchemy" },
+    });
+    const exited = new Promise<number | null>((resolve, reject) => {
+      runner.once("exit", resolve);
+      runner.once("error", reject);
+    });
+    const timeout = setTimeout(() => runner.kill("SIGKILL"), 6000);
+    let childPid: number | undefined;
+    try {
+      await pollUntil(
+        "CLI started",
+        () => (existsSync(join(root, "child.pid")) ? true : undefined),
+        { tries: 80, delayMs: 50 },
+      );
+      childPid = Number(readFileSync(join(root, "child.pid"), "utf8"));
+      process.kill(-runner.pid!, signal);
+      // A launcher can forward the same terminal signal more than once.
+      await Bun.sleep(50);
+      process.kill(-runner.pid!, signal);
+      expect(await exited).toBe(signal === "SIGINT" ? 130 : 143);
+      expect(existsSync(join(root, "cleaned"))).toBe(true);
+      expect(existsSync(join(root, "afterAll"))).toBe(false);
+      expect(() => process.kill(childPid!, 0)).toThrow();
+    } finally {
+      clearTimeout(timeout);
+      runner.kill("SIGKILL");
+      if (childPid !== undefined) {
+        try {
+          process.kill(childPid, "SIGKILL");
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code !== "ESRCH") throw error;
+        }
+      }
+      rmSync(root, { recursive: true, force: true });
+    }
+  }, 10000);
+}

--- a/scripts/test-example-cli.ts
+++ b/scripts/test-example-cli.ts
@@ -2,6 +2,7 @@ import { spawn } from "node:child_process";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
+import { forwardSignals } from "../packages/alchemy-test/src/DevCli.ts";
 
 const example = process.argv[2];
 if (example === undefined) {
@@ -72,6 +73,7 @@ const run = (
       env: childEnv,
       stdio: ["ignore", "pipe", "pipe"],
     });
+    forwardSignals(child);
     let output = "";
     const killGroup = () => {
       if (child.pid === undefined) return;
@@ -107,6 +109,7 @@ const runDev = (): Promise<CommandResult> =>
       env: childEnv,
       stdio: ["ignore", "pipe", "pipe"],
     });
+    forwardSignals(child);
     let output = "";
     let settled = false;
     let ready = false;


### PR DESCRIPTION
This is a bun test runner problem, bun skips afterAll on Ctrl-C (according to my agent)

## Summary

- Forward SIGINT and SIGTERM from test runners to detached CLI children.
- Wait for child cleanup before exiting with the conventional signal status.
- Add regression coverage for signal forwarding and cleanup behavior.