### PR TITLE
feat(test): default Test.make stage to test_$USER

### DIFF
--- a/examples/aws-ecs/test/integ.test.ts
+++ b/examples/aws-ecs/test/integ.test.ts
@@ -20,7 +20,6 @@ import Stack from "../alchemy.run.ts";
 const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   providers: AWS.providers(),
   state: Alchemy.localState(),
-  stage: "test",
 });
 
 // The first deploy builds + pushes container images and waits for two

--- a/examples/aws-website-astro/test/integ.test.ts
+++ b/examples/aws-website-astro/test/integ.test.ts
@@ -45,7 +45,6 @@ const getBodyWhenReady = (url: string, expected: string) =>
 const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   providers: AWS.providers(),
   state: AWS.state(),
-  stage: "test",
 });
 
 // The first deploy runs the full Astro build AND creates a CloudFront

--- a/examples/aws-website-foldkit/test/integ.test.ts
+++ b/examples/aws-website-foldkit/test/integ.test.ts
@@ -44,7 +44,6 @@ const getBodyWhenReady = (url: string, expected: string) =>
 const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   providers: AWS.providers(),
   state: AWS.state(),
-  stage: "test",
 });
 
 // The first deploy runs the full Vite build AND creates a CloudFront

--- a/examples/aws-website-nextjs/test/integ.test.ts
+++ b/examples/aws-website-nextjs/test/integ.test.ts
@@ -45,7 +45,6 @@ const getBodyWhenReady = (url: string, expected: string) =>
 const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   providers: AWS.providers(),
   state: AWS.state(),
-  stage: "test",
 });
 
 // The first deploy runs the full Next.js + OpenNext build AND creates a

--- a/examples/aws-website-nuxt/test/integ.test.ts
+++ b/examples/aws-website-nuxt/test/integ.test.ts
@@ -45,7 +45,6 @@ const getBodyWhenReady = (url: string, expected: string) =>
 const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   providers: AWS.providers(),
   state: AWS.state(),
-  stage: "test",
 });
 
 // The first deploy runs the full Nuxt build AND creates a CloudFront

--- a/examples/aws-website-react-router/test/integ.test.ts
+++ b/examples/aws-website-react-router/test/integ.test.ts
@@ -45,7 +45,6 @@ const getBodyWhenReady = (url: string, expected: string) =>
 const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   providers: AWS.providers(),
   state: AWS.state(),
-  stage: "test",
 });
 
 // The first deploy runs the full React Router build AND creates a

--- a/examples/aws-website-solidstart/test/integ.test.ts
+++ b/examples/aws-website-solidstart/test/integ.test.ts
@@ -45,7 +45,6 @@ const getBodyWhenReady = (url: string, expected: string) =>
 const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   providers: AWS.providers(),
   state: AWS.state(),
-  stage: "test",
 });
 
 // The first deploy runs the full SolidStart (vite/nitro) build AND

--- a/examples/aws-website-sveltekit/test/integ.test.ts
+++ b/examples/aws-website-sveltekit/test/integ.test.ts
@@ -45,7 +45,6 @@ const getBodyWhenReady = (url: string, expected: string) =>
 const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   providers: AWS.providers(),
   state: AWS.state(),
-  stage: "test",
 });
 
 // The first deploy runs the full SvelteKit build AND creates a CloudFront

--- a/examples/aws-website-tanstack-start/test/integ.test.ts
+++ b/examples/aws-website-tanstack-start/test/integ.test.ts
@@ -45,7 +45,6 @@ const getBodyWhenReady = (url: string, expected: string) =>
 const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   providers: AWS.providers(),
   state: AWS.state(),
-  stage: "test",
 });
 
 // The first deploy runs the full Vite build AND creates a CloudFront

--- a/examples/aws-website-vite/test/integ.test.ts
+++ b/examples/aws-website-vite/test/integ.test.ts
@@ -44,7 +44,6 @@ const getBodyWhenReady = (url: string, expected: string) =>
 const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   providers: AWS.providers(),
   state: AWS.state(),
-  stage: "test",
 });
 
 // The first deploy runs the full Vite build AND creates a CloudFront

--- a/examples/aws-website-waku/test/integ.test.ts
+++ b/examples/aws-website-waku/test/integ.test.ts
@@ -14,7 +14,6 @@ const { getWhenReady } = Test;
 const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   providers: AWS.providers(),
   state: AWS.state(),
-  stage: "test",
 });
 
 // The first deploy runs the full Waku build AND creates a CloudFront

--- a/examples/cloudflare-foldkit-ssr/test/integ.test.ts
+++ b/examples/cloudflare-foldkit-ssr/test/integ.test.ts
@@ -41,7 +41,6 @@ const getBodyWhenReady = (url: string, expected: string) =>
 const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   providers: Cloudflare.providers(),
   state: Cloudflare.state(),
-  stage: "test",
 });
 
 // The first deploy runs the full Vite build, so give the hook more headroom

--- a/examples/cloudflare-foldkit/test/integ.test.ts
+++ b/examples/cloudflare-foldkit/test/integ.test.ts
@@ -44,7 +44,6 @@ const getBodyWhenReady = (url: string, expected: string) =>
 const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   providers: Cloudflare.providers(),
   state: Cloudflare.state(),
-  stage: "test",
 });
 
 // The first deploy runs the full Vite build, so give the hook more headroom

--- a/examples/cloudflare-octane/test/integ.test.ts
+++ b/examples/cloudflare-octane/test/integ.test.ts
@@ -43,7 +43,6 @@ const getBodyWhenReady = (url: string, expected: string) =>
 const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   providers: Cloudflare.providers(),
   state: Cloudflare.state(),
-  stage: "test",
 });
 
 // The first deploy runs the full Octane (vite) build, so give the hook more

--- a/examples/cloudflare-pr-package/test/integ.test.ts
+++ b/examples/cloudflare-pr-package/test/integ.test.ts
@@ -13,7 +13,6 @@ import Stack from "../alchemy.run.ts";
 const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   providers: Cloudflare.providers(),
   state: Cloudflare.state(),
-  stage: "test",
 });
 
 const stack = beforeAll(deploy(Stack), { timeout: 180_000 });

--- a/examples/cloudflare-tanstack-start-solid/test/integ.test.ts
+++ b/examples/cloudflare-tanstack-start-solid/test/integ.test.ts
@@ -8,7 +8,6 @@ import Stack from "../alchemy.run.ts";
 const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   providers: Cloudflare.providers(),
   state: Cloudflare.state(),
-  stage: "test",
 });
 
 const stack = beforeAll(deploy(Stack).pipe(Effect.tap(Console.log)));

--- a/examples/cloudflare-vue/test/integ.test.ts
+++ b/examples/cloudflare-vue/test/integ.test.ts
@@ -44,7 +44,6 @@ const getBodyWhenReady = (url: string, expected: string) =>
 const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   providers: Cloudflare.providers(),
   state: Cloudflare.state(),
-  stage: "test",
 });
 
 // The first deploy runs the full Vite build, so give the hook more headroom

--- a/examples/cloudflare-website-astro/test/integ.test.ts
+++ b/examples/cloudflare-website-astro/test/integ.test.ts
@@ -44,7 +44,6 @@ const getBodyWhenReady = (url: string, expected: string) =>
 const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   providers: Cloudflare.providers(),
   state: Cloudflare.state(),
-  stage: "test",
 });
 
 // The first deploy runs the full Astro build, so give the hook more headroom

--- a/examples/cloudflare-website-foldkit/test/integ.test.ts
+++ b/examples/cloudflare-website-foldkit/test/integ.test.ts
@@ -44,7 +44,6 @@ const getBodyWhenReady = (url: string, expected: string) =>
 const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   providers: Cloudflare.providers(),
   state: Cloudflare.state(),
-  stage: "test",
 });
 
 // The first deploy runs the full Vite build, so give the hook more headroom

--- a/examples/cloudflare-website-nextjs/test/integ.test.ts
+++ b/examples/cloudflare-website-nextjs/test/integ.test.ts
@@ -44,7 +44,6 @@ const getBodyWhenReady = (url: string, expected: string) =>
 const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   providers: Cloudflare.providers(),
   state: Cloudflare.state(),
-  stage: "test",
 });
 
 // The first deploy runs the full Next.js + OpenNext build, so give the hook

--- a/examples/cloudflare-website-nuxt/test/integ.test.ts
+++ b/examples/cloudflare-website-nuxt/test/integ.test.ts
@@ -44,7 +44,6 @@ const getBodyWhenReady = (url: string, expected: string) =>
 const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   providers: Cloudflare.providers(),
   state: Cloudflare.state(),
-  stage: "test",
 });
 
 // The first deploy runs the full Nuxt build, so give the hook more

--- a/examples/cloudflare-website-react-router/test/integ.test.ts
+++ b/examples/cloudflare-website-react-router/test/integ.test.ts
@@ -44,7 +44,6 @@ const getBodyWhenReady = (url: string, expected: string) =>
 const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   providers: Cloudflare.providers(),
   state: Cloudflare.state(),
-  stage: "test",
 });
 
 // The first deploy runs the full RSC build, so give the hook more headroom

--- a/examples/cloudflare-website-solidstart/test/integ.test.ts
+++ b/examples/cloudflare-website-solidstart/test/integ.test.ts
@@ -44,7 +44,6 @@ const getBodyWhenReady = (url: string, expected: string) =>
 const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   providers: Cloudflare.providers(),
   state: Cloudflare.state(),
-  stage: "test",
 });
 
 // The first deploy runs the full SolidStart (vite/nitro) build, so give the

--- a/examples/cloudflare-website-sveltekit/test/integ.test.ts
+++ b/examples/cloudflare-website-sveltekit/test/integ.test.ts
@@ -44,7 +44,6 @@ const getBodyWhenReady = (url: string, expected: string) =>
 const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   providers: Cloudflare.providers(),
   state: Cloudflare.state(),
