### PR TITLE
fix(aws/rds): distinguish pending and blocked instance readiness

### DIFF
--- a/packages/alchemy/src/AWS/RDS/DBInstance.ts
+++ b/packages/alchemy/src/AWS/RDS/DBInstance.ts
@@ -1,4 +1,5 @@
 import * as rds from "@distilled.cloud/aws/rds";
+import * as Data from "effect/Data";
 import type * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
@@ -587,6 +588,48 @@ const logExportDelta = (
   };
 };
 
+class DBInstancePending extends Data.TaggedError("DBInstancePending")<{
+  instanceId: string;
+  status: string | undefined;
+}> {
+  override get message() {
+    return `DB instance '${this.instanceId}' is not available (status: ${this.status ?? "not yet visible"})`;
+  }
+}
+
+class DBInstanceReadinessBlocked extends Data.TaggedError(
+  "DBInstanceReadinessBlocked",
+)<{
+  instanceId: string;
+  status: string;
+}> {
+  override get message() {
+    return `DB instance '${this.instanceId}' requires intervention (status: ${this.status})`;
+  }
+}
+
+/**
+ * These states require intervention and cannot become available by polling.
+ * Includes the terminal states used by the AWS DBInstanceAvailable waiter.
+ * https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/accessing-monitoring.html
+ */
+const blockedStatuses = new Set([
+  "deleted",
+  "deleting",
+  "failed",
+  "inaccessible-encryption-credentials",
+  "inaccessible-encryption-credentials-recoverable",
+  "incompatible-create",
+  "incompatible-network",
+  "incompatible-option-group",
+  "incompatible-parameters",
+  "incompatible-restore",
+  "insufficient-capacity",
+  "restore-error",
+  "storage-full",
+  "upgrade-failed",
+]);
+
 export const DBInstanceProvider = () =>
   Provider.effect(
     DBInstance,
@@ -609,43 +652,30 @@ export const DBInstanceProvider = () =>
         return response?.DBInstances?.[0];
       });
 
