### PR TITLE
fix: DSQL SNI (sql-pg rc.113), ECS Service delete on a draining service, Nextjs preview proxy secret

### DIFF
--- a/packages/alchemy/src/AWS/ECS/Service.ts
+++ b/packages/alchemy/src/AWS/ECS/Service.ts
@@ -3711,13 +3711,12 @@ export const ServiceProvider = () =>
               desiredCount: 0,
             })
             .pipe(
-              Effect.retry({
-                while: (error) => error._tag === "ServiceNotActiveException",
-                schedule: Schedule.max([
-                  Schedule.spaced("5 seconds"),
-                  Schedule.recurs(8),
-                ]),
-              }),
+              // `ServiceNotActiveException` means the service is DRAINING or
+              // INACTIVE — an earlier, interrupted delete already issued
+              // `deleteService`. Neither status ever returns to ACTIVE, so
+              // there is nothing to scale: fall through to the drain/delete
+              // waits below, which treat both as progress toward "gone".
+              Effect.catchTag("ServiceNotActiveException", () => Effect.void),
               Effect.catchTag("ServiceNotFoundException", () => Effect.void),
               Effect.catchTag("ClusterNotFoundException", () => Effect.void),
             );

--- a/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/LocalWorkerProvider.ts
@@ -1265,6 +1265,7 @@ export const LocalWorkerProvider = () =>
                     {
                       rootDir: root,
                       publicUrl: proxy.url.toString().replace(/\/$/, ""),
+                      proxySharedSecret: proxy.proxySharedSecret,
                       accountId,
                       storageDirectory,
                       stack: { name: stack.name, stage: stack.stage },
@@ -1409,6 +1410,7 @@ export const LocalWorkerProvider = () =>
           extraOptions: worker.bundleOptions.extraOptions,
           assets: worker.assets,
           worker: {
+            proxySharedSecret: proxy.proxySharedSecret,
             bindings: worker.workerBindings,
             durableObjectNamespaces: worker.durableObjectNamespaces,
             hyperdrives: worker.hyperdrives,

--- a/packages/alchemy/src/Cloudflare/Workers/Source.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Source.ts
@@ -121,6 +121,16 @@ export interface SourceContext {
  */
 export interface DevContext extends SourceContext {
   readonly worker: {
+    /**
+     * Shared secret the host's WorkerProxy signs forwarded requests with
+     * (original URL / Host restoration). A server-mode source that exposes
+     * a workerd DIRECTLY behind the proxy must start it with this secret —
+     * the entry worker answers 400 "Invalid proxy shared secret" to a
+     * signed request whose secret it doesn't hold. Sources that front their
+     * workerd with their own server (the vite plugin) re-sign with their
+     * own secret and can ignore this.
+     */
+    readonly proxySharedSecret: string;
     readonly bindings: BindingHook<BindingServices>[];
     readonly durableObjectNamespaces: (RuntimeDurableObject & {
       uniqueKey: string;

--- a/packages/alchemy/src/Cloudflare/Workers/ViteChild.shared.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/ViteChild.shared.ts
@@ -20,6 +20,11 @@ export const DEFAULT_DEV_PORT = 1337;
 export interface ViteChildConfig {
   rootDir: string;
   publicUrl: string;
+  /**
+   * The host WorkerProxy's shared secret, for server-mode sources whose
+   * workerd is exposed directly behind the proxy (see `DevContext.worker`).
+   */
+  proxySharedSecret: string;
   accountId: string;
   storageDirectory: string;
   stack: { name: string; stage: string };

--- a/packages/alchemy/src/Cloudflare/Workers/ViteChildRunner.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/ViteChildRunner.ts
@@ -108,6 +108,7 @@ const program = Effect.scoped(
               extraOptions: undefined,
               assets: source.assets,
               worker: {
+                proxySharedSecret: config.proxySharedSecret,
                 bindings,
                 durableObjectNamespaces: config.worker.durableObjectNamespaces,
                 hyperdrives: config.worker.hyperdrives,

--- a/packages/alchemy/src/Drizzle/Postgres.ts
+++ b/packages/alchemy/src/Drizzle/Postgres.ts
@@ -9,6 +9,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import type * as Redacted from "effect/Redacted";
 import { makeExecutionMemo } from "../Runtime/ExecutionMemo.ts";
+import { withServername } from "../SQL/PostgresTls.ts";
 import { proxyChain } from "../Util/proxy-chain.ts";
 
 /**
@@ -64,8 +65,9 @@ export const Postgres = <
             import("drizzle-orm/effect-postgres"),
           ]),
         );
+        const url = yield* connectionString;
         const pgCtx = yield* Layer.build(
-          PgClient.layer({ url: yield* connectionString }),
+          PgClient.layer({ url, ssl: withServername(url, undefined) }),
         );
         return yield* PgDrizzle.makeWithDefaults(config).pipe(
           Effect.provideContext(pgCtx),

--- a/packages/alchemy/src/SQL/Postgres.ts
+++ b/packages/alchemy/src/SQL/Postgres.ts
@@ -6,6 +6,7 @@ import type * as Redacted from "effect/Redacted";
 import * as Sql from "effect/unstable/sql/SqlClient";
 import { makeExecutionMemo } from "../Runtime/ExecutionMemo.ts";
 import { proxyChain } from "../Util/proxy-chain.ts";
+import { withServername } from "./PostgresTls.ts";
 
 /**
  * Options for {@link Postgres}: `@effect/sql-pg`'s pool configuration, with
@@ -55,7 +56,11 @@ export const Postgres = <E = never, R = never>(config: PostgresConfig<E, R>) =>
         const { url, ...pool } = config;
         const resolved = Effect.isEffect(url) ? yield* url : url;
         const pgCtx = yield* Layer.build(
-          PgClient.layer({ ...pool, url: resolved }),
+          PgClient.layer({
+            ...pool,
+            url: resolved,
+            ssl: withServername(resolved, pool.ssl),
+          }),
         );
         return Context.get(pgCtx, PgClient.PgClient);
       }),

--- a/packages/alchemy/src/SQL/PostgresTls.ts
+++ b/packages/alchemy/src/SQL/PostgresTls.ts
@@ -1,0 +1,63 @@
+import type * as PgClient from "@effect/sql-pg/PgClient";
+import * as Redacted from "effect/Redacted";
+
+type PgSsl = PgClient.PgPoolConfig["ssl"];
+
+/** `sslmode` values that libpq (and `@effect/sql-pg`'s URL parser) read as "use TLS". */
+const TLS_SSL_MODES: ReadonlySet<string> = new Set([
+  "require",
+  "verify-ca",
+  "verify-full",
+]);
+
+const isIpLiteral = (hostname: string): boolean =>
+  // `new URL` keeps IPv6 literals bracketed; IPv4 is four decimal octets.
+  hostname.startsWith("[") || /^\d{1,3}(\.\d{1,3}){3}$/.test(hostname);
+
+/**
+ * Resolve the `ssl` option to hand `@effect/sql-pg` so a TLS connection
+ * carries SNI for the URL's hostname.
+ *
+ * `@effect/sql-pg` ≥ 4.0.0-rc.113 speaks the Postgres wire protocol itself
+ * (no `pg` underneath) and upgrades the socket with
+ * `tls.connect({ host, socket })`. Node only sends the SNI extension when
+ * `servername` is set explicitly — it is never derived from `host`, and with
+ * a caller-supplied `socket` there is no connect step that could fill it in.
+ * Servers that route on SNI reject the session: Aurora DSQL answers
+ * `unable to accept connection, sni was not received`. node-postgres set
+ * `servername = host` for non-IP hosts, which is why this never surfaced
+ * before the swap.
+ *
+ * The result mirrors the URL's own TLS intent so behaviour is unchanged for
+ * plaintext URLs: when TLS is requested (`ssl: true`, an `ssl` object, or
+ * `sslmode=require|verify-ca|verify-full`) and the host is a name rather
+ * than an IP literal, the returned options include `servername`. Otherwise
+ * the caller's `ssl` is returned untouched (so `sslmode` in the URL keeps
+ * driving the decision inside `@effect/sql-pg`).
+ */
+export const withServername = (
+  url: Redacted.Redacted<string>,
+  ssl: PgSsl,
+): PgSsl => {
+  if (ssl === false) return ssl;
+  let parsed: URL;
+  try {
+    parsed = new URL(Redacted.value(url));
+  } catch {
+    // Let `@effect/sql-pg` report the malformed URL.
+    return ssl;
+  }
+  const hostname = parsed.hostname;
+  if (hostname === "" || isIpLiteral(hostname)) return ssl;
+
+  const sslmode = parsed.searchParams.get("sslmode");
+  const tlsRequested =
+    ssl === true ||
+    typeof ssl === "object" ||
+    (sslmode !== null && TLS_SSL_MODES.has(sslmode));
+  if (!tlsRequested) return ssl;
+
+  return typeof ssl === "object"
+    ? { ...ssl, servername: ssl.servername ?? hostname }
+    : { servername: hostname };
+};

--- a/packages/alchemy/src/State/PostgresState.ts
+++ b/packages/alchemy/src/State/PostgresState.ts
@@ -7,6 +7,7 @@ import * as Scope from "effect/Scope";
 import * as Semaphore from "effect/Semaphore";
 import type * as SqlClient from "effect/unstable/sql/SqlClient";
 import type * as SqlError from "effect/unstable/sql/SqlError";
+import { withServername } from "../SQL/PostgresTls.ts";
 import { recordStateStoreInit } from "../Telemetry/Metrics.ts";
 import { STATE_STORE_VERSION } from "./HttpStateApi.ts";
 import type { ReplacedResourceState } from "./ResourceState.ts";
@@ -274,7 +275,10 @@ export const makePostgresState = <E = never, R = never>(
           ? yield* Effect.provideContext(url, context).pipe(stateError)
           : url;
         const built = yield* Layer.build(
-          PgClient.layer({ url: resolved }),
+          PgClient.layer({
+            url: resolved,
+            ssl: withServername(resolved, undefined),
+          }),
         ).pipe(Scope.provide(scope), stateError);
         return Context.get(built, PgClient.PgClient);
       });

--- a/packages/alchemy/test/AWS/DSQL/Connect.test.ts
+++ b/packages/alchemy/test/AWS/DSQL/Connect.test.ts
@@ -32,14 +32,22 @@ let clusterId: string | undefined;
 class TransientUpstream extends Data.TaggedError("TransientUpstream")<{
   readonly status: number;
   readonly body: string;
-}> {}
+}> {
+  override get message() {
+    return `fixture answered ${this.status}: ${this.body.slice(0, 500)}`;
+  }
+}
 
 class FixtureReadinessFailed extends Data.TaggedError(
   "FixtureReadinessFailed",
 )<{
   readonly status: number;
   readonly body: string;
-}> {}
+}> {
+  override get message() {
+    return `fixture answered ${this.status}: ${this.body.slice(0, 500)}`;
+  }
+}
 
 class ClusterStillPresent extends Data.TaggedError("ClusterStillPresent")<{
   readonly clusterId: string;

--- a/packages/alchemy/test/AWS/DSQL/fixtures/direct-handler.ts
+++ b/packages/alchemy/test/AWS/DSQL/fixtures/direct-handler.ts
@@ -77,7 +77,15 @@ export default DsqlDirectFunction.make(
         // closed when the invocation settles.
         if (request.method === "POST" && pathname === "/roundtrip") {
           const info = yield* conn;
-          const ctx = yield* Layer.build(PgClient.layer({ url: info.url }));
+          // `@effect/sql-pg` ≥ rc.113 upgrades to TLS with
+          // `tls.connect({ host, socket })`, which sends no SNI unless
+          // `servername` is explicit — and DSQL refuses sessions without it
+          // ("sni was not received"). Alchemy's own clients (`SQL.Postgres`,
+          // `Drizzle.Postgres`) derive it via `SQL/PostgresTls.ts`; a direct
+          // `PgClient` consumer has to pass it.
+          const ctx = yield* Layer.build(
+            PgClient.layer({ url: info.url, ssl: { servername: info.host } }),
+          );
           const sqlClient = Context.get(ctx, PgClient.PgClient);
           // DSQL runs DDL as its own autocommit statement (no DDL+DML
           // transactions) — each call below is a separate statement.

--- a/packages/alchemy/test/SQL/PostgresTls.test.ts
+++ b/packages/alchemy/test/SQL/PostgresTls.test.ts
@@ -1,0 +1,83 @@
+import { withServername } from "@/SQL/PostgresTls.ts";
+import { describe, expect, it } from "alchemy-test";
+import * as Redacted from "effect/Redacted";
+
+const url = (s: string) => Redacted.make(s);
+
+describe("SQL/PostgresTls withServername", () => {
+  it("adds servername when the URL requests TLS via sslmode", () => {
+    expect(
+      withServername(
+        url(
+          "postgresql://admin:tok@abc.dsql.us-west-2.on.aws:5432/postgres?sslmode=require",
+        ),
+        undefined,
+      ),
+    ).toEqual({ servername: "abc.dsql.us-west-2.on.aws" });
+    for (const mode of ["verify-ca", "verify-full"]) {
+      expect(
+        withServername(
+          url(`postgres://u@db.example.com/x?sslmode=${mode}`),
+          undefined,
+        ),
+      ).toEqual({ servername: "db.example.com" });
+    }
+  });
+
+  it("adds servername when the caller asks for TLS explicitly", () => {
+    expect(withServername(url("postgres://u@db.example.com/x"), true)).toEqual({
+      servername: "db.example.com",
+    });
+    expect(
+      withServername(url("postgres://u@db.example.com/x"), {
+        rejectUnauthorized: false,
+      }),
+    ).toEqual({ rejectUnauthorized: false, servername: "db.example.com" });
+  });
+
+  it("keeps a caller-provided servername", () => {
+    expect(
+      withServername(url("postgres://u@db.example.com/x?sslmode=require"), {
+        servername: "override.example.com",
+      }),
+    ).toEqual({ servername: "override.example.com" });
+  });
+
+  it("leaves plaintext URLs alone so sslmode keeps driving @effect/sql-pg", () => {
+    expect(
+      withServername(url("postgres://u@db.example.com/x"), undefined),
+    ).toBeUndefined();
+    expect(
+      withServername(
+        url("postgres://u@db.example.com/x?sslmode=disable"),
+        undefined,
+      ),
+    ).toBeUndefined();
+    expect(
+      withServername(
+        url("postgres://u@db.example.com/x?sslmode=prefer"),
+        undefined,
+      ),
+    ).toBeUndefined();
+    expect(
+      withServername(
+        url("postgres://u@db.example.com/x?sslmode=require"),
+        false,
+      ),
+    ).toBe(false);
+  });
+
+  it("never sets an IP literal as servername", () => {
+    expect(
+      withServername(url("postgres://u@10.0.0.5/x?sslmode=require"), undefined),
+    ).toBeUndefined();
+    expect(
+      withServername(url("postgres://u@[::1]:5432/x?sslmode=require"), true),
+    ).toBe(true);
+  });
+
+  it("passes malformed URLs through untouched", () => {
+    expect(withServername(url("not a url"), undefined)).toBeUndefined();
+    expect(withServername(url("not a url"), true)).toBe(true);
+  });
+});

--- a/packages/frontend-frameworks/src/nextjs/Nextjs.ts
+++ b/packages/frontend-frameworks/src/nextjs/Nextjs.ts
@@ -486,6 +486,12 @@ export const make = (
         const url = yield* Runtime.Runtime.use((runtime) =>
           runtime.start({
             name: worker?.name ?? "distilled-nextjs-dev",
+            // This workerd sits directly behind the host's WorkerProxy, which
+            // signs every forwarded request with its shared secret. The entry
+            // worker rejects a signed request whose secret it doesn't hold
+            // (400 "Invalid proxy shared secret"), so the host's secret must
+            // reach this start call.
+            proxySharedSecret: worker?.proxySharedSecret,
             compatibilityDate:
               options?.vite?.compatibilityDate ?? DEFAULT_COMPATIBILITY_DATE,
             compatibilityFlags: [

--- a/packages/frontend-frameworks/src/nextjs/source.ts
+++ b/packages/frontend-frameworks/src/nextjs/source.ts
@@ -116,6 +116,12 @@ type WorkerWiring = Omit<
 export interface DevContext extends SourceContext {
   readonly worker: {
     readonly name: string;
+    /**
+     * Shared secret the host's WorkerProxy signs forwarded requests with.
+     * The preview workerd runs directly behind that proxy, so it must be
+     * started with the same secret (see `Nextjs.ts` `dev`).
+     */
+    readonly proxySharedSecret?: string | undefined;
     readonly bindings: NonNullable<WorkerWiring["bindings"]>;
     readonly durableObjectNamespaces: NonNullable<
       WorkerWiring["durableObjectNamespaces"]
@@ -687,6 +693,10 @@ const makeProvider = (options: NextjsSourceOptions): SourceProvider => {
           compatibilityFlags: ctx.compatibility.flags,
           worker: {
             name: ctx.worker.name,
+            // The preview workerd is served straight through the host's
+            // WorkerProxy; it must hold the proxy's secret to accept the
+            // signed original-URL headers.
+            proxySharedSecret: ctx.worker.proxySharedSecret,
             bindings: ctx.worker.bindings,
             durableObjectNamespaces: ctx.worker.durableObjectNamespaces,
             hyperdrives: ctx.worker.hyperdrives,


### PR DESCRIPTION
Fixes for two consistently failing AWS suites surfaced by the post-rc.113 test runs.

### `@effect/sql-pg` rc.113 sends no SNI on TLS (DSQL)

`test/AWS/DSQL/Connect.test.ts` fails consistently since the effect 4.0.0-rc.113 bump (#1562): every fixture request 500s with

```
PgConnection: Failed to connect (cause: Error: unable to accept connection, sni was not received)
```

`@effect/sql-pg` rc.113 no longer wraps `pg`; it speaks the wire protocol itself and upgrades to TLS with `tls.connect({ host, ...ssl, socket })`. Node only sends the SNI extension when `servername` is set explicitly — it is never derived from `host`, and with a caller-supplied `socket` there is no connect step that could fill it in (verified against a local `SNICallback` server: `{ host, socket }` → no SNI, `{ host, socket, servername }` → SNI). node-postgres set `servername = host` for non-IP hosts, which is why SNI-routed servers like Aurora DSQL worked before.

```ts
// SQL/PostgresTls.ts — mirrors the URL's own TLS intent; plaintext URLs are untouched
withServername(url, undefined)
// postgresql://…@abc.dsql.us-west-2.on.aws/postgres?sslmode=require  →  { servername: "abc.dsql.us-west-2.on.aws" }
// postgresql://…@db.internal/app                                      →  undefined
// postgresql://…@10.0.0.5/app?sslmode=require                         →  undefined
```

Applied at every place alchemy builds a `PgClient`: `SQL.Postgres`, `Drizzle.Postgres`, `postgresState({ url })`.

- The DSQL "direct" fixture drives `PgClient.layer` itself, so it passes `ssl: { servername: info.host }` explicitly — the same footgun any direct `@effect/sql-pg` consumer of a DSQL URL hits.
- `TransientUpstream` / `FixtureReadinessFailed` now carry a `message` with status and body; the failure previously printed as a bare `TransientUpstream:`.

This is an upstream bug in `@effect/sql-pg` (`PgConnection` should default `servername` to a non-IP `host`, as `pg` did); the helper can go once that lands.

### ECS Service delete never converges on a DRAINING/INACTIVE service

`test/AWS/ECS/Service.test.ts > service wires a user-supplied target group without creating an ALB` failed on every retry with `DestroyError: ManualLbService (AWS.ECS.Service): ServiceNotActiveException: Service was not ACTIVE.` The scale-to-zero `updateService` retried `ServiceNotActiveException` for ~44s waiting for a status that never returns to `ACTIVE` (the service was left draining by an earlier interrupted destroy), then failed and blocked the cluster/subnet deletes.

```diff
 ecs.updateService({ cluster, service, desiredCount: 0 }).pipe(
-  Effect.retry({
-    while: (error) => error._tag === "ServiceNotActiveException",
-    schedule: Schedule.max([Schedule.spaced("5 seconds"), Schedule.recurs(8)]),
-  }),
+  // DRAINING/INACTIVE: deleteService was already issued — nothing to scale,
+  // fall through to the drain/delete waits which treat both as "gone".
+  Effect.catchTag("ServiceNotActiveException", () => Effect.void),
   Effect.catchTag("ServiceNotFoundException", () => Effect.void),
   Effect.catchTag("ClusterNotFoundException", () => Effect.void),
 );
```

### Nextjs preview dev: every request 400 "Invalid proxy shared secret"

#1573 made the runtime entry worker reject proxied requests whose shared secret doesn't match its `BINDING_PROXY_SHARED_SECRET`. The secret was wired for workerds the `LocalWorkerProvider` starts itself and for the vite dev/preview servers, but the Nextjs preview path (`Website.Nextjs` default `dev.mode`) starts its own workerd inside the dev child via `runtime.start` and never received it — so the secret was `""` and the WorkerProxy's signed requests all got 400 (`test/Cloudflare/Website/Nextjs.local.test.ts`, both preview-mode cases, consistently).

```ts
// DevContext.worker / ViteChildConfig now carry the host proxy's secret …
proxySharedSecret: proxy.proxySharedSecret,
// … and the Nextjs source hands it to its preview workerd:
runtime.start({ name, proxySharedSecret: worker?.proxySharedSecret, ... })
```