-  stage: "test",
 });
 
 // The first deploy runs the full SvelteKit build, so give the hook more

--- a/examples/cloudflare-website-tanstack-start/test/integ.test.ts
+++ b/examples/cloudflare-website-tanstack-start/test/integ.test.ts
@@ -47,7 +47,6 @@ const getBodyWhenReady = (url: string, expected: string) =>
 const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   providers: Cloudflare.providers(),
   state: Cloudflare.state(),
-  stage: "test",
 });
 
 const stack = beforeAll(deploy(Stack).pipe(Effect.tap(Console.log)), {

--- a/examples/cloudflare-website-vite/test/integ.test.ts
+++ b/examples/cloudflare-website-vite/test/integ.test.ts
@@ -44,7 +44,6 @@ const getBodyWhenReady = (url: string, expected: string) =>
 const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   providers: Cloudflare.providers(),
   state: Cloudflare.state(),
-  stage: "test",
 });
 
 // The first deploy runs the full Vite build, so give the hook more headroom

--- a/examples/cloudflare-website-vocs/test/integ.test.ts
+++ b/examples/cloudflare-website-vocs/test/integ.test.ts
@@ -11,7 +11,6 @@ const { getWhenReady } = Test;
 const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   providers: Cloudflare.providers(),
   state: Cloudflare.state(),
-  stage: "test",
 });
 
 const stack = beforeAll(deploy(Stack).pipe(Effect.tap(Console.log)), {

--- a/examples/cloudflare-website-waku/test/integ.test.ts
+++ b/examples/cloudflare-website-waku/test/integ.test.ts
@@ -13,7 +13,6 @@ const { getWhenReady } = Test;
 const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   providers: Cloudflare.providers(),
   state: Cloudflare.state(),
-  stage: "test",
 });
 
 // The first deploy runs the full Waku build, so give the hook more headroom

--- a/examples/cloudflare-worker/test/integ.test.ts
+++ b/examples/cloudflare-worker/test/integ.test.ts
@@ -13,7 +13,6 @@ import { WORKFLOW_SECRET_VALUE } from "../src/NotifyWorkflow.ts";
 const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   providers: Cloudflare.providers(),
   state: Cloudflare.state(),
-  stage: "test",
   // dev: true,
 });
 

--- a/examples/fly-website-astro/test/integ.test.ts
+++ b/examples/fly-website-astro/test/integ.test.ts
@@ -47,7 +47,6 @@ const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   providers: Fly.providers(),
   state: Alchemy.localState(),
   profile: process.env.ALCHEMY_PROFILE,
-  stage: "test",
 });
 
 // The first deploy runs the full Astro build AND creates a Fly

--- a/examples/fly-website-foldkit/test/integ.test.ts
+++ b/examples/fly-website-foldkit/test/integ.test.ts
@@ -46,7 +46,6 @@ const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   providers: Fly.providers(),
   state: Alchemy.localState(),
   profile: process.env.ALCHEMY_PROFILE,
-  stage: "test",
 });
 
 // The first deploy runs the full Vite build AND creates a Fly

--- a/examples/fly-website-nextjs/test/integ.test.ts
+++ b/examples/fly-website-nextjs/test/integ.test.ts
@@ -47,7 +47,6 @@ const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   providers: Fly.providers(),
   state: Alchemy.localState(),
   profile: process.env.ALCHEMY_PROFILE,
-  stage: "test",
 });
 
 // The first deploy runs the full Next.js + Node build AND creates a

--- a/examples/fly-website-nuxt/test/integ.test.ts
+++ b/examples/fly-website-nuxt/test/integ.test.ts
@@ -47,7 +47,6 @@ const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   providers: Fly.providers(),
   state: Alchemy.localState(),
   profile: process.env.ALCHEMY_PROFILE,
-  stage: "test",
 });
 
 // The first deploy runs the full Nuxt build AND creates a Fly

--- a/examples/fly-website-react-router/test/integ.test.ts
+++ b/examples/fly-website-react-router/test/integ.test.ts
@@ -47,7 +47,6 @@ const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   providers: Fly.providers(),
   state: Alchemy.localState(),
   profile: process.env.ALCHEMY_PROFILE,
-  stage: "test",
 });
 
 // The first deploy runs the full React Router build AND creates a Fly

--- a/examples/fly-website-solidstart/test/integ.test.ts
+++ b/examples/fly-website-solidstart/test/integ.test.ts
@@ -47,7 +47,6 @@ const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   providers: Fly.providers(),
   state: Alchemy.localState(),
   profile: process.env.ALCHEMY_PROFILE,
-  stage: "test",
 });
 
 // The first deploy runs the full SolidStart (vite/nitro) build AND

--- a/examples/fly-website-sveltekit/test/integ.test.ts
+++ b/examples/fly-website-sveltekit/test/integ.test.ts
@@ -47,7 +47,6 @@ const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   providers: Fly.providers(),
   state: Alchemy.localState(),
   profile: process.env.ALCHEMY_PROFILE,
-  stage: "test",
 });
 
 // The first deploy runs the full SvelteKit build AND creates a Fly

--- a/examples/fly-website-tanstack-start/test/integ.test.ts
+++ b/examples/fly-website-tanstack-start/test/integ.test.ts
@@ -47,7 +47,6 @@ const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   providers: Fly.providers(),
   state: Alchemy.localState(),
   profile: process.env.ALCHEMY_PROFILE,
-  stage: "test",
 });
 
 // The first deploy runs the full Vite build AND creates a Fly

--- a/examples/fly-website-vocs/test/integ.test.ts
+++ b/examples/fly-website-vocs/test/integ.test.ts
@@ -12,7 +12,6 @@ const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   providers: Fly.providers(),
   state: Alchemy.localState(),
   profile: process.env.ALCHEMY_PROFILE,
-  stage: "test",
 });
 
 const stack = beforeAll(deploy(Stack).pipe(Effect.tap(Console.log)), {

--- a/examples/fly-website-waku/test/integ.test.ts
+++ b/examples/fly-website-waku/test/integ.test.ts
@@ -16,7 +16,6 @@ const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   providers: Fly.providers(),
   state: Alchemy.localState(),
   profile: process.env.ALCHEMY_PROFILE,
-  stage: "test",
 });
 
 // The first deploy runs the full Waku build AND creates a Fly

--- a/examples/hetzner-website-astro/test/integ.test.ts
+++ b/examples/hetzner-website-astro/test/integ.test.ts
@@ -49,7 +49,6 @@ const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   providers: Hetzner.providers(),
   state: Alchemy.localState(),
   profile: process.env.ALCHEMY_PROFILE,
-  stage: "test",
 });
 
 // The first deploy runs the full Astro build AND creates a Hetzner

--- a/examples/hetzner-website-foldkit/test/integ.test.ts
+++ b/examples/hetzner-website-foldkit/test/integ.test.ts
@@ -48,7 +48,6 @@ const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   providers: Hetzner.providers(),
   state: Alchemy.localState(),
   profile: process.env.ALCHEMY_PROFILE,
-  stage: "test",
 });
 
 // The first deploy runs the full Vite build AND creates a Hetzner

--- a/examples/hetzner-website-nextjs/test/integ.test.ts
+++ b/examples/hetzner-website-nextjs/test/integ.test.ts
@@ -49,7 +49,6 @@ const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   providers: Hetzner.providers(),
   state: Alchemy.localState(),
   profile: process.env.ALCHEMY_PROFILE,
-  stage: "test",
 });
 
 // The first deploy runs the full Next.js + Node build AND creates a

--- a/examples/hetzner-website-nuxt/test/integ.test.ts
+++ b/examples/hetzner-website-nuxt/test/integ.test.ts
@@ -49,7 +49,6 @@ const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   providers: Hetzner.providers(),
   state: Alchemy.localState(),
   profile: process.env.ALCHEMY_PROFILE,
-  stage: "test",
 });
 
 // The first deploy runs the full Nuxt build AND creates a Hetzner

--- a/examples/hetzner-website-react-router/test/integ.test.ts
+++ b/examples/hetzner-website-react-router/test/integ.test.ts
@@ -49,7 +49,6 @@ const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   providers: Hetzner.providers(),
   state: Alchemy.localState(),
   profile: process.env.ALCHEMY_PROFILE,
-  stage: "test",
 });
 
 // The first deploy runs the full React Router build AND creates a Hetzner

--- a/examples/hetzner-website-solidstart/test/integ.test.ts
+++ b/examples/hetzner-website-solidstart/test/integ.test.ts
@@ -49,7 +49,6 @@ const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   providers: Hetzner.providers(),
   state: Alchemy.localState(),
   profile: process.env.ALCHEMY_PROFILE,
-  stage: "test",
 });
 
 // The first deploy runs the full SolidStart (vite/nitro) build AND

--- a/examples/hetzner-website-sveltekit/test/integ.test.ts
+++ b/examples/hetzner-website-sveltekit/test/integ.test.ts
@@ -49,7 +49,6 @@ const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   providers: Hetzner.providers(),
   state: Alchemy.localState(),
   profile: process.env.ALCHEMY_PROFILE,
-  stage: "test",
 });
 
 // The first deploy runs the full SvelteKit build AND creates a Hetzner

--- a/examples/hetzner-website-tanstack-start/test/integ.test.ts
+++ b/examples/hetzner-website-tanstack-start/test/integ.test.ts
@@ -49,7 +49,6 @@ const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   providers: Hetzner.providers(),
   state: Alchemy.localState(),
   profile: process.env.ALCHEMY_PROFILE,
-  stage: "test",
 });
 
 // The first deploy runs the full Vite build AND creates a Hetzner

--- a/examples/hetzner-website-vocs/test/integ.test.ts
+++ b/examples/hetzner-website-vocs/test/integ.test.ts
@@ -14,7 +14,6 @@ const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   providers: Hetzner.providers(),
   state: Alchemy.localState(),
   profile: process.env.ALCHEMY_PROFILE,
