### PR TITLE
fix(aws/ecs): converge Service delete on a DRAINING/INACTIVE service

### DIFF
--- a/packages/alchemy/src/AWS/ECS/Service.ts
+++ b/packages/alchemy/src/AWS/ECS/Service.ts
@@ -3711,13 +3711,12 @@ export const ServiceProvider = () =>
               desiredCount: 0,
             })
             .pipe(
-              Effect.retry({
-                while: (error) => error._tag === "ServiceNotActiveException",
-                schedule: Schedule.max([
-                  Schedule.spaced("5 seconds"),
-                  Schedule.recurs(8),
-                ]),
-              }),
+              // `ServiceNotActiveException` means the service is DRAINING or
+              // INACTIVE — an earlier, interrupted delete already issued
+              // `deleteService`. Neither status ever returns to ACTIVE, so
+              // there is nothing to scale: fall through to the drain/delete
+              // waits below, which treat both as progress toward "gone".
+              Effect.catchTag("ServiceNotActiveException", () => Effect.void),
               Effect.catchTag("ServiceNotFoundException", () => Effect.void),
               Effect.catchTag("ClusterNotFoundException", () => Effect.void),
             );


### PR DESCRIPTION
`AWS.ECS.Service` delete could never converge on a service left `DRAINING`/`INACTIVE` by an earlier interrupted destroy: the scale-to-zero `updateService` retried `ServiceNotActiveException` for ~44s waiting for a status that never returns to `ACTIVE`, then failed and blocked every downstream delete (cluster, subnets).

```diff
 ecs.updateService({ cluster, service, desiredCount: 0 }).pipe(
-  Effect.retry({
-    while: (error) => error._tag === "ServiceNotActiveException",
-    schedule: Schedule.max([Schedule.spaced("5 seconds"), Schedule.recurs(8)]),
-  }),
+  // DRAINING/INACTIVE: deleteService was already issued — nothing to scale,
+  // fall through to the drain/delete waits which treat both as "gone".
+  Effect.catchTag("ServiceNotActiveException", () => Effect.void),
   Effect.catchTag("ServiceNotFoundException", () => Effect.void),
   Effect.catchTag("ClusterNotFoundException", () => Effect.void),
 );
```

Seen as `test/AWS/ECS/Service.test.ts > service wires a user-supplied target group without creating an ALB` failing on every retry with `DestroyError: ManualLbService (AWS.ECS.Service): ServiceNotActiveException: Service was not ACTIVE.` The existing `drained`/`deleted` convergence waits already handle a draining or inactive service.
