### PR TITLE
fix: effect rc.113 proxyChain/BunHttpServer regressions; AWS destroy after drifted state

### DIFF
--- a/examples/cloudflare-dev/test/dev.test.ts
+++ b/examples/cloudflare-dev/test/dev.test.ts
@@ -56,6 +56,13 @@ afterAll(async () => {
 test(
   "alchemy dev serves every local binding end-to-end",
   async () => {
+    // Start from an empty stage. The local D1 provider trusts its state row
+    // for "migrations applied", so a stage left deployed by an interrupted
+    // run (remote state store) combined with a wiped `.alchemy/local` (e.g.
+    // `git clean -fdx`) would skip the migrations and fail `/d1` with
+    // `no such table: greetings` — a stale-environment failure, not the
+    // #1007 regression this route exists to pin.
+    cli.destroy();
     cli.start();
 
     // The first dev deploy applies D1 migrations through the sidecar,

--- a/examples/cloudflare-neon-drizzle/test/integ.test.ts
+++ b/examples/cloudflare-neon-drizzle/test/integ.test.ts
@@ -30,9 +30,15 @@ afterAll.skipIf(!!process.env.NO_DESTROY)(destroy(Stack), {
 
 // Fresh `workers.dev` URLs transiently 404 (route still propagating) or 5xx
 // (Hyperdrive/Neon binding still settling). `Test.getWhenReady` fails on that
-// cold-start window and retries until the worker answers; the first hit in
-// each test rides it, subsequent requests run against the warmed worker.
+// cold-start window and retries until the worker answers — but one 200 does
+// not mean the route has converged everywhere: for the first ~30s after
+// "Enabling workers.dev subdomain" consecutive requests can interleave 200s
+// with edge-generated HTML 404s. The worker itself only ever answers JSON
+// (including its own 400/405/500), so guard the client on content-type: any
+// HTML edge page is rejected and retried, while the worker's real statuses
+// stay observable for the assertions below.
 const { getWhenReady } = Test;
+const jsonClient = Test.guardedFetchLayer("application/json", { times: 10 });
 
 test(
   "worker exposes a URL, hyperdrive id, and neon branch id",
@@ -124,7 +130,7 @@ test(
     expect(finalBody.users.some((user) => user.id === createdUser.id)).toBe(
       false,
     );
-  }),
+  }).pipe(Effect.provide(jsonClient)),
   // The cold-start `getWhenReady` window plus a full CRUD round-trip against a
   // freshly-warmed Neon/Hyperdrive connection routinely exceeds 20s. Match the
   // sequential-query case's budget.
@@ -154,6 +160,6 @@ test(
       Effect.zip(jitter),
       Effect.repeat(Schedule.recurs(99)),
     );
-  }),
+  }).pipe(Effect.provide(jsonClient)),
   { timeout: 120_000 },
 );

--- a/packages/alchemy/src/AWS/DynamoDB/Table.ts
+++ b/packages/alchemy/src/AWS/DynamoDB/Table.ts
@@ -2148,29 +2148,45 @@ export const TableProvider = () =>
           // cleanup and strands the rules — CloudWatch rejects direct
           // deletion of DynamoDB-managed rules with AccessDenied, so only
           // AWS support can remove them afterwards.
