### PR TITLE
fix(aws/rds): repair parameter group drift with desired defaults

### DIFF
--- a/packages/alchemy/src/AWS/RDS/DBParameterGroup.ts
+++ b/packages/alchemy/src/AWS/RDS/DBParameterGroup.ts
@@ -185,12 +185,15 @@ export const DBParameterGroupProvider = () =>
           );
       });
 
-      const toUserParameterRecord = (
+      const toManagedParameterRecord = (
         parameters: rds.Parameter[],
+        desired: Record<string, string> = {},
       ): Record<string, string> =>
         Object.fromEntries(
           parameters.flatMap((p) =>
-            p.ParameterName !== undefined && p.ParameterValue !== undefined
+            p.ParameterName !== undefined &&
+            p.ParameterValue !== undefined &&
+            (p.Source === "user" || Object.hasOwn(desired, p.ParameterName))
               ? [[p.ParameterName, p.ParameterValue]]
               : [],
           ),
@@ -212,15 +215,25 @@ export const DBParameterGroupProvider = () =>
           ) {
             return { action: "replace" } as const;
           }
-          // Props alone would miss an out-of-band edit: the engine's fallback
-          // compares props, so a console change to a parameter this resource
-          // owns would never schedule the reconcile that corrects it.
-          if (
-            news.parameters !== undefined &&
-            output !== undefined &&
-            !deepEqual(news.parameters, output.parameters)
-          ) {
-            return { action: "update" } as const;
+          // Plans normally use persisted outputs. Read only this managed group's
+          // parameters so out-of-band edits are visible without a separate sync.
+          if (news.parameters !== undefined && output !== undefined) {
+            const parameters = yield* readParameters(
+              output.dbParameterGroupName,
+            ).pipe(
+              Effect.map((parameters) =>
+                toManagedParameterRecord(parameters, news.parameters),
+              ),
+              Effect.catchTag("DBParameterGroupNotFoundFault", () =>
+                Effect.succeed(undefined),
+              ),
+            );
+            if (parameters === undefined) {
+              return { action: "update", stables: [] } as const;
+            }
+            if (!deepEqual(news.parameters, parameters)) {
+              return { action: "update" } as const;
+            }
           }
         }),
         list: () =>
@@ -269,8 +282,9 @@ export const DBParameterGroupProvider = () =>
             return undefined;
           }
           // Unlike tags, parameters come back from the API.
