### PR TITLE
feat(aws/rds): manage the RDS master secret resource policy

### DIFF
--- a/packages/alchemy/src/AWS/RDS/DBInstance.ts
+++ b/packages/alchemy/src/AWS/RDS/DBInstance.ts
@@ -1,4 +1,6 @@
 import * as rds from "@distilled.cloud/aws/rds";
+import * as secretsmanager from "@distilled.cloud/aws/secrets-manager";
+import * as Data from "effect/Data";
 import type * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
@@ -10,6 +12,11 @@ import { createPhysicalName } from "../../PhysicalName.ts";
 import * as Provider from "../../Provider.ts";
 import { Resource } from "../../Resource.ts";
 import type { Providers } from "../Providers.ts";
+import {
+  normalizePolicyDocument,
+  stringifyPolicyDocument,
+  type PolicyDocument,
+} from "../IAM/Policy.ts";
 import { createInternalTags, diffTags } from "../../Tags.ts";
 import { sha256 } from "../../Util/sha256.ts";
 
@@ -83,6 +90,15 @@ export interface DBInstanceProps {
    * KMS key used to encrypt the managed master user secret.
    */
   masterUserSecretKmsKeyId?: string;
+  /**
+   * Resource policy for this instance's RDS-managed master secret. RDS retains
+   * ownership of the secret value, rotation, and deletion. Requires a managed
+   * master secret and `secretsmanager:GetResourcePolicy` / `PutResourcePolicy`
+   * permissions. Public policies are rejected with `BlockPublicPolicy`.
+   *
+   * Omission leaves any existing policy unchanged and stops managing it.
+   */
+  masterUserSecretResourcePolicy?: PolicyDocument;
   /**
    * Listener port. In-place modify (sent as `DBPortNumber` on modify).
    */
@@ -399,6 +415,11 @@ export interface DBInstance extends Resource<
      */
     masterUserSecretArn: string | undefined;
     /**
+     * Canonical observed policy when `masterUserSecretResourcePolicy` is managed.
+     * Undefined when policy management is omitted or AWS reports no policy.
+     */
+    masterUserSecretResourcePolicy: string | undefined;
+    /**
      * Option group memberships.
      */
     optionGroupMemberships: string[];
@@ -472,6 +493,27 @@ export interface DBInstance extends Resource<
  * });
  * ```
  *
+ * ### Managed Master Secret Policy
+ * **Example:** Allow a role to read the RDS-managed master secret
+ * ```typescript
+ * const db = yield* DBInstance("Db", {
+ *   engine: "postgres",
+ *   dbInstanceClass: "db.t3.micro",
+ *   allocatedStorage: 20,
+ *   masterUsername: "admin",
+ *   manageMasterUserPassword: true,
+ *   masterUserSecretResourcePolicy: {
+ *     Version: "2012-10-17",
+ *     Statement: [{
+ *       Effect: "Allow",
+ *       Principal: { AWS: reader.roleArn },
+ *       Action: ["secretsmanager:GetSecretValue"],
+ *       Resource: "*",
+ *     }],
+ *   },
+ * });
+ * ```
+ *
  * @resource
  */
 export const DBInstance = Resource<DBInstance>("AWS.RDS.DBInstance");
@@ -506,12 +548,14 @@ const toAttrs = ({
   skipFinalSnapshot,
   finalDBSnapshotIdentifier,
   masterUserPasswordFingerprint,
+  masterUserSecretResourcePolicy,
 }: {
   instance: rds.DBInstance;
   tags: Record<string, string>;
   skipFinalSnapshot?: boolean | undefined;
   finalDBSnapshotIdentifier?: string | undefined;
   masterUserPasswordFingerprint?: Redacted.Redacted<string> | undefined;
+  masterUserSecretResourcePolicy?: string | undefined;
 }): DBInstance["Attributes"] => ({
   skipFinalSnapshot,
   finalDBSnapshotIdentifier,
@@ -554,6 +598,7 @@ const toAttrs = ({
   dbiResourceId: instance.DbiResourceId,
   masterUsername: instance.MasterUsername,
   masterUserSecretArn: instance.MasterUserSecret?.SecretArn,
+  masterUserSecretResourcePolicy,
   optionGroupMemberships: (instance.OptionGroupMemberships ?? []).flatMap(
     (membership) =>
       membership.OptionGroupName ? [membership.OptionGroupName] : [],
@@ -586,6 +631,26 @@ const logExportDelta = (
     ...(DisableLogTypes.length > 0 ? { DisableLogTypes } : {}),
   };
 };
+
+class DBInstanceManagedSecretMissing extends Data.TaggedError(
+  "DBInstanceManagedSecretMissing",
+)<{
+  instanceId: string;
+}> {
+  override get message() {
+    return `DB instance '${this.instanceId}' has no RDS-managed master secret for its resource policy`;
+  }
+}
+
+class DBInstanceSecretPolicyPending extends Data.TaggedError(
+  "DBInstanceSecretPolicyPending",
+)<{
+  instanceId: string;
+}> {
+  override get message() {
+    return `DB instance '${this.instanceId}' managed-secret resource policy has not propagated`;
+  }
+}
 
 export const DBInstanceProvider = () =>
   Provider.effect(
@@ -649,6 +714,76 @@ export const DBInstanceProvider = () =>
         );
       });
 
+      const readMasterSecretPolicy = Effect.fn(function* (secretArn: string) {
+        const observed = yield* secretsmanager.getResourcePolicy({
+          SecretId: secretArn,
+        });
+        return observed.ResourcePolicy === undefined
+          ? undefined
+          : normalizePolicyDocument(observed.ResourcePolicy);
+      });
+
+      const reconcileMasterSecretPolicy = Effect.fn(function* (
+        instanceId: string,
+        instance: rds.DBInstance,
+        policy: PolicyDocument,
+      ) {
+        const managedSecret =
+          instance.MasterUserSecret?.SecretArn === undefined
+            ? yield* readInstance(instanceId).pipe(
+                Effect.flatMap((current) =>
+                  current?.MasterUserSecret?.SecretArn === undefined
+                    ? Effect.fail(
+                        new DBInstanceManagedSecretMissing({ instanceId }),
+                      )
+                    : Effect.succeed({
+                        instance: current,
+                        secretArn: current.MasterUserSecret.SecretArn,
+                      }),
+                ),
+                Effect.retry({
+                  while: (error) =>
+                    error._tag === "DBInstanceManagedSecretMissing",
+                  schedule: Schedule.fixed("5 seconds"),
+                  times: 10,
+                }),
+              )
+            : { instance, secretArn: instance.MasterUserSecret.SecretArn };
+        const desired = normalizePolicyDocument(policy);
+        const readPolicy = readMasterSecretPolicy(managedSecret.secretArn);
+        // RDS can report the managed ARN before Secrets Manager's metadata
+        // is visible. A missing secret is retried, never treated as no policy.
+        const observed = yield* readPolicy.pipe(
+          Effect.retry({
+            while: (error) => error._tag === "ResourceNotFoundException",
+            schedule: Schedule.fixed("5 seconds"),
+            times: 10,
+          }),
+        );
+        if (observed === desired)
+          return { instance: managedSecret.instance, policy: observed };
+        yield* secretsmanager.putResourcePolicy({
+          SecretId: managedSecret.secretArn,
+          ResourcePolicy: stringifyPolicyDocument(policy),
+          BlockPublicPolicy: true,
+        });
+        const appliedPolicy = yield* readPolicy.pipe(
+          Effect.flatMap((actual) =>
+            actual === desired
+              ? Effect.succeed(actual)
+              : Effect.fail(new DBInstanceSecretPolicyPending({ instanceId })),
+          ),
+          Effect.retry({
+            while: (error) =>
+              error._tag === "DBInstanceSecretPolicyPending" ||
+              error._tag === "ResourceNotFoundException",
+            schedule: Schedule.fixed("5 seconds"),
+            times: 10,
+          }),
+        );
+        return { instance: managedSecret.instance, policy: appliedPolicy };
+      });
+
       return {
         stables: ["dbInstanceArn", "dbInstanceIdentifier"],
         // Pattern (a) AWS account/region collection: `describeDBInstances` is
@@ -682,7 +817,7 @@ export const DBInstanceProvider = () =>
               Effect.succeed([] as DBInstance["Attributes"][]),
             ),
           ),
-        diff: Effect.fn(function* ({ id, olds, news }) {
+        diff: Effect.fn(function* ({ id, olds, news, output }) {
           if (!isResolved(news)) return undefined;
           if (
             (yield* toIdentifier(id, olds ?? ({} as DBInstanceProps))) !==
@@ -702,6 +837,23 @@ export const DBInstanceProvider = () =>
               olds.dbSubnetGroupName !== news.dbSubnetGroupName)
           ) {
             return { action: "replace" } as const;
+          }
+          if (
+            output !== undefined &&
+            news.masterUserSecretResourcePolicy !== undefined
+          ) {
+            const instance = yield* readInstance(output.dbInstanceIdentifier);
+            if (!instance?.DBInstanceArn) {
+              return { action: "update", stables: [] } as const;
+            }
+            const secretArn = instance.MasterUserSecret?.SecretArn;
+            if (
+              secretArn === undefined ||
+              normalizePolicyDocument(news.masterUserSecretResourcePolicy) !==
+                (yield* readMasterSecretPolicy(secretArn))
+            ) {
+              return { action: "update" } as const;
+            }
           }
         }),
         read: Effect.fn(function* ({ id, olds, output }) {
@@ -724,6 +876,13 @@ export const DBInstanceProvider = () =>
             finalDBSnapshotIdentifier: output?.finalDBSnapshotIdentifier,
             masterUserPasswordFingerprint:
               output?.masterUserPasswordFingerprint,
+            masterUserSecretResourcePolicy:
+              olds?.masterUserSecretResourcePolicy !== undefined &&
+              instance.MasterUserSecret?.SecretArn !== undefined
+                ? yield* readMasterSecretPolicy(
+                    instance.MasterUserSecret.SecretArn,
+                  )
+                : undefined,
           });
         }),
         reconcile: Effect.fn(function* ({ id, news, output, session }) {
@@ -950,13 +1109,22 @@ export const DBInstanceProvider = () =>
             });
           }
 
+          const managedSecret =
+            news.masterUserSecretResourcePolicy === undefined
+              ? undefined
+              : yield* reconcileMasterSecretPolicy(
+                  identifier,
+                  observed,
+                  news.masterUserSecretResourcePolicy,
+                );
           yield* session.note(dbInstanceArn || identifier);
           return toAttrs({
-            instance: observed,
+            instance: managedSecret?.instance ?? observed,
             tags: desiredTags,
             skipFinalSnapshot: news.skipFinalSnapshot,
             finalDBSnapshotIdentifier: news.finalDBSnapshotIdentifier,
             masterUserPasswordFingerprint: passwordFingerprint,
+            masterUserSecretResourcePolicy: managedSecret?.policy,
           });
         }),
         delete: Effect.fn(function* ({ output }) {

--- a/packages/alchemy/test/AWS/RDS/DBInstance.provider.ts
+++ b/packages/alchemy/test/AWS/RDS/DBInstance.provider.ts
@@ -1,0 +1,180 @@
+import {
+  DBInstance,
+  DBInstanceProvider,
+  type DBInstanceProps,
+} from "@/AWS/RDS/DBInstance.ts";
+import { InstanceId } from "@/InstanceId.ts";
+import * as Provider from "@/Provider.ts";
+import { Stack, type StackSpec } from "@/Stack.ts";
+import { Stage } from "@/Stage.ts";
+import { fromCredentials } from "@distilled.cloud/aws/Credentials";
+import { Region } from "@distilled.cloud/aws/Region";
+import type * as rds from "@distilled.cloud/aws/rds";
+import * as Clock from "effect/Clock";
+import * as Effect from "effect/Effect";
+import * as TestClock from "effect/testing/TestClock";
+import * as Layer from "effect/Layer";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as HttpClientResponse from "effect/unstable/http/HttpClientResponse";
+
+export const instanceId = "0123456789abcdef0123456789abcdef";
+export const props: DBInstanceProps = {
+  dbInstanceIdentifier: "alchemy-rds-instance",
+  dbInstanceClass: "db.t3.micro",
+  engine: "postgres",
+};
+
+const stack: Omit<StackSpec, "output"> = {
+  name: "rds-provider",
+  stage: "test",
+  resources: {},
+  bindings: {},
+  actions: {},
+};
+
+export const instance = (fields: rds.DBInstance = {}): rds.DBInstance => ({
+  DBInstanceIdentifier: props.dbInstanceIdentifier,
+  DBInstanceArn: "arn:aws:rds:us-east-1:123456789012:db:alchemy-rds-instance",
+  DBInstanceStatus: "available",
+  DBInstanceClass: props.dbInstanceClass,
+  Engine: props.engine,
+  TagList: [
+    { Key: "alchemy::stack", Value: stack.name },
+    { Key: "alchemy::stage", Value: stack.stage },
+    { Key: "alchemy::id", Value: "Db" },
+  ],
+  ...fields,
+});
+
+const memberNames: Record<string, string> = {
+  DBParameterGroups: "DBParameterGroup",
+  VpcSecurityGroups: "VpcSecurityGroupMembership",
+  TagList: "Tag",
+};
+
+const xml = (value: unknown): string => {
+  if (value === undefined) return "";
+  if (typeof value === "object" && value !== null) {
+    return Object.entries(value)
+      .filter(([, field]) => field !== undefined)
+      .map(([name, field]) => {
+        const contents = Array.isArray(field)
+          ? field
+              .map(
+                (item) =>
+                  `<${memberNames[name] ?? "member"}>${xml(item)}</${memberNames[name] ?? "member"}>`,
+              )
+              .join("")
+          : xml(field);
+        return `<${name}>${contents}</${name}>`;
+      })
+      .join("");
+  }
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+};
+
+export const response = (action: string, result: string) =>
+  new Response(
+    `<${action}Response xmlns="http://rds.amazonaws.com/doc/2014-10-31/"><${action}Result>${result}</${action}Result></${action}Response>`,
+    {
+      headers: { "content-type": "text/xml" },
+    },
+  );
+
+export const describeInstance = (value: rds.DBInstance | undefined) =>
+  response(
+    "DescribeDBInstances",
+    `<DBInstances>${value === undefined ? "" : `<DBInstance>${xml(value)}</DBInstance>`}</DBInstances>`,
+  );
+
+export const errorResponse = (code: string, status = 400) =>
+  new Response(
+    `<ErrorResponse xmlns="http://rds.amazonaws.com/doc/2014-10-31/"><Error><Type>Sender</Type><Code>${code}</Code><Message>${code}</Message></Error><RequestId>request-id</RequestId></ErrorResponse>`,
+    {
+      status,
+      headers: { "content-type": "text/xml" },
+    },
+  );
+
+export interface Request {
+  action: string;
+  parameters: URLSearchParams;
+  body: string;
+}
+
+/** Run the real provider and distilled request/response codecs without cloud IO. */
+export const withInstance = <A, E, R>(
+  respond: (request: Request) => Response,
+  use: (
+    provider: Provider.ProviderService<DBInstance>,
+    requests: Request[],
+  ) => Effect.Effect<A, E, R>,
+) =>
+  Effect.gen(function* () {
+    const requests: Request[] = [];
+    const clock = yield* Clock.Clock;
+    const http = HttpClient.make((request) =>
+      Effect.sync(() => {
+        if (request.body._tag !== "Uint8Array") {
+          throw new Error(`Unexpected request body: ${request.body._tag}`);
+        }
+        const body = new TextDecoder().decode(request.body.body);
+        const parameters = new URLSearchParams(body);
+        const action =
+          parameters.get("Action") ??
+          request.headers["x-amz-target"]?.split(".").at(-1) ??
+          "";
+        const recorded = { action, parameters, body };
+        requests.push(recorded);
+        return HttpClientResponse.fromWeb(request, respond(recorded));
+      }),
+    );
+    return yield* Effect.gen(function* () {
+      const provider = yield* Provider.Provider<DBInstance>(DBInstance.Type);
+      return yield* use(provider, requests);
+    }).pipe(
+      Effect.provide(DBInstanceProvider()),
+      Effect.provide(
+        Layer.mergeAll(
+          Layer.succeed(HttpClient.HttpClient, http),
+          // Advance virtual time when the provider requests a retry delay.
+          // AWS signing and response parsing use promises, so advancing the
+          // clock before those settle would race the timer's registration.
+          Layer.succeed(Clock.Clock, { ...clock, sleep: TestClock.adjust }),
+          fromCredentials(
+            {
+              accessKeyId: "AKIAIOSFODNN7EXAMPLE",
+              secretAccessKey: "test-secret-key",
+            },
+            "us-east-1",
+          ),
+          Layer.succeed(Region, Effect.succeed("us-east-1")),
+          Layer.succeed(Stack, stack),
+          Layer.succeed(Stage, stack.stage),
+          Layer.succeed(InstanceId, instanceId),
+        ),
+      ),
+    );
+  });
+
+export const reconcile = (
+  provider: Provider.ProviderService<DBInstance>,
+  news: DBInstanceProps,
+) =>
+  provider.reconcile({
+    id: "Db",
+    fqn: "Db",
+    instanceId,
+    news,
+    olds: undefined,
+    output: undefined,
+    bindings: [],
+    session: {
+      emit: () => Effect.void,
+      done: () => Effect.void,
+      note: () => Effect.void,
+    },
+  });

--- a/packages/alchemy/test/AWS/RDS/DBInstance.secret-policy.test.ts
+++ b/packages/alchemy/test/AWS/RDS/DBInstance.secret-policy.test.ts
@@ -1,0 +1,291 @@
+import type { PolicyDocument } from "@/AWS/IAM/Policy.ts";
+import { normalizePolicyDocument } from "@/AWS/IAM/Policy.ts";
+import { expect, it } from "alchemy-test";
+import * as Effect from "effect/Effect";
+import {
+  describeInstance,
+  instance,
+  instanceId,
+  props,
+  reconcile,
+  response,
+  withInstance,
+} from "./DBInstance.provider.ts";
+
+const secretArn =
+  "arn:aws:secretsmanager:us-east-1:123456789012:secret:rds!db-instance-abcdef";
+const policy: PolicyDocument = {
+  Version: "2012-10-17",
+  Statement: [
+    {
+      Effect: "Allow",
+      Principal: { AWS: "arn:aws:iam::123456789012:role/reader" },
+      Action: ["secretsmanager:GetSecretValue"],
+      Resource: "*",
+    },
+  ],
+};
+const managed = instance({
+  MasterUserSecret: { SecretArn: secretArn, SecretStatus: "active" },
+});
+const news = {
+  ...props,
+  manageMasterUserPassword: true,
+  masterUserSecretResourcePolicy: policy,
+};
+const json = (body: object, status = 200) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/x-amz-json-1.1" },
+  });
+
+it.effect(
+  "new instances wait for the RDS-managed secret and its policy metadata",
+  () => {
+    let created = false;
+    let instanceReads = 0;
+    let policyReads = 0;
+    let written = false;
+    return withInstance(
+      ({ action }) => {
+        if (action === "DescribeDBInstances") {
+          instanceReads++;
+          return describeInstance(
+            !created ? undefined : instanceReads < 4 ? instance() : managed,
+          );
+        }
+        if (action === "CreateDBInstance") {
+          created = true;
+          return response(action, "");
+        }
+        if (action === "GetResourcePolicy") {
+          if (++policyReads === 1)
+            return json(
+              {
+                __type: "ResourceNotFoundException",
+                Message: "Not visible yet",
+              },
+              400,
+            );
+          return json(
+            written ? { ResourcePolicy: JSON.stringify(policy) } : {},
+          );
+        }
+        if (action === "PutResourcePolicy") {
+          written = true;
+          return json({ ARN: secretArn });
+        }
+        throw new Error(`Unexpected operation: ${action}`);
+      },
+      (provider, requests) =>
+        Effect.gen(function* () {
+          const result = yield* reconcile(provider, news);
+          expect(result.masterUserSecretArn).toBe(secretArn);
+          expect(result.masterUserSecretResourcePolicy).toBe(
+            normalizePolicyDocument(policy),
+          );
+          const creates = requests.filter(
+            ({ action }) => action === "CreateDBInstance",
+          );
+          expect(creates).toHaveLength(1);
+          expect(creates[0]!.parameters.get("ManageMasterUserPassword")).toBe(
+            "true",
+          );
+          expect(
+            requests.filter(({ action }) => action === "PutResourcePolicy"),
+          ).toHaveLength(1);
+          expect(
+            requests.filter(({ action }) => action === "GetResourcePolicy"),
+          ).toHaveLength(3);
+        }),
+    );
+  },
+  { timeout: 5000 },
+);
+
+it.effect(
+  "policy convergence stops after its retry budget without rewriting",
+  () =>
+    withInstance(
+      ({ action }) => {
+        if (action === "DescribeDBInstances") return describeInstance(managed);
+        if (action === "GetResourcePolicy" || action === "PutResourcePolicy")
+          return json({});
+        throw new Error(`Unexpected operation: ${action}`);
+      },
+      (provider, requests) =>
+        Effect.gen(function* () {
+          const error = yield* reconcile(provider, news).pipe(Effect.flip);
+          expect(error._tag).toBe("DBInstanceSecretPolicyPending");
+          expect(
+            requests.filter(({ action }) => action === "PutResourcePolicy"),
+          ).toHaveLength(1);
+          expect(
+            requests.filter(({ action }) => action === "GetResourcePolicy"),
+          ).toHaveLength(12);
+        }),
+    ),
+  { timeout: 5000 },
+);
+
+it.effect(
+  "equivalent observed policy skips writes and reads no secret values",
+  () =>
+    withInstance(
+      ({ action }) => {
+        if (action === "DescribeDBInstances") return describeInstance(managed);
+        if (action === "GetResourcePolicy")
+          return json({ ResourcePolicy: JSON.stringify(policy, null, 2) });
+        throw new Error(`Unexpected operation: ${action}`);
+      },
+      (provider, requests) =>
+        Effect.gen(function* () {
+          const result = yield* reconcile(provider, news);
+          expect(result.masterUserSecretResourcePolicy).toBe(
+            normalizePolicyDocument(policy),
+          );
+          expect(
+            requests.filter(({ action }) => action === "GetResourcePolicy"),
+          ).toHaveLength(1);
+        }),
+    ),
+  { timeout: 5000 },
+);
+
+it.effect(
+  "writes a private resource policy once and waits for readback",
+  () => {
+    let policyReads = 0;
+    return withInstance(
+      ({ action }) => {
+        if (action === "DescribeDBInstances") return describeInstance(managed);
+        if (action === "GetResourcePolicy")
+          return json(
+            ++policyReads >= 3
+              ? { ResourcePolicy: JSON.stringify(policy) }
+              : {},
+          );
+        if (action === "PutResourcePolicy") return json({ ARN: secretArn });
+        throw new Error(`Unexpected operation: ${action}`);
+      },
+      (provider, requests) =>
+        Effect.gen(function* () {
+          const result = yield* reconcile(provider, news);
+          expect(result.masterUserSecretResourcePolicy).toBe(
+            normalizePolicyDocument(policy),
+          );
+          const puts = requests.filter(
+            ({ action }) => action === "PutResourcePolicy",
+          );
+          expect(puts).toHaveLength(1);
+          expect(JSON.parse(puts[0]!.body)).toEqual({
+            SecretId: secretArn,
+            ResourcePolicy: JSON.stringify(policy),
+            BlockPublicPolicy: true,
+          });
+        }),
+    );
+  },
+  { timeout: 5000 },
+);
+
+it.effect(
+  "omitting policy management leaves the RDS-managed secret alone",
+  () =>
+    withInstance(
+      ({ action }) => {
+        if (action === "DescribeDBInstances") return describeInstance(managed);
+        throw new Error(`Unexpected operation: ${action}`);
+      },
+      (provider) =>
+        Effect.gen(function* () {
+          const result = yield* reconcile(provider, props);
+          expect(result.masterUserSecretResourcePolicy).toBeUndefined();
+          expect(result.masterUserSecretArn).toBe(secretArn);
+        }),
+    ),
+  { timeout: 5000 },
+);
+
+it.effect(
+  "a missing managed secret is a typed configuration failure",
+  () =>
+    withInstance(
+      () => describeInstance(instance()),
+      (provider, requests) =>
+        Effect.gen(function* () {
+          const error = yield* reconcile(provider, news).pipe(Effect.flip);
+          expect(error._tag).toBe("DBInstanceManagedSecretMissing");
+          expect(
+            requests.every(({ action }) => action === "DescribeDBInstances"),
+          ).toBe(true);
+        }),
+    ),
+  { timeout: 5000 },
+);
+
+it.effect(
+  "policy reads preserve authorization failures without retries or writes",
+  () =>
+    withInstance(
+      ({ action }) =>
+        action === "DescribeDBInstances"
+          ? describeInstance(managed)
+          : json(
+              { __type: "AccessDeniedException", Message: "Access denied" },
+              400,
+            ),
+      (provider, requests) =>
+        Effect.gen(function* () {
+          const error = yield* reconcile(provider, news).pipe(Effect.flip);
+          expect(error._tag).not.toBe("DBInstanceSecretPolicyPending");
+          expect(
+            requests.filter(({ action }) => action === "GetResourcePolicy"),
+          ).toHaveLength(1);
+          expect(
+            requests.some(({ action }) => action === "PutResourcePolicy"),
+          ).toBe(false);
+        }),
+    ),
+  { timeout: 5000 },
+);
+
+it.effect(
+  "unchanged props still detect live policy drift",
+  () => {
+    let drifted = false;
+    return withInstance(
+      ({ action }) => {
+        if (action === "DescribeDBInstances") return describeInstance(managed);
+        if (action === "GetResourcePolicy")
+          return json(
+            drifted ? {} : { ResourcePolicy: JSON.stringify(policy) },
+          );
+        throw new Error(`Unexpected operation: ${action}`);
+      },
+      (provider) =>
+        Effect.gen(function* () {
+          const output = yield* provider.read!({
+            id: "Db",
+            fqn: "Db",
+            instanceId,
+            olds: news,
+            output: undefined,
+          });
+          drifted = true;
+          const diff = yield* provider.diff!({
+            id: "Db",
+            fqn: "Db",
+            instanceId,
+            olds: news,
+            news,
+            output,
+            oldBindings: [],
+            newBindings: [],
+          });
+          expect(diff).toEqual({ action: "update" });
+        }),
+    );
+  },
+  { timeout: 5000 },
+);


### PR DESCRIPTION
Manage the resource policy on an RDS-managed master secret while leaving credential values, rotation, and secret deletion to RDS.

```ts
yield* DBInstance("Db", {
  engine: "postgres",
  dbInstanceClass: "db.t3.micro",
  masterUsername: "admin",
  manageMasterUserPassword: true,
  masterUserSecretResourcePolicy: readerPolicy,
});
```

- Omitting or removing the policy deletes its attachment, including after adoption or external drift. The secret remains intact.
- Validate declared policies on unchanged plans as well as updates; writes additionally use `BlockPublicPolicy` and wait for canonical readback.
- Support enabling RDS-managed credentials on an existing instance before attaching the policy. Cluster-owned secrets and RDS Custom are excluded.

Deployment requires Secrets Manager policy read, validation, write, and delete permissions.
