### PR TITLE
fix(aws/s3): compare decoded encryption key values

### DIFF
--- a/packages/alchemy/src/AWS/S3/Bucket.ts
+++ b/packages/alchemy/src/AWS/S3/Bucket.ts
@@ -5,6 +5,7 @@ import * as Arr from "effect/Array";
 import type * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Order from "effect/Order";
+import * as Redacted from "effect/Redacted";
 import * as Schedule from "effect/Schedule";
 import * as Stream from "effect/Stream";
 import type { HttpClient } from "effect/unstable/http";
@@ -862,10 +863,16 @@ export const BucketProvider = () =>
               ),
             ),
           );
+        // SensitiveString decodes to Redacted; its JSON form hides the key identity.
+        const keyValue = (
+          key: s3.ServerSideEncryptionByDefault["KMSMasterKeyID"],
+        ) => (Redacted.isRedacted(key) ? Redacted.value(key) : key);
         const canon = (r: s3.ServerSideEncryptionRule | undefined) =>
           JSON.stringify({
             alg: r?.ApplyServerSideEncryptionByDefault?.SSEAlgorithm ?? null,
-            key: r?.ApplyServerSideEncryptionByDefault?.KMSMasterKeyID ?? null,
+            key:
+              keyValue(r?.ApplyServerSideEncryptionByDefault?.KMSMasterKeyID) ??
+              null,
             bucketKey: r?.BucketKeyEnabled ?? false,
           });
         if (canon(current) === canon(desiredRule)) return;

--- a/packages/alchemy/src/AWS/StateStore/State.ts
+++ b/packages/alchemy/src/AWS/StateStore/State.ts
@@ -3,6 +3,7 @@ import type { Region } from "@distilled.cloud/aws/Region";
 import * as s3 from "@distilled.cloud/aws/s3";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
+import * as Redacted from "effect/Redacted";
 import * as Schedule from "effect/Schedule";
 import * as Stream from "effect/Stream";
 import type { HttpClient } from "effect/unstable/http/HttpClient";
@@ -462,13 +463,19 @@ const ensureStateBucket = (
       },
       BucketKeyEnabled: desiredEncryption.bucketKeyEnabled ?? false,
     };
