### PR TITLE
fix: sql-pg rc.113 sslmode=prefer, Prisma.Database branch attachment

### DIFF
--- a/packages/alchemy/src/Drizzle/Postgres.ts
+++ b/packages/alchemy/src/Drizzle/Postgres.ts
@@ -9,7 +9,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import type * as Redacted from "effect/Redacted";
 import { makeExecutionMemo } from "../Runtime/ExecutionMemo.ts";
-import { withServername } from "../SQL/PostgresTls.ts";
+import { resolveSsl } from "../SQL/PostgresTls.ts";
 import { proxyChain } from "../Util/proxy-chain.ts";
 
 /**
@@ -67,7 +67,7 @@ export const Postgres = <
         );
         const url = yield* connectionString;
         const pgCtx = yield* Layer.build(
-          PgClient.layer({ url, ssl: withServername(url, undefined) }),
+          PgClient.layer({ url, ssl: resolveSsl(url, undefined) }),
         );
         return yield* PgDrizzle.makeWithDefaults(config).pipe(
           Effect.provideContext(pgCtx),

--- a/packages/alchemy/src/Prisma/Database.ts
+++ b/packages/alchemy/src/Prisma/Database.ts
@@ -145,13 +145,18 @@ export interface DatabaseProps {
    */
   source?: DatabaseSourceInput;
   /**
-   * Branch ID to attach the database to. Mutually exclusive with branchGitName.
+   * Branch ID to attach the database to. Mutually exclusive with
+   * branchGitName. Every Prisma database belongs to a Branch: omit both
+   * fields to let the Management API attach it to the project's default
+   * Branch, which Alchemy then leaves unmanaged.
    */
-  branchId?: string | null;
+  branchId?: string;
   /**
-   * Branch git name to attach the database to. Mutually exclusive with branchId.
+   * Branch git name to attach the database to (the Branch is created when it
+   * does not exist). Mutually exclusive with branchId. Omit both fields to
+   * attach to the project's default Branch.
    */