-  stage: "test",
 });
 
 if (!hasCreds) {

--- a/examples/hetzner-website-waku/test/integ.test.ts
+++ b/examples/hetzner-website-waku/test/integ.test.ts
@@ -18,7 +18,6 @@ const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   providers: Hetzner.providers(),
   state: Alchemy.localState(),
   profile: process.env.ALCHEMY_PROFILE,
-  stage: "test",
 });
 
 // The first deploy runs the full Waku build AND creates a Hetzner

--- a/examples/railway-website-astro/test/integ.test.ts
+++ b/examples/railway-website-astro/test/integ.test.ts
@@ -47,7 +47,6 @@ const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   providers: Railway.providers(),
   state: Alchemy.localState(),
   profile: process.env.ALCHEMY_PROFILE,
-  stage: "test",
 });
 
 // The first deploy runs the full Astro build AND creates a Railway

--- a/examples/railway-website-foldkit/test/integ.test.ts
+++ b/examples/railway-website-foldkit/test/integ.test.ts
@@ -46,7 +46,6 @@ const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   providers: Railway.providers(),
   state: Alchemy.localState(),
   profile: process.env.ALCHEMY_PROFILE,
-  stage: "test",
 });
 
 // The first deploy runs the full Vite build AND creates a Railway

--- a/examples/railway-website-nextjs/test/integ.test.ts
+++ b/examples/railway-website-nextjs/test/integ.test.ts
@@ -47,7 +47,6 @@ const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   providers: Railway.providers(),
   state: Alchemy.localState(),
   profile: process.env.ALCHEMY_PROFILE,
-  stage: "test",
 });
 
 // The first deploy runs the full Next.js + Node build AND creates a

--- a/examples/railway-website-nuxt/test/integ.test.ts
+++ b/examples/railway-website-nuxt/test/integ.test.ts
@@ -47,7 +47,6 @@ const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   providers: Railway.providers(),
   state: Alchemy.localState(),
   profile: process.env.ALCHEMY_PROFILE,
-  stage: "test",
 });
 
 // The first deploy runs the full Nuxt build AND creates a Railway

--- a/examples/railway-website-react-router/test/integ.test.ts
+++ b/examples/railway-website-react-router/test/integ.test.ts
@@ -47,7 +47,6 @@ const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   providers: Railway.providers(),
   state: Alchemy.localState(),
   profile: process.env.ALCHEMY_PROFILE,
-  stage: "test",
 });
 
 // The first deploy runs the full React Router build AND creates a Railway

--- a/examples/railway-website-solidstart/test/integ.test.ts
+++ b/examples/railway-website-solidstart/test/integ.test.ts
@@ -47,7 +47,6 @@ const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   providers: Railway.providers(),
   state: Alchemy.localState(),
   profile: process.env.ALCHEMY_PROFILE,
-  stage: "test",
 });
 
 // The first deploy runs the full SolidStart (vite/nitro) build AND

--- a/examples/railway-website-sveltekit/test/integ.test.ts
+++ b/examples/railway-website-sveltekit/test/integ.test.ts
@@ -47,7 +47,6 @@ const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   providers: Railway.providers(),
   state: Alchemy.localState(),
   profile: process.env.ALCHEMY_PROFILE,
-  stage: "test",
 });
 
 // The first deploy runs the full SvelteKit build AND creates a Railway

--- a/examples/railway-website-tanstack-start/test/integ.test.ts
+++ b/examples/railway-website-tanstack-start/test/integ.test.ts
@@ -47,7 +47,6 @@ const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   providers: Railway.providers(),
   state: Alchemy.localState(),
   profile: process.env.ALCHEMY_PROFILE,
-  stage: "test",
 });
 
 // The first deploy runs the full Vite build AND creates a Railway

--- a/examples/railway-website-vocs/test/integ.test.ts
+++ b/examples/railway-website-vocs/test/integ.test.ts
@@ -12,7 +12,6 @@ const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   providers: Railway.providers(),
   state: Alchemy.localState(),
   profile: process.env.ALCHEMY_PROFILE,
-  stage: "test",
 });
 
 const stack = beforeAll(deploy(Stack).pipe(Effect.tap(Console.log)), {

--- a/examples/railway-website-waku/test/integ.test.ts
+++ b/examples/railway-website-waku/test/integ.test.ts
@@ -16,7 +16,6 @@ const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   providers: Railway.providers(),
   state: Alchemy.localState(),
   profile: process.env.ALCHEMY_PROFILE,
-  stage: "test",
 });
 
 // The first deploy runs the full Waku build AND creates a Railway

--- a/packages/alchemy/src/Cli/commands/flags.ts
+++ b/packages/alchemy/src/Cli/commands/flags.ts
@@ -15,6 +15,13 @@ export const USER = Config.String("USER").pipe(
   Config.withDefault("unknown"),
 );
 
