### PR TITLE
fix(aws/ecr): skip updates for relocated image contexts

### DIFF
--- a/packages/alchemy/src/AWS/ECR/Image.ts
+++ b/packages/alchemy/src/AWS/ECR/Image.ts
@@ -309,12 +309,18 @@ export const ImageProvider = () =>
         // the build inputs and request an update when the hash drifts from
         // the pushed tag. Replacement is never needed — a new hash is just a
         // new tag + digest on the same resource.
-        diff: Effect.fn(function* ({ news, output }) {
+        diff: Effect.fn(function* ({ news, output, olds }) {
           if (!isResolved(news) || !output) return undefined;
           const hash = yield* hashBuildInputs(news);
-          if (hash !== output.imageTag) {
+          if (
+            hash !== output.imageTag ||
+            olds.repositoryUri !== news.repositoryUri
+          ) {
             return { action: "update" } as const;
           }
+          // Build paths may move without changing the image. All build options
+          // participate in the hash; repository ownership is compared above.
+          return { action: "noop" } as const;
         }),
         reconcile: Effect.fn(function* ({ id, news, output, session }) {
           // Resolve the target repository: user-supplied URI, or an

--- a/packages/alchemy/test/AWS/ECR/Image.diff.test.ts
+++ b/packages/alchemy/test/AWS/ECR/Image.diff.test.ts
@@ -1,0 +1,168 @@
+import { Image, ImageProvider, type ImageProps } from "@/AWS/ECR/Image.ts";
+import { hashDockerBuildInputs } from "@/Docker/BuildHash.ts";
+import { DockerLive } from "@/Docker/Docker.ts";
+import * as Provider from "@/Provider.ts";
+import { Stack } from "@/Stack.ts";
+import { Stage } from "@/Stage.ts";
+import { fromCredentials } from "@distilled.cloud/aws/Credentials";
+import * as NodeServices from "@effect/platform-node/NodeServices";
+import { describe, expect, it } from "alchemy-test";
+import * as Effect from "effect/Effect";
+import * as FileSystem from "effect/FileSystem";
+import * as Layer from "effect/Layer";
+import * as Path from "effect/Path";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+
+// Exercise the real provider and filesystem hash without building an image or
+// contacting ECR. An absolute build path is not part of the image's identity.
+const fixture = Effect.gen(function* () {
+  const fs = yield* FileSystem.FileSystem;
+  const path = yield* Path.Path;
+  const root = yield* fs.makeTempDirectoryScoped({ prefix: "ecr-image-diff-" });
+  const context = path.join(root, "original");
+  const relocated = path.join(root, "relocated");
+  yield* fs.makeDirectory(context);
+  yield* fs.writeFileString(
+    path.join(context, "Dockerfile"),
+    "FROM scratch\nCOPY payload /payload\n",
+  );
+  yield* fs.writeFileString(path.join(context, "payload"), "original\n");
+  yield* fs.copy(context, relocated);
+  const imageTag = yield* hashDockerBuildInputs(
+    { context, dockerfile: "Dockerfile", platform: "linux/amd64" },
+    "all",
+  );
+  const repositoryUri = "123456789012.dkr.ecr.us-east-1.amazonaws.com/app";
+  const output: Image["Attributes"] = {
+    imageTag,
+    repositoryUri,
+    repositoryName: "app",
+    imageUri: `${repositoryUri}:${imageTag}`,
+    digest: "sha256:existing-image",
+    ownsRepository: false,
+  };
+  const provider = yield* Provider.Provider<Image>(Image.Type);
+  const diff = provider.diff!;
+  const olds: ImageProps = { context, repositoryUri };
+  return {
+    context,
+    relocated,
+    output,
+    diff: (
+      news: ImageProps,
+      previous: ImageProps = olds,
+      observed: Image["Attributes"] | undefined = output,
+    ) =>
+      diff({
+        id: "Image",
+        fqn: "Image",
+        instanceId: "image-diff",
+        olds: previous,
+        news,
+        output: observed,
+        oldBindings: [],
+        newBindings: [],
+      }),
+  };
+});
+
+const services = ImageProvider().pipe(
+  Layer.provide(DockerLive),
+  Layer.provideMerge(NodeServices.layer),
+  Layer.provide(
+    Layer.mergeAll(
+      fromCredentials(
+        { accessKeyId: "test-key", secretAccessKey: "test-secret" },
+        "us-east-1",
+      ),
+      Layer.succeed(
+        HttpClient.HttpClient,
+        HttpClient.make(() =>
+          Effect.die(new Error("Image diff must not contact AWS")),
+        ),
+      ),
+      Layer.succeed(Stack, {
+        name: "image-diff",
+        stage: "test",
+        resources: {},
+        bindings: {},
+        actions: {},
+      }),
+      Layer.succeed(Stage, "test"),
+    ),
+  ),
+);
+
+describe("ECR image content identity", () => {
+  it.effect("does not update when identical build inputs move", () =>
+    Effect.gen(function* () {
+      const { diff, relocated, output } = yield* fixture;
+      expect(
+        yield* diff({
+          context: relocated,
+          repositoryUri: output.repositoryUri,
+        }),
+      ).toEqual({ action: "noop" });
+    }).pipe(Effect.provide(services), Effect.scoped),
+  );
+
+  it.effect("updates when content changes at the same path", () =>
+    Effect.gen(function* () {
+      const { diff, context, output } = yield* fixture;
+      const fs = yield* FileSystem.FileSystem;
+      const path = yield* Path.Path;
+      yield* fs.writeFileString(path.join(context, "payload"), "changed\n");
+      expect(
+        yield* diff({ context, repositoryUri: output.repositoryUri }),
+      ).toEqual({ action: "update" });
+    }).pipe(Effect.provide(services), Effect.scoped),
+  );
+
+  it.effect(
+    "updates when the repository changes without changing content",
+    () =>
+      Effect.gen(function* () {
+        const { diff, context, output } = yield* fixture;
+        expect(
+          yield* diff({
+            context,
+            repositoryUri: `${output.repositoryUri}-other`,
+          }),
+        ).toEqual({ action: "update" });
+      }).pipe(Effect.provide(services), Effect.scoped),
+  );
+
+  it.effect(
+    "does not skip transitions between managed and external repositories",
+    () =>
+      Effect.gen(function* () {
+        const { diff, context, output } = yield* fixture;
+        expect(yield* diff({ context })).toEqual({ action: "update" });
+        expect(
+          yield* diff(
+            { context, repositoryUri: output.repositoryUri },
+            { context },
+            { ...output, ownsRepository: true },
+          ),
+        ).toEqual({ action: "update" });
+      }).pipe(Effect.provide(services), Effect.scoped),
+  );
+
+  it.effect("includes platform and build arguments in the decision", () =>
+    Effect.gen(function* () {
+      const { diff, context, output } = yield* fixture;
+      for (const options of [
+        { platform: "linux/arm64" },
+        { buildArgs: { MODE: "production" } },
+      ]) {
+        expect(
+          yield* diff({
+            context,
+            repositoryUri: output.repositoryUri,
+            ...options,
+          }),
+        ).toEqual({ action: "update" });
+      }
+    }).pipe(Effect.provide(services), Effect.scoped),
+  );
+});


### PR DESCRIPTION
Skip ECR Image updates when identical build inputs move to a different directory and the image still exists in the desired repository.

```diff
 const image = yield* AWS.ECR.Image("AppImage", {
   repositoryUri: repository.repositoryUri,
-  context: "./app",
+  context: "./relocated-app",
 });
```

Compare the content hash and repository setting before returning a no-op. Content, build-argument, platform, and repository changes still update the image; switching repository ownership also schedules an update.

Observe the image before skipping reconciliation so a deleted image or auto-created repository is recreated even with unchanged inputs.