-  branchGitName?: string | null;
+  branchGitName?: string;
   /**
    * Local database settings for `alchemy dev`. Set to `false` to keep only
    * placeholder IDs.
@@ -443,10 +448,10 @@ const branchNeedsSync = Effect.fn(function* (
     return database.branchId !== props.branchId;
   }
   if (props.branchGitName === undefined) {
-    return database.branchId !== null;
-  }
-  if (props.branchGitName === null) {
-    return database.branchId !== null;
+    // No attachment requested: the Management API attaches every database to
+    // a Branch (the project default when omitted) and rejects detaching, so
+    // the observed attachment is left alone.
+    return false;
   }
   const branchId = yield* branchIdForGitName(
     client,
@@ -484,6 +489,16 @@ const validateDatabaseProps = (props: DatabaseProps) =>
     if (props.branchId !== undefined && props.branchGitName !== undefined) {
       return yield* Effect.fail(
         new Error("branchId and branchGitName are mutually exclusive."),
+      );
+    }
+    if (
+      (props.branchId as unknown) === null ||
+      (props.branchGitName as unknown) === null
+    ) {
+      return yield* Effect.fail(
+        new Error(
+          "Every Prisma database belongs to a Branch; the Management API rejects detaching (null). Omit both branchId and branchGitName to attach to the project's default branch, or provide one of them.",
+        ),
       );
     }
   });
@@ -584,6 +599,9 @@ const ProviderLive = () =>
           const desiredName = yield* createName(id, news.name);
           const observedName =
             output?.databaseName ?? (yield* createName(id, olds.name));
+          // Omitting both branch fields leaves the observed attachment
+          // unmanaged (every database belongs to a Branch; detaching is not
+          // an API operation), so only an explicit target can mismatch.
           let branchMismatch = false;
           if (isResolved(news.branchId) && news.branchId !== undefined) {
             branchMismatch =
@@ -593,10 +611,7 @@ const ProviderLive = () =>
             isResolved(news.branchGitName) &&
             news.branchGitName !== undefined
           ) {
-            if (news.branchGitName === null) {
-              branchMismatch =
-                (output?.branchId ?? olds.branchId ?? null) !== null;
-            } else if (output && newProjectId !== undefined) {
+            if (output && newProjectId !== undefined) {
               const desiredBranchId = yield* branchIdForGitName(
                 client,
                 newProjectId,
@@ -608,12 +623,6 @@ const ProviderLive = () =>
             } else {
               branchMismatch = news.branchGitName !== olds.branchGitName;
             }
-          } else if (
-            isResolved(news.branchId) &&
-            isResolved(news.branchGitName)
-          ) {
-            branchMismatch =
-              (output?.branchId ?? olds.branchId ?? null) !== null;
           }
           if (desiredName !== observedName || branchMismatch) {
             return { action: "update" } as const;
@@ -798,15 +807,12 @@ const ProviderLive = () =>
             database.name !== name ||
             (yield* branchNeedsSync(client, projectId, database, desired));
           if (needsPatch) {
-            const updateAttachment =
-              attach.branchId === undefined &&
-              attach.branchGitName === undefined
-                ? { branchId: null, branchGitName: undefined }
-                : attach;
+            // With no attachment requested only the name is patched; sending
+            // `branchId: null` is a detach, which the API rejects (422).
             database = yield* client.updateDatabase(database.id, {
               name,
-              branchId: updateAttachment.branchId,
-              branchGitName: updateAttachment.branchGitName,
+              branchId: attach.branchId,
+              branchGitName: attach.branchGitName,
             });
           }
 

--- a/packages/alchemy/src/SQL/Postgres.ts
+++ b/packages/alchemy/src/SQL/Postgres.ts
@@ -6,7 +6,7 @@ import type * as Redacted from "effect/Redacted";
 import * as Sql from "effect/unstable/sql/SqlClient";
 import { makeExecutionMemo } from "../Runtime/ExecutionMemo.ts";
 import { proxyChain } from "../Util/proxy-chain.ts";
-import { withServername } from "./PostgresTls.ts";
+import { resolveSsl } from "./PostgresTls.ts";
 
 /**
  * Options for {@link Postgres}: `@effect/sql-pg`'s pool configuration, with
@@ -59,7 +59,7 @@ export const Postgres = <E = never, R = never>(config: PostgresConfig<E, R>) =>
           PgClient.layer({
             ...pool,
             url: resolved,
-            ssl: withServername(resolved, pool.ssl),
+            ssl: resolveSsl(resolved, pool.ssl),
           }),
         );
         return Context.get(pgCtx, PgClient.PgClient);

--- a/packages/alchemy/src/SQL/PostgresTls.ts
+++ b/packages/alchemy/src/SQL/PostgresTls.ts
@@ -3,11 +3,26 @@ import * as Redacted from "effect/Redacted";
 
 type PgSsl = PgClient.PgPoolConfig["ssl"];
 
-/** `sslmode` values that libpq (and `@effect/sql-pg`'s URL parser) read as "use TLS". */
+/**
+ * `sslmode` values that `@effect/sql-pg`'s URL parser reads as "use TLS"
+ * on its own.
+ */
 const TLS_SSL_MODES: ReadonlySet<string> = new Set([
   "require",
   "verify-ca",
   "verify-full",
+]);
+
+/**
+ * `sslmode` values `@effect/sql-pg` ≥ 4.0.0-rc.113 refuses unless `ssl` is
+ * set explicitly (`sslmode "prefer" is not supported: set ssl explicitly to
+ * true or false`). node-postgres treated both as "TLS on" (aliases of
+ * `verify-full`), so that is what they resolve to here — the same wire
+ * behaviour those URLs had before the swap.
+ */
+const OPPORTUNISTIC_SSL_MODES: ReadonlySet<string> = new Set([
+  "prefer",
+  "allow",
 ]);
 
 const isIpLiteral = (hostname: string): boolean =>
