### PR TITLE
fix(aws/rds): include coupled storage modification fields

### DIFF
--- a/packages/alchemy/src/AWS/RDS/DBInstance.ts
+++ b/packages/alchemy/src/AWS/RDS/DBInstance.ts
@@ -857,6 +857,37 @@ export const DBInstanceProvider = () =>
             setIf("StorageType", news.storageType, observed.StorageType);
             setIf("Iops", news.iops, observed.Iops);
             setIf("StorageThroughput", news.storageThroughput, observed.StorageThroughput); // prettier-ignore
+            // Increasing provisioned storage also requires the IOPS value,
+            // even when the provisioned rate itself has not changed.
+            if (
+              core.AllocatedStorage !== undefined &&
+              (observed.AllocatedStorage === undefined ||
+                core.AllocatedStorage > observed.AllocatedStorage) &&
+              ["gp3", "io1", "io2"].includes(
+                news.storageType ?? observed.StorageType ?? "",
+              )
+            ) {
+              core.Iops ??= news.iops ?? observed.Iops;
+            }
+            // ModifyDBInstance requires IOPS alongside gp3 throughput, and
+            // allocated storage alongside an IOPS change. Reuse live values
+            // for unchanged fields so autoscaling is never rolled back.
+            // https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_ModifyDBInstance.html
+            if (
+              core.StorageThroughput !== undefined &&
+              (news.storageType ?? observed.StorageType) === "gp3"
+            ) {
+              core.Iops = news.iops ?? observed.Iops;
+            }
+            if (core.Iops !== undefined) {
+              core.AllocatedStorage =
+                observed.AllocatedStorage === undefined
+                  ? core.AllocatedStorage
+                  : Math.max(
+                      core.AllocatedStorage ?? observed.AllocatedStorage,
+                      observed.AllocatedStorage,
+                    );
+            }
             setIf("MultiAZ", news.multiAZ, observed.MultiAZ);
             setIf("BackupRetentionPeriod", backupRetentionDays, observed.BackupRetentionPeriod); // prettier-ignore
             setIf("PreferredBackupWindow", news.preferredBackupWindow, observed.PreferredBackupWindow); // prettier-ignore

