### PR TITLE
fix(aws/s3): propagate configuration read failures

### DIFF
--- a/packages/alchemy/src/AWS/S3/Bucket.ts
+++ b/packages/alchemy/src/AWS/S3/Bucket.ts
@@ -7,14 +7,12 @@ import * as Effect from "effect/Effect";
 import * as Order from "effect/Order";
 import * as Schedule from "effect/Schedule";
 import * as Stream from "effect/Stream";
-import type { HttpClient } from "effect/unstable/http";
 import type { ScopedPlanStatusSession } from "../../Report.ts";
 import { isResolved } from "../../Diff.ts";
 import { createPhysicalName } from "../../PhysicalName.ts";
 import * as Provider from "../../Provider.ts";
 import { Resource, type ResourceBinding } from "../../Resource.ts";
 import { diffTags } from "../../Tags.ts";
-import type { Credentials } from "../Credentials.ts";
 import { AWSEnvironment, type AccountID } from "../Environment.ts";
 import { durationToDays } from "../IAM/common.ts";
 import type { PolicyStatement } from "../IAM/Policy.ts";
@@ -588,19 +586,12 @@ export const BucketProvider = () =>
         };
       });
 
-      const fetchBucketTags = (
-        bucketName: string,
-      ): Effect.Effect<
-        Record<string, string>,
-        never,
-        Credentials | HttpClient.HttpClient | Region
-      > =>
+      const fetchBucketTags = (bucketName: string) =>
         s3.getBucketTagging({ Bucket: bucketName }).pipe(
           Effect.map((r) =>
             Object.fromEntries((r.TagSet ?? []).map((t) => [t.Key!, t.Value!])),
           ),
           Effect.catchTag("NoSuchTagSet", () => Effect.succeed({})),
-          Effect.catch(() => Effect.succeed({})),
         );
 
       const syncBucketTags = Effect.fn(function* ({
@@ -854,13 +845,6 @@ export const BucketProvider = () =>
           .getBucketEncryption({ Bucket: bucketName })
           .pipe(
             Effect.map((r) => r.ServerSideEncryptionConfiguration?.Rules?.[0]),
-            // Some partitions return 404 with no default config; treat any
-            // not-configured read as "no rule" so we converge by writing.
-            Effect.catch(() =>
-              Effect.succeed<s3.ServerSideEncryptionRule | undefined>(
-                undefined,
-              ),
-            ),
           );
         const canon = (r: s3.ServerSideEncryptionRule | undefined) =>
           JSON.stringify({

--- a/packages/alchemy/test/AWS/S3/Bucket.configuration-reads.test.ts
+++ b/packages/alchemy/test/AWS/S3/Bucket.configuration-reads.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "alchemy-test";
+import * as Effect from "effect/Effect";
+import * as HttpClientError from "effect/unstable/http/HttpClientError";
+import {
+  bucketName,
+  bucketProvider,
+  error,
+  existingBucket,
+  fixture,
+  instanceId,
+  output,
+  provideBucket,
+  session,
+  xml,
+  type Call,
+} from "./fixtures/bucket-provider.ts";
+
+const reconcile = (aspect: "tagging" | "encryption") =>
+  Effect.gen(function* () {
+    const provider = yield* bucketProvider;
+    yield* provider.reconcile({
+      id: "Bucket",
+      fqn: "Bucket",
+      instanceId,
+      news: {
+        bucketName,
+        ...(aspect === "tagging"
+          ? { tags: { managed: "yes" } }
+          : { encryption: { sseAlgorithm: "AES256" as const } }),
+      },
+      olds: undefined,
+      output,
+      session,
+      bindings: [],
+    });
+  });
+
+for (const aspect of ["tagging", "encryption"] as const) {
+  describe(`Bucket ${aspect} observation`, () => {
+    const observe = (
+      read: (
+        call: Call,
+      ) =>
+        | ReturnType<typeof error>
+        | Effect.Effect<never, HttpClientError.HttpClientError>,
+    ) =>
+      fixture((call) => {
+        if (call.query.has(aspect))
+          return call.method === "GET" ? read(call) : xml("");
+        return existingBucket(call);
+      });
+
+    it.effect("does not write after AccessDenied", () =>
+      Effect.gen(function* () {
+        const transport = observe(() => error("AccessDenied", 403));
+        const failure = yield* provideBucket(
+          reconcile(aspect),
+          transport.environment,
+        ).pipe(Effect.flip);
+        expect(failure._tag).toBe("AccessDeniedException");
+        expect(
+          transport.calls.filter(
+            (call) => call.method !== "GET" && call.query.has(aspect),
+          ),
+        ).toEqual([]);
+      }),
+    );
+
+    it.effect("does not write after a transport failure", () =>
+      Effect.gen(function* () {
+        const transport = observe(({ request }) =>
+          Effect.fail(
+            new HttpClientError.HttpClientError({
+              reason: new HttpClientError.TransportError({
+                request,
+                cause: new Error("connection closed"),
+              }),
+            }),
+          ),
+        );
+        yield* provideBucket(reconcile(aspect), transport.environment).pipe(
+          Effect.flip,
+        );
+        expect(
+          transport.calls.filter(
+            (call) => call.method !== "GET" && call.query.has(aspect),
+          ),
+        ).toEqual([]);
+      }),
+    );
+
+    it.effect("still initializes explicitly absent configuration", () =>
+      Effect.gen(function* () {
+        const transport = observe(() =>
+          aspect === "tagging"
+            ? error("NoSuchTagSet", 404)
+            : xml("<ServerSideEncryptionConfiguration/>"),
+        );
+        yield* provideBucket(reconcile(aspect), transport.environment);
+        expect(
+          transport.calls.filter(
+            (call) => call.method === "PUT" && call.query.has(aspect),
+          ),
+        ).toHaveLength(1);
+      }),
+    );
+
+    it.effect("does not turn a missing bucket into missing configuration", () =>
+      Effect.gen(function* () {
+        const transport = observe(() => error("NoSuchBucket", 404));
+        const failure = yield* provideBucket(
+          reconcile(aspect),
+          transport.environment,
+        ).pipe(Effect.flip);
+        expect(failure._tag).toBe("NoSuchBucket");
+        expect(
+          transport.calls.filter(
+            (call) => call.method !== "GET" && call.query.has(aspect),
+          ),
+        ).toEqual([]);
+      }),
+    );
+  });
+}

--- a/packages/alchemy/test/AWS/S3/fixtures/bucket-provider.ts
+++ b/packages/alchemy/test/AWS/S3/fixtures/bucket-provider.ts
@@ -1,0 +1,150 @@
+import { AWSEnvironment } from "@/AWS/Environment.ts";
+import { Bucket, BucketProvider } from "@/AWS/S3/Bucket.ts";
+import { InstanceId } from "@/InstanceId.ts";
+import * as Provider from "@/Provider.ts";
+import { Stack } from "@/Stack.ts";
+import { Stage } from "@/Stage.ts";
+import { Credentials, fromCredentials } from "@distilled.cloud/aws/Credentials";
+import { Region } from "@distilled.cloud/aws/Region";
+import { Retry } from "@distilled.cloud/aws/Retry";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import type * as HttpClientError from "effect/unstable/http/HttpClientError";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import type * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
+import * as HttpClientResponse from "effect/unstable/http/HttpClientResponse";
+
+export const accountId = "123456789012";
+export const bucketName = "alchemy-bucket-provider-test";
+export const instanceId = "0123456789abcdef0123456789abcdef";
+
+export const output: Bucket["Attributes"] = {
+  accountId,
+  bucketName,
+  bucketArn: `arn:aws:s3:::${bucketName}`,
+  bucketDomainName: `${bucketName}.s3.amazonaws.com`,
+  bucketRegionalDomainName: `${bucketName}.s3.us-east-1.amazonaws.com`,
+  region: "us-east-1",
+};
+
+export const session = {
+  emit: () => Effect.void,
+  done: () => Effect.void,
+  note: () => Effect.void,
+};
+
+export interface Call {
+  request: HttpClientRequest.HttpClientRequest;
+  method: string;
+  query: URLSearchParams;
+  body: string;
+}
+
+export const xml = (body: string, status = 200) =>
+  Effect.sync(
+    () =>
+      new Response(body, {
+        status,
+        headers: { "content-type": "application/xml" },
+      }),
+  );
+
+export const error = (code: string, status: number) =>
+  xml(`<Error><Code>${code}</Code><Message>${code}</Message></Error>`, status);
+
+/** Inject only the HTTP boundary; signing, XML codecs and providers stay real. */
+export const fixture = (
+  respond: (
+    call: Call,
+  ) => Effect.Effect<Response, HttpClientError.HttpClientError>,
+  region = "us-east-1",
+) => {
+  const calls: Call[] = [];
+  const client = HttpClient.make((request, url) =>
+    Effect.gen(function* () {
+      const call = yield* Effect.sync(() => ({
+        request,
+        method: request.method,
+        query: url.searchParams,
+        body:
+          request.body._tag === "Uint8Array"
+            ? new TextDecoder().decode(request.body.body)
+            : "",
+      }));
+      calls.push(call);
+      return HttpClientResponse.fromWeb(request, yield* respond(call));
+    }),
+  );
+  const credentials = fromCredentials(
+    {
+      accessKeyId: "AKIAIOSFODNN7EXAMPLE",
+      secretAccessKey: "test-secret-key",
+    },
+    region,
+  );
+  const environment = Layer.mergeAll(
+    credentials,
+    Layer.succeed(Region, Effect.succeed(region)),
+    Layer.effect(
+      AWSEnvironment,
+      Effect.map(Credentials, (credentials) =>
+        Effect.succeed({ accountId, region, credentials }),
+      ),
+    ).pipe(Layer.provide(credentials)),
+    Layer.succeed(Stack, {
+      name: "bucket-provider-test",
+      stage: "test",
+      resources: {},
+      bindings: {},
+      actions: {},
+    }),
+    Layer.succeed(Stage, "test"),
+    Layer.succeed(InstanceId, instanceId),
+    Layer.succeed(HttpClient.HttpClient, client),
+    Layer.succeed(Retry, { while: () => false }),
+  );
+  return { calls, environment };
+};
+
+export const bucketProvider = Provider.Provider<Bucket>("AWS.S3.Bucket");
+
+export const provideBucket = <A, E>(
+  operation: Effect.Effect<A, E, Provider.Provider<Bucket>>,
+  environment: ReturnType<typeof fixture>["environment"],
+) =>
+  operation.pipe(Effect.provide(BucketProvider()), Effect.provide(environment));
+
+/** Responses for configuration outside the aspect under examination. */
+export const existingBucket = (call: Call) => {
+  if (call.method === "HEAD") return xml("");
+  if (call.query.has("location")) return xml("<LocationConstraint/>");
+  if (call.query.has("tagging")) return xml("<Tagging><TagSet/></Tagging>");
+  if (call.query.has("policy")) return error("NoSuchBucketPolicy", 404);
+  return Effect.die(
+    `Unexpected S3 request: ${call.method} ${call.request.url}`,
+  );
+};
+
+export const existingStateBucket = (call: Call) => {
+  if (call.query.has("versioning")) {
+    return xml(
+      "<VersioningConfiguration><Status>Enabled</Status></VersioningConfiguration>",
+    );
+  }
+  if (call.query.has("publicAccessBlock")) {
+    return xml(
+      "<PublicAccessBlockConfiguration><BlockPublicAcls>true</BlockPublicAcls><IgnorePublicAcls>true</IgnorePublicAcls><BlockPublicPolicy>true</BlockPublicPolicy><RestrictPublicBuckets>true</RestrictPublicBuckets></PublicAccessBlockConfiguration>",
+    );
+  }
+  if (call.query.has("ownershipControls")) {
+    return xml(
+      "<OwnershipControls><Rule><ObjectOwnership>BucketOwnerEnforced</ObjectOwnership></Rule></OwnershipControls>",
+    );
+  }
+  if (call.query.has("list-type")) {
+    return xml(
+      "<ListBucketResult><IsTruncated>false</IsTruncated></ListBucketResult>",
+    );
+  }
+  return existingBucket(call);
+};


### PR DESCRIPTION
Propagate S3 tag and encryption read failures before reconciling those settings. Continue treating `NoSuchTagSet` as an empty tag set; successful encryption responses with no rule can still initialize defaults.

Prepared with AI assistance.