@@ -15,27 +30,32 @@ const isIpLiteral = (hostname: string): boolean =>
   hostname.startsWith("[") || /^\d{1,3}(\.\d{1,3}){3}$/.test(hostname);
 
 /**
- * Resolve the `ssl` option to hand `@effect/sql-pg` so a TLS connection
- * carries SNI for the URL's hostname.
+ * Resolve the `ssl` option to hand `@effect/sql-pg` for a connection URL.
  *
  * `@effect/sql-pg` ≥ 4.0.0-rc.113 speaks the Postgres wire protocol itself
- * (no `pg` underneath) and upgrades the socket with
- * `tls.connect({ host, socket })`. Node only sends the SNI extension when
- * `servername` is set explicitly — it is never derived from `host`, and with
- * a caller-supplied `socket` there is no connect step that could fill it in.
- * Servers that route on SNI reject the session: Aurora DSQL answers
- * `unable to accept connection, sni was not received`. node-postgres set
- * `servername = host` for non-IP hosts, which is why this never surfaced
- * before the swap.
+ * (no `pg` underneath). Two of its choices diverge from node-postgres in
+ * ways that break URLs which used to work, and this helper papers over both
+ * so every alchemy Postgres layer (`SQL.Postgres`, `Drizzle.Postgres`, the
+ * Postgres state store) behaves as it did before the swap:
  *
- * The result mirrors the URL's own TLS intent so behaviour is unchanged for
- * plaintext URLs: when TLS is requested (`ssl: true`, an `ssl` object, or
- * `sslmode=require|verify-ca|verify-full`) and the host is a name rather
- * than an IP literal, the returned options include `servername`. Otherwise
- * the caller's `ssl` is returned untouched (so `sslmode` in the URL keeps
- * driving the decision inside `@effect/sql-pg`).
+ * 1. **No SNI.** It upgrades the socket with `tls.connect({ host, socket })`
+ *    and Node only sends the SNI extension when `servername` is set
+ *    explicitly — it is never derived from `host`. Servers that route on SNI
+ *    reject the session (Aurora DSQL: `unable to accept connection, sni was
+ *    not received`; Neon likewise). node-postgres set `servername = host` for
+ *    non-IP hosts. When TLS is requested and the host is a name, the returned
+ *    options include `servername`.
+ * 2. **`sslmode=prefer|allow` is an error** unless `ssl` is explicit.
+ *    node-postgres read them as "TLS on", and URLs carry them by default in
+ *    places (Hyperdrive's local `dev` origin passthrough hands the worker
+ *    `?sslmode=prefer`). They resolve to TLS on here as well.
+ *
+ * TLS is "requested" when `ssl` is `true` or an object, or the URL's
+ * `sslmode` is `require|verify-ca|verify-full|prefer|allow`. Otherwise the
+ * caller's `ssl` is returned untouched so `sslmode=disable` / a bare URL
+ * keep driving the decision inside `@effect/sql-pg`.
  */