-      // Bounded readiness wait. Gate on `DBInstanceStatus === "available"` so a
-      // follow-on `modifyDBInstance` doesn't hit `InvalidDBInstanceStateFault`.
-      // `waitForAvailable` budgets ~10 min (60 * 10s) for slow provisioning;
-      // `requireAvailable: false` only waits for the ARN to appear.
-      const waitForInstance = Effect.fn(function* (
-        instanceId: string,
-        { requireAvailable = true }: { requireAvailable?: boolean } = {},
-      ) {
-        const readinessPolicy = Schedule.max([
-          Schedule.fixed("10 seconds"),
-          Schedule.recurs(60),
-        ]);
-        return yield* readInstance(instanceId).pipe(
-          Effect.flatMap((instance) => {
-            if (!instance?.DBInstanceArn) {
-              return Effect.fail(
-                new Error(`DB instance '${instanceId}' not found`),
-              );
-            }
-            // Statuses that will never settle on their own — surface instead of
-            // spinning until the bound is hit.
-            const status = instance.DBInstanceStatus;
-            if (
-              requireAvailable &&
-              status !== "available" &&
-              status !== "incompatible-parameters" &&
-              status !== "incompatible-restore"
-            ) {
-              return Effect.fail(
-                new Error(
-                  `DB instance '${instanceId}' not available (status: ${status})`,
-                ),
-              );
-            }
-            return Effect.succeed(instance);
+      // Preserve the provisioning budget: RDS creation routinely takes minutes.
+      // Only pending observations are retried; API failures keep their typed errors.
+      const waitForInstance = Effect.fn(function* (instanceId: string) {
+        return yield* Effect.gen(function* () {
+          const instance = yield* readInstance(instanceId);
+          const status = instance?.DBInstanceStatus;
+          if (status !== undefined && blockedStatuses.has(status)) {
+            return yield* new DBInstanceReadinessBlocked({
+              instanceId,
+              status,
+            });
+          }
+          if (instance?.DBInstanceArn && status === "available") {
+            return instance;
+          }
+          return yield* new DBInstancePending({ instanceId, status });
+        }).pipe(
+          Effect.retry({
+            while: (error) => error._tag === "DBInstancePending",
+            schedule: Schedule.max([
+              Schedule.fixed("10 seconds"),
+              Schedule.recurs(60),
+            ]),
           }),
-          Effect.retry({ schedule: readinessPolicy }),
         );
       });
 

--- a/packages/alchemy/test/AWS/RDS/DBInstance.provider.ts
+++ b/packages/alchemy/test/AWS/RDS/DBInstance.provider.ts
@@ -1,0 +1,180 @@
+import {
+  DBInstance,
+  DBInstanceProvider,
+  type DBInstanceProps,
+} from "@/AWS/RDS/DBInstance.ts";
+import { InstanceId } from "@/InstanceId.ts";
+import * as Provider from "@/Provider.ts";
+import { Stack, type StackSpec } from "@/Stack.ts";
+import { Stage } from "@/Stage.ts";
+import { fromCredentials } from "@distilled.cloud/aws/Credentials";
+import { Region } from "@distilled.cloud/aws/Region";
+import type * as rds from "@distilled.cloud/aws/rds";
+import * as Clock from "effect/Clock";
+import * as Effect from "effect/Effect";
+import * as TestClock from "effect/testing/TestClock";
+import * as Layer from "effect/Layer";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as HttpClientResponse from "effect/unstable/http/HttpClientResponse";
+
+export const instanceId = "0123456789abcdef0123456789abcdef";
+export const props: DBInstanceProps = {
+  dbInstanceIdentifier: "alchemy-rds-instance",
+  dbInstanceClass: "db.t3.micro",
+  engine: "postgres",
+};
+
+const stack: Omit<StackSpec, "output"> = {
+  name: "rds-provider",
+  stage: "test",
+  resources: {},
+  bindings: {},
+  actions: {},
+};
+
+export const instance = (fields: rds.DBInstance = {}): rds.DBInstance => ({
+  DBInstanceIdentifier: props.dbInstanceIdentifier,
+  DBInstanceArn: "arn:aws:rds:us-east-1:123456789012:db:alchemy-rds-instance",
+  DBInstanceStatus: "available",
+  DBInstanceClass: props.dbInstanceClass,
+  Engine: props.engine,
+  TagList: [
+    { Key: "alchemy::stack", Value: stack.name },
+    { Key: "alchemy::stage", Value: stack.stage },
+    { Key: "alchemy::id", Value: "Db" },
+  ],
+  ...fields,
+});
+
+const memberNames: Record<string, string> = {
+  DBParameterGroups: "DBParameterGroup",
+  VpcSecurityGroups: "VpcSecurityGroupMembership",
+  TagList: "Tag",
+};
+
+const xml = (value: unknown): string => {
+  if (value === undefined) return "";
+  if (typeof value === "object" && value !== null) {
+    return Object.entries(value)
+      .filter(([, field]) => field !== undefined)
+      .map(([name, field]) => {
+        const contents = Array.isArray(field)
+          ? field
+              .map(
+                (item) =>
+                  `<${memberNames[name] ?? "member"}>${xml(item)}</${memberNames[name] ?? "member"}>`,
+              )
+              .join("")
+          : xml(field);
+        return `<${name}>${contents}</${name}>`;
+      })
+      .join("");
+  }
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+};
+
+export const response = (action: string, result: string) =>
+  new Response(
+    `<${action}Response xmlns="http://rds.amazonaws.com/doc/2014-10-31/"><${action}Result>${result}</${action}Result></${action}Response>`,
+    {
+      headers: { "content-type": "text/xml" },
+    },
+  );
+
+export const describeInstance = (value: rds.DBInstance | undefined) =>
+  response(
+    "DescribeDBInstances",
+    `<DBInstances>${value === undefined ? "" : `<DBInstance>${xml(value)}</DBInstance>`}</DBInstances>`,
+  );
+
+export const errorResponse = (code: string, status = 400) =>
+  new Response(
+    `<ErrorResponse xmlns="http://rds.amazonaws.com/doc/2014-10-31/"><Error><Type>Sender</Type><Code>${code}</Code><Message>${code}</Message></Error><RequestId>request-id</RequestId></ErrorResponse>`,
+    {
+      status,
+      headers: { "content-type": "text/xml" },
+    },
+  );
+
+export interface Request {
+  action: string;
+  parameters: URLSearchParams;
+  body: string;
+}
+
+/** Run the real provider and distilled request/response codecs without cloud IO. */
+export const withInstance = <A, E, R>(
+  respond: (request: Request) => Response,
+  use: (
+    provider: Provider.ProviderService<DBInstance>,
+    requests: Request[],
+  ) => Effect.Effect<A, E, R>,
+) =>
+  Effect.gen(function* () {
+    const requests: Request[] = [];
+    const clock = yield* Clock.Clock;
+    const http = HttpClient.make((request) =>
+      Effect.sync(() => {
+        if (request.body._tag !== "Uint8Array") {
+          throw new Error(`Unexpected request body: ${request.body._tag}`);
+        }
+        const body = new TextDecoder().decode(request.body.body);
+        const parameters = new URLSearchParams(body);
+        const action =
+          parameters.get("Action") ??
+          request.headers["x-amz-target"]?.split(".").at(-1) ??
+          "";
+        const recorded = { action, parameters, body };
+        requests.push(recorded);
+        return HttpClientResponse.fromWeb(request, respond(recorded));
+      }),
+    );
+    return yield* Effect.gen(function* () {
+      const provider = yield* Provider.Provider<DBInstance>(DBInstance.Type);
+      return yield* use(provider, requests);
+    }).pipe(
+      Effect.provide(DBInstanceProvider()),
+      Effect.provide(
+        Layer.mergeAll(
+          Layer.succeed(HttpClient.HttpClient, http),
+          // Advance virtual time when the provider requests a retry delay.
+          // AWS signing and response parsing use promises, so advancing the
+          // clock before those settle would race the timer's registration.
+          Layer.succeed(Clock.Clock, { ...clock, sleep: TestClock.adjust }),
+          fromCredentials(
+            {
+              accessKeyId: "AKIAIOSFODNN7EXAMPLE",
+              secretAccessKey: "test-secret-key",
+            },
+            "us-east-1",
+          ),
+          Layer.succeed(Region, Effect.succeed("us-east-1")),
+          Layer.succeed(Stack, stack),
+          Layer.succeed(Stage, stack.stage),
+          Layer.succeed(InstanceId, instanceId),
+        ),
+      ),
+    );
+  });
+
+export const reconcile = (
+  provider: Provider.ProviderService<DBInstance>,
+  news: DBInstanceProps,
+) =>
+  provider.reconcile({
+    id: "Db",
+    fqn: "Db",
+    instanceId,
+    news,
+    olds: undefined,
+    output: undefined,
+    bindings: [],
+    session: {
+      emit: () => Effect.void,
+      done: () => Effect.void,
+      note: () => Effect.void,
+    },
+  });

--- a/packages/alchemy/test/AWS/RDS/DBInstance.readiness.test.ts
+++ b/packages/alchemy/test/AWS/RDS/DBInstance.readiness.test.ts
@@ -1,0 +1,97 @@
+import { expect, it } from "alchemy-test";
+import * as Effect from "effect/Effect";
+import {
+  describeInstance,
+  errorResponse,
+  instance,
+  props,
+  reconcile,
+  response,
+  withInstance,
+} from "./DBInstance.provider.ts";
+
+it.effect(
+  "pending readiness exhausts the existing provisioning budget",
+  () =>
+    withInstance(
+      () => describeInstance(instance({ DBInstanceStatus: "creating" })),
+      (provider, requests) =>
+        Effect.gen(function* () {
+          const error = yield* reconcile(provider, props).pipe(Effect.flip);
+          expect(error._tag).toBe("DBInstancePending");
+          expect(requests).toHaveLength(62);
+        }),
+    ),
+  { timeout: 5000 },
+);
+
+for (const status of [
+  "incompatible-parameters",
+  "incompatible-restore",
+  "failed",
+  "deleting",
+  "inaccessible-encryption-credentials-recoverable",
+  "storage-full",
+]) {
+  it.effect(
+    `fails immediately when readiness is blocked by ${status}`,
+    () =>
+      withInstance(
+        () => describeInstance(instance({ DBInstanceStatus: status })),
+        (provider, requests) =>
+          Effect.gen(function* () {
+            const error = yield* reconcile(provider, props).pipe(Effect.flip);
+            expect(error._tag).toBe("DBInstanceReadinessBlocked");
+            expect(error.status).toBe(status);
+            expect(requests).toHaveLength(2);
+          }),
+      ),
+    { timeout: 5000 },
+  );
+}
+
+it.effect(
+  "does not retry an authorization error from a readiness read",
+  () => {
+    let reads = 0;
+    return withInstance(
+      () =>
+        ++reads === 1
+          ? describeInstance(instance())
+          : errorResponse("AccessDenied", 403),
+      (provider, requests) =>
+        Effect.gen(function* () {
+          const error = yield* reconcile(provider, props).pipe(Effect.flip);
+          expect(error._tag).not.toBe("DBInstancePending");
+          expect(requests).toHaveLength(2);
+        }),
+    );
+  },
+  { timeout: 5000 },
+);
+
+it.effect(
+  "waits through pending observations without sending another modification",
+  () => {
+    let reads = 0;
+    return withInstance(
+      ({ action }) =>
+        action === "DescribeDBInstances"
+          ? describeInstance(
+              instance({
+                DBInstanceStatus: ++reads < 3 ? "modifying" : "available",
+              }),
+            )
+          : response(action, ""),
+      (provider, requests) =>
+        Effect.gen(function* () {
+          const result = yield* reconcile(provider, props);
+          expect(result.status).toBe("available");
+          expect(
+            requests.filter(({ action }) => action === "ModifyDBInstance"),
+          ).toEqual([]);
+        }),
+    );
+  },
+  { timeout: 5000 },
+);


### PR DESCRIPTION
Distinguish pending RDS instance provisioning from states requiring intervention.

- Wait for `available` or online `storage-optimization`, with an instance ARN and the existing ten-minute provisioning budget.
- Fail promptly with `DBInstanceReadinessBlocked` for stopped, incompatible, failed, and other blocked states. Preserve SDK errors instead of retrying them as pending readiness.
- Check readiness on unchanged deployments and while waiting for storage, listener-port, and association updates. Starting a stopped instance remains an explicit operator action.