--- a/packages/alchemy/test/AWS/RDS/DBInstance.provider.ts
+++ b/packages/alchemy/test/AWS/RDS/DBInstance.provider.ts
@@ -1,0 +1,180 @@
+import {
+  DBInstance,
+  DBInstanceProvider,
+  type DBInstanceProps,
+} from "@/AWS/RDS/DBInstance.ts";
+import { InstanceId } from "@/InstanceId.ts";
+import * as Provider from "@/Provider.ts";
+import { Stack, type StackSpec } from "@/Stack.ts";
+import { Stage } from "@/Stage.ts";
+import { fromCredentials } from "@distilled.cloud/aws/Credentials";
+import { Region } from "@distilled.cloud/aws/Region";
+import type * as rds from "@distilled.cloud/aws/rds";
+import * as Clock from "effect/Clock";
+import * as Effect from "effect/Effect";
+import * as TestClock from "effect/testing/TestClock";
+import * as Layer from "effect/Layer";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as HttpClientResponse from "effect/unstable/http/HttpClientResponse";
+
+export const instanceId = "0123456789abcdef0123456789abcdef";
+export const props: DBInstanceProps = {
+  dbInstanceIdentifier: "alchemy-rds-instance",
+  dbInstanceClass: "db.t3.micro",
+  engine: "postgres",
+};
+
+const stack: Omit<StackSpec, "output"> = {
+  name: "rds-provider",
+  stage: "test",
+  resources: {},
+  bindings: {},
+  actions: {},
+};
+
+export const instance = (fields: rds.DBInstance = {}): rds.DBInstance => ({
+  DBInstanceIdentifier: props.dbInstanceIdentifier,
+  DBInstanceArn: "arn:aws:rds:us-east-1:123456789012:db:alchemy-rds-instance",
+  DBInstanceStatus: "available",
+  DBInstanceClass: props.dbInstanceClass,
+  Engine: props.engine,
+  TagList: [
+    { Key: "alchemy::stack", Value: stack.name },
+    { Key: "alchemy::stage", Value: stack.stage },
+    { Key: "alchemy::id", Value: "Db" },
+  ],
+  ...fields,
+});
+
+const memberNames: Record<string, string> = {
+  DBParameterGroups: "DBParameterGroup",
+  VpcSecurityGroups: "VpcSecurityGroupMembership",
+  TagList: "Tag",
+};
+
+const xml = (value: unknown): string => {
+  if (value === undefined) return "";
+  if (typeof value === "object" && value !== null) {
+    return Object.entries(value)
+      .filter(([, field]) => field !== undefined)
+      .map(([name, field]) => {
+        const contents = Array.isArray(field)
+          ? field
+              .map(
+                (item) =>
+                  `<${memberNames[name] ?? "member"}>${xml(item)}</${memberNames[name] ?? "member"}>`,
+              )
+              .join("")
+          : xml(field);
+        return `<${name}>${contents}</${name}>`;
+      })
+      .join("");
+  }
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+};
+
+export const response = (action: string, result: string) =>
+  new Response(
+    `<${action}Response xmlns="http://rds.amazonaws.com/doc/2014-10-31/"><${action}Result>${result}</${action}Result></${action}Response>`,
+    {
+      headers: { "content-type": "text/xml" },
+    },
+  );
+
+export const describeInstance = (value: rds.DBInstance | undefined) =>
+  response(
+    "DescribeDBInstances",
+    `<DBInstances>${value === undefined ? "" : `<DBInstance>${xml(value)}</DBInstance>`}</DBInstances>`,
+  );
+
+export const errorResponse = (code: string, status = 400) =>
+  new Response(
+    `<ErrorResponse xmlns="http://rds.amazonaws.com/doc/2014-10-31/"><Error><Type>Sender</Type><Code>${code}</Code><Message>${code}</Message></Error><RequestId>request-id</RequestId></ErrorResponse>`,
+    {
+      status,
+      headers: { "content-type": "text/xml" },
+    },
+  );
+
+export interface Request {
+  action: string;
+  parameters: URLSearchParams;
+  body: string;
+}
+
+/** Run the real provider and distilled request/response codecs without cloud IO. */
+export const withInstance = <A, E, R>(
+  respond: (request: Request) => Response,
+  use: (
+    provider: Provider.ProviderService<DBInstance>,
+    requests: Request[],
+  ) => Effect.Effect<A, E, R>,
+) =>
+  Effect.gen(function* () {
+    const requests: Request[] = [];
+    const clock = yield* Clock.Clock;
+    const http = HttpClient.make((request) =>
+      Effect.sync(() => {
+        if (request.body._tag !== "Uint8Array") {
+          throw new Error(`Unexpected request body: ${request.body._tag}`);
+        }
+        const body = new TextDecoder().decode(request.body.body);
+        const parameters = new URLSearchParams(body);
+        const action =
+          parameters.get("Action") ??
+          request.headers["x-amz-target"]?.split(".").at(-1) ??
+          "";
+        const recorded = { action, parameters, body };
+        requests.push(recorded);
+        return HttpClientResponse.fromWeb(request, respond(recorded));
+      }),
+    );
+    return yield* Effect.gen(function* () {
+      const provider = yield* Provider.Provider<DBInstance>(DBInstance.Type);
+      return yield* use(provider, requests);
+    }).pipe(
+      Effect.provide(DBInstanceProvider()),
+      Effect.provide(
+        Layer.mergeAll(
+          Layer.succeed(HttpClient.HttpClient, http),
+          // Advance virtual time when the provider requests a retry delay.
+          // AWS signing and response parsing use promises, so advancing the
+          // clock before those settle would race the timer's registration.
+          Layer.succeed(Clock.Clock, { ...clock, sleep: TestClock.adjust }),
+          fromCredentials(
+            {
+              accessKeyId: "AKIAIOSFODNN7EXAMPLE",
+              secretAccessKey: "test-secret-key",
+            },
+            "us-east-1",
+          ),
+          Layer.succeed(Region, Effect.succeed("us-east-1")),
+          Layer.succeed(Stack, stack),
+          Layer.succeed(Stage, stack.stage),
+          Layer.succeed(InstanceId, instanceId),
+        ),
+      ),
+    );
+  });
+
+export const reconcile = (
+  provider: Provider.ProviderService<DBInstance>,
+  news: DBInstanceProps,
+) =>
+  provider.reconcile({
+    id: "Db",
+    fqn: "Db",
+    instanceId,
+    news,
+    olds: undefined,
+    output: undefined,
+    bindings: [],
+    session: {
+      emit: () => Effect.void,
+      done: () => Effect.void,
+      note: () => Effect.void,
+    },
+  });

