### PR TITLE
feat(aws/s3): manage blocked encryption types

### DIFF
--- a/packages/alchemy/src/AWS/S3/Bucket.ts
+++ b/packages/alchemy/src/AWS/S3/Bucket.ts
@@ -871,7 +871,15 @@ export const BucketProvider = () =>
         if (canon(current) === canon(desiredRule)) return;
         yield* s3.putBucketEncryption({
           Bucket: bucketName,
-          ServerSideEncryptionConfiguration: { Rules: [desiredRule] },
+          ServerSideEncryptionConfiguration: {
+            // BucketEncryption owns the defaults, not encryption-type blocks.
+            Rules: [
+              {
+                ...desiredRule,
+                BlockedEncryptionTypes: current?.BlockedEncryptionTypes,
+              },
+            ],
+          },
         });
         yield* session.note(`Updated bucket encryption: ${bucketName}`);
       });

--- a/packages/alchemy/src/AWS/StateStore/State.ts
+++ b/packages/alchemy/src/AWS/StateStore/State.ts
@@ -478,7 +478,14 @@ const ensureStateBucket = (
       yield* s3.putBucketEncryption({
         Bucket: bucket,
         ServerSideEncryptionConfiguration: {
-          Rules: [desiredEncryptionRule],
+          // Preserve encryption-type blocks managed outside the state store.
+          Rules: [
+            {
+              ...desiredEncryptionRule,
+              BlockedEncryptionTypes:
+                observedEncryption?.BlockedEncryptionTypes,
+            },
+          ],
         },
       });
     }

--- a/packages/alchemy/test/AWS/S3/EncryptionPolicy.test.ts
+++ b/packages/alchemy/test/AWS/S3/EncryptionPolicy.test.ts
@@ -1,0 +1,116 @@
+import { makeS3State } from "@/AWS/StateStore/State.ts";
+import { describe, expect, it } from "alchemy-test";
+import * as Effect from "effect/Effect";
+import {
+  bucketName,
+  bucketProvider,
+  existingStateBucket,
+  fixture,
+  instanceId,
+  output,
+  provideBucket,
+  session,
+  xml,
+} from "./fixtures/bucket-provider.ts";
+
+for (const owner of ["Bucket", "StateStore"] as const) {
+  describe(`${owner} encryption type blocks`, () => {
+    const reconcile = (
+      blocked: "SSE-C" | "NONE" | undefined,
+      algorithm: "AES256" | "aws:kms",
+    ) => {
+      const transport = fixture((call) => {
+        if (call.query.has("encryption")) {
+          return call.method === "GET"
+            ? xml(`<ServerSideEncryptionConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+                <Rule><ApplyServerSideEncryptionByDefault><SSEAlgorithm>${algorithm}</SSEAlgorithm></ApplyServerSideEncryptionByDefault>
+                ${blocked === undefined ? "" : `<BlockedEncryptionTypes><EncryptionType>${blocked}</EncryptionType></BlockedEncryptionTypes>`}
+                </Rule>
+              </ServerSideEncryptionConfiguration>`)
+            : xml("");
+        }
+        return existingStateBucket(call);
+      });
+      const operation =
+        owner === "Bucket"
+          ? provideBucket(
+              Effect.gen(function* () {
+                const provider = yield* bucketProvider;
+                yield* provider.reconcile({
+                  id: "Bucket",
+                  fqn: "Bucket",
+                  instanceId,
+                  news: { bucketName, encryption: { sseAlgorithm: "AES256" } },
+                  olds: undefined,
+                  output,
+                  session,
+                  bindings: [],
+                });
+              }),
+              transport.environment,
+            )
+          : Effect.gen(function* () {
+              const state = yield* makeS3State({ bucketName });
+              yield* state.listStacks();
+            }).pipe(Effect.provide(transport.environment));
+      return operation.pipe(Effect.as(transport.calls));
+    };
+
+    it.effect(
+      "retains the observed SSE-C block when default encryption changes",
+      () =>
+        Effect.gen(function* () {
+          const calls = yield* reconcile("SSE-C", "aws:kms");
+          const puts = calls.filter(
+            (call) => call.method === "PUT" && call.query.has("encryption"),
+          );
+          expect(puts).toHaveLength(1);
+          expect(puts[0]!.body).toContain(
+            "<SSEAlgorithm>AES256</SSEAlgorithm>",
+          );
+          expect(puts[0]!.body).toContain(
+            "<BlockedEncryptionTypes><EncryptionType>SSE-C</EncryptionType></BlockedEncryptionTypes>",
+          );
+        }),
+    );
+
+    it.effect("retains an explicit allowance for encryption types", () =>
+      Effect.gen(function* () {
+        const calls = yield* reconcile("NONE", "aws:kms");
+        const puts = calls.filter(
+          (call) => call.method === "PUT" && call.query.has("encryption"),
+        );
+        expect(puts).toHaveLength(1);
+        expect(puts[0]!.body).toContain(
+          "<BlockedEncryptionTypes><EncryptionType>NONE</EncryptionType></BlockedEncryptionTypes>",
+        );
+      }),
+    );
+
+    it.effect(
+      "does not invent encryption blocks when none are configured",
+      () =>
+        Effect.gen(function* () {
+          const calls = yield* reconcile(undefined, "aws:kms");
+          const puts = calls.filter(
+            (call) => call.method === "PUT" && call.query.has("encryption"),
+          );
+          expect(puts).toHaveLength(1);
+          expect(puts[0]!.body).not.toContain("BlockedEncryptionTypes");
+        }),
+    );
+
+    it.effect(
+      "leaves externally managed blocks untouched when defaults already match",
+      () =>
+        Effect.gen(function* () {
+          const calls = yield* reconcile("SSE-C", "AES256");
+          expect(
+            calls.filter(
+              (call) => call.method === "PUT" && call.query.has("encryption"),
+            ),
+          ).toEqual([]);
+        }),
+    );
+  });
+}