-          const parameters = toUserParameterRecord(
-            yield* readUserParameters(group.DBParameterGroupName),
+          const parameters = toManagedParameterRecord(
+            yield* readParameters(group.DBParameterGroupName),
+            olds?.parameters,
           );
           return {
             dbParameterGroupName: group.DBParameterGroupName,

--- a/packages/alchemy/test/AWS/RDS/DBParameterGroup.drift.test.ts
+++ b/packages/alchemy/test/AWS/RDS/DBParameterGroup.drift.test.ts
@@ -1,0 +1,119 @@
+import { expect, it } from "alchemy-test";
+import * as Effect from "effect/Effect";
+import {
+  context,
+  errorResponse,
+  output,
+  parametersResponse,
+  props,
+  withGroup,
+} from "./DBParameterGroup.provider.ts";
+
+const desired = { ...props, parameters: { work_mem: "8192" } };
+const diffContext = {
+  ...context,
+  olds: desired,
+  news: desired,
+  output: { ...output, parameters: desired.parameters },
+  oldBindings: [],
+  newBindings: [],
+};
+
+it.effect(
+  "detects a console change even when cached props and outputs match",
+  () =>
+    withGroup(
+      () =>
+        parametersResponse([
+          { ParameterName: "work_mem", ParameterValue: "4096", Source: "user" },
+        ]),
+      (provider) =>
+        Effect.gen(function* () {
+          expect(yield* provider.diff!(diffContext)).toEqual({
+            action: "update",
+          });
+        }),
+    ),
+);
+
+it.effect(
+  "does not update matching user overrides and explicitly managed engine defaults",
+  () =>
+    withGroup(
+      () =>
+        parametersResponse([
+          { ParameterName: "work_mem", ParameterValue: "8192", Source: "user" },
+          {
+            ParameterName: "max_connections",
+            ParameterValue: "100",
+            Source: "engine-default",
+          },
+          {
+            ParameterName: "unmanaged_default",
+            ParameterValue: "1",
+            Source: "engine-default",
+          },
+        ]),
+      (provider, requests) =>
+        Effect.gen(function* () {
+          const matching = {
+            ...props,
+            parameters: { work_mem: "8192", max_connections: "100" },
+          };
+          expect(
+            yield* provider.diff!({
+              ...diffContext,
+              olds: matching,
+              news: matching,
+              output: { ...output, parameters: matching.parameters },
+            }),
+          ).toBeUndefined();
+          expect(requests).toHaveLength(1);
+          expect(requests[0]!.action).toBe("DescribeDBParameters");
+        }),
+    ),
+);
+
+it.effect(
+  "clears stable attributes only when the parameter group is missing",
+  () =>
+    withGroup(
+      () => errorResponse("DBParameterGroupNotFound"),
+      (provider) =>
+        Effect.gen(function* () {
+          expect(yield* provider.diff!(diffContext)).toEqual({
+            action: "update",
+            stables: [],
+          });
+        }),
+    ),
+);
+
+it.effect("planning propagates authorization failures", () =>
+  withGroup(
+    () => errorResponse("AccessDenied", 403),
+    (provider, requests) =>
+      Effect.gen(function* () {
+        const error = yield* provider.diff!(diffContext).pipe(Effect.flip);
+        expect(error._tag).toBe("AccessDeniedException");
+        expect(requests).toHaveLength(1);
+      }),
+  ),
+);
+
+it.effect(
+  "unmanaged parameter groups do not add parameter reads to planning",
+  () =>
+    withGroup(
+      () => {
+        throw new Error("Unexpected parameter read");
+      },
+      (provider, requests) =>
+        Effect.gen(function* () {
+          expect(
+            yield* provider.diff!({ ...diffContext, olds: props, news: props }),
+          ).toBeUndefined();
+          expect(requests).toHaveLength(0);
+        }),
+    ),
+);

--- a/packages/alchemy/test/AWS/RDS/DBParameterGroup.provider.ts
+++ b/packages/alchemy/test/AWS/RDS/DBParameterGroup.provider.ts
@@ -1,0 +1,145 @@
+import {
+  DBParameterGroup,
+  DBParameterGroupProvider,
+  type DBParameterGroupProps,
+} from "@/AWS/RDS/DBParameterGroup.ts";
+import { InstanceId } from "@/InstanceId.ts";
+import * as Provider from "@/Provider.ts";
+import { Stack } from "@/Stack.ts";
+import { Stage } from "@/Stage.ts";
+import { fromCredentials } from "@distilled.cloud/aws/Credentials";
+import { Region } from "@distilled.cloud/aws/Region";
+import type { Parameter } from "@distilled.cloud/aws/rds";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as HttpClientResponse from "effect/unstable/http/HttpClientResponse";
+
+export const props: DBParameterGroupProps = {
+  dbParameterGroupName: "alchemy-parameters",
+  family: "postgres16",
+};
+export const output: DBParameterGroup["Attributes"] = {
+  dbParameterGroupName: "alchemy-parameters",
+  dbParameterGroupArn:
+    "arn:aws:rds:us-east-1:123456789012:pg:alchemy-parameters",
+  family: "postgres16",
+  description: "Managed parameters",
+  parameters: {},
+  tags: {
+    "alchemy::stack": "parameter-group",
+    "alchemy::stage": "test",
+    "alchemy::id": "Parameters",
+  },
+};
+export const context = {
+  id: "Parameters",
+  fqn: "Parameters",
+  instanceId: "0123456789abcdef0123456789abcdef",
+};
+export const response = (action: string, result = "") =>
+  new Response(
+    `<${action}Response xmlns="http://rds.amazonaws.com/doc/2014-10-31/"><${action}Result>${result}</${action}Result></${action}Response>`,
+    { headers: { "content-type": "text/xml" } },
+  );
+export const groupResponse = () =>
+  response(
+    "DescribeDBParameterGroups",
+    `<DBParameterGroups><DBParameterGroup><DBParameterGroupName>${output.dbParameterGroupName}</DBParameterGroupName><DBParameterGroupArn>${output.dbParameterGroupArn}</DBParameterGroupArn><DBParameterGroupFamily>${output.family}</DBParameterGroupFamily><Description>${output.description}</Description></DBParameterGroup></DBParameterGroups>`,
+  );
+const escape = (value: string) =>
+  value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+export const parametersResponse = (parameters: Parameter[], marker?: string) =>
+  response(
+    "DescribeDBParameters",
+    `<Parameters>${parameters
+      .map(
+        (parameter) =>
+          `<Parameter>${Object.entries(parameter)
+            .map(([key, value]) => `<${key}>${escape(String(value))}</${key}>`)
+            .join("")}</Parameter>`,
+      )
+      .join(
+        "",
+      )}</Parameters>${marker === undefined ? "" : `<Marker>${marker}</Marker>`}`,
+  );
+export const errorResponse = (code: string, status = 400) =>
+  new Response(
+    `<ErrorResponse xmlns="http://rds.amazonaws.com/doc/2014-10-31/"><Error><Type>Sender</Type><Code>${code}</Code><Message>${code}</Message></Error><RequestId>request-id</RequestId></ErrorResponse>`,
+    { status, headers: { "content-type": "text/xml" } },
+  );
+export interface Request {
+  action: string;
+  parameters: URLSearchParams;
+}
+
+// Exercise the provider through distilled's real query protocol and codecs.
+export const withGroup = <A, E, R>(
+  respond: (request: Request) => Response,
+  use: (
+    provider: Provider.ProviderService<DBParameterGroup>,
+    requests: Request[],
+  ) => Effect.Effect<A, E, R>,
+) =>
+  Effect.gen(function* () {
+    const requests: Request[] = [];
+    const http = HttpClient.make((request) =>
+      Effect.sync(() => {
+        if (request.body._tag !== "Uint8Array")
+          throw new Error(`Unexpected body: ${request.body._tag}`);
+        const parameters = new URLSearchParams(
+          new TextDecoder().decode(request.body.body),
+        );
+        const recorded = { action: parameters.get("Action") ?? "", parameters };
+        requests.push(recorded);
+        return HttpClientResponse.fromWeb(request, respond(recorded));
+      }),
+    );
+    return yield* Effect.gen(function* () {
+      return yield* use(
+        yield* Provider.Provider<DBParameterGroup>(DBParameterGroup.Type),
+        requests,
+      );
+    }).pipe(
+      Effect.provide(DBParameterGroupProvider()),
+      Effect.provide(
+        Layer.mergeAll(
+          Layer.succeed(HttpClient.HttpClient, http),
+          fromCredentials(
+            { accessKeyId: "test-key", secretAccessKey: "test-secret" },
+            "us-east-1",
+          ),
+          Layer.succeed(Region, Effect.succeed("us-east-1")),
+          Layer.succeed(Stack, {
+            name: "parameter-group",
+            stage: "test",
+            resources: {},
+            bindings: {},
+            actions: {},
+          }),
+          Layer.succeed(Stage, "test"),
+          Layer.succeed(InstanceId, context.instanceId),
+        ),
+      ),
+    );
+  });
+
+export const reconcile = (
+  provider: Provider.ProviderService<DBParameterGroup>,
+  news: DBParameterGroupProps,
+) =>
+  provider.reconcile({
+    ...context,
+    news,
+    olds: props,
+    output,
+    bindings: [],
+    session: {
+      emit: () => Effect.void,
+      done: () => Effect.void,
+      note: () => Effect.void,
+    },
+  });


### PR DESCRIPTION
Detect live RDS parameter-group drift during planning, including when `parameters` is omitted.

```ts
const group = yield* AWS.RDS.DBParameterGroup("DatabaseSettings", {
  family: "postgres16",
  // No declared overrides: restore engine defaults.
});
```

- Normalize omitted parameters to `{}` in planning and reconciliation; reset undeclared overrides rather than preserving console edits.
- Read back settled values after changes and resets, including explicitly managed engine defaults.
- Keep name and ARN references stable for in-place corrections. A missing group clears stable references and schedules recreation.
- Reconcile tags against observed AWS tags.
