### PR TITLE
fix(railway): mount volumes and wait for the uploaded Service deploy

### DIFF
--- a/packages/alchemy/src/Railway/Function.ts
+++ b/packages/alchemy/src/Railway/Function.ts
@@ -33,6 +33,7 @@ import {
   type MountSpec,
   type ServiceBinding,
 } from "./MountVolume.ts";
+import { attachVolumeToService } from "./Volume.ts";
 import {
   ownedProjects,
   projectEnvironmentIds,
@@ -851,23 +852,18 @@ const syncEnv = Effect.fn(function* (input: {
 
 const syncMounts = Effect.fn(function* (input: {
   environmentId: string;
+  projectId: string;
   serviceId: string;
   mounts: MountSpec[];
 }) {
   for (const mount of input.mounts) {
-    if (mount.volumeId.length === 0) continue;
-    yield* railway
-      .updateVolumeInstance({
-        volumeId: mount.volumeId,
-        environmentId: input.environmentId,
-        input: {
-          serviceId: input.serviceId,
-          mountPath: mount.path,
-        },
-      })
-      .pipe(
-        Effect.catchTag(["RailwayNotFound", "NotFound"], () => Effect.void),
-      );
+    yield* attachVolumeToService({
+      environmentId: input.environmentId,
+      projectId: input.projectId,
+      serviceId: input.serviceId,
+      volumeId: mount.volumeId,
+      mountPath: mount.path,
+    });
   }
 });
 
@@ -1260,6 +1256,7 @@ export const FunctionProvider = () =>
 
           yield* syncMounts({
             environmentId,
+            projectId,
             serviceId: current.id,
             mounts: bound.mounts,
           });

--- a/packages/alchemy/src/Railway/MountVolume.ts
+++ b/packages/alchemy/src/Railway/MountVolume.ts
@@ -33,10 +33,11 @@ export interface MountSpec {
   path: string;
 }
 
-const volumeIdOf = (volume: Volume): string => {
-  const value = (volume as { volumeId?: unknown }).volumeId;
-  return typeof value === "string" ? value : "";
-};
+// Pass `volume.volumeId` through as-is. At bind time it is an Output,
+// never a materialized string — `typeof === "string"` would store `""`
+// and every downstream guard would skip the mount. `Input<Binding>`
+// resolves the Output before reconcile.
+const volumeIdOf = (volume: Volume) => volume.volumeId ?? "";
 
 const RAILWAY_BIND_HOST_TYPES = new Set([
   "Railway.Service",

--- a/packages/alchemy/src/Railway/ServiceProvider.ts
+++ b/packages/alchemy/src/Railway/ServiceProvider.ts
@@ -23,7 +23,7 @@ import { Stack } from "../Stack.ts";
 import { createRailwayName, matchesAlchemyPhysicalName } from "./Metadata.ts";
 import { assertHostDisk, type MountSpec } from "./MountVolume.ts";
 import { ownedProjects } from "./Project.ts";
-import { listServiceVolumes } from "./Volume.ts";
+import { attachVolumeToService, listServiceVolumes } from "./Volume.ts";
 import {
   deleteOwnedServiceDomain,
   ensureServiceDomain,
@@ -574,6 +574,59 @@ const waitForDeployment = (environmentId: string, serviceId: string) =>
     }),
   );
 
+type DeployRef = {
+  id: string;
+  status: string | undefined;
+};
+
+const asDeployRef = (
+  row: { id: string; status?: string | null } | undefined,
+): DeployRef | undefined =>
+  row === undefined
+    ? undefined
+    : { id: row.id, status: row.status ?? undefined };
+
+const matchUploadedDeployment = (
+  instance: ServiceInstanceResponse | undefined,
+  deploymentId: string,
+): DeployRef | undefined => {
+  const latest = instance?.latestDeployment;
+  if (latest?.id === deploymentId) return asDeployRef(latest);
+  return asDeployRef(
+    (instance?.activeDeployments ?? []).find(
+      (deployment) => deployment.id === deploymentId,
+    ),
+  );
+};
+
+const listUploadedDeployment = (input: {
+  deploymentId: string;
+  serviceId: string;
+  environmentId: string;
+}) =>
+  railway.deployments
+    .items({
+      first: 10,
+      input: {
+        serviceId: input.serviceId,
+        environmentId: input.environmentId,
+      },
+    })
+    .pipe(
+      Stream.filter((row) => row.id === input.deploymentId),
+      Stream.take(1),
+      Stream.runCollect,
+      Effect.map((chunk) => Array.from(chunk)[0]),
+      Effect.timeoutOrElse({
+        duration: "8 seconds",
+        orElse: () => Effect.succeed(undefined),
+      }),
+      Effect.catchTag(
+        ["NotFound", "UnknownRailwayError", "RailwayParseError"],
+        () => Effect.succeed(undefined),
+      ),
+    );
+
 const waitForDeploymentById = (input: {
   deploymentId: string;
   serviceId: string;
@@ -583,23 +636,17 @@ const waitForDeploymentById = (input: {
     // Poll the instance, not `deployment(id)`. Distilled's deployment
     // query is a huge nested selection that 404s/times out for /up ids;
     // `serviceInstance.latestDeployment` is the same record the rest of
-    // reconcile already uses.
+    // reconcile already uses. The placeholder `hashicorp/http-echo`
+    // deploy often FAILED (wrong port / no `/health`) before `railway up`
+    // replaces it — do not inherit that FAILED onto this wait.
     const instance = yield* getInstance(input.environmentId, input.serviceId);
-    const latest = instance?.latestDeployment;
     const match =
-      latest?.id === input.deploymentId
-        ? latest
-        : (instance?.activeDeployments ?? []).find(
-            (deployment) => deployment.id === input.deploymentId,
-          );
-    // Hosted `main` creates the service with a public-image placeholder
-    // (`hashicorp/http-echo`). That first deploy often FAILED (wrong
-    // port / no `/health`) before `railway up` replaces it. Do not
-    // inherit `latest` — only the upload we queued can fail this wait.
+      matchUploadedDeployment(instance, input.deploymentId) ??
+      asDeployRef(yield* listUploadedDeployment(input));
     if (match === undefined) {
       return yield* new ServiceDeployPending({
         serviceId: input.serviceId,
-        status: latest?.status ?? "pending",
+        status: "pending",
       });
     }
     const status = match.status;
@@ -625,6 +672,32 @@ const waitForDeploymentById = (input: {
       times: 90,
       schedule: Schedule.spaced("5 seconds"),
     }),
+    Effect.catchTag("Railway.ServiceDeployPending", (pending) =>
+      Effect.gen(function* () {
+        const instance = yield* getInstance(
+          input.environmentId,
+          input.serviceId,
+        );
+        const match =
+          matchUploadedDeployment(instance, input.deploymentId) ??
+          asDeployRef(yield* listUploadedDeployment(input));
+        const status = match?.status;
+        if (
+          match !== undefined &&
+          status !== undefined &&
+          deployFailed(status)
+        ) {
+          const logs = yield* fetchDeployLogs(match.id);
+          return yield* new ServiceDeployFailed({
+            serviceId: input.serviceId,
+            status,
+            deploymentId: match.id,
+            logs,
+          });
+        }
+        return yield* pending;
+      }),
+    ),
   );
 
 const upsertVariable = (input: {
@@ -707,23 +780,18 @@ const syncEnv = Effect.fn(function* (input: {
 
 const syncMounts = Effect.fn(function* (input: {
   environmentId: string;
+  projectId: string;
   serviceId: string;
   mounts: MountSpec[];
 }) {
   for (const mount of input.mounts) {
-    if (mount.volumeId.length === 0) continue;
-    yield* railway
-      .updateVolumeInstance({
-        volumeId: mount.volumeId,
-        environmentId: input.environmentId,
-        input: {
-          serviceId: input.serviceId,
-          mountPath: mount.path,
-        },
-      })
-      .pipe(
-        Effect.catchTag(["RailwayNotFound", "NotFound"], () => Effect.void),
-      );
+    yield* attachVolumeToService({
+      environmentId: input.environmentId,
+      projectId: input.projectId,
+      serviceId: input.serviceId,
+      volumeId: mount.volumeId,
+      mountPath: mount.path,
+    });
   }
 });
 
@@ -1249,6 +1317,7 @@ export const ServiceProvider = () =>
 
           yield* syncMounts({
             environmentId,
+            projectId,
             serviceId: current.id,
             mounts: bound.mounts,
           });

--- a/packages/alchemy/src/Railway/Volume.ts
+++ b/packages/alchemy/src/Railway/Volume.ts
@@ -571,6 +571,58 @@ const waitForInstance = (
     ),
   );
 
+/**
+ * Attach a volume instance to a service and wait until Railway reports
+ * the mount path and service id. Used by Service/Function reconcile
+ * (`MountVolume`); uploading a build before the attach is READY is
+ * how `railway up` deploys land FAILED.
+ */
+export const attachVolumeToService = Effect.fn(function* (input: {
+  environmentId: string;
+  projectId: string;
+  serviceId: string;
+  volumeId: string;
+  mountPath: string;
+}) {
+  if (input.volumeId.length === 0) return;
+  const observed = yield* findInEnvironment(
+    input.environmentId,
+    input.projectId,
+    (instance) => instance.volumeId === input.volumeId,
+  );
+  const already =
+    observed !== undefined &&
+    (observed.serviceId ?? undefined) === input.serviceId &&
+    observed.mountPath === input.mountPath &&
+    !transientState(observed.state);
+  if (!already) {
+    yield* railway
+      .updateVolumeInstance({
+        volumeId: input.volumeId,
+        environmentId: input.environmentId,
+        input: {
+          serviceId: input.serviceId,
+          mountPath: input.mountPath,
+        },
+      })
+      .pipe(
+        Effect.catchTag(["RailwayNotFound", "NotFound"], () => Effect.void),
+      );
+  }
+  const instance =
+    observed ??
+    (yield* waitForInstance(
+      input.environmentId,
+      input.projectId,
+      input.volumeId,
+    ));
+  if (instance === undefined) return;
+  yield* waitUntilSynced(instance.id, input.volumeId, {
+    mountPath: input.mountPath,
+    serviceId: input.serviceId,
+  });
+});
+
 const waitUntilGone = (input: {
   volumeInstanceId?: string;
   volumeId: string;

--- a/packages/alchemy/src/Railway/hosted.ts
+++ b/packages/alchemy/src/Railway/hosted.ts
@@ -571,9 +571,16 @@ const createBundleProgram = (
             );
           },
           resolve: {
+            // Hosted images run on Node but must still match the `bun`
+            // export of workspace packages (`@distilled.cloud/*`, alchemy).
+            // Those maps have no `node` condition — only `bun`/`worker`/
+            // `default` — and `default` is `lib/` which is absent in a
+            // source checkout. Leaving the specifier unresolved makes
+            // rolldown treat it as external, so the container dies with
+            // `ERR_MODULE_NOT_FOUND` (the Volume tutorial's FAILED deploy).
             conditionNames: canvasExternals
               ? ["bun", "import", "module", "default"]
-              : [...Bundle.NODE_CONDITION_NAMES],
+              : [...Bundle.BUN_CONDITION_NAMES],
             ...props.build?.input?.resolve,
           },
           plugins: [

--- a/packages/alchemy/test/Railway/Volume.test.ts
+++ b/packages/alchemy/test/Railway/Volume.test.ts
@@ -8,6 +8,15 @@ import { expect } from "alchemy-test";
 import * as Effect from "effect/Effect";
 import { MinimumLogLevel } from "effect/References";
 import * as Result from "effect/Result";
+import * as Schedule from "effect/Schedule";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
+import VolumeApi, {
+  Data,
+  MARKER,
+  MARKER_FILE,
+  VOLUME_PATH,
+} from "./fixtures/volume-api.ts";
 
 const { test } = Test.make({ providers: Railway.providers() });
 
@@ -169,6 +178,68 @@ test.provider(
       }
 
       yield* stack.destroy();
+    }).pipe(logLevel),
+  { timeout: 3_600_000 },
+);
+
+test.provider(
+  "MountVolume attaches a disk to a hosted Service",
+  (stack) =>
+    Effect.gen(function* () {
+      yield* stack.destroy();
+
+      const created = yield* stack.deploy(
+        Effect.gen(function* () {
+          const data = yield* Data;
+          const api = yield* VolumeApi;
+          return { data, api };
+        }),
+      );
+
+      expect(created.data.volumeId.length).toBeGreaterThan(0);
+      // Volume is created disconnected; MountVolume attaches it from
+      // the Service. Resource attrs are not refreshed after that bind.
+      expect(created.data.serviceId).toBeUndefined();
+      expect(created.data.mountPath).toEqual(VOLUME_PATH);
+      expect(created.api.url).toEqual(expect.any(String));
+      expect(created.api.url).toContain("up.railway.app");
+
+      const fetched = yield* railway.volumeInstance({
+        id: created.data.volumeInstanceId,
+      });
+      expect(fetched.serviceId).toEqual(created.api.serviceId);
+      expect(fetched.mountPath).toEqual(VOLUME_PATH);
+      expect(fetched.volumeId).toEqual(created.data.volumeId);
+
+      const client = yield* HttpClient.HttpClient;
+      const health = yield* client.get(`${created.api.url}/health`).pipe(
+        Effect.flatMap((res) =>
+          res.status === 200
+            ? Effect.succeed(res)
+            : Effect.fail(new Error(`health returned ${res.status}`)),
+        ),
+        Effect.retry({
+          schedule: Schedule.spaced("4 seconds"),
+          times: 10,
+        }),
+      );
+      expect(health.status).toEqual(200);
+
+      const put = yield* client.execute(
+        HttpClientRequest.put(`${created.api.url}/${MARKER_FILE}`).pipe(
+          HttpClientRequest.bodyText(MARKER),
+        ),
+      );
+      expect(put.status).toEqual(204);
+
+      const got = yield* client.get(`${created.api.url}/${MARKER_FILE}`);
+      expect(got.status).toEqual(200);
+      expect(yield* got.text).toEqual(MARKER);
+
+      yield* stack.destroy();
+
+      const gone = yield* waitUntilVolumeGone(created.data.volumeInstanceId);
+      expect(gone).toEqual("gone");
     }).pipe(logLevel),
   { timeout: 3_600_000 },
 );

--- a/packages/alchemy/test/Railway/fixtures/volume-api.ts
+++ b/packages/alchemy/test/Railway/fixtures/volume-api.ts
@@ -42,7 +42,10 @@ export default class VolumeApi extends Railway.Service<VolumeApi>()(
         const request = yield* HttpServerRequest;
         const url = new URL(request.url, "http://service");
         if (url.pathname === "/health") {
-          return HttpServerResponse.json({ ok: true, path: mount.path });
+          return yield* HttpServerResponse.json({
+            ok: true,
+            path: mount.path,
+          });
         }
         const file = `${mount.path}${url.pathname}`;
         if (request.method === "PUT") {

--- a/packages/alchemy/test/Railway/fixtures/volume-api.ts
+++ b/packages/alchemy/test/Railway/fixtures/volume-api.ts
@@ -1,0 +1,66 @@
+import * as Railway from "@/Railway";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
+import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
+import { Partition, Site } from "./suite-env.ts";
+
+export { Site };
+
+export const VOLUME_PATH = "/data";
+export const MARKER_FILE = "hello.txt";
+export const MARKER = "hello-from-railway-volume";
+export const VOLUME_PORT = 3000;
+
+/**
+ * Block disk {@link VolumeApi} mounts at {@link VOLUME_PATH}.
+ */
+export const Data = Railway.Volume("Data", {
+  project: Site,
+  environment: Partition,
+  mountPath: VOLUME_PATH,
+});
+
+/**
+ * HTTP Service that mounts {@link Data} via {@link Railway.MountVolume}
+ * and round-trips a file — the Volume tutorial shape.
+ */
+export default class VolumeApi extends Railway.Service<VolumeApi>()(
+  "VolumeApi",
+  {
+    project: Site,
+    environment: Partition,
+    main: import.meta.url,
+    port: VOLUME_PORT,
+  },
+  Effect.gen(function* () {
+    const mount = yield* Railway.MountVolume(Data, { path: VOLUME_PATH });
+    const fs = yield* FileSystem.FileSystem;
+
+    return {
+      fetch: Effect.gen(function* () {
+        const request = yield* HttpServerRequest;
+        const url = new URL(request.url, "http://service");
+        if (url.pathname === "/health") {
+          return HttpServerResponse.json({ ok: true, path: mount.path });
+        }
+        const file = `${mount.path}${url.pathname}`;
+        if (request.method === "PUT") {
+          const body = yield* request.text;
+          yield* fs.writeFileString(file, body).pipe(Effect.orDie);
+          return HttpServerResponse.empty({ status: 204 });
+        }
+        if (request.method === "GET") {
+          const text = yield* fs
+            .readFileString(file)
+            .pipe(Effect.catch(() => Effect.succeed(undefined)));
+          if (text === undefined) {
+            return HttpServerResponse.text("Not found", { status: 404 });
+          }
+          return HttpServerResponse.text(text);
+        }
+        return HttpServerResponse.text("Hello from Railway!");
+      }),
+    };
+  }).pipe(Effect.provide(Railway.MountVolumeLive)),
+) {}

--- a/website/src/content/docs/fly/tutorial/part-3.mdx
+++ b/website/src/content/docs/fly/tutorial/part-3.mdx
@@ -121,7 +121,7 @@ if (request.method === "PUT") {
 
 +if (request.method === "GET") {
 +  const text = yield* fs.readFileString(file).pipe(
-+    Effect.catchAll(() => Effect.succeed(undefined)),
++    Effect.catch(() => Effect.succeed(undefined)),
 +  );
 +  if (text === undefined) {
 +    return HttpServerResponse.text("Not found", { status: 404 });

--- a/website/src/content/docs/hetzner/tutorial/part-3.mdx
+++ b/website/src/content/docs/hetzner/tutorial/part-3.mdx
@@ -132,7 +132,7 @@ if (request.method === "PUT") {
 
 +if (request.method === "GET") {
 +  const text = yield* fs.readFileString(file).pipe(
-+    Effect.catchAll(() => Effect.succeed(undefined)),
++    Effect.catch(() => Effect.succeed(undefined)),
 +  );
 +  if (text === undefined) {
 +    return HttpServerResponse.text("Not found", { status: 404 });

--- a/website/src/content/docs/railway/tutorial/part-3.mdx
+++ b/website/src/content/docs/railway/tutorial/part-3.mdx
@@ -26,11 +26,14 @@ export const Site = Railway.Project("Site");
 +export const Data = Railway.Volume("Data", {
 +  project: Site,
 +  mountPath: "/data",
++  region: "us-west2",
 +});
 ```
 
 The volume is disconnected until a Service mounts it. `mountPath` is
-the path in the container.
+the path in the container. `region` must match the Service from
+Part 2 — a Volume cannot move, and attaching across regions fails
+the deploy.
 
 ## Mount a disk into the Service
 
@@ -141,7 +144,7 @@ if (request.method === "PUT") {
 
 +if (request.method === "GET") {
 +  const text = yield* fs.readFileString(file).pipe(
-+    Effect.catchAll(() => Effect.succeed(undefined)),
++    Effect.catch(() => Effect.succeed(undefined)),
 +  );
 +  if (text === undefined) {
 +    return HttpServerResponse.text("Not found", { status: 404 });


### PR DESCRIPTION
MountVolume stored an empty volumeId at bind time, so the disk never attached. Hosted Service images then left `@distilled.cloud/railway` as a bare import (`ERR_MODULE_NOT_FOUND`) and the waiter copied the placeholder http-echo FAILED onto `Railway.ServiceDeployPending: deployment still FAILED`.

```ts
const volumeIdOf = (volume: Volume) => volume.volumeId ?? "";
```

`Input<Binding>` resolves that Output at deploy time. Reconcile waits until the volume is attached before `railway up`. Hosted bundles use `BUN_CONDITION_NAMES` so Distilled's `bun` export (src) is packed into the image. The waiter looks up the uploaded deployment by id and surfaces `ServiceDeployFailed` with logs if that upload actually failed.

Tutorial Part 3 pins the Volume to `us-west2` and uses `Effect.catch` (Fly/Hetzner Part 3 too).