-          yield* Effect.gen(function* () {
-            const insightsStatus = yield* waitForContributorInsightsSettled(
-              session,
-              output.tableName,
+          //
+          // Observe existence first: `waitForContributorInsightsSettled`
+          // retries `ResourceNotFoundException` as a control-plane blip (its
+          // reconcile-side callers run right after the table was created),
+          // so a table that is already gone would otherwise spin through the
+          // full ~90s settle budget before this delete can notice.
+          const tableExists = yield* dynamodb
+            .describeTable({ TableName: output.tableName })
+            .pipe(
+              Effect.as(true),
+              Effect.catchTag("ResourceNotFoundException", () =>
+                Effect.succeed(false),
+              ),
             );
-            if (insightsStatus !== "DISABLED") {
-              yield* session.note(
-                `Table ${output.tableName}: disabling Contributor Insights before delete`,
-              );
-              yield* updateTableContributorInsights(output.tableName, false);
-              yield* waitForContributorInsightsSettled(
+          if (tableExists) {
+            yield* Effect.gen(function* () {
+              const insightsStatus = yield* waitForContributorInsightsSettled(
                 session,
                 output.tableName,
               );
-            }
-            yield* waitForContributorInsightsRulesDeleted(
-              session,
-              output.tableName,
+              if (insightsStatus !== "DISABLED") {
+                yield* session.note(
+                  `Table ${output.tableName}: disabling Contributor Insights before delete`,
+                );
+                yield* updateTableContributorInsights(output.tableName, false);
+                yield* waitForContributorInsightsSettled(
+                  session,
+                  output.tableName,
+                );
+              }
+              yield* waitForContributorInsightsRulesDeleted(
+                session,
+                output.tableName,
+              );
+            }).pipe(
+              // Table vanished mid-teardown — nothing left to tear down.
+              Effect.catchTag("ResourceNotFoundException", () => Effect.void),
             );
-          }).pipe(
-            // Table already gone — nothing to tear down.
-            Effect.catchTag("ResourceNotFoundException", () => Effect.void),
-          );
+          }
 
           let deleteAttempt = 0;
 

--- a/packages/alchemy/src/AWS/SNS/Subscription.ts
+++ b/packages/alchemy/src/AWS/SNS/Subscription.ts
@@ -295,7 +295,13 @@ export const SubscriptionProvider = () =>
             topicArn: (output.topicArn ?? olds.topicArn) as string | undefined,
             protocol: output.protocol ?? olds.protocol,
             endpoint: (output.endpoint ?? olds.endpoint) as string | undefined,
-          })
+          }).pipe(
+            // The topic is already gone — SNS drops its subscriptions with
+            // it, so there is nothing left to unsubscribe.
+            Effect.catchTag("NotFoundException", () =>
+              Effect.succeed(undefined),
+            ),
+          )
         : output.subscriptionArn;
 
       if (!subscriptionArn) {
@@ -366,14 +372,28 @@ const readSubscription = Effect.fn(function* ({
   protocol?: string;
   endpoint: string | undefined;
 }) {
-  const resolvedSubscriptionArn =
-    subscriptionArn && !isPendingConfirmation(subscriptionArn)
-      ? subscriptionArn
-      : yield* findSubscription({
-          topicArn,
-          protocol,
-          endpoint,
-        });
+  let resolvedSubscriptionArn: string | undefined;
+  if (subscriptionArn && !isPendingConfirmation(subscriptionArn)) {
+    resolvedSubscriptionArn = subscriptionArn;
+  } else {
+    // No concrete ARN to hydrate — list the topic's subscriptions and match
+    // by (protocol, endpoint). If the topic itself no longer exists (deleted
+    // out of band, or by an interrupted destroy that committed the topic's
+    // state row late) then the subscription is gone too: report "missing"
+    // rather than failing the read, so a subsequent destroy can proceed.
+    const found = yield* findSubscription({
+      topicArn,
+      protocol,
+      endpoint,
+    }).pipe(
+      Effect.map((arn) => ({ arn })),
+      Effect.catchTag("NotFoundException", () => Effect.succeed(undefined)),
+    );
+    if (found === undefined) {
+      return undefined;
+    }
+    resolvedSubscriptionArn = found.arn;
+  }
 
   if (!resolvedSubscriptionArn) {
     if (!topicArn || !protocol) {

--- a/packages/alchemy/src/Http.ts
+++ b/packages/alchemy/src/Http.ts
@@ -134,7 +134,15 @@ export const resolvePort = (options: { port?: number } | undefined) =>
 export interface BunHttpServerOptions {
   /**
    * Network interface on which the Bun HTTP server listens.
-   * Omit to use Bun's default.
+   *
+   * Always passed explicitly to `Bun.serve`: when `hostname` is omitted Bun
+   * listens on every interface but reports `server.hostname === "localhost"`,
+   * and `@effect/platform-bun`'s `BunHttpServer.make` (≥ 4.0.0-rc.113)
+   * parses that back as an IP literal — failing with
+   * `ServeError(NetAddressError: expected exactly four decimal octets)`, so
+   * every container bootstrap crash-looped on boot.
+   *
+   * @default "0.0.0.0"
    */
   hostname?: string;
 }
@@ -152,9 +160,7 @@ export const BunHttpServer = (serverOptions?: BunHttpServerOptions) =>
             const port = yield* resolvePort(options);
             const server = yield* BunHttpServerPlatform.make({
               port,
-              ...(serverOptions?.hostname === undefined
-                ? {}
-                : { hostname: serverOptions.hostname }),
+              hostname: serverOptions?.hostname ?? "0.0.0.0",
             });
             yield* server.serve(safeHttpEffect(handler));
           }).pipe(Effect.orDie),

--- a/packages/alchemy/src/Util/proxy-chain.ts
+++ b/packages/alchemy/src/Util/proxy-chain.ts
@@ -122,6 +122,22 @@ const replayArg = (
 export const proxyChain = <T>(cached: Effect.Effect<T, any, any>): T =>
   chain(cached) as T;
 
+/**
+ * Property reads the Effect runtime uses as *brand probes* — `symbol` keys
+ * and `~effect/...` type-id strings (`~effect/Exit`, `~effect/Effect`, …).
+ * The fiber's generator runner distinguishes a yielded Effect from an Exit
+ * with `value[ExitTypeId] !== undefined` (effect ≥ 4.0.0-rc.113; earlier
+ * releases used `in`, which the `has` trap already answers). Recording such
+ * a read as a chain step would hand back a truthy proxy, so the runner
+ * would treat every chain as an already-settled Exit and resume the
+ * generator with `proxy.value` — another proxy — instead of running it.
+ * Brand probes therefore answer `undefined` when the underlying effect
+ * lacks the key; the `has` trap keeps `in`-based probes correct too.
+ */
+const isBrandProbe = (prop: PropertyKey): boolean =>
+  typeof prop === "symbol" ||
+  (typeof prop === "string" && prop.startsWith("~effect/"));
+
 const chain = (
   cached: Effect.Effect<unknown, any, any>,
   ops: ReadonlyArray<Op> = [],
@@ -135,6 +151,9 @@ const chain = (
     get(_, prop) {
       if (Reflect.has(effect, prop)) {
         return Reflect.get(effect, prop);
+      }
+      if (isBrandProbe(prop)) {
+        return undefined;
       }
       return chain(cached, [...ops, { kind: "get", prop }]);
     },

--- a/packages/alchemy/test/Util/proxy-chain.test.ts
+++ b/packages/alchemy/test/Util/proxy-chain.test.ts
@@ -1,6 +1,7 @@
 import { proxyChain } from "@/Util/proxy-chain.ts";
 import { describe, expect, it } from "alchemy-test";
 import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
 
 const TIMEOUT = 5_000;
 
@@ -129,6 +130,32 @@ describe("proxyChain", () => {
       );
 
       expect(result).toBe("recovered");
+    }),
+  );
+
+  /**
+   * effect ≥ 4.0.0-rc.113's generator runner asks `value[ExitTypeId] !==
+   * undefined` to tell an Exit from an Effect. If the proxy answered that
+   * brand probe with a chain step, every `yield*` would resume with the
+   * proxy itself instead of the query result (the bug behind `users.length`
+   * serializing as `{ _id: "Effect", op: "OnSuccess" }`).
+   */
+  it.effect("does not record Effect brand probes as chain steps", () =>
+    Effect.gen(function* () {
+      const db = proxyChain<Db>(Effect.succeed(makeDb()));
+      const query = db.select().from("users") as unknown as Record<
+        PropertyKey,
+        unknown
+      >;
+      expect(query["~effect/Exit"]).toBeUndefined();
+      expect(Exit.isExit(query)).toBe(false);
+      expect(Effect.isEffect(query)).toBe(true);
+      // Symbols the runtime does not define on an Effect are absent too.
+      expect(query[Symbol.for("some/unrelated/probe")]).toBeUndefined();
+      // …and the chain still resolves to the real value when yielded.
+      const rows = yield* db.select().from("users");
+      expect(Array.isArray(rows)).toBe(true);
+      expect(rows).toEqual(["hi/users"]);
     }),
   );
 


### PR DESCRIPTION
Two runtime regressions from the effect 4.0.0-rc.113 bump (#1562), a stale-environment guard in the `cloudflare-dev` dev test, and two AWS providers that could not destroy past an already-deleted parent. Broke `cloudflare-neon-drizzle`, `fly-postgres`, `fly-website-vite`, `cloudflare-dev`, and (after an interrupted run) `aws-lambda` in `test:examples`.

### `proxyChain` answered Effect brand probes with a chain step

rc.113 changed the generator runner's Exit check:

```diff
-export const effectIsExit = effect => ExitTypeId in effect;
+export const effectIsExit = effect => effect[ExitTypeId] !== undefined;
```

`in` went through the proxy's `has` trap (correctly false); `[ExitTypeId]` goes through `get`, which recorded it as a chain step and returned a truthy proxy. Every `yield* db.select().from(users)` was treated as a settled Exit and resumed with `proxy.value` — so responses serialized `users` as `{ _id: "Effect", op: "OnSuccess", … }`.

```ts
// Util/proxy-chain.ts — symbols and `~effect/…` type-id keys the effect lacks are absent, not chained
if (isBrandProbe(prop)) return undefined;
```

`test/Util/proxy-chain.test.ts` already failed 8/16 on `main`; added a test pinning the probe directly.

### `BunHttpServer()` crash-looped every Bun container bootstrap

`@effect/platform-bun` rc.113's `BunHttpServer.make` re-parses `server.hostname` as an IP literal. With `hostname` omitted Bun binds `0.0.0.0` but reports `"localhost"`, so `make` fails with `ServeError(NetAddressError: expected exactly four decimal octets)` before listening — `ContainerCrashedError: Container exited while waiting for port 3000` for Cloudflare Container, Docker, ECS, EC2, microVM, K8s, and AppRunner hosts.

```diff
-...(serverOptions?.hostname === undefined ? {} : { hostname: serverOptions.hostname }),
+hostname: serverOptions?.hostname ?? "0.0.0.0",
```

### `cloudflare-dev` dev test destroys the stage before starting

The local D1 provider trusts its state row for "migrations applied". A stage left deployed by an interrupted run (remote state store) plus a wiped `.alchemy/local` skipped the migrations and failed `/d1` with `no such table: greetings` — a stale environment, not the #1007 regression the route pins.

### AWS `SNS.Subscription` read and `DynamoDB.Table` delete tolerate an already-deleted parent

An interrupted `aws-lambda` destroy deleted the topic and table in the cloud but never committed those state rows. The next run's destroy then wedged twice:

- `Subscription.read` (invoked for the interrupted-create row) hit `listSubscriptionsByTopic` → `NotFoundException: Topic does not exist` and failed, blocking `JobFunction`, the topic, queue, and table behind it (`DestroyError`).
- `Table.delete` polled `describeContributorInsights` on the gone table, and its settle loop retries `ResourceNotFoundException` as a control-plane blip — ~90s of spinning before the `catchTag` at the call site could fire, past the test's `afterAll` timeout.

```ts
// SNS/Subscription.ts — topic gone ⇒ subscription gone (read → undefined, delete → no-op)
findSubscription(...).pipe(Effect.catchTag("NotFoundException", () => Effect.succeed(undefined)))

// DynamoDB/Table.ts — observe existence before the Contributor Insights teardown
const tableExists = yield* dynamodb.describeTable({ TableName }).pipe(
  Effect.as(true),
  Effect.catchTag("ResourceNotFoundException", () => Effect.succeed(false)),
);
```

### `cloudflare-neon-drizzle` test guards against workers.dev edge 404s

The worker never returns 404 (`Api.ts` answers 400/405/500 as JSON), yet the 100-query test saw one ~5s after "Enabling workers.dev subdomain": a single 200 from `getWhenReady` does not mean the fresh route has converged, and consecutive requests can interleave edge HTML 404s for ~30s.

```ts
// worker only ever answers JSON — reject+retry any edge HTML page, keep real 400/405/500 observable
const jsonClient = Test.guardedFetchLayer("application/json", { times: 10 });
test("…", Effect.gen(function* () { … }).pipe(Effect.provide(jsonClient)));
```