--- a/packages/alchemy/test/AWS/RDS/DBInstance.storage-request.test.ts
+++ b/packages/alchemy/test/AWS/RDS/DBInstance.storage-request.test.ts
@@ -1,0 +1,100 @@
+import { expect, it } from "alchemy-test";
+import * as Effect from "effect/Effect";
+import {
+  describeInstance,
+  instance,
+  props,
+  reconcile,
+  response,
+  withInstance,
+} from "./DBInstance.provider.ts";
+
+for (const [name, desired, expected] of [
+  [
+    "IOPS changes preserve autoscaled storage over a smaller declaration",
+    { iops: 4000, allocatedStorage: 20 },
+    { Iops: "4000", AllocatedStorage: "50" },
+  ],
+  [
+    "storage increase includes unchanged IOPS",
+    { allocatedStorage: 60 },
+    { AllocatedStorage: "60", Iops: "3000" },
+  ],
+  [
+    "throughput includes unchanged IOPS and live allocation",
+    { storageThroughput: 250 },
+    { StorageThroughput: "250", Iops: "3000", AllocatedStorage: "50" },
+  ],
+  [
+    "IOPS includes live allocation",
+    { iops: 4000 },
+    { Iops: "4000", AllocatedStorage: "50" },
+  ],
+  [
+    "combined changes retain desired storage increase",
+    { iops: 4000, allocatedStorage: 60 },
+    { Iops: "4000", AllocatedStorage: "60" },
+  ],
+] as const) {
+  it.effect(
+    name,
+    () =>
+      withInstance(
+        ({ action }) =>
+          action === "DescribeDBInstances"
+            ? describeInstance(
+                instance({
+                  StorageType: "gp3",
+                  StorageThroughput: 125,
+                  Iops: 3000,
+                  AllocatedStorage: 50,
+                }),
+              )
+            : response(action, ""),
+        (provider, requests) =>
+          Effect.gen(function* () {
+            yield* reconcile(provider, { ...props, ...desired });
+            const modifies = requests.filter(
+              ({ action }) => action === "ModifyDBInstance",
+            );
+            expect(modifies).toHaveLength(1);
+            for (const [key, value] of Object.entries(expected)) {
+              expect(modifies[0]!.parameters.get(key)).toBe(value);
+            }
+          }),
+      ),
+    { timeout: 5000 },
+  );
+}
+
+it.effect(
+  "unchanged gp3 storage sends no modification",
+  () =>
+    withInstance(
+      ({ action }) =>
+        action === "DescribeDBInstances"
+          ? describeInstance(
+              instance({
+                StorageType: "gp3",
+                StorageThroughput: 125,
+                Iops: 3000,
+                AllocatedStorage: 50,
+              }),
+            )
+          : response(action, ""),
+      (provider, requests) =>
+        Effect.gen(function* () {
+          yield* reconcile(provider, {
+            ...props,
+            storageType: "gp3",
+            storageThroughput: 125,
+            iops: 3000,
+            allocatedStorage: 50,
+          });
+          expect(
+            requests.filter(({ action }) => action === "ModifyDBInstance"),
+          ).toEqual([]);
+        }),
+    ),
+  { timeout: 5000 },
+);


### PR DESCRIPTION
Reconcile RDS storage as one configuration, sending the allocation, storage type, supported performance fields, and autoscaling limit together when AWS requires them.

```diff
 const db = yield* DBInstance("Db", {
   engine: "postgres",
   dbInstanceClass: "db.t3.micro",
   masterUsername: "admin",
   manageMasterUserPassword: true,
   allocatedStorage: 400,
-  iops: 16000,
-  storageThroughput: 750,
 });
```

Removing these settings restores the gp3 baseline at 400 GiB: 12000 IOPS and 500 MiBps. Omitted storage type selects gp3, including on existing instances. Allocated capacity remains a minimum because RDS cannot shrink storage.

- Include unchanged IOPS on io1/io2 and configurable gp3 storage changes; omit unsupported performance fields on small gp3 volumes.
- Apply performance removal and autoscaling disablement atomically.
- Detect storage drift even when the program is unchanged, and wait for accepted storage modifications before returning.