-export const withServername = (
+export const resolveSsl = (
   url: Redacted.Redacted<string>,
   ssl: PgSsl,
 ): PgSsl => {
@@ -47,15 +67,21 @@ export const withServername = (
     // Let `@effect/sql-pg` report the malformed URL.
     return ssl;
   }
-  const hostname = parsed.hostname;
-  if (hostname === "" || isIpLiteral(hostname)) return ssl;
 
   const sslmode = parsed.searchParams.get("sslmode");
   const tlsRequested =
     ssl === true ||
     typeof ssl === "object" ||
-    (sslmode !== null && TLS_SSL_MODES.has(sslmode));
+    (sslmode !== null &&
+      (TLS_SSL_MODES.has(sslmode) || OPPORTUNISTIC_SSL_MODES.has(sslmode)));
   if (!tlsRequested) return ssl;
+
+  const hostname = parsed.hostname;
+  if (hostname === "" || isIpLiteral(hostname)) {
+    // Nothing to put in SNI, but `prefer`/`allow` still need `ssl` to be
+    // explicit or `@effect/sql-pg` rejects the URL.
+    return ssl ?? true;
+  }
 
   return typeof ssl === "object"
     ? { ...ssl, servername: ssl.servername ?? hostname }

--- a/packages/alchemy/src/State/PostgresState.ts
+++ b/packages/alchemy/src/State/PostgresState.ts
@@ -7,7 +7,7 @@ import * as Scope from "effect/Scope";
 import * as Semaphore from "effect/Semaphore";
 import type * as SqlClient from "effect/unstable/sql/SqlClient";
 import type * as SqlError from "effect/unstable/sql/SqlError";
-import { withServername } from "../SQL/PostgresTls.ts";
+import { resolveSsl } from "../SQL/PostgresTls.ts";
 import { recordStateStoreInit } from "../Telemetry/Metrics.ts";
 import { STATE_STORE_VERSION } from "./HttpStateApi.ts";
 import type { ReplacedResourceState } from "./ResourceState.ts";
@@ -277,7 +277,7 @@ export const makePostgresState = <E = never, R = never>(
         const built = yield* Layer.build(
           PgClient.layer({
             url: resolved,
-            ssl: withServername(resolved, undefined),
+            ssl: resolveSsl(resolved, undefined),
           }),
         ).pipe(Scope.provide(scope), stateError);
         return Context.get(built, PgClient.PgClient);

--- a/packages/alchemy/test/Cloudflare/Hyperdrive/Connection.local.test.ts
+++ b/packages/alchemy/test/Cloudflare/Hyperdrive/Connection.local.test.ts
@@ -33,7 +33,11 @@ const logLevel = Effect.provideService(
 class WorkerNotReady extends Data.TaggedError("WorkerNotReady")<{
   status: number;
   body: string;
-}> {}
+}> {
+  override get message() {
+    return `worker answered ${this.status}: ${this.body.slice(0, 500)}`;
+  }
+}
 
 const getJsonReady = (url: string) =>
   Effect.gen(function* () {

--- a/packages/alchemy/test/Prisma/Resources.test.ts
+++ b/packages/alchemy/test/Prisma/Resources.test.ts
@@ -3513,91 +3513,82 @@ describe("Prisma resource providers", () => {
     },
   );
 
-  it.effect("detaches an observed branch when branch props are omitted", () => {
-    const calls: Call[] = [];
-    const database = {
-      id: "database-1",
-      type: "database" as const,
-      url: "https://api.prisma.test/v1/databases/database-1",
-      name: "main",
-      status: "ready" as const,
-      createdAt,
-      isDefault: false,
-      defaultConnectionId: "connection-1",
-      connections: [],
-      project: resourceRef("projects", "project-1", "app"),
-      region: { id: "us-east-1", name: "US East" },
-      source: { type: "empty" as const },
-      branchId: "branch-1",
-    };
-    const client = {
-      getDatabase: (id: string) =>
-        Effect.sync(() => {
-          calls.push(["getDatabase", id]);
-          return database;
-        }),
-      updateDatabase: (id: string, input: unknown) =>
-        Effect.sync(() => {
-          calls.push(["updateDatabase", { id, input }]);
-          return { ...database, branchId: null };
-        }),
-      rotateConnection: () =>
-        Effect.die("persisted credentials must prevent an unrelated rotation"),
-    } as unknown as PrismaManagementClient;
+  it.effect(
+    "leaves the observed branch alone when branch props are omitted",
+    () => {
+      const calls: Call[] = [];
+      const database = {
+        id: "database-1",
+        type: "database" as const,
+        url: "https://api.prisma.test/v1/databases/database-1",
+        name: "main",
+        status: "ready" as const,
+        createdAt,
+        isDefault: false,
+        defaultConnectionId: "connection-1",
+        connections: [],
+        project: resourceRef("projects", "project-1", "app"),
+        region: { id: "us-east-1", name: "US East" },
+        source: { type: "empty" as const },
+        branchId: "branch-1",
+      };
+      const client = {
+        getDatabase: (id: string) =>
+          Effect.sync(() => {
+            calls.push(["getDatabase", id]);
+            return database;
+          }),
+        updateDatabase: () =>
+          Effect.die(
+            "every database belongs to a Branch; omitted branch props must not detach",
+          ),
+        rotateConnection: () =>
+          Effect.die(
+            "persisted credentials must prevent an unrelated rotation",
+          ),
+      } as unknown as PrismaManagementClient;
 
-    return Effect.gen(function* () {
-      const provider = yield* PrismaDatabase.Provider;
-      const result = yield* provider.reconcile(
-        reconcileInput(
-          "Database",
-          {
-            project: "project-1",
-            name: "main",
-            region: "us-east-1",
-          },
-          {
-            databaseId: "database-1",
-            databaseName: "main",
-            projectId: "project-1",
-            status: "ready" as const,
-            region: "us-east-1",
-            isDefault: false,
-            branchId: "branch-1",
-            defaultConnectionId: "connection-1",
-            createdAt,
-            directConnectionString: Redacted.make("postgres://persisted"),
-            pooledConnectionString: undefined,
-            accelerateConnectionString: undefined,
-            host: "db.prisma.test",
-            user: "user",
-            password: undefined,
-          },
-          {
-            project: "project-1",
-            name: "main",
-            region: "us-east-1",
-            branchId: "branch-1",
-          },
-        ),
-      );
-
-      expect(result.branchId).toBeNull();
-      expect(calls).toEqual([
-        ["getDatabase", "database-1"],
-        [
-          "updateDatabase",
-          {
-            id: "database-1",
-            input: {
+      return Effect.gen(function* () {
+        const provider = yield* PrismaDatabase.Provider;
+        const result = yield* provider.reconcile(
+          reconcileInput(
+            "Database",
+            {
+              project: "project-1",
               name: "main",
-              branchId: null,
-              branchGitName: undefined,
+              region: "us-east-1",
             },
-          },
-        ],
-      ]);
-    }).pipe(Effect.provide(providerLayer(client)));
-  });
+            {
+              databaseId: "database-1",
+              databaseName: "main",
+              projectId: "project-1",
+              status: "ready" as const,
+              region: "us-east-1",
+              isDefault: false,
+              branchId: "branch-1",
+              defaultConnectionId: "connection-1",
+              createdAt,
+              directConnectionString: Redacted.make("postgres://persisted"),
+              pooledConnectionString: undefined,
+              accelerateConnectionString: undefined,
+              host: "db.prisma.test",
+              user: "user",
+              password: undefined,
+            },
+            {
+              project: "project-1",
+              name: "main",
+              region: "us-east-1",
+              branchId: "branch-1",
+            },
+          ),
+        );
+
+        expect(result.branchId).toBe("branch-1");
+        expect(calls).toEqual([["getDatabase", "database-1"]]);
+      }).pipe(Effect.provide(providerLayer(client)));
+    },
+  );
 
   it.effect(
     "forces Project and Database reconcile when adoption rotation is enabled",

--- a/packages/alchemy/test/SQL/PostgresTls.test.ts
+++ b/packages/alchemy/test/SQL/PostgresTls.test.ts
@@ -1,13 +1,13 @@
-import { withServername } from "@/SQL/PostgresTls.ts";
+import { resolveSsl } from "@/SQL/PostgresTls.ts";
 import { describe, expect, it } from "alchemy-test";
 import * as Redacted from "effect/Redacted";
 
 const url = (s: string) => Redacted.make(s);
 
-describe("SQL/PostgresTls withServername", () => {
+describe("SQL/PostgresTls resolveSsl", () => {
   it("adds servername when the URL requests TLS via sslmode", () => {
     expect(
-      withServername(
+      resolveSsl(
         url(
           "postgresql://admin:tok@abc.dsql.us-west-2.on.aws:5432/postgres?sslmode=require",
         ),
@@ -16,7 +16,7 @@ describe("SQL/PostgresTls withServername", () => {
     ).toEqual({ servername: "abc.dsql.us-west-2.on.aws" });
     for (const mode of ["verify-ca", "verify-full"]) {
       expect(
-        withServername(
+        resolveSsl(
           url(`postgres://u@db.example.com/x?sslmode=${mode}`),
           undefined,
         ),
@@ -25,11 +25,11 @@ describe("SQL/PostgresTls withServername", () => {
   });
 
   it("adds servername when the caller asks for TLS explicitly", () => {
-    expect(withServername(url("postgres://u@db.example.com/x"), true)).toEqual({
+    expect(resolveSsl(url("postgres://u@db.example.com/x"), true)).toEqual({
       servername: "db.example.com",
     });
     expect(
-      withServername(url("postgres://u@db.example.com/x"), {
+      resolveSsl(url("postgres://u@db.example.com/x"), {
         rejectUnauthorized: false,
       }),
     ).toEqual({ rejectUnauthorized: false, servername: "db.example.com" });
@@ -37,7 +37,7 @@ describe("SQL/PostgresTls withServername", () => {
 
   it("keeps a caller-provided servername", () => {
     expect(
-      withServername(url("postgres://u@db.example.com/x?sslmode=require"), {
+      resolveSsl(url("postgres://u@db.example.com/x?sslmode=require"), {
         servername: "override.example.com",
       }),
     ).toEqual({ servername: "override.example.com" });
@@ -45,39 +45,52 @@ describe("SQL/PostgresTls withServername", () => {
 
   it("leaves plaintext URLs alone so sslmode keeps driving @effect/sql-pg", () => {
     expect(
-      withServername(url("postgres://u@db.example.com/x"), undefined),
+      resolveSsl(url("postgres://u@db.example.com/x"), undefined),
     ).toBeUndefined();
     expect(
-      withServername(
+      resolveSsl(
         url("postgres://u@db.example.com/x?sslmode=disable"),
         undefined,
       ),
     ).toBeUndefined();
     expect(
-      withServername(
-        url("postgres://u@db.example.com/x?sslmode=prefer"),
-        undefined,
-      ),
-    ).toBeUndefined();
-    expect(
-      withServername(
-        url("postgres://u@db.example.com/x?sslmode=require"),
-        false,
-      ),
+      resolveSsl(url("postgres://u@db.example.com/x?sslmode=require"), false),
     ).toBe(false);
+  });
+
+  it("resolves sslmode=prefer|allow to TLS on (rc.113 rejects them when ssl is implicit)", () => {
+    for (const mode of ["prefer", "allow"]) {
+      expect(
+        resolveSsl(
+          url(`postgres://u@ep-x.neon.tech/x?sslmode=${mode}`),
+          undefined,
+        ),
+      ).toEqual({ servername: "ep-x.neon.tech" });
+      expect(
+        resolveSsl(
+          url(`postgres://u@127.0.0.1:5432/x?sslmode=${mode}`),
+          undefined,
+        ),
+      ).toBe(true);
+    }
   });
 
   it("never sets an IP literal as servername", () => {
     expect(
-      withServername(url("postgres://u@10.0.0.5/x?sslmode=require"), undefined),
-    ).toBeUndefined();
-    expect(
-      withServername(url("postgres://u@[::1]:5432/x?sslmode=require"), true),
+      resolveSsl(url("postgres://u@10.0.0.5/x?sslmode=require"), undefined),
     ).toBe(true);
+    expect(
+      resolveSsl(url("postgres://u@[::1]:5432/x?sslmode=require"), true),
+    ).toBe(true);
+    expect(
+      resolveSsl(url("postgres://u@[::1]:5432/x?sslmode=require"), {
+        rejectUnauthorized: false,
+      }),
+    ).toEqual({ rejectUnauthorized: false });
   });
 
   it("passes malformed URLs through untouched", () => {
-    expect(withServername(url("not a url"), undefined)).toBeUndefined();
-    expect(withServername(url("not a url"), true)).toBe(true);
+    expect(resolveSsl(url("not a url"), undefined)).toBeUndefined();
+    expect(resolveSsl(url("not a url"), true)).toBe(true);
   });
 });


### PR DESCRIPTION
Two fixes surfaced by running the Postgres-backed suites (Neon, Planetscale, Prisma, Hyperdrive) after the effect 4.0.0-rc.113 bump.

### `@effect/sql-pg` rc.113 rejects `sslmode=prefer`

`test/Cloudflare/Hyperdrive/Connection.local.test.ts > Hyperdrive binding round-trips SQL through the local passthrough` fails consistently: the worker's `/query` route 500s with

```
PgConnection: sslmode "prefer" is not supported: set ssl explicitly to true or false
```

The local Hyperdrive `dev` origin passthrough hands the worker `postgresql://…?sslmode=prefer` (the documented `DevOrigin.sslmode` default). node-postgres read `prefer`/`allow` as "TLS on"; rc.113's native `PgConnection` rejects both unless `ssl` is passed explicitly. Second divergence after the missing SNI (#1580), so the helper now covers both and is renamed `withServername` → `resolveSsl`:

```ts
// SQL/PostgresTls.ts
resolveSsl(url, undefined)
// postgresql://…@ep-x.neon.tech/db?sslmode=prefer   →  { servername: "ep-x.neon.tech" }
// postgresql://…@127.0.0.1:5432/db?sslmode=prefer   →  true
// postgresql://…@db.internal/app                     →  undefined   (unchanged)
// postgresql://…@db.internal/app?sslmode=disable     →  undefined   (unchanged)
```

Applied through the same three call sites: `SQL.Postgres`, `Drizzle.Postgres`, `postgresState({ url })`.

- The Hyperdrive local test's `WorkerNotReady` now carries status + body in its `message` (it printed as a bare `WorkerNotReady:` before).

### Prisma.Database: every database now belongs to a Branch

`test/Prisma/Hyperdrive.test.ts` failed on first deploy with `PrismaApiError: … (validation-error)`. The Management API changed its model: databases are always attached to a Branch (the project default when omitted) and `branchId: null` is rejected:

```
PATCH /v1/databases/{id} → 422
"Every database belongs to a Branch. Set branchId or branchGitName to another Branch to move the database; detaching is not supported."
```

`Prisma.Database` still treated omitted `branchId`/`branchGitName` as "must be unattached" and PATCHed `branchId: null` right after every create.

```diff
 export interface DatabaseProps {
-  branchId?: string | null;
-  branchGitName?: string | null;
+  /** Omit both to attach to the project's default Branch (left unmanaged). */
+  branchId?: string;
+  branchGitName?: string;
 }
```

- Omitted branch props leave the observed attachment alone in `diff`, `branchNeedsSync`, and the reconcile PATCH (only `name` is patched).
- Explicit `null` is rejected up front with the same message shape `Prisma.App` uses.
- Unit test "detaches an observed branch when branch props are omitted" inverted to pin the new behaviour.

Results: Neon 13/13, Planetscale 52/52, Prisma unit 364/364, Prisma Hyperdrive live test passes. Remaining Prisma live failures are destroy-time `DELETE /v1/projects/*` and `DELETE /v1/databases/*` 500s reproducible with curl for every payload — a Prisma-side incident, not ours.
