### PR TITLE
fix(aws/logs): normalize log group ARN from state before tagging calls

### DIFF
--- a/packages/alchemy/src/AWS/Logs/LogGroup.ts
+++ b/packages/alchemy/src/AWS/Logs/LogGroup.ts
@@ -266,8 +266,14 @@ export const LogGroupProvider = () =>
           const { accountId, region } = yield* AWSEnvironment.current;
           const logGroupName =
             output?.logGroupName ?? (yield* toLogGroupName(id, news));
-          const arn = (output?.logGroupArn ??
-            `arn:aws:logs:${region}:${accountId}:log-group:${logGroupName}`) as LogGroupArn;
+          // `output.logGroupArn` may be state written by an older provider
+          // version (or anything else) that persisted `describeLogGroups`'
+          // trailing `:*` form — normalize before it reaches the tagging
+          // APIs, which reject that suffix with "Invalid resourceArn".
+          const arn = normalizeLogGroupArn(
+            (output?.logGroupArn ??
+              `arn:aws:logs:${region}:${accountId}:log-group:${logGroupName}`) as LogGroupArn,
+          );
           const internalTags = yield* createInternalTags(id);
           const desiredTags = { ...internalTags, ...news.tags };
           // Wire unit is whole days (retentionInDays).


### PR DESCRIPTION
CloudWatch Logs' `describeLogGroups` returns log group ARNs ending in `:*`. The tagging APIs (`listTagsForResource`, `tagResource`, `untagResource`) reject that suffix with `ValidationException: Invalid resourceArn`.

`list()` and `read()` already normalize this via `normalizeLogGroupArn` before it lands in resource output (since 2.0.0-beta.65). `reconcile()` doesn't — it trusts whatever ARN is already sitting in state:

```diff
-          const arn = (output?.logGroupArn ??
-            `arn:aws:logs:${region}:${accountId}:log-group:${logGroupName}`) as LogGroupArn;
+          const arn = normalizeLogGroupArn(
+            (output?.logGroupArn ??
+              `arn:aws:logs:${region}:${accountId}:log-group:${logGroupName}`) as LogGroupArn,
+          );
```

We hit this adopting three pre-existing Lambda log groups on 2.0.0-beta.58: every converge died on the tagging calls with a content-less `ValidationException`. Upgrading alone would not have fixed it — `normalizeLogGroupArn` only runs in `list()`/`read()`, and by then the `:*` ARN from the beta.58 adoption was already persisted in `output.logGroupArn`, so `reconcile()` kept reading it back unnormalized on every subsequent run. The only working fix was hand-editing state.

`pnpm tsc -b` (the root Check workflow's typecheck step) is clean with this change:

```
$ pnpm tsc -b
$ echo $?
0
```

No new test was added: the resource's suite (`packages/alchemy/test/AWS/Logs/LogGroup.test.ts`) is entirely `test.provider`, deploying real log groups against live AWS — not runnable here without credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