--- a/packages/alchemy/test/AWS/S3/fixtures/bucket-provider.ts
+++ b/packages/alchemy/test/AWS/S3/fixtures/bucket-provider.ts
@@ -1,0 +1,150 @@
+import { AWSEnvironment } from "@/AWS/Environment.ts";
+import { Bucket, BucketProvider } from "@/AWS/S3/Bucket.ts";
+import { InstanceId } from "@/InstanceId.ts";
+import * as Provider from "@/Provider.ts";
+import { Stack } from "@/Stack.ts";
+import { Stage } from "@/Stage.ts";
+import { Credentials, fromCredentials } from "@distilled.cloud/aws/Credentials";
+import { Region } from "@distilled.cloud/aws/Region";
+import { Retry } from "@distilled.cloud/aws/Retry";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import type * as HttpClientError from "effect/unstable/http/HttpClientError";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import type * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
+import * as HttpClientResponse from "effect/unstable/http/HttpClientResponse";
+
+export const accountId = "123456789012";
+export const bucketName = "alchemy-bucket-provider-test";
+export const instanceId = "0123456789abcdef0123456789abcdef";
+
+export const output: Bucket["Attributes"] = {
+  accountId,
+  bucketName,
+  bucketArn: `arn:aws:s3:::${bucketName}`,
+  bucketDomainName: `${bucketName}.s3.amazonaws.com`,
+  bucketRegionalDomainName: `${bucketName}.s3.us-east-1.amazonaws.com`,
+  region: "us-east-1",
+};
+
+export const session = {
+  emit: () => Effect.void,
+  done: () => Effect.void,
+  note: () => Effect.void,
+};
+
+export interface Call {
+  request: HttpClientRequest.HttpClientRequest;
+  method: string;
+  query: URLSearchParams;
+  body: string;
+}
+
+export const xml = (body: string, status = 200) =>
+  Effect.sync(
+    () =>
+      new Response(body, {
+        status,
+        headers: { "content-type": "application/xml" },
+      }),
+  );
+
+export const error = (code: string, status: number) =>
+  xml(`<Error><Code>${code}</Code><Message>${code}</Message></Error>`, status);
+
+/** Inject only the HTTP boundary; signing, XML codecs and providers stay real. */
+export const fixture = (
+  respond: (
+    call: Call,
+  ) => Effect.Effect<Response, HttpClientError.HttpClientError>,
+  region = "us-east-1",
+) => {
+  const calls: Call[] = [];
+  const client = HttpClient.make((request, url) =>
+    Effect.gen(function* () {
+      const call = yield* Effect.sync(() => ({
+        request,
+        method: request.method,
+        query: url.searchParams,
+        body:
+          request.body._tag === "Uint8Array"
+            ? new TextDecoder().decode(request.body.body)
+            : "",
+      }));
+      calls.push(call);
+      return HttpClientResponse.fromWeb(request, yield* respond(call));
+    }),
+  );
+  const credentials = fromCredentials(
+    {
+      accessKeyId: "AKIAIOSFODNN7EXAMPLE",
+      secretAccessKey: "test-secret-key",
+    },
+    region,
+  );
+  const environment = Layer.mergeAll(
+    credentials,
+    Layer.succeed(Region, Effect.succeed(region)),
+    Layer.effect(
+      AWSEnvironment,
+      Effect.map(Credentials, (credentials) =>
+        Effect.succeed({ accountId, region, credentials }),
+      ),
+    ).pipe(Layer.provide(credentials)),
+    Layer.succeed(Stack, {
+      name: "bucket-provider-test",
+      stage: "test",
+      resources: {},
+      bindings: {},
+      actions: {},
+    }),
+    Layer.succeed(Stage, "test"),
+    Layer.succeed(InstanceId, instanceId),
+    Layer.succeed(HttpClient.HttpClient, client),
+    Layer.succeed(Retry, { while: () => false }),
+  );
+  return { calls, environment };
+};
+
+export const bucketProvider = Provider.Provider<Bucket>("AWS.S3.Bucket");
+
+export const provideBucket = <A, E>(
+  operation: Effect.Effect<A, E, Provider.Provider<Bucket>>,
+  environment: ReturnType<typeof fixture>["environment"],
+) =>
+  operation.pipe(Effect.provide(BucketProvider()), Effect.provide(environment));
+
+/** Responses for configuration outside the aspect under examination. */
+export const existingBucket = (call: Call) => {
+  if (call.method === "HEAD") return xml("");
+  if (call.query.has("location")) return xml("<LocationConstraint/>");
+  if (call.query.has("tagging")) return xml("<Tagging><TagSet/></Tagging>");
+  if (call.query.has("policy")) return error("NoSuchBucketPolicy", 404);
+  return Effect.die(
+    `Unexpected S3 request: ${call.method} ${call.request.url}`,
+  );
+};
+
+export const existingStateBucket = (call: Call) => {
+  if (call.query.has("versioning")) {
+    return xml(
+      "<VersioningConfiguration><Status>Enabled</Status></VersioningConfiguration>",
+    );
+  }
+  if (call.query.has("publicAccessBlock")) {
+    return xml(
+      "<PublicAccessBlockConfiguration><BlockPublicAcls>true</BlockPublicAcls><IgnorePublicAcls>true</IgnorePublicAcls><BlockPublicPolicy>true</BlockPublicPolicy><RestrictPublicBuckets>true</RestrictPublicBuckets></PublicAccessBlockConfiguration>",
+    );
+  }
+  if (call.query.has("ownershipControls")) {
+    return xml(
+      "<OwnershipControls><Rule><ObjectOwnership>BucketOwnerEnforced</ObjectOwnership></Rule></OwnershipControls>",
+    );
+  }
+  if (call.query.has("list-type")) {
+    return xml(
+      "<ListBucketResult><IsTruncated>false</IsTruncated></ListBucketResult>",
+    );
+  }
+  return existingBucket(call);
+};


### PR DESCRIPTION
Expose `encryption.blockedEncryptionTypes` on S3 buckets and the S3 state store.

```ts
const bucket = yield* AWS.S3.Bucket("my-bucket", {
  encryption: {
    sseAlgorithm: "AES256",
    blockedEncryptionTypes: ["SSE-C"],
  },
});
```

- Omit the setting to preserve the bucket's observed restrictions, including when changing the default encryption algorithm or KMS key.
- Set `["SSE-C"]` to block new writes encrypted with customer-provided keys.
- Set `[]` to allow SSE-C writes, translated to AWS's `"NONE"` value.
- Compare normalized restrictions alongside encryption defaults so setting-only changes apply and equivalent configurations skip unnecessary writes.

The same configuration is available through `AWS.state({ encryption: { ... } })`.