+    // SensitiveString decodes to Redacted; its JSON form hides the key identity.
+    const keyValue = (
+      key: s3.ServerSideEncryptionByDefault["KMSMasterKeyID"],
+    ) => (Redacted.isRedacted(key) ? Redacted.value(key) : key);
     const encryptionFingerprint = (
       rule: s3.ServerSideEncryptionRule | undefined,
     ) =>
       JSON.stringify({
         algorithm:
           rule?.ApplyServerSideEncryptionByDefault?.SSEAlgorithm ?? null,
-        key: rule?.ApplyServerSideEncryptionByDefault?.KMSMasterKeyID ?? null,
+        key:
+          keyValue(rule?.ApplyServerSideEncryptionByDefault?.KMSMasterKeyID) ??
+          null,
         bucketKey: rule?.BucketKeyEnabled ?? false,
       });
     if (

--- a/packages/alchemy/test/AWS/S3/EncryptionIdentity.test.ts
+++ b/packages/alchemy/test/AWS/S3/EncryptionIdentity.test.ts
@@ -1,0 +1,115 @@
+import type { BucketEncryption } from "@/AWS/S3/Bucket.ts";
+import { makeS3State } from "@/AWS/StateStore/State.ts";
+import { describe, expect, it } from "alchemy-test";
+import * as Effect from "effect/Effect";
+import {
+  bucketName,
+  bucketProvider,
+  existingStateBucket,
+  fixture,
+  instanceId,
+  output,
+  provideBucket,
+  session,
+  xml,
+} from "./fixtures/bucket-provider.ts";
+
+const keyArn =
+  "arn:aws:kms:us-east-1:123456789012:key/11111111-1111-1111-1111-111111111111";
+const otherKeyArn =
+  "arn:aws:kms:us-east-1:123456789012:key/22222222-2222-2222-2222-222222222222";
+
+for (const owner of ["Bucket", "StateStore"] as const) {
+  describe(`${owner} encryption key identity`, () => {
+    const reconcile = (desired: BucketEncryption) => {
+      const transport = fixture((call) => {
+        if (call.query.has("encryption")) {
+          return call.method === "GET"
+            ? xml(`<ServerSideEncryptionConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                <Rule><ApplyServerSideEncryptionByDefault>
+                  <SSEAlgorithm>aws:kms</SSEAlgorithm>
+                  <KMSMasterKeyID>${keyArn}</KMSMasterKeyID>
+                </ApplyServerSideEncryptionByDefault><BucketKeyEnabled>false</BucketKeyEnabled></Rule>
+              </ServerSideEncryptionConfiguration>`)
+            : xml("");
+        }
+        return existingStateBucket(call);
+      });
+      const operation =
+        owner === "Bucket"
+          ? provideBucket(
+              Effect.gen(function* () {
+                const provider = yield* bucketProvider;
+                yield* provider.reconcile({
+                  id: "Bucket",
+                  fqn: "Bucket",
+                  instanceId,
+                  news: { bucketName, encryption: desired },
+                  olds: undefined,
+                  output,
+                  session,
+                  bindings: [],
+                });
+              }),
+              transport.environment,
+            )
+          : Effect.gen(function* () {
+              const state = yield* makeS3State({
+                bucketName,
+                encryption: desired,
+              });
+              yield* state.listStacks();
+            }).pipe(Effect.provide(transport.environment));
+      return operation.pipe(Effect.as(transport.calls));
+    };
+
+    it.effect("does not rewrite an unchanged decoded KMS key", () =>
+      Effect.gen(function* () {
+        const calls = yield* reconcile({
+          sseAlgorithm: "aws:kms",
+          kmsMasterKeyId: keyArn,
+        });
+        expect(
+          calls.filter(
+            (call) => call.method === "PUT" && call.query.has("encryption"),
+          ),
+        ).toEqual([]);
+      }),
+    );
+
+    it.effect(
+      "writes a different key instead of equating redacted values",
+      () =>
+        Effect.gen(function* () {
+          const calls = yield* reconcile({
+            sseAlgorithm: "aws:kms",
+            kmsMasterKeyId: otherKeyArn,
+          });
+          const puts = calls.filter(
+            (call) => call.method === "PUT" && call.query.has("encryption"),
+          );
+          expect(puts).toHaveLength(1);
+          expect(puts[0]!.body).toContain(
+            `<KMSMasterKeyID>${otherKeyArn}</KMSMasterKeyID>`,
+          );
+        }),
+    );
+
+    it.effect("still reconciles bucket key settings for the same KMS key", () =>
+      Effect.gen(function* () {
+        const calls = yield* reconcile({
+          sseAlgorithm: "aws:kms",
+          kmsMasterKeyId: keyArn,
+          bucketKeyEnabled: true,
+        });
+        const puts = calls.filter(
+          (call) => call.method === "PUT" && call.query.has("encryption"),
+        );
+        expect(puts).toHaveLength(1);
+        expect(puts[0]!.body).toContain(
+          "<BucketKeyEnabled>true</BucketKeyEnabled>",
+        );
+      }),
+    );
+  });
+}

--- a/packages/alchemy/test/AWS/S3/fixtures/bucket-provider.ts
+++ b/packages/alchemy/test/AWS/S3/fixtures/bucket-provider.ts
@@ -1,0 +1,150 @@
+import { AWSEnvironment } from "@/AWS/Environment.ts";
+import { Bucket, BucketProvider } from "@/AWS/S3/Bucket.ts";
+import { InstanceId } from "@/InstanceId.ts";
+import * as Provider from "@/Provider.ts";
+import { Stack } from "@/Stack.ts";
+import { Stage } from "@/Stage.ts";
+import { Credentials, fromCredentials } from "@distilled.cloud/aws/Credentials";
+import { Region } from "@distilled.cloud/aws/Region";
+import { Retry } from "@distilled.cloud/aws/Retry";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import type * as HttpClientError from "effect/unstable/http/HttpClientError";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import type * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
+import * as HttpClientResponse from "effect/unstable/http/HttpClientResponse";
+
+export const accountId = "123456789012";
+export const bucketName = "alchemy-bucket-provider-test";
+export const instanceId = "0123456789abcdef0123456789abcdef";
+
+export const output: Bucket["Attributes"] = {
+  accountId,
+  bucketName,
+  bucketArn: `arn:aws:s3:::${bucketName}`,
+  bucketDomainName: `${bucketName}.s3.amazonaws.com`,
+  bucketRegionalDomainName: `${bucketName}.s3.us-east-1.amazonaws.com`,
+  region: "us-east-1",
+};
+
+export const session = {
+  emit: () => Effect.void,
+  done: () => Effect.void,
+  note: () => Effect.void,
+};
+
+export interface Call {
+  request: HttpClientRequest.HttpClientRequest;
+  method: string;
+  query: URLSearchParams;
+  body: string;
+}
+
+export const xml = (body: string, status = 200) =>
+  Effect.sync(
+    () =>
+      new Response(body, {
+        status,
+        headers: { "content-type": "application/xml" },
+      }),
+  );
+
+export const error = (code: string, status: number) =>
+  xml(`<Error><Code>${code}</Code><Message>${code}</Message></Error>`, status);
+
+/** Inject only the HTTP boundary; signing, XML codecs and providers stay real. */
+export const fixture = (
+  respond: (
+    call: Call,
+  ) => Effect.Effect<Response, HttpClientError.HttpClientError>,
+  region = "us-east-1",
+) => {
+  const calls: Call[] = [];
+  const client = HttpClient.make((request, url) =>
+    Effect.gen(function* () {
+      const call = yield* Effect.sync(() => ({
+        request,
+        method: request.method,
+        query: url.searchParams,
+        body:
+          request.body._tag === "Uint8Array"
+            ? new TextDecoder().decode(request.body.body)
+            : "",
+      }));
+      calls.push(call);
+      return HttpClientResponse.fromWeb(request, yield* respond(call));
+    }),
+  );
+  const credentials = fromCredentials(
+    {
+      accessKeyId: "AKIAIOSFODNN7EXAMPLE",
+      secretAccessKey: "test-secret-key",
+    },
+    region,
+  );
+  const environment = Layer.mergeAll(
+    credentials,
+    Layer.succeed(Region, Effect.succeed(region)),
+    Layer.effect(
+      AWSEnvironment,
+      Effect.map(Credentials, (credentials) =>
+        Effect.succeed({ accountId, region, credentials }),
+      ),
+    ).pipe(Layer.provide(credentials)),
+    Layer.succeed(Stack, {
+      name: "bucket-provider-test",
+      stage: "test",
+      resources: {},
+      bindings: {},
+      actions: {},
+    }),
+    Layer.succeed(Stage, "test"),
+    Layer.succeed(InstanceId, instanceId),
+    Layer.succeed(HttpClient.HttpClient, client),
+    Layer.succeed(Retry, { while: () => false }),
+  );
+  return { calls, environment };
+};
+
+export const bucketProvider = Provider.Provider<Bucket>("AWS.S3.Bucket");
+
+export const provideBucket = <A, E>(
+  operation: Effect.Effect<A, E, Provider.Provider<Bucket>>,
+  environment: ReturnType<typeof fixture>["environment"],
+) =>
+  operation.pipe(Effect.provide(BucketProvider()), Effect.provide(environment));
+
+/** Responses for configuration outside the aspect under examination. */
+export const existingBucket = (call: Call) => {
+  if (call.method === "HEAD") return xml("");
+  if (call.query.has("location")) return xml("<LocationConstraint/>");
+  if (call.query.has("tagging")) return xml("<Tagging><TagSet/></Tagging>");
+  if (call.query.has("policy")) return error("NoSuchBucketPolicy", 404);
+  return Effect.die(
+    `Unexpected S3 request: ${call.method} ${call.request.url}`,
+  );
+};
+
+export const existingStateBucket = (call: Call) => {
+  if (call.query.has("versioning")) {
+    return xml(
+      "<VersioningConfiguration><Status>Enabled</Status></VersioningConfiguration>",
+    );
+  }
+  if (call.query.has("publicAccessBlock")) {
+    return xml(
+      "<PublicAccessBlockConfiguration><BlockPublicAcls>true</BlockPublicAcls><IgnorePublicAcls>true</IgnorePublicAcls><BlockPublicPolicy>true</BlockPublicPolicy><RestrictPublicBuckets>true</RestrictPublicBuckets></PublicAccessBlockConfiguration>",
+    );
+  }
+  if (call.query.has("ownershipControls")) {
+    return xml(
+      "<OwnershipControls><Rule><ObjectOwnership>BucketOwnerEnforced</ObjectOwnership></Rule></OwnershipControls>",
+    );
+  }
+  if (call.query.has("list-type")) {
+    return xml(
+      "<ListBucketResult><IsTruncated>false</IsTruncated></ListBucketResult>",
+    );
+  }
+  return existingBucket(call);
+};


### PR DESCRIPTION
Compare the underlying values of redacted KMS identifiers when reconciling S3 buckets and the AWS state store. Matching identifiers no longer trigger redundant `PutBucketEncryption` requests.

Prepared with AI assistance.