+/** `live_$USER`, `dev_$USER`, or `test_$USER` (falls back to `*_unknown`). */
+export const userStage = (kind: "live" | "dev" | "test") =>
+  USER.pipe(
+    Effect.map((user) => `${kind}_${user}`),
+    Effect.catch(() => Effect.succeed(`${kind}_unknown`)),
+  );
+
 export const ALCHEMY_STAGE = Config.String("ALCHEMY_STAGE").pipe(
   Config.option,
   Effect.map(Option.getOrUndefined),
@@ -69,10 +76,7 @@ export const resolveStage = Effect.fn(function* (
     }
     return configured;
   }
-  return yield* USER.pipe(
-    Effect.map((user) => `${kind}_${user}`),
-    Effect.catch(() => Effect.succeed(`${kind}_unknown`)),
-  );
+  return yield* userStage(kind);
 });
 
 export const envFile = Flag.File("env-file").pipe(

--- a/packages/alchemy/src/Test/Alchemy.ts
+++ b/packages/alchemy/src/Test/Alchemy.ts
@@ -42,6 +42,8 @@ export type ScratchStack = Core.ScratchStack;
 export type TestEffect<A, R = never> = Core.TestEffect<A, R>;
 export const ALCHEMY_TEST_DEV = Core.ALCHEMY_TEST_DEV;
 export const resolveDev = Core.resolveDev;
+export const defaultStage = Core.defaultStage;
+export const resolveStage = Core.resolveStage;
 
 interface TestFn {
   (name: string, eff: TestEffect<void>, options?: TestOptions): void;

--- a/packages/alchemy/src/Test/Bun.ts
+++ b/packages/alchemy/src/Test/Bun.ts
@@ -25,6 +25,8 @@ export {
 export type MakeOptions<ROut = any> = Core.MakeOptions<ROut>;
 export type ScratchStack = Core.ScratchStack;
 export type TestEffect<A, R = never> = Core.TestEffect<A, R>;
+export const defaultStage = Core.defaultStage;
+export const resolveStage = Core.resolveStage;
 
 export interface TestApi {
   test: TestFn;

--- a/packages/alchemy/src/Test/Core.ts
+++ b/packages/alchemy/src/Test/Core.ts
@@ -24,6 +24,7 @@ import { CredentialsStoreLive } from "../Auth/Credentials.ts";
 import { ProfileStoreLive } from "../Auth/Profile.ts";
 import { withProfileOverride } from "../Auth/Resolve.ts";
 import * as Interaction from "../Interaction.ts";
+import { userStage } from "../Cli/commands/flags.ts";
 import { LoggingCli } from "../Cli/LoggingCli.ts";
 import { deploy as _deploy } from "../Deploy.ts";
 import { destroy as _destroy } from "../Destroy.ts";
@@ -55,7 +56,12 @@ export interface MakeOptions<ROut = any> {
   state?: Layer.Layer<State.State, never, StackServices>;
   /** Override the current profile; otherwise resolved from env or the built-in `default`. */
   profile?: string;
-  /** Default stage for deploy/destroy (default `"test"`). */
+  /**
+   * Default stage for deploy/destroy. Defaults to `test_$USER` (or
+   * `test_$USERNAME` on Windows, `test_unknown` if neither is set) so two
+   * people running the same suite against one account don't collide.
+   * Does **not** read `$ALCHEMY_STAGE` — that is the CLI deploy/dev stage.
+   */
   stage?: string;
   /**
    * Engine-level adoption policy for this test run. When `true`, resources
@@ -146,6 +152,16 @@ export const resolveDev = (options: { dev?: boolean }): boolean => {
 /** Resolve the effective `sidecar` flag: defaults to the resolved `dev` flag. */
 export const resolveSidecar = (options: MakeOptions): boolean =>
   options.sidecar ?? resolveDev(options);
+
+/**
+ * Default test stage: `test_$USER` (or `test_$USERNAME` / `test_unknown`).
+ * Matches the CLI's `live_$USER` / `dev_$USER` per-developer isolation.
+ */
+export const defaultStage = (): string => Effect.runSync(userStage("test"));
+
+/** File-level stage: `options.stage` if set, otherwise {@link defaultStage}. */
+export const resolveStage = (options: { stage?: string }): string =>
+  options.stage ?? defaultStage();
 
 /**
  * The sidecar runtime handed to each adapter's `make(...)`.
@@ -409,19 +425,20 @@ export const withProviders = <A, E, R, ROut>(
     Option.getOrElse(alchemyTestDevOverride(), () => false) === true
       ? Effect.provide(effect, flociServices())
       : effect;
+  const stage = resolveStage(options);
   return body.pipe(
     Effect.provide(
       (options.providers as Layer.Layer<any, never, any>).pipe(
         Layer.provideMerge(
           Layer.succeed(Stack, {
             name: stackName,
-            stage: options.stage ?? "test",
+            stage,
             resources: {},
             bindings: {},
             actions: {},
           }),
         ),
-        Layer.provideMerge(Layer.succeed(Stage, options.stage ?? "test")),
+        Layer.provideMerge(Layer.succeed(Stage, stage)),
       ),
     ),
   ) as Effect.Effect<A, E, Exclude<R, ROut | Stack | Stage>>;
@@ -444,7 +461,7 @@ export const deploy = <A>(
 ) =>
   _deploy({
     stack: stack as Effect.Effect<CompiledStack<A>, never, any>,
-    stage: callOptions?.stage ?? options.stage ?? "test",
+    stage: callOptions?.stage ?? resolveStage(options),
     dev: resolveDev(options),
     scope: callOptions?.scope,
   }).pipe(Effect.provide(TelemetryLive));
@@ -456,7 +473,7 @@ export const destroy = (
 ) =>
   _destroy({
     stack: stack as Effect.Effect<CompiledStack, never, any>,
-    stage: callOptions?.stage ?? options.stage ?? "test",
+    stage: callOptions?.stage ?? resolveStage(options),
     dev: resolveDev(options),
     scope: callOptions?.scope,
   }).pipe(Effect.provide(TelemetryLive));
@@ -482,6 +499,8 @@ export const destroy = (
  */
 export interface ScratchStack<ROut = any> {
   readonly name: string;
+  /** Stage this scratch deploys to ({@link resolveStage} of the file options). */
+  readonly stage: string;
   /** The shared in-memory state Layer for this scratch. @internal */
   readonly state: Layer.Layer<State.State, never, never>;
   deploy<A, E, R>(
@@ -532,7 +551,7 @@ export const scratchStack = <ROut>(
   name: string,
   file?: string,
 ): ScratchStack<ROut> => {
-  const stage = options.stage ?? "test";
+  const stage = resolveStage(options);
   const stackName = sanitizeStackName(
     file === undefined ? name : `${scratchNamespace(file)}-${name}`,
   );
@@ -587,6 +606,7 @@ export const scratchStack = <ROut>(
 
   return {
     name: stackName,
+    stage,
     state: stateLayer,
     deploy: ((effect: Effect.Effect<any, any, any>) =>
       buildAndApply(effect)) as ScratchStack<ROut>["deploy"],

--- a/packages/alchemy/src/Test/Vitest.ts
+++ b/packages/alchemy/src/Test/Vitest.ts
@@ -29,6 +29,8 @@ export {
 export type MakeOptions<ROut = any> = Core.MakeOptions<ROut>;
 export type ScratchStack = Core.ScratchStack;
 export type TestEffect<A, R = never> = Core.TestEffect<A, R>;
+export const defaultStage = Core.defaultStage;
+export const resolveStage = Core.resolveStage;
 
 type TestOptions = number | { timeout?: number };
 

--- a/packages/alchemy/src/Test/index.ts
+++ b/packages/alchemy/src/Test/index.ts
@@ -1,2 +1,7 @@
 export * from "./TestState.ts";
-export { ALCHEMY_TEST_DEV, resolveDev } from "./Core.ts";
+export {
+  ALCHEMY_TEST_DEV,
+  defaultStage,
+  resolveDev,
+  resolveStage,
+} from "./Core.ts";

--- a/packages/alchemy/test/AWS/ACM/Certificate.test.ts
+++ b/packages/alchemy/test/AWS/ACM/Certificate.test.ts
@@ -218,7 +218,7 @@ test.provider.skipIf(!!process.env.FAST)(
       // interrupted deploy leaves behind: `creating`, no attributes, and the
       // props lost in the Output round-trip.
       const state = yield* yield* State;
-      const stage = "test"; // scratch stacks default to the "test" stage
+      const stage = stack.stage;
       const fqns = yield* state.list({ stack: stack.name, stage });
       const rows = yield* Effect.forEach(fqns, (fqn) =>
         state

--- a/packages/alchemy/test/AWS/AutoScaling/ScalingPolicy.test.ts
+++ b/packages/alchemy/test/AWS/AutoScaling/ScalingPolicy.test.ts
@@ -205,7 +205,7 @@ test.provider(
       // Output-valued `autoScalingGroup` lost in the round-trip.
       const wedgeRow = Effect.gen(function* () {
         const state = yield* yield* State;
-        const stage = "test"; // scratch stacks default to the "test" stage
+        const stage = stack.stage;
         const fqns = yield* state.list({ stack: stack.name, stage });
         const rows = yield* Effect.forEach(fqns, (fqn) =>
           state

--- a/packages/alchemy/test/AWS/CloudFront/PublicKey.test.ts
+++ b/packages/alchemy/test/AWS/CloudFront/PublicKey.test.ts
@@ -136,7 +136,7 @@ describe("AWS.CloudFront.PublicKey", () => {
         // deploy leaves behind: `creating`, no attributes, and the
         // Output-valued `encodedKey` lost in the round-trip (#736).
         const state = yield* yield* State;
-        const stage = "test"; // scratch stacks default to the "test" stage
+        const stage = stack.stage;
         const fqns = yield* state.list({ stack: stack.name, stage });
         const rows = yield* Effect.forEach(fqns, (fqn) =>
           state

--- a/packages/alchemy/test/AWS/DynamoDB/Table.test.ts
+++ b/packages/alchemy/test/AWS/DynamoDB/Table.test.ts
@@ -1154,7 +1154,7 @@ describe.skipIf(!!process.env.FAST)("AWS.DynamoDB.Table", () => {
             const state = yield* yield* State;
             yield* state.delete({
               stack: stack.name,
-              stage: "test",
+              stage: stack.stage,
               fqn: "AdoptableTable",
             });
           }).pipe(Effect.provide(stack.state));
@@ -1218,7 +1218,7 @@ describe.skipIf(!!process.env.FAST)("AWS.DynamoDB.Table", () => {
             const state = yield* yield* State;
             yield* state.delete({
               stack: stack.name,
-              stage: "test",
+              stage: stack.stage,
               fqn: "Original",
             });
           }).pipe(Effect.provide(stack.state));
@@ -1292,7 +1292,7 @@ describe.skipIf(!!process.env.FAST)("AWS.DynamoDB.Table", () => {
         // interrupted deploy leaves behind: `creating`, no attributes, and
         // the `attributes` prop lost in the state round-trip.
         const state = yield* yield* State;
-        const stage = "test"; // scratch stacks default to the "test" stage
+        const stage = stack.stage;
         const fqns = yield* state.list({ stack: stack.name, stage });
         const rows = yield* Effect.forEach(fqns, (fqn) =>
           state

--- a/packages/alchemy/test/AWS/ECS/PlatformInlineClass.test.ts
+++ b/packages/alchemy/test/AWS/ECS/PlatformInlineClass.test.ts
@@ -122,7 +122,7 @@ test.provider(
       const state = yield* yield* State;
       const row = yield* state.get({
         stack: stack.name,
-        stage: "test",
+        stage: stack.stage,
         fqn: "InlineService",
       });
       const props = (row as { props?: Record<string, unknown> } | undefined)

--- a/packages/alchemy/test/AWS/ECS/Service.platform.test.ts
+++ b/packages/alchemy/test/AWS/ECS/Service.platform.test.ts
@@ -332,7 +332,7 @@ test.provider(
 
       // Rewrite the service's state row into the legacy inline shape.
       const state = yield* yield* State;
-      const stage = "test"; // scratch stacks default to the "test" stage
+      const stage = stack.stage;
       const fqns = yield* state.list({ stack: stack.name, stage });
       const rows = yield* Effect.forEach(fqns, (fqn) =>
         state

--- a/packages/alchemy/test/AWS/ECS/Service.test.ts
+++ b/packages/alchemy/test/AWS/ECS/Service.test.ts
@@ -551,7 +551,7 @@ test.provider(
       // interrupted deploy leaves behind: `creating`, no attributes, and
       // every Output-valued prop lost in the round-trip.
       const state = yield* yield* State;
-      const stage = "test"; // scratch stacks default to the "test" stage
+      const stage = stack.stage;
       const fqns = yield* state.list({ stack: stack.name, stage });
       const rows = yield* Effect.forEach(fqns, (fqn) =>
         state

--- a/packages/alchemy/test/AWS/IAM/OpenIDConnectProvider.test.ts
+++ b/packages/alchemy/test/AWS/IAM/OpenIDConnectProvider.test.ts
@@ -84,7 +84,7 @@ describe("AWS.IAM.OpenIDConnectProvider", () => {
         // interrupted deploy leaves behind: `creating`, no attributes, and
         // the Output-valued `url` prop lost in the round-trip.
         const state = yield* yield* State;
-        const stage = "test"; // scratch stacks default to the "test" stage
+        const stage = stack.stage;
         const fqns = yield* state.list({ stack: stack.name, stage });
         const rows = yield* Effect.forEach(fqns, (fqn) =>
           state

--- a/packages/alchemy/test/AWS/IAM/Role.test.ts
+++ b/packages/alchemy/test/AWS/IAM/Role.test.ts
@@ -284,7 +284,7 @@ test.provider(
         const state = yield* yield* State;
         yield* state.delete({
           stack: stack.name,
-          stage: "test",
+          stage: stack.stage,
           fqn: "AdoptableRole",
         });
       }).pipe(Effect.provide(stack.state));
@@ -335,7 +335,7 @@ test.provider(
         const state = yield* yield* State;
         yield* state.delete({
           stack: stack.name,
-          stage: "test",
+          stage: stack.stage,
           fqn: "Original",
         });
       }).pipe(Effect.provide(stack.state));

--- a/packages/alchemy/test/AWS/Kinesis/Stream.test.ts
+++ b/packages/alchemy/test/AWS/Kinesis/Stream.test.ts
@@ -581,7 +581,7 @@ describe.skipIf(!!process.env.FAST)("AWS.Kinesis.Stream", () => {
             const state = yield* yield* State;
             yield* state.delete({
               stack: stack.name,
-              stage: "test",
+              stage: stack.stage,
               fqn: "AdoptableStream",
             });
           }).pipe(Effect.provide(stack.state));
@@ -628,7 +628,7 @@ describe.skipIf(!!process.env.FAST)("AWS.Kinesis.Stream", () => {
             const state = yield* yield* State;
             yield* state.delete({
               stack: stack.name,
-              stage: "test",
+              stage: stack.stage,
               fqn: "Original",
             });
           }).pipe(Effect.provide(stack.state));

--- a/packages/alchemy/test/AWS/Lambda/Version.test.ts
+++ b/packages/alchemy/test/AWS/Lambda/Version.test.ts
@@ -134,7 +134,7 @@ test.provider(
       // State resolves to an Effect that initializes and yields the concrete
       // state-store service.
       const state = yield* yield* State;
-      const stage = "test";
+      const stage = stack.stage;
       const fqns = yield* state.list({ stack: stack.name, stage });
       const rows = yield* Effect.forEach(fqns, (fqn) =>
         state

--- a/packages/alchemy/test/AWS/Organizations/DelegatedAdministrator.test.ts
+++ b/packages/alchemy/test/AWS/Organizations/DelegatedAdministrator.test.ts
@@ -116,7 +116,7 @@ test.provider.skipIf(!memberAccountId)(
       // interrupted deploy leaves behind: `creating`, no attributes, and
       // every Output-valued prop lost in the round-trip.
       const state = yield* yield* State;
-      const stage = "test"; // scratch stacks default to the "test" stage
+      const stage = stack.stage;
       const fqns = yield* state.list({ stack: stack.name, stage });
       const rows = yield* Effect.forEach(fqns, (fqn) =>
         state

--- a/packages/alchemy/test/AWS/Organizations/PolicyAttachment.test.ts
+++ b/packages/alchemy/test/AWS/Organizations/PolicyAttachment.test.ts
@@ -182,7 +182,7 @@ test.provider.skipIf(!process.env.AWS_ORG_MANAGEMENT_ACCOUNT)(
       // interrupted deploy leaves behind: `creating`, no attributes, and
       // every Output-valued prop lost in the round-trip.
       const state = yield* yield* State;
-      const stage = "test"; // scratch stacks default to the "test" stage
+      const stage = stack.stage;
       const fqns = yield* state.list({ stack: stack.name, stage });
       const rows = yield* Effect.forEach(fqns, (fqn) =>
         state

--- a/packages/alchemy/test/AWS/Organizations/RootPolicyType.test.ts
+++ b/packages/alchemy/test/AWS/Organizations/RootPolicyType.test.ts
@@ -79,7 +79,7 @@ test.provider.skipIf(!process.env.AWS_ORG_MANAGEMENT_ACCOUNT)(
       // is list-and-find; the crash this fix guards is the `olds!` deref on
       // a row with no props at all).
       const state = yield* yield* State;
-      const stage = "test"; // scratch stacks default to the "test" stage
+      const stage = stack.stage;
       const fqns = yield* state.list({ stack: stack.name, stage });
       const rows = yield* Effect.forEach(fqns, (fqn) =>
         state

--- a/packages/alchemy/test/AWS/Organizations/TrustedServiceAccess.test.ts
+++ b/packages/alchemy/test/AWS/Organizations/TrustedServiceAccess.test.ts
@@ -105,7 +105,7 @@ test.provider.skipIf(!process.env.AWS_ORG_MANAGEMENT_ACCOUNT)(
       // `readTrustedServiceAccess` is list-and-find; the crash this fix
       // guards is the `olds!` deref on a row with no props at all).
       const state = yield* yield* State;
-      const stage = "test"; // scratch stacks default to the "test" stage
+      const stage = stack.stage;
       const fqns = yield* state.list({ stack: stack.name, stage });
       const rows = yield* Effect.forEach(fqns, (fqn) =>
         state

--- a/packages/alchemy/test/AWS/Route53/HostedZone.test.ts
+++ b/packages/alchemy/test/AWS/Route53/HostedZone.test.ts
@@ -195,7 +195,7 @@ test.provider(
       // deploy leaves behind: `creating`, no attributes, and the Output-valued
       // `name` lost in the state round-trip.
       const state = yield* yield* State;
-      const stage = "test"; // scratch stacks default to the "test" stage
+      const stage = stack.stage;
       const fqns = yield* state.list({ stack: stack.name, stage });
       const rows = yield* Effect.forEach(fqns, (fqn) =>
         state

--- a/packages/alchemy/test/AWS/Route53/Record.test.ts
+++ b/packages/alchemy/test/AWS/Route53/Record.test.ts
@@ -395,7 +395,7 @@ test.provider(
       // no attributes, and the Output-valued identity props lost in the
       // state round-trip.
       const state = yield* yield* State;
-      const stage = "test"; // scratch stacks default to the "test" stage
+      const stage = stack.stage;
       const fqns = yield* state.list({ stack: stack.name, stage });
       const rows = yield* Effect.forEach(fqns, (fqn) =>
         state

--- a/packages/alchemy/test/AWS/S3/Bucket.test.ts
+++ b/packages/alchemy/test/AWS/S3/Bucket.test.ts
@@ -381,7 +381,7 @@ test.provider(
           const state = yield* yield* State;
           yield* state.delete({
             stack: stack.name,
-            stage: "test",
+            stage: stack.stage,
             fqn: "AdoptableBucket",
           });
         }).pipe(Effect.provide(stack.state));

--- a/packages/alchemy/test/AWS/SNS/Topic.test.ts
+++ b/packages/alchemy/test/AWS/SNS/Topic.test.ts
@@ -171,7 +171,7 @@ describe("AWS.SNS.Topic", () => {
             const state = yield* yield* State;
             yield* state.delete({
               stack: stack.name,
-              stage: "test",
+              stage: stack.stage,
               fqn: "AdoptableTopic",
             });
           }).pipe(Effect.provide(stack.state));
@@ -215,7 +215,7 @@ describe("AWS.SNS.Topic", () => {
             const state = yield* yield* State;
             yield* state.delete({
               stack: stack.name,
-              stage: "test",
+              stage: stack.stage,
               fqn: "Original",
             });
           }).pipe(Effect.provide(stack.state));

--- a/packages/alchemy/test/AWS/SQS/Queue.test.ts
+++ b/packages/alchemy/test/AWS/SQS/Queue.test.ts
@@ -282,7 +282,7 @@ provider(
         const state = yield* yield* State;
         yield* state.delete({
           stack: stack.name,
-          stage: "test",
+          stage: stack.stage,
           fqn: "AdoptableQueue",
         });
       }).pipe(Effect.provide(stack.state));
@@ -321,7 +321,7 @@ provider("foreign-tagged queue requires adopt(true) to take over", (stack) =>
       const state = yield* yield* State;
       yield* state.delete({
         stack: stack.name,
-        stage: "test",
+        stage: stack.stage,
         fqn: "Original",
       });
     }).pipe(Effect.provide(stack.state));

--- a/packages/alchemy/test/Cli/StageEnvironment.test.ts
+++ b/packages/alchemy/test/Cli/StageEnvironment.test.ts
@@ -1,5 +1,5 @@
 import { UserInputError } from "@/Cli/commands/errors.ts";
-import { resolveStage, stage } from "@/Cli/commands/flags.ts";
+import { resolveStage, stage, userStage } from "@/Cli/commands/flags.ts";
 import { PlatformServices } from "@/Util/PlatformServices.ts";
 import { describe, expect, test } from "alchemy-test";
 import * as ConfigProvider from "effect/ConfigProvider";
@@ -177,5 +177,11 @@ describe("default stages", () => {
         );
       }).pipe(provideStageTest),
     { exclusive: true },
+  );
+
+  test.effect("userStage('test') is test_${USER}", () =>
+    Effect.gen(function* () {
+      expect(yield* userStage("test")).toBe("test_sam");
+    }).pipe(Effect.provide(TestEnv)),
   );
 });

--- a/packages/alchemy/test/Cloudflare/AI/Gateway.test.ts
+++ b/packages/alchemy/test/Cloudflare/AI/Gateway.test.ts
@@ -240,7 +240,7 @@ test.provider(
         const state = yield* yield* State;
         yield* state.delete({
           stack: stack.name,
-          stage: "test",
+          stage: stack.stage,
           fqn: "AdoptableGateway",
         });
       }).pipe(Effect.provide(stack.state));
@@ -262,7 +262,7 @@ test.provider(
         const state = yield* yield* State;
         return yield* state.get({
           stack: stack.name,
-          stage: "test",
+          stage: stack.stage,
           fqn: "AdoptableGateway",
         });
       }).pipe(Effect.provide(stack.state));

--- a/packages/alchemy/test/Cloudflare/Access/Application.test.ts
+++ b/packages/alchemy/test/Cloudflare/Access/Application.test.ts
@@ -390,7 +390,7 @@ test.provider(
       const state = yield* yield* State.State;
       yield* state.delete({
         stack: stack.name,
-        stage: "test",
+        stage: stack.stage,
         fqn: "ColdReadApp",
       });
 

--- a/packages/alchemy/test/Cloudflare/Access/InfrastructureTarget.test.ts
+++ b/packages/alchemy/test/Cloudflare/Access/InfrastructureTarget.test.ts
@@ -91,7 +91,7 @@ test.provider(
       // the Output-valued `ip` prop lost in the round-trip. `hostname`
       // survives so the cold-read identity path runs.
       const state = yield* yield* State;
-      const stage = "test"; // scratch stacks default to the "test" stage
+      const stage = stack.stage;
       const fqns = yield* state.list({ stack: stack.name, stage });
       const rows = yield* Effect.forEach(fqns, (fqn) =>
         state

--- a/packages/alchemy/test/Cloudflare/D1/Database.test.ts
+++ b/packages/alchemy/test/Cloudflare/D1/Database.test.ts
@@ -483,7 +483,7 @@ test.provider(
         const state = yield* yield* State;
         const row = yield* state.get({
           stack: stack.name,
-          stage: "test",
+          stage: stack.stage,
           fqn: "RollForwardDb",
         });
         const attr = {
@@ -492,7 +492,7 @@ test.provider(
         };
         yield* state.set({
           stack: stack.name,
-          stage: "test",
+          stage: stack.stage,
           fqn: "RollForwardDb",
           value: { ...(row as any), attr },
         });
@@ -605,7 +605,7 @@ test.provider(
         const state = yield* yield* State;
         const row = yield* state.get({
           stack: stack.name,
-          stage: "test",
+          stage: stack.stage,
           fqn: "RollForwardDrizzleDb",
         });
         const attr = {
@@ -616,7 +616,7 @@ test.provider(
         };
         yield* state.set({
           stack: stack.name,
-          stage: "test",
+          stage: stack.stage,
           fqn: "RollForwardDrizzleDb",
           value: { ...(row as any), attr },
         });
@@ -1064,7 +1064,7 @@ test.provider(
         const state = yield* yield* State;
         yield* state.delete({
           stack: stack.name,
-          stage: "test",
+          stage: stack.stage,
           fqn: "AdoptableDatabase",
         });
       }).pipe(Effect.provide(stack.state));
@@ -1088,7 +1088,7 @@ test.provider(
         const state = yield* yield* State;
         return yield* state.get({
           stack: stack.name,
-          stage: "test",
+          stage: stack.stage,
           fqn: "AdoptableDatabase",
         });
       }).pipe(Effect.provide(stack.state));

--- a/packages/alchemy/test/Cloudflare/Email/EmailCatchAll.test.ts
+++ b/packages/alchemy/test/Cloudflare/Email/EmailCatchAll.test.ts
@@ -219,7 +219,7 @@ describe.sequential.skipIf(!emailRoutingScoped)("EmailCatchAll", () => {
         // deploy leaves behind: `creating`, no attributes, and the
         // Output-valued `zone` prop lost in the round-trip.
         const state = yield* yield* State;
-        const stage = "test"; // scratch stacks default to the "test" stage
+        const stage = stack.stage;
         const fqns = yield* state.list({ stack: stack.name, stage });
         const rows = yield* Effect.forEach(fqns, (fqn) =>
           state

--- a/packages/alchemy/test/Cloudflare/GoogleTagGateway/GoogleTagGateway.test.ts
+++ b/packages/alchemy/test/Cloudflare/GoogleTagGateway/GoogleTagGateway.test.ts
@@ -228,7 +228,7 @@ describe.sequential("GoogleTagGateway", () => {
           // deploy leaves behind: `creating`, no attributes, and the
           // Output-valued `zone` prop lost in the state round-trip (#736).
           const state = yield* yield* State;
-          const stage = "test"; // scratch stacks default to the "test" stage
+          const stage = stack.stage;
           const fqns = yield* state.list({ stack: stack.name, stage });
           const rows = yield* Effect.forEach(fqns, (fqn) =>
             state

--- a/packages/alchemy/test/Cloudflare/KV/Namespace.test.ts
+++ b/packages/alchemy/test/Cloudflare/KV/Namespace.test.ts
@@ -142,7 +142,7 @@ test.provider(
         const state = yield* yield* State;
         yield* state.delete({
           stack: stack.name,
-          stage: "test",
+          stage: stack.stage,
           fqn: "AdoptableNamespace",
         });
       }).pipe(Effect.provide(stack.state));
@@ -164,7 +164,7 @@ test.provider(
         const state = yield* yield* State;
         return yield* state.get({
           stack: stack.name,
-          stage: "test",
+          stage: stack.stage,
           fqn: "AdoptableNamespace",
         });
       }).pipe(Effect.provide(stack.state));

--- a/packages/alchemy/test/Cloudflare/OriginCaCertificate/OriginCaCertificate.test.ts
+++ b/packages/alchemy/test/Cloudflare/OriginCaCertificate/OriginCaCertificate.test.ts
@@ -181,7 +181,7 @@ test.provider(
       // interrupted deploy leaves behind: `creating`, no attributes, and the
       // Output-valued props lost in the state round-trip (#736).
       const state = yield* yield* State;
-      const stage = "test"; // scratch stacks default to the "test" stage
+      const stage = stack.stage;
       const wedgeRow = (junk: Record<string, unknown>) =>
         Effect.gen(function* () {
           const fqns = yield* state.list({ stack: stack.name, stage });

--- a/packages/alchemy/test/Cloudflare/OriginTlsClientAuth/HostnameCertificate.test.ts
+++ b/packages/alchemy/test/Cloudflare/OriginTlsClientAuth/HostnameCertificate.test.ts
@@ -252,7 +252,7 @@ test.provider(
       // leaves behind when `certificate` was Output-valued: `creating`, no
       // attributes, and the certificate lost in the round-trip (#736).
       const state = yield* yield* State;
-      const stage = "test"; // scratch stacks default to the "test" stage
+      const stage = stack.stage;
       const fqns = yield* state.list({ stack: stack.name, stage });
       const rows = yield* Effect.forEach(fqns, (fqn) =>
         state

--- a/packages/alchemy/test/Cloudflare/Queue/QueueConsumer.test.ts
+++ b/packages/alchemy/test/Cloudflare/Queue/QueueConsumer.test.ts
@@ -277,7 +277,7 @@ test.provider("adopts existing consumer after local state loss", (stack) =>
       const state = yield* yield* State;
       yield* state.delete({
         stack: stack.name,
-        stage: "test",
+        stage: stack.stage,
         fqn: "Consumer",
       });
     }).pipe(Effect.provide(stack.state));
@@ -354,7 +354,7 @@ test.provider(
         const state = yield* yield* State;
         yield* state.delete({
           stack: stack.name,
-          stage: "test",
+          stage: stack.stage,
           fqn: "Consumer",
         });
       }).pipe(Effect.provide(stack.state));
@@ -448,7 +448,7 @@ test.provider(
         const state = yield* yield* State;
         yield* state.delete({
           stack: stack.name,
-          stage: "test",
+          stage: stack.stage,
           fqn: "Consumer",
         });
       }).pipe(Effect.provide(stack.state));
@@ -520,7 +520,7 @@ test.provider("suppresses deletion of a dev-only consumer", (stack) =>
       const state = yield* yield* State;
       yield* state.set({
         stack: stack.name,
-        stage: "test",
+        stage: stack.stage,
         fqn: "Consumer",
         value: {
           kind: "resource",
@@ -556,7 +556,7 @@ test.provider("suppresses deletion of a dev-only consumer", (stack) =>
       const state = yield* yield* State;
       return yield* state.get({
         stack: stack.name,
-        stage: "test",
+        stage: stack.stage,
         fqn: "Consumer",
       });
     });
@@ -608,12 +608,12 @@ test.provider("promotes a dev consumer to a live consumer on deploy", (stack) =>
       const state = yield* yield* State;
       const currentConsumer = (yield* state.get({
         stack: stack.name,
-        stage: "test",
+        stage: stack.stage,
         fqn: "Consumer",
       })) as CreatedResourceState;
       yield* state.set({
         stack: stack.name,
-        stage: "test",
+        stage: stack.stage,
         fqn: "Consumer",
         value: {
           ...currentConsumer,

--- a/packages/alchemy/test/Cloudflare/R2/Bucket.test.ts
+++ b/packages/alchemy/test/Cloudflare/R2/Bucket.test.ts
@@ -149,7 +149,7 @@ test.provider(
         const state = yield* yield* State;
         yield* state.delete({
           stack: stack.name,
-          stage: "test",
+          stage: stack.stage,
           fqn: "AdoptableBucket",
         });
       }).pipe(Effect.provide(stack.state));
@@ -172,7 +172,7 @@ test.provider(
         const state = yield* yield* State;
         return yield* state.get({
           stack: stack.name,
-          stage: "test",
+          stage: stack.stage,
           fqn: "AdoptableBucket",
         });
       }).pipe(Effect.provide(stack.state));
@@ -668,7 +668,7 @@ test.provider("cors reconciliation converges drift and adoption", (stack) =>
       const state = yield* yield* State;
       yield* state.delete({
         stack: stack.name,
-        stage: "test",
+        stage: stack.stage,
         fqn: "DriftCorsBucket",
       });
     }).pipe(Effect.provide(stack.state));
@@ -726,7 +726,7 @@ test.provider(
 
       const detected = yield* Drift.detect({
         name: stack.name,
-        stage: "test",
+        stage: stack.stage,
       }).pipe(Effect.provide(stack.state));
       expect(detected.resources.DriftRepairBucket).toMatchObject({
         action: "drifted",
@@ -735,7 +735,7 @@ test.provider(
 
       const repaired = yield* Drift.repair({
         name: stack.name,
-        stage: "test",
+        stage: stack.stage,
       }).pipe(Effect.provide(stack.state));
       expect(repaired.resources.DriftRepairBucket).toMatchObject({
         action: "repaired",
@@ -774,7 +774,7 @@ test.provider(
 
       const detected = yield* Drift.detect({
         name: stack.name,
-        stage: "test",
+        stage: stack.stage,
       }).pipe(Effect.provide(stack.state));
       expect(detected.resources.DriftRecreateBucket).toMatchObject({
         action: "missing",
@@ -783,7 +783,7 @@ test.provider(
 
       const repaired = yield* Drift.repair({
         name: stack.name,
-        stage: "test",
+        stage: stack.stage,
       }).pipe(Effect.provide(stack.state));
       expect(repaired.resources.DriftRecreateBucket).toMatchObject({
         action: "recreated",
@@ -988,7 +988,7 @@ test.provider("managed r2.dev domain converges drift and adoption", (stack) =>
       const state = yield* yield* State;
       yield* state.delete({
         stack: stack.name,
-        stage: "test",
+        stage: stack.stage,
         fqn: "DriftPublicBucket",
       });
     }).pipe(Effect.provide(stack.state));
@@ -1145,19 +1145,21 @@ const listKeysWhenReady = Effect.fn(function* (
 class ListLagError extends Data.TaggedError("ListLagError") {}
 
 const stateOf = Effect.fn(function* (
-  stack: { name: string; state: Layer.Layer<State> },
+  stack: { name: string; stage: string; state: Layer.Layer<State> },
   fqn: string,
 ) {
   return yield* Effect.gen(function* () {
     const state = yield* yield* State;
-    return (yield* state.get({ stack: stack.name, stage: "test", fqn })) as
-      | ResourceState
-      | undefined;
+    return (yield* state.get({
+      stack: stack.name,
+      stage: stack.stage,
+      fqn,
+    })) as ResourceState | undefined;
   }).pipe(Effect.provide(stack.state));
 });
 
 const removalPolicyOf = Effect.fn(function* (
-  stack: { name: string; state: Layer.Layer<State> },
+  stack: { name: string; stage: string; state: Layer.Layer<State> },
   fqn: string,
 ) {
   return (yield* stateOf(stack, fqn))?.removalPolicy;

--- a/packages/alchemy/test/Cloudflare/Ruleset/Ruleset.test.ts
+++ b/packages/alchemy/test/Cloudflare/Ruleset/Ruleset.test.ts
@@ -271,7 +271,7 @@ describe.sequential("Ruleset", () => {
         // interrupted deploy leaves behind: `creating`, no attributes, and the
         // Output-valued `zone` prop lost in the round-trip.
         const state = yield* yield* State;
-        const stage = "test"; // scratch stacks default to the "test" stage
+        const stage = stack.stage;
         const fqns = yield* state.list({ stack: stack.name, stage });
         const rows = yield* Effect.forEach(fqns, (fqn) =>
           state

--- a/packages/alchemy/test/Cloudflare/Workers/Worker.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/Worker.test.ts
@@ -515,7 +515,7 @@ describe.concurrent("Cloudflare.Worker", () => {
           const state = yield* yield* State;
           yield* state.delete({
             stack: stack.name,
-            stage: "test",
+            stage: stack.stage,
             fqn: "AdoptableWorker",
           });
         }).pipe(Effect.provide(stack.state));
@@ -541,7 +541,7 @@ describe.concurrent("Cloudflare.Worker", () => {
           const state = yield* yield* State;
           return yield* state.get({
             stack: stack.name,
-            stage: "test",
+            stage: stack.stage,
             fqn: "AdoptableWorker",
           });
         }).pipe(Effect.provide(stack.state));
@@ -587,7 +587,7 @@ describe.concurrent("Cloudflare.Worker", () => {
         const state = yield* yield* State;
         yield* state.delete({
           stack: stack.name,
-          stage: "test",
+          stage: stack.stage,
           fqn: "Original",
         });
       }).pipe(Effect.provide(stack.state));
@@ -1501,7 +1501,7 @@ describe.concurrent("Cloudflare.Worker", () => {
           const state = yield* yield* State;
           const key = {
             stack: stack.name,
-            stage: "test",
+            stage: stack.stage,
             fqn: "LegacyStateWorker",
           };
           const current = yield* state.get(key);
@@ -1597,7 +1597,11 @@ describe.concurrent("Cloudflare.Worker", () => {
         // surface (any value the new code can't reproduce).
         yield* Effect.gen(function* () {
           const state = yield* yield* State;
-          const key = { stack: stack.name, stage: "test", fqn: "BareUpstream" };
+          const key = {
+            stack: stack.name,
+            stage: stack.stage,
+            fqn: "BareUpstream",
+          };
           const current = yield* state.get(key);
           expect(current).toBeDefined();
           const attr = {

--- a/packages/alchemy/test/Cloudflare/Workers/WorkerId.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/WorkerId.test.ts
@@ -82,7 +82,7 @@ test.provider(
       // Rewrite the persisted row into the pre-rename shape: older betas
       // stored the script *name* in `workerId`.
       const state = yield* yield* State;
-      const stage = "test"; // scratch stacks default to the "test" stage
+      const stage = stack.stage;
       const fqns = yield* state.list({ stack: stack.name, stage });
       const rows = yield* Effect.forEach(fqns, (fqn) =>
         state
@@ -143,7 +143,7 @@ test.provider(
       // Simulate state loss: the script lives on in Cloudflare, but the
       // engine has no row for it.
       const state = yield* yield* State;
-      const stage = "test";
+      const stage = stack.stage;
       const fqns = yield* state.list({ stack: stack.name, stage });
       const rows = yield* Effect.forEach(fqns, (fqn) =>
         state

--- a/packages/alchemy/test/Cloudflare/Workers/WorkerVersion.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workers/WorkerVersion.test.ts
@@ -381,7 +381,11 @@ describe.concurrent("Cloudflare.Worker version", () => {
         // preview URLs in `domains`, no `urls`/`domain`, legacy hash.
         yield* Effect.gen(function* () {
           const state = yield* yield* State;
-          const key = { stack: stack.name, stage: "test", fqn: "MigrPreview" };
+          const key = {
+            stack: stack.name,
+            stage: stack.stage,
+            fqn: "MigrPreview",
+          };
           const current = yield* state.get(key);
           expect(current).toBeDefined();
           const attr = {

--- a/packages/alchemy/test/Cloudflare/Workflows/Workflow.local.test.ts
+++ b/packages/alchemy/test/Cloudflare/Workflows/Workflow.local.test.ts
@@ -108,9 +108,13 @@ const waitForTerminal = (url: string, instanceId: string) =>
 const readWorkflowRow = (stack: Test.ScratchStack) =>
   Effect.gen(function* () {
     const state = yield* yield* State.State;
-    const fqns = yield* state.list({ stack: stack.name, stage: "test" });
+    const fqns = yield* state.list({ stack: stack.name, stage: stack.stage });
     for (const fqn of fqns) {
-      const row = yield* state.get({ stack: stack.name, stage: "test", fqn });
+      const row = yield* state.get({
+        stack: stack.name,
+        stage: stack.stage,
+        fqn,
+      });
       if (
         row &&
         (row as { resourceType?: string }).resourceType ===

--- a/packages/alchemy/test/Cloudflare/Zaraz/ZarazConfig.test.ts
+++ b/packages/alchemy/test/Cloudflare/Zaraz/ZarazConfig.test.ts
@@ -242,7 +242,7 @@ describe.sequential("Config", () => {
           // deploy leaves behind: `creating`, no attributes, and the
           // Output-valued `zone` prop lost in the round-trip (#736).
           const state = yield* yield* State;
-          const stage = "test"; // scratch stacks default to the "test" stage
+          const stage = stack.stage;
           const fqns = yield* state.list({ stack: stack.name, stage });
           const rows = yield* Effect.forEach(fqns, (fqn) =>
             state

--- a/packages/alchemy/test/Docker/Container.test.ts
+++ b/packages/alchemy/test/Docker/Container.test.ts
@@ -233,10 +233,13 @@ describe("Docker.Container", { concurrent: false }, () => {
   // Rewrite the container's persisted row into the wedged shape an
   // interrupted deploy leaves behind: `creating`, no attributes, and the
   // Output-valued `image` prop lost in the round-trip (#736).
-  const wedgeContainerRow = (stack: { readonly name: string }) =>
+  const wedgeContainerRow = (stack: {
+    readonly name: string;
+    readonly stage: string;
+  }) =>
     Effect.gen(function* () {
       const state = yield* yield* State;
-      const stage = "test"; // scratch stacks default to the "test" stage
+      const stage = stack.stage;
       const fqns = yield* state.list({ stack: stack.name, stage });
       const rows = yield* Effect.forEach(fqns, (fqn) =>
         state

--- a/packages/alchemy/test/Neon/Branch.test.ts
+++ b/packages/alchemy/test/Neon/Branch.test.ts
@@ -218,10 +218,13 @@ test.provider("replaces branch when project is replaced", (stack) =>
 // out-of-band so recovery must recreate it, redeploy, and assert convergence.
 
 /** Rewrite the deployed branch's state row into a wedged `creating` row. */
-const wedgeBranchRow = (stack: { name: string }, project: unknown) =>
+const wedgeBranchRow = (
+  stack: { name: string; stage: string },
+  project: unknown,
+) =>
   Effect.gen(function* () {
     const state = yield* yield* State;
-    const stage = "test"; // scratch stacks default to the "test" stage
+    const stage = stack.stage;
     const fqns = yield* state.list({ stack: stack.name, stage });
     const rows = yield* Effect.forEach(fqns, (fqn) =>
       state

--- a/packages/alchemy/test/action.test.ts
+++ b/packages/alchemy/test/action.test.ts
@@ -318,7 +318,7 @@ describe("Apply", () => {
       const state = yield* yield* State;
       const persisted = yield* state.get({
         stack: stack.name,
-        stage: "test",
+        stage: stack.stage,
         fqn: "Sync",
       });
       expect(persisted).toMatchObject({
@@ -424,7 +424,11 @@ describe("Apply", () => {
 
         const state = yield* yield* State;
         expect(
-          yield* state.get({ stack: stack.name, stage: "test", fqn: "Sync" }),
+          yield* state.get({
+            stack: stack.name,
+            stage: stack.stage,
+            fqn: "Sync",
+          }),
         ).toMatchObject({ kind: "action", status: "ran" });
 
         // Re-deploy WITHOUT the task — state should be dropped.
@@ -433,7 +437,11 @@ describe("Apply", () => {
         void deleteSpy;
 
         expect(
-          yield* state.get({ stack: stack.name, stage: "test", fqn: "Sync" }),
+          yield* state.get({
+            stack: stack.name,
+            stage: stack.stage,
+            fqn: "Sync",
+          }),
         ).toBeUndefined();
       }),
   );

--- a/packages/alchemy/test/scratch-state.test.ts
+++ b/packages/alchemy/test/scratch-state.test.ts
@@ -26,7 +26,7 @@ describe("test.provider scratch state durability", () => {
   const listRows = (scratch: Core.ScratchStack, stackName: string) =>
     Effect.gen(function* () {
       const state = yield* yield* State;
-      return yield* state.list({ stack: stackName, stage: "test" });
+      return yield* state.list({ stack: stackName, stage: scratch.stage });
     }).pipe(Effect.provide(scratch.state));
 
   test(
@@ -69,6 +69,22 @@ describe("test.provider scratch state durability", () => {
       // the name stays the bare test name — the pre-existing behavior.
       const bare = Core.scratchStack(options, "same name");
       expect(bare.name).toEqual("same-name");
+    }),
+  );
+
+  test(
+    "scratch stacks default to test_${USER}",
+    Effect.sync(() => {
+      const expected = `test_${process.env.USER || process.env.USERNAME || "unknown"}`;
+      expect(Core.defaultStage()).toBe(expected);
+      const scratch = Core.scratchStack(options, NAME, FILE);
+      expect(scratch.stage).toBe(expected);
+      const overridden = Core.scratchStack(
+        { ...options, stage: "custom" },
+        NAME,
+        FILE,
+      );
+      expect(overridden.stage).toBe("custom");
     }),
   );
 });

--- a/scripts/aws-leak-sweep.ts
+++ b/scripts/aws-leak-sweep.ts
@@ -5,9 +5,9 @@
  *
  * Discovery is tag-driven: every alchemy resource is branded with
  * `alchemy::stack` / `alchemy::stage` / `alchemy::id` (see src/Tags.ts
- * createInternalTags). Test suites deploy with stage `"test"` (the default in
- * packages/alchemy/src/Test/Core.ts), so we sweep everything tagged
- * `alchemy::stage = test`.
+ * createInternalTags). Test suites deploy with stage `test_$USER` (the default
+ * in packages/alchemy/src/Test/Core.ts), so we sweep everything tagged
+ * `alchemy::stage = test_$USER`.
  *
  * Primary discovery path: resourcegroupstaggingapi GetResources (regional).
  * Fallbacks for resources the tagging API can't see from a regional query:
@@ -19,7 +19,7 @@
  *   bun scripts/aws-leak-sweep.ts                      # DRY RUN (default)
  *   bun scripts/aws-leak-sweep.ts --delete             # actually delete
  *   bun scripts/aws-leak-sweep.ts --older-than 12      # only >= 12h old (default 6)
- *   bun scripts/aws-leak-sweep.ts --stage test         # tag stage filter (default test)
+ *   bun scripts/aws-leak-sweep.ts --stage test_sam     # tag stage filter (default test_$USER)
  *   bun scripts/aws-leak-sweep.ts --region us-west-2   # region (default env or us-west-2)
  *
  * KMS keys are ALWAYS report-only — never deleted by this tool.
@@ -80,7 +80,9 @@ const parseArgs = Effect.sync((): Args => {
   return {
     delete: flag("delete"),
     olderThanHours: Number(opt("older-than") ?? 6),
-    stage: opt("stage") ?? "test",
+    stage:
+      opt("stage") ??
+      `test_${process.env.USER || process.env.USERNAME || "unknown"}`,
     region:
       opt("region") ??
       process.env.AWS_REGION ??

--- a/website/src/content/docs/aws/tutorial/part-3.mdx
+++ b/website/src/content/docs/aws/tutorial/part-3.mdx
@@ -90,10 +90,11 @@ already deployed). Subsequent runs are fast because Alchemy diffs and
 skips unchanged resources.
 
 :::note[Which stage do tests deploy to?]
-The test harness defaults to a stage named `test`, separate from the
-`dev_<user>` stage your `alchemy deploy` runs target — so tests never
-clobber your working deployment. More on stages in
-[Part 4](/aws/tutorial/part-4).
+The test harness defaults to `test_$USER` (e.g. `test_sam`),
+separate from the `live_$USER` / `dev_$USER` stages your
+`alchemy deploy` / `alchemy dev` runs target — so tests never
+clobber your working deployment, and two people running the suite
+don't collide. More on stages in [Part 4](/aws/tutorial/part-4).
 :::
 
 ## Add HTTP assertions

--- a/website/src/content/docs/aws/tutorial/part-4.mdx
+++ b/website/src/content/docs/aws/tutorial/part-4.mdx
@@ -128,17 +128,17 @@ other stage alone.
 
 ## Stages in tests
 
-The test harness from Part 3 defaults to a stage named `test`. You
-can override it per file — or per call — which is how multiple CI
-runs can test in parallel against the same AWS account without
-colliding:
+The test harness from Part 3 defaults to `test_$USER` (e.g.
+`test_sam`). Override it per file — or per call — which is how
+multiple CI runs can test in parallel against the same AWS account
+without colliding:
 
 ```diff lang="typescript"
 // test/integ.test.ts
 const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   providers: AWS.providers(),
   state: AWS.state(),
-+  stage: process.env.STAGE ?? "test",
++  stage: `pr-${process.env.PR_NUMBER}`,
 });
 ```
 

--- a/website/src/content/docs/environments/stages.mdx
+++ b/website/src/content/docs/environments/stages.mdx
@@ -18,7 +18,9 @@ If you don't pass `--stage`, **`alchemy deploy`** uses **`live_$USER`**
 `dev_sam`). Each developer gets a personal cloud sandbox and a
 separate local-dev sandbox without any config — so a bare `alchemy
 dev` cannot replace resources you deployed. Existing default `alchemy
-dev` stacks keep the `dev_$USER` name.
+dev` stacks keep the `dev_$USER` name. **`Test.make`** uses
+**`test_$USER`** the same way, so two people running the suite
+against one account don't collide.
 
 ```sh
 $ whoami
@@ -52,6 +54,7 @@ The resolution order is:
 | ----------------- | ---------------------------------------------------- |
 | `live_<user>`     | Per-developer cloud sandbox (`alchemy deploy` default) |
 | `dev_<user>`      | Per-developer local-dev sandbox (`alchemy dev` default) |
+| `test_<user>`     | Per-developer test sandbox (`Test.make` default)     |
 | `pr-<n>`          | Per-pull-request preview environment                 |
 | `staging`         | Shared pre-production                                |
 | `prod`            | Production                                           |

--- a/website/src/content/docs/testing/index.mdx
+++ b/website/src/content/docs/testing/index.mdx
@@ -34,7 +34,12 @@ For every option, hook, and variant, see the [Test harness](/testing/test-harnes
 
 ## Stage isolation
 
-Tests default to the `test` stage, so they never touch your dev or prod deployments. A unique stage per PR lets multiple suites run in parallel against the same account without colliding:
+Tests default to `test_$USER` (e.g. `test_sam`), matching how
+`alchemy deploy` uses `live_$USER` and `alchemy dev` uses
+`dev_$USER` — so they never touch your live or local-dev
+deployments, and two people running the same suite don't collide. A
+unique stage per PR lets CI suites run in parallel against the same
+account:
 
 ```typescript
 Test.make({ providers, stage: "ci-pr-42" });

--- a/website/src/content/docs/testing/test-harness.mdx
+++ b/website/src/content/docs/testing/test-harness.mdx
@@ -102,7 +102,8 @@ the same way the CLI does.
 ### `stage`
 
 Default stage for `deploy(Stack)` / `destroy(Stack)`. Defaults to
-`"test"`. Override per file, or per call:
+`test_$USER` (e.g. `test_sam`) so two people running the same suite
+against one account don't collide. Override per file, or per call:
 
 ```typescript
 Test.make({ providers, stage: "ci-pr-42" });

--- a/website/src/content/docs/testing/testing-a-stack.mdx
+++ b/website/src/content/docs/testing/testing-a-stack.mdx
@@ -67,7 +67,7 @@ Run the suite with your runner:
 bun test test/integ.test.ts
 ```
 
-The first run deploys; re-runs diff and skip unchanged Resources, and tests default to the isolated `test` [stage](/environments/stages) so they never clobber your dev deployment.
+The first run deploys; re-runs diff and skip unchanged Resources, and tests default to the isolated `test_$USER` [stage](/environments/stages) so they never clobber your `live_$USER` / `dev_$USER` deployments.
 
 ## Run it locally with dev mode
 
@@ -179,14 +179,14 @@ const stack = beforeAll(
 
 ## Share one Stack across files
 
-Give every file's `Test.make` the same remote state and the same stage — identical state + stage means the second file's `deploy(Stack)` is a no-op diff:
+Give every file's `Test.make` the same remote state and the same stage — identical state + stage means the second file's `deploy(Stack)` is a no-op diff. The default `test_$USER` stage already does this for a single developer; pin an explicit stage when files must share a stack across users or CI jobs:
 
 ```typescript
 // test/api.integ.test.ts AND test/queue.integ.test.ts
 const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
   providers: Cloudflare.providers(),
   state: Cloudflare.state(), // remote, shared across files and runners
-  stage: "test",             // same stage → same Stack instance
+  stage: "shared",           // same stage → same Stack instance
 });
 ```
 


### PR DESCRIPTION
Default `Test.make` to `test_$USER`, matching `live_$USER` / `dev_$USER`, so two people running the same suite against one account don't collide.

```ts
// before
Test.make({ providers }) // stage "test"

// after
Test.make({ providers }) // stage "test_sam"
```

`$ALCHEMY_STAGE` is not consulted — that's the CLI deploy/dev stage. Override with `Test.make({ stage })` or `deploy(Stack, { stage })`.

Scratch stacks expose `stack.stage`. Example integ tests drop the hardcoded `stage: "test"`.
