### PR TITLE
fix(aws/s3): check bucket ownership with GetBucketLocation

### DIFF
--- a/packages/alchemy/src/AWS/S3/Bucket.ts
+++ b/packages/alchemy/src/AWS/S3/Bucket.ts
@@ -516,11 +516,15 @@ export const BucketProvider = () =>
         // For us-east-1, BucketAlreadyOwnedByYou is not thrown, so we need to
         // pre-emptively check if the bucket exists for idempotency
         if (region === "us-east-1") {
-          const exists = yield* s3.headBucket({ Bucket: bucketName }).pipe(
-            Effect.map(() => true),
-            Effect.catchTag("NotFound", () => Effect.succeed(false)),
-            Effect.catch(() => Effect.succeed(false)),
-          );
+          const exists = yield* s3
+            .getBucketLocation({
+              Bucket: bucketName,
+              ExpectedBucketOwner: accountId,
+            })
+            .pipe(
+              Effect.map(() => true),
+              Effect.catchTag("NoSuchBucket", () => Effect.succeed(false)),
+            );
 
           yield* Effect.logInfo(
             `S3 Bucket create: us-east-1 existence check for ${bucketName} -> ${exists}`,
@@ -569,10 +573,18 @@ export const BucketProvider = () =>
         }
 
         // Wait for bucket to exist (eventual consistency)
-        yield* Effect.retry(
-          s3.headBucket({ Bucket: bucketName }),
-          Schedule.max([Schedule.exponential(100), Schedule.recurs(10)]),
-        );
+        yield* s3
+          .getBucketLocation({
+            Bucket: bucketName,
+            ExpectedBucketOwner: accountId,
+          })
+          .pipe(
+            Effect.retry({
+              while: (error) => error._tag === "NoSuchBucket",
+              schedule: Schedule.exponential(100),
+              times: 8,
+            }),
+          );
         yield* Effect.logInfo(
           `S3 Bucket create: bucket is available ${bucketName}`,
         );
@@ -1333,10 +1345,10 @@ export const BucketProvider = () =>
 
       return {
         stables: ["bucketName", "bucketArn", "region", "accountId"],
-        // S3 bucket names are globally unique. `headBucket` succeeds only when
-        // the bucket exists in our account, so a successful response is itself
-        // proof of account-level ownership — there is no separate ownership
-        // signal to surface as `Unowned`.
+        // ListBuckets enumerates this account. Read verifies the same ownership
+        // with ExpectedBucketOwner; cross-account access alone is not ownership.
+        // GetBucketLocation needs configuration access, not HeadBucket's
+        // s3:ListBucket permission to enumerate the bucket's objects.
         list: () =>
           Effect.gen(function* () {
             const { accountId, region } = yield* AWSEnvironment.current;
@@ -1373,11 +1385,15 @@ export const BucketProvider = () =>
           const bucketName =
             output?.bucketName ?? (yield* createBucketName(id, olds ?? {}));
           const { accountId, region } = yield* AWSEnvironment.current;
-          const exists = yield* s3.headBucket({ Bucket: bucketName }).pipe(
-            Effect.map(() => true),
-            Effect.catchTag("NotFound", () => Effect.succeed(false)),
-            Effect.catch(() => Effect.succeed(false)),
-          );
+          const exists = yield* s3
+            .getBucketLocation({
+              Bucket: bucketName,
+              ExpectedBucketOwner: accountId,
+            })
+            .pipe(
+              Effect.map(() => true),
+              Effect.catchTag("NoSuchBucket", () => Effect.succeed(false)),
+            );
           if (!exists) return undefined;
           return {
             bucketName,
@@ -1553,10 +1569,10 @@ export const BucketProvider = () =>
           //   operator-confirmed account teardown. Nuke enumerates buckets
           //   straight from the cloud (its `olds` is Attributes, not Props),
           //   so `forceDestroy` is never present there. S3 ownership is
-          //   account-level (see `list`/`read`: buckets are globally unique
-          //   and only enumerable/headable in our own account; this provider
-          //   deliberately does not stamp alchemy tags on buckets), so every
-          //   bucket nuke hands us is one this account owns.
+          //   account-level: list enumerates this account and read verifies
+          //   ExpectedBucketOwner. This provider deliberately does not stamp
+          //   alchemy tags on buckets, so every bucket nuke hands us is one
+          //   this account owns.
           // A normal destroy without `forceDestroy` must NOT empty the
           // bucket — a non-empty bucket fails with BucketNotEmpty, which is
           // the data-protection behavior users rely on.

--- a/packages/alchemy/test/AWS/S3/Bucket.ownership.test.ts
+++ b/packages/alchemy/test/AWS/S3/Bucket.ownership.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from "alchemy-test";
+import * as Effect from "effect/Effect";
+import * as HttpClientError from "effect/unstable/http/HttpClientError";
+import {
+  accountId,
+  bucketName,
+  bucketProvider,
+  error,
+  fixture,
+  instanceId,
+  provideBucket,
+  session,
+  xml,
+} from "./fixtures/bucket-provider.ts";
+
+const read = Effect.gen(function* () {
+  const provider = yield* bucketProvider;
+  return yield* provider.read!({
+    id: "Bucket",
+    fqn: "Bucket",
+    instanceId,
+    olds: { bucketName },
+    output: undefined,
+  });
+});
+
+const precreate = Effect.gen(function* () {
+  const provider = yield* bucketProvider;
+  return yield* provider.precreate!({
+    id: "Bucket",
+    fqn: "Bucket",
+    instanceId,
+    news: { bucketName },
+    session,
+    bindings: [],
+  });
+});
+
+describe("Bucket ownership admission", () => {
+  it.effect(
+    "reads a bucket through an ownership-checked configuration request",
+    () =>
+      Effect.gen(function* () {
+        const transport = fixture((call) =>
+          call.method === "GET" && call.query.has("location")
+            ? xml("<LocationConstraint/>")
+            : error("AccessDenied", 403),
+        );
+        const bucket = yield* provideBucket(read, transport.environment);
+        expect(bucket?.bucketName).toBe(bucketName);
+        expect(transport.calls).toHaveLength(1);
+        expect(
+          transport.calls[0]!.request.headers["x-amz-expected-bucket-owner"],
+        ).toBe(accountId);
+      }),
+  );
+
+  it.effect("returns missing only for NoSuchBucket", () =>
+    Effect.gen(function* () {
+      const transport = fixture(() => error("NoSuchBucket", 404));
+      expect(yield* provideBucket(read, transport.environment)).toBeUndefined();
+    }),
+  );
+
+  it.effect(
+    "propagates AccessDenied instead of reporting an absent bucket",
+    () =>
+      Effect.gen(function* () {
+        const transport = fixture(() => error("AccessDenied", 403));
+        const failure = yield* provideBucket(read, transport.environment).pipe(
+          Effect.flip,
+        );
+        expect(failure._tag).toBe("AccessDeniedException");
+      }),
+  );
+
+  it.effect(
+    "propagates transport failures instead of reporting an absent bucket",
+    () =>
+      Effect.gen(function* () {
+        const transport = fixture(({ request }) =>
+          Effect.fail(
+            new HttpClientError.HttpClientError({
+              reason: new HttpClientError.TransportError({
+                request,
+                cause: new Error("connection closed"),
+              }),
+            }),
+          ),
+        );
+        yield* provideBucket(read, transport.environment).pipe(Effect.flip);
+        expect(transport.calls.length).toBeGreaterThan(0);
+      }),
+  );
+
+  it.effect(
+    "does not recreate an existing us-east-1 bucket without ListBucket",
+    () =>
+      Effect.gen(function* () {
+        const transport = fixture((call) =>
+          call.query.has("location")
+            ? xml("<LocationConstraint/>")
+            : error("AccessDenied", 403),
+        );
+        const bucket = yield* provideBucket(precreate, transport.environment);
+        expect(bucket.bucketName).toBe(bucketName);
+        expect(
+          transport.calls.every(
+            (call) => call.method === "GET" && call.query.has("location"),
+          ),
+        ).toBe(true);
+        expect(
+          transport.calls.every(
+            (call) =>
+              call.request.headers["x-amz-expected-bucket-owner"] === accountId,
+          ),
+        ).toBe(true);
+      }),
+  );
+
+  it.effect(
+    "creates after an explicit absence and verifies the expected owner",
+    () =>
+      Effect.gen(function* () {
+        let created = false;
+        const transport = fixture((call) => {
+          if (call.method === "PUT") {
+            created = true;
+            return xml("");
+          }
+          return created
+            ? xml("<LocationConstraint/>")
+            : error("NoSuchBucket", 404);
+        });
+        yield* provideBucket(precreate, transport.environment);
+        expect(transport.calls.map((call) => call.method)).toEqual([
+          "GET",
+          "PUT",
+          "GET",
+        ]);
+        expect(
+          transport.calls[2]!.request.headers["x-amz-expected-bucket-owner"],
+        ).toBe(accountId);
+      }),
+  );
+
+  it.effect(
+    "never creates a bucket after an ownership or permission rejection",
+    () =>
+      Effect.gen(function* () {
+        const transport = fixture(() => error("AccessDenied", 403));
+        const failure = yield* provideBucket(
+          precreate,
+          transport.environment,
+        ).pipe(Effect.flip);
+        expect(failure._tag).toBe("AccessDeniedException");
+        expect(transport.calls).toHaveLength(1);
+        expect(transport.calls[0]!.method).toBe("GET");
+      }),
+  );
+
+  it.effect(
+    "fails readiness immediately on authorization errors after a regional create",
+    () =>
+      Effect.gen(function* () {
+        const transport = fixture(
+          (call) =>
+            call.method === "PUT" ? xml("") : error("AccessDenied", 403),
+          "eu-west-1",
+        );
+        const failure = yield* provideBucket(
+          precreate,
+          transport.environment,
+        ).pipe(Effect.flip);
+        expect(failure._tag).toBe("AccessDeniedException");
+        expect(transport.calls.map((call) => call.method)).toEqual([
+          "PUT",
+          "GET",
+        ]);
+        expect(
+          transport.calls[1]!.request.headers["x-amz-expected-bucket-owner"],
+        ).toBe(accountId);
+      }),
+  );
+});

--- a/packages/alchemy/test/AWS/S3/fixtures/bucket-provider.ts
+++ b/packages/alchemy/test/AWS/S3/fixtures/bucket-provider.ts
@@ -1,0 +1,150 @@
+import { AWSEnvironment } from "@/AWS/Environment.ts";
+import { Bucket, BucketProvider } from "@/AWS/S3/Bucket.ts";
+import { InstanceId } from "@/InstanceId.ts";
+import * as Provider from "@/Provider.ts";
+import { Stack } from "@/Stack.ts";
+import { Stage } from "@/Stage.ts";
+import { Credentials, fromCredentials } from "@distilled.cloud/aws/Credentials";
+import { Region } from "@distilled.cloud/aws/Region";
+import { Retry } from "@distilled.cloud/aws/Retry";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import type * as HttpClientError from "effect/unstable/http/HttpClientError";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import type * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
+import * as HttpClientResponse from "effect/unstable/http/HttpClientResponse";
+
+export const accountId = "123456789012";
+export const bucketName = "alchemy-bucket-provider-test";
+export const instanceId = "0123456789abcdef0123456789abcdef";
+
+export const output: Bucket["Attributes"] = {
+  accountId,
+  bucketName,
+  bucketArn: `arn:aws:s3:::${bucketName}`,
+  bucketDomainName: `${bucketName}.s3.amazonaws.com`,
+  bucketRegionalDomainName: `${bucketName}.s3.us-east-1.amazonaws.com`,
+  region: "us-east-1",
+};
+
+export const session = {
+  emit: () => Effect.void,
+  done: () => Effect.void,
+  note: () => Effect.void,
+};
+
+export interface Call {
+  request: HttpClientRequest.HttpClientRequest;
+  method: string;
+  query: URLSearchParams;
+  body: string;
+}
+
+export const xml = (body: string, status = 200) =>
+  Effect.sync(
+    () =>
+      new Response(body, {
+        status,
+        headers: { "content-type": "application/xml" },
+      }),
+  );
+
+export const error = (code: string, status: number) =>
+  xml(`<Error><Code>${code}</Code><Message>${code}</Message></Error>`, status);
+
+/** Inject only the HTTP boundary; signing, XML codecs and providers stay real. */
+export const fixture = (
+  respond: (
+    call: Call,
+  ) => Effect.Effect<Response, HttpClientError.HttpClientError>,
+  region = "us-east-1",
+) => {
+  const calls: Call[] = [];
+  const client = HttpClient.make((request, url) =>
+    Effect.gen(function* () {
+      const call = yield* Effect.sync(() => ({
+        request,
+        method: request.method,
+        query: url.searchParams,
+        body:
+          request.body._tag === "Uint8Array"
+            ? new TextDecoder().decode(request.body.body)
+            : "",
+      }));
+      calls.push(call);
+      return HttpClientResponse.fromWeb(request, yield* respond(call));
+    }),
+  );
+  const credentials = fromCredentials(
+    {
+      accessKeyId: "AKIAIOSFODNN7EXAMPLE",
+      secretAccessKey: "test-secret-key",
+    },
+    region,
+  );
+  const environment = Layer.mergeAll(
+    credentials,
+    Layer.succeed(Region, Effect.succeed(region)),
+    Layer.effect(
+      AWSEnvironment,
+      Effect.map(Credentials, (credentials) =>
+        Effect.succeed({ accountId, region, credentials }),
+      ),
+    ).pipe(Layer.provide(credentials)),
+    Layer.succeed(Stack, {
+      name: "bucket-provider-test",
+      stage: "test",
+      resources: {},
+      bindings: {},
+      actions: {},
+    }),
+    Layer.succeed(Stage, "test"),
+    Layer.succeed(InstanceId, instanceId),
+    Layer.succeed(HttpClient.HttpClient, client),
+    Layer.succeed(Retry, { while: () => false }),
+  );
+  return { calls, environment };
+};
+
+export const bucketProvider = Provider.Provider<Bucket>("AWS.S3.Bucket");
+
+export const provideBucket = <A, E>(
+  operation: Effect.Effect<A, E, Provider.Provider<Bucket>>,
+  environment: ReturnType<typeof fixture>["environment"],
+) =>
+  operation.pipe(Effect.provide(BucketProvider()), Effect.provide(environment));
+
+/** Responses for configuration outside the aspect under examination. */
+export const existingBucket = (call: Call) => {
+  if (call.method === "HEAD") return xml("");
+  if (call.query.has("location")) return xml("<LocationConstraint/>");
+  if (call.query.has("tagging")) return xml("<Tagging><TagSet/></Tagging>");
+  if (call.query.has("policy")) return error("NoSuchBucketPolicy", 404);
+  return Effect.die(
+    `Unexpected S3 request: ${call.method} ${call.request.url}`,
+  );
+};
+
+export const existingStateBucket = (call: Call) => {
+  if (call.query.has("versioning")) {
+    return xml(
+      "<VersioningConfiguration><Status>Enabled</Status></VersioningConfiguration>",
+    );
+  }
+  if (call.query.has("publicAccessBlock")) {
+    return xml(
+      "<PublicAccessBlockConfiguration><BlockPublicAcls>true</BlockPublicAcls><IgnorePublicAcls>true</IgnorePublicAcls><BlockPublicPolicy>true</BlockPublicPolicy><RestrictPublicBuckets>true</RestrictPublicBuckets></PublicAccessBlockConfiguration>",
+    );
+  }
+  if (call.query.has("ownershipControls")) {
+    return xml(
+      "<OwnershipControls><Rule><ObjectOwnership>BucketOwnerEnforced</ObjectOwnership></Rule></OwnershipControls>",
+    );
+  }
+  if (call.query.has("list-type")) {
+    return xml(
+      "<ListBucketResult><IsTruncated>false</IsTruncated></ListBucketResult>",
+    );
+  }
+  return existingBucket(call);
+};


### PR DESCRIPTION
Use `GetBucketLocation` with `ExpectedBucketOwner` for bucket reads and readiness checks. Configuration-only operators no longer need `s3:ListBucket`, and denied access no longer makes an existing bucket appear absent. Readiness retries only `NoSuchBucket`.

Prepared with AI assistance.
