### PR TITLE
fix(aws/rds): observe instance security drift and application state

### DIFF
--- a/packages/alchemy/src/AWS/RDS/DBInstance.ts
+++ b/packages/alchemy/src/AWS/RDS/DBInstance.ts
@@ -1,4 +1,5 @@
 import * as rds from "@distilled.cloud/aws/rds";
+import * as Data from "effect/Data";
 import type * as Duration from "effect/Duration";
 import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
@@ -85,6 +86,7 @@ export interface DBInstanceProps {
   masterUserSecretKmsKeyId?: string;
   /**
    * Listener port. In-place modify (sent as `DBPortNumber` on modify).
+   * Ignored for Aurora cluster members; configure the port on the DB cluster.
    */
   port?: number;
   /**
@@ -143,7 +145,8 @@ export interface DBInstanceProps {
    */
   caCertificateIdentifier?: string;
   /**
-   * Enable IAM database authentication. In-place modify.
+   * Enable IAM database authentication. In-place modify. Ignored for Aurora
+   * cluster members, where IAM authentication is managed by the DB cluster.
    */
   enableIAMDatabaseAuthentication?: boolean;
   /**
@@ -171,14 +174,18 @@ export interface DBInstanceProps {
   /**
    * Log types to export to CloudWatch Logs. Diffed against observed state and
    * applied via the delta-shaped `CloudwatchLogsExportConfiguration` on modify.
+   * Ignored for Aurora cluster members; configure log exports on the DB cluster.
    */
   enableCloudwatchLogsExports?: string[];
   /**
-   * Block accidental deletion. In-place modify.
+   * Block accidental deletion. In-place modify. Ignored for Aurora cluster
+   * members; configure deletion protection on the DB cluster. Cluster deletion
+   * protection does not prevent deleting individual Aurora instances.
    */
   deletionProtection?: boolean;
   /**
-   * Network type: `IPV4` | `DUAL`. In-place modify.
+   * Network type: `IPV4` | `DUAL`. In-place modify. Ignored for Aurora cluster
+   * members; configure the network type on the DB cluster.
    */
   networkType?: string;
   /**
@@ -278,6 +285,26 @@ export interface DBInstance extends Resource<
      */
     dbParameterGroupNames: string[];
     /**
+     * Observed parameter groups and their AWS application states. A group in
+     * `pending-reboot` needs an explicit reboot before its static changes apply;
+     * Alchemy does not reboot the instance automatically.
+     */
+    dbParameterGroups: Array<{
+      /** Name of the associated parameter group. */
+      name: string | undefined;
+      /** AWS parameter application state, such as `in-sync` or `pending-reboot`. */
+      status: string | undefined;
+    }>;
+    /**
+     * Observed VPC security group associations and their AWS application states.
+     */
+    vpcSecurityGroups: Array<{
+      /** ID of the associated VPC security group. */
+      id: string | undefined;
+      /** AWS association state, such as `active`. */
+      status: string | undefined;
+    }>;
+    /**
      * Allocated storage in GiB.
      */
     allocatedStorage: number | undefined;
@@ -337,6 +364,10 @@ export interface DBInstance extends Resource<
      * Whether IAM database authentication is enabled.
      */
     iamDatabaseAuthenticationEnabled: boolean | undefined;
+    /**
+     * A scheduled IAM authentication change that has not applied yet.
+     */
+    pendingIamDatabaseAuthenticationEnabled: boolean | undefined;
     /**
      * Whether Performance Insights is enabled.
      */
@@ -512,57 +543,70 @@ const toAttrs = ({
   skipFinalSnapshot?: boolean | undefined;
   finalDBSnapshotIdentifier?: string | undefined;
   masterUserPasswordFingerprint?: Redacted.Redacted<string> | undefined;
-}): DBInstance["Attributes"] => ({
-  skipFinalSnapshot,
-  finalDBSnapshotIdentifier,
-  masterUserPasswordFingerprint,
-  dbInstanceIdentifier: instance.DBInstanceIdentifier ?? "",
-  dbInstanceArn: instance.DBInstanceArn ?? "",
-  dbClusterIdentifier: instance.DBClusterIdentifier,
-  endpointAddress: instance.Endpoint?.Address,
-  endpointPort: instance.Endpoint?.Port,
-  dbInstanceClass: instance.DBInstanceClass,
-  engine: instance.Engine,
-  engineVersion: instance.EngineVersion,
-  status: instance.DBInstanceStatus,
-  promotionTier: instance.PromotionTier,
-  publiclyAccessible: instance.PubliclyAccessible,
-  dbSubnetGroupName: instance.DBSubnetGroup?.DBSubnetGroupName,
-  dbParameterGroupNames: (instance.DBParameterGroups ?? []).flatMap((group) =>
-    group.DBParameterGroupName ? [group.DBParameterGroupName] : [],
-  ),
-  allocatedStorage: instance.AllocatedStorage,
-  maxAllocatedStorage: instance.MaxAllocatedStorage,
-  storageType: instance.StorageType,
-  iops: instance.Iops,
-  storageThroughput: instance.StorageThroughput,
-  multiAZ: instance.MultiAZ,
-  availabilityZone: instance.AvailabilityZone,
-  secondaryAvailabilityZone: instance.SecondaryAvailabilityZone,
-  backupRetentionPeriod: instance.BackupRetentionPeriod,
-  preferredBackupWindow: instance.PreferredBackupWindow,
-  preferredMaintenanceWindow: instance.PreferredMaintenanceWindow,
-  kmsKeyId: instance.KmsKeyId,
-  storageEncrypted: instance.StorageEncrypted,
-  caCertificateIdentifier: instance.CACertificateIdentifier,
-  iamDatabaseAuthenticationEnabled: instance.IAMDatabaseAuthenticationEnabled,
-  performanceInsightsEnabled: instance.PerformanceInsightsEnabled,
-  monitoringInterval: instance.MonitoringInterval,
-  enhancedMonitoringResourceArn: instance.EnhancedMonitoringResourceArn,
-  enabledCloudwatchLogsExports: instance.EnabledCloudwatchLogsExports ?? [],
-  deletionProtection: instance.DeletionProtection,
-  dbiResourceId: instance.DbiResourceId,
-  masterUsername: instance.MasterUsername,
-  masterUserSecretArn: instance.MasterUserSecret?.SecretArn,
-  optionGroupMemberships: (instance.OptionGroupMemberships ?? []).flatMap(
-    (membership) =>
-      membership.OptionGroupName ? [membership.OptionGroupName] : [],
-  ),
-  licenseModel: instance.LicenseModel,
-  dbInstancePort: instance.DbInstancePort,
-  networkType: instance.NetworkType,
-  tags,
-});
+}): DBInstance["Attributes"] => {
+  const dbParameterGroups = (instance.DBParameterGroups ?? []).map((group) => ({
+    name: group.DBParameterGroupName,
+    status: group.ParameterApplyStatus,
+  }));
+  return {
+    skipFinalSnapshot,
+    finalDBSnapshotIdentifier,
+    masterUserPasswordFingerprint,
+    dbInstanceIdentifier: instance.DBInstanceIdentifier ?? "",
+    dbInstanceArn: instance.DBInstanceArn ?? "",
+    dbClusterIdentifier: instance.DBClusterIdentifier,
+    endpointAddress: instance.Endpoint?.Address,
+    endpointPort: instance.Endpoint?.Port,
+    dbInstanceClass: instance.DBInstanceClass,
+    engine: instance.Engine,
+    engineVersion: instance.EngineVersion,
+    status: instance.DBInstanceStatus,
+    promotionTier: instance.PromotionTier,
+    publiclyAccessible: instance.PubliclyAccessible,
+    dbSubnetGroupName: instance.DBSubnetGroup?.DBSubnetGroupName,
+    dbParameterGroupNames: dbParameterGroups.flatMap((group) =>
+      group.name === undefined ? [] : [group.name],
+    ),
+    dbParameterGroups,
+    vpcSecurityGroups: (instance.VpcSecurityGroups ?? []).map((group) => ({
+      id: group.VpcSecurityGroupId,
+      status: group.Status,
+    })),
+    allocatedStorage: instance.AllocatedStorage,
+    maxAllocatedStorage: instance.MaxAllocatedStorage,
+    storageType: instance.StorageType,
+    iops: instance.Iops,
+    storageThroughput: instance.StorageThroughput,
+    multiAZ: instance.MultiAZ,
+    availabilityZone: instance.AvailabilityZone,
+    secondaryAvailabilityZone: instance.SecondaryAvailabilityZone,
+    backupRetentionPeriod: instance.BackupRetentionPeriod,
+    preferredBackupWindow: instance.PreferredBackupWindow,
+    preferredMaintenanceWindow: instance.PreferredMaintenanceWindow,
+    kmsKeyId: instance.KmsKeyId,
+    storageEncrypted: instance.StorageEncrypted,
+    caCertificateIdentifier: instance.CACertificateIdentifier,
+    iamDatabaseAuthenticationEnabled: instance.IAMDatabaseAuthenticationEnabled,
+    pendingIamDatabaseAuthenticationEnabled:
+      instance.PendingModifiedValues?.IAMDatabaseAuthenticationEnabled,
+    performanceInsightsEnabled: instance.PerformanceInsightsEnabled,
+    monitoringInterval: instance.MonitoringInterval,
+    enhancedMonitoringResourceArn: instance.EnhancedMonitoringResourceArn,
+    enabledCloudwatchLogsExports: instance.EnabledCloudwatchLogsExports ?? [],
+    deletionProtection: instance.DeletionProtection,
+    dbiResourceId: instance.DbiResourceId,
+    masterUsername: instance.MasterUsername,
+    masterUserSecretArn: instance.MasterUserSecret?.SecretArn,
+    optionGroupMemberships: (instance.OptionGroupMemberships ?? []).flatMap(
+      (membership) =>
+        membership.OptionGroupName ? [membership.OptionGroupName] : [],
+    ),
+    licenseModel: instance.LicenseModel,
+    dbInstancePort: instance.DbInstancePort,
+    networkType: instance.NetworkType,
+    tags,
+  };
+};
 
 /**
  * Compute the CloudWatch Logs export delta. The modify API is delta-shaped
@@ -586,6 +630,133 @@ const logExportDelta = (
     ...(DisableLogTypes.length > 0 ? { DisableLogTypes } : {}),
   };
 };
+
+const sameMembers = (
+  desired: readonly string[],
+  observed: readonly (string | undefined)[],
+): boolean => {
+  const want = new Set(desired);
+  const have = new Set(observed);
+  return want.size === have.size && [...want].every((value) => have.has(value));
+};
+
+/**
+ * Aurora cluster members inherit these settings from their DB cluster. Project
+ * the same instance-owned configuration for writes, drift, and convergence.
+ * https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_CreateDBInstance.html
+ * https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/USER_VPC.WorkingWithRDSInstanceinaVPC.html
+ */
+const toManagedConfiguration = (props: DBInstanceProps) => ({
+  publiclyAccessible: props.publiclyAccessible,
+  dbParameterGroupName: props.dbParameterGroupName,
+  ...(props.dbClusterIdentifier === undefined
+    ? {
+        enableIAMDatabaseAuthentication: props.enableIAMDatabaseAuthentication,
+        vpcSecurityGroupIds: props.vpcSecurityGroupIds,
+        port: props.port,
+        deletionProtection: props.deletionProtection,
+        networkType: props.networkType,
+        enableCloudwatchLogsExports: props.enableCloudwatchLogsExports,
+      }
+    : {}),
+});
+
+const hasManagedConfiguration = (props: DBInstanceProps): boolean =>
+  Object.values(toManagedConfiguration(props)).some(
+    (value) => value !== undefined,
+  );
+
+/**
+ * Compare managed configuration with AWS observations, including pending changes.
+ * `pending-reboot` is an honest, durable outcome for a static parameter change,
+ * not an instruction for Alchemy to reboot a database.
+ */
+const configurationConverged = (
+  props: DBInstanceProps,
+  instance: rds.DBInstance,
+): boolean => {
+  const desired = toManagedConfiguration(props);
+  return (
+    (desired.enableIAMDatabaseAuthentication === undefined ||
+      (desired.enableIAMDatabaseAuthentication ===
+        instance.IAMDatabaseAuthenticationEnabled &&
+        instance.PendingModifiedValues?.IAMDatabaseAuthenticationEnabled ===
+          undefined)) &&
+    (desired.publiclyAccessible === undefined ||
+      desired.publiclyAccessible === instance.PubliclyAccessible) &&
+    (desired.networkType === undefined ||
+      desired.networkType === instance.NetworkType) &&
+    (desired.port === undefined || desired.port === instance.Endpoint?.Port) &&
+    (desired.deletionProtection === undefined ||
+      desired.deletionProtection === instance.DeletionProtection) &&
+    (desired.enableCloudwatchLogsExports === undefined ||
+      sameMembers(
+        desired.enableCloudwatchLogsExports,
+        instance.EnabledCloudwatchLogsExports ?? [],
+      )) &&
+    (desired.dbParameterGroupName === undefined ||
+      (instance.DBParameterGroups?.length === 1 &&
+        instance.DBParameterGroups.every(
+          (group) =>
+            group.DBParameterGroupName === desired.dbParameterGroupName &&
+            (group.ParameterApplyStatus === "in-sync" ||
+              group.ParameterApplyStatus === "pending-reboot"),
+        ))) &&
+    (desired.vpcSecurityGroupIds === undefined ||
+      (sameMembers(
+        desired.vpcSecurityGroupIds,
+        (instance.VpcSecurityGroups ?? []).map(
+          (group) => group.VpcSecurityGroupId,
+        ),
+      ) &&
+        (instance.VpcSecurityGroups ?? []).every(
+          (group) => group.Status === "active",
+        )))
+  );
+};
+
+class DBInstanceConfigurationPending extends Data.TaggedError(
+  "DBInstanceConfigurationPending",
+)<{
+  instanceId: string;
+}> {
+  override get message() {
+    return `DB instance '${this.instanceId}' has not applied its managed configuration`;
+  }
+}
+
+class DBInstanceReadinessBlocked extends Data.TaggedError(
+  "DBInstanceReadinessBlocked",
+)<{
+  instanceId: string;
+  status: string;
+}> {
+  override get message() {
+    return `DB instance '${this.instanceId}' requires intervention (status: ${this.status})`;
+  }
+}
+
+/**
+ * These states require intervention and cannot become available by polling.
+ * Includes the terminal states used by the AWS DBInstanceAvailable waiter.
+ * https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/accessing-monitoring.html
+ */
+const blockedStatuses = new Set([
+  "deleted",
+  "deleting",
+  "failed",
+  "inaccessible-encryption-credentials",
+  "inaccessible-encryption-credentials-recoverable",
+  "incompatible-create",
+  "incompatible-network",
+  "incompatible-option-group",
+  "incompatible-parameters",
+  "incompatible-restore",
+  "insufficient-capacity",
+  "restore-error",
+  "storage-full",
+  "upgrade-failed",
+]);
 
 export const DBInstanceProvider = () =>
   Provider.effect(
@@ -649,6 +820,36 @@ export const DBInstanceProvider = () =>
         );
       });
 
+      const waitForConfiguration = Effect.fn(function* (
+        instanceId: string,
+        props: DBInstanceProps,
+      ) {
+        return yield* Effect.gen(function* () {
+          const instance = yield* readInstance(instanceId);
+          const status = instance?.DBInstanceStatus;
+          if (status !== undefined && blockedStatuses.has(status)) {
+            return yield* new DBInstanceReadinessBlocked({
+              instanceId,
+              status,
+            });
+          }
+          if (
+            instance?.DBInstanceArn &&
+            status === "available" &&
+            configurationConverged(props, instance)
+          ) {
+            return instance;
+          }
+          return yield* new DBInstanceConfigurationPending({ instanceId });
+        }).pipe(
+          Effect.retry({
+            while: (error) => error._tag === "DBInstanceConfigurationPending",
+            schedule: Schedule.fixed("5 seconds"),
+            times: 10,
+          }),
+        );
+      });
+
       return {
         stables: ["dbInstanceArn", "dbInstanceIdentifier"],
         // Pattern (a) AWS account/region collection: `describeDBInstances` is
@@ -682,7 +883,7 @@ export const DBInstanceProvider = () =>
               Effect.succeed([] as DBInstance["Attributes"][]),
             ),
           ),
-        diff: Effect.fn(function* ({ id, olds, news }) {
+        diff: Effect.fn(function* ({ id, olds, news, output }) {
           if (!isResolved(news)) return undefined;
           if (
             (yield* toIdentifier(id, olds ?? ({} as DBInstanceProps))) !==
@@ -702,6 +903,26 @@ export const DBInstanceProvider = () =>
               olds.dbSubnetGroupName !== news.dbSubnetGroupName)
           ) {
             return { action: "replace" } as const;
+          }
+          // Existing state may predate the observed association attributes.
+          // Populate them once even when props and live configuration match.
+          if (
+            output !== undefined &&
+            (!Object.hasOwn(output, "dbParameterGroups") ||
+              !Object.hasOwn(output, "vpcSecurityGroups"))
+          ) {
+            return { action: "update" } as const;
+          }
+          if (output !== undefined && hasManagedConfiguration(news)) {
+            const instance = yield* readInstance(output.dbInstanceIdentifier);
+            if (!instance?.DBInstanceArn) {
+              // The physical instance is gone; downstream references must be
+              // resolved again when it is recreated.
+              return { action: "update", stables: [] } as const;
+            }
+            if (!configurationConverged(news, instance)) {
+              return { action: "update" } as const;
+            }
           }
         }),
         read: Effect.fn(function* ({ id, olds, output }) {
@@ -729,6 +950,7 @@ export const DBInstanceProvider = () =>
         reconcile: Effect.fn(function* ({ id, news, output, session }) {
           const identifier =
             output?.dbInstanceIdentifier ?? (yield* toIdentifier(id, news));
+          const configuration = toManagedConfiguration(news);
           // AWS never returns the master password, so there is nothing to
           // observe-and-diff — fingerprint the configured value instead and
           // only send `MasterUserPassword` when the fingerprint changed.
@@ -779,37 +1001,36 @@ export const DBInstanceProvider = () =>
                 MasterUserPassword: news.masterUserPassword,
                 ManageMasterUserPassword: news.manageMasterUserPassword,
                 MasterUserSecretKmsKeyId: news.masterUserSecretKmsKeyId,
-                Port: news.port,
+                Port: configuration.port,
                 MultiAZ: news.multiAZ,
                 AvailabilityZone: news.availabilityZone,
                 BackupRetentionPeriod: backupRetentionDays,
                 PreferredBackupWindow: news.preferredBackupWindow,
                 PreferredMaintenanceWindow: news.preferredMaintenanceWindow,
                 DBSubnetGroupName: news.dbSubnetGroupName,
-                DBParameterGroupName: news.dbParameterGroupName,
+                DBParameterGroupName: configuration.dbParameterGroupName,
                 OptionGroupName: news.optionGroupName,
                 LicenseModel: news.licenseModel,
                 StorageEncrypted: news.storageEncrypted,
                 KmsKeyId: news.kmsKeyId,
                 CACertificateIdentifier: news.caCertificateIdentifier,
                 EnableIAMDatabaseAuthentication:
-                  news.enableIAMDatabaseAuthentication,
+                  configuration.enableIAMDatabaseAuthentication,
                 EnablePerformanceInsights: news.enablePerformanceInsights,
                 PerformanceInsightsKMSKeyId: news.performanceInsightsKMSKeyId,
                 PerformanceInsightsRetentionPeriod:
                   performanceInsightsRetentionDays,
                 MonitoringInterval: monitoringIntervalSeconds,
                 MonitoringRoleArn: news.monitoringRoleArn,
-                EnableCloudwatchLogsExports: news.enableCloudwatchLogsExports,
-                DeletionProtection: news.deletionProtection,
-                NetworkType: news.networkType,
+                EnableCloudwatchLogsExports:
+                  configuration.enableCloudwatchLogsExports,
+                DeletionProtection: configuration.deletionProtection,
+                NetworkType: configuration.networkType,
                 // Cluster members inherit VPC security groups from the DB
                 // cluster; passing them fails with InvalidParameterCombination
                 // ("Set vpc security group for the DB Cluster").
-                VpcSecurityGroupIds: news.dbClusterIdentifier
-                  ? undefined
-                  : news.vpcSecurityGroupIds,
-                PubliclyAccessible: news.publiclyAccessible,
+                VpcSecurityGroupIds: configuration.vpcSecurityGroupIds,
+                PubliclyAccessible: configuration.publiclyAccessible,
                 PromotionTier: news.promotionTier,
                 AutoMinorVersionUpgrade: news.autoMinorVersionUpgrade,
                 CopyTagsToSnapshot: news.copyTagsToSnapshot,
@@ -861,31 +1082,46 @@ export const DBInstanceProvider = () =>
             setIf("BackupRetentionPeriod", backupRetentionDays, observed.BackupRetentionPeriod); // prettier-ignore
             setIf("PreferredBackupWindow", news.preferredBackupWindow, observed.PreferredBackupWindow); // prettier-ignore
             setIf("PreferredMaintenanceWindow", news.preferredMaintenanceWindow, observed.PreferredMaintenanceWindow); // prettier-ignore
-            setIf("DBPortNumber", news.port, observed.DbInstancePort);
+            setIf("DBPortNumber", configuration.port, observed.DbInstancePort);
             setIf("OptionGroupName", news.optionGroupName, undefined);
             setIf("LicenseModel", news.licenseModel, observed.LicenseModel);
             setIf("CACertificateIdentifier", news.caCertificateIdentifier, observed.CACertificateIdentifier); // prettier-ignore
-            setIf("EnableIAMDatabaseAuthentication", news.enableIAMDatabaseAuthentication, observed.IAMDatabaseAuthenticationEnabled); // prettier-ignore
+            setIf(
+              "EnableIAMDatabaseAuthentication",
+              configuration.enableIAMDatabaseAuthentication,
+              observed.PendingModifiedValues
+                ?.IAMDatabaseAuthenticationEnabled !== undefined &&
+                observed.PendingModifiedValues
+                  .IAMDatabaseAuthenticationEnabled !==
+                  configuration.enableIAMDatabaseAuthentication
+                ? undefined
+                : observed.IAMDatabaseAuthenticationEnabled,
+            );
             setIf("EnablePerformanceInsights", news.enablePerformanceInsights, observed.PerformanceInsightsEnabled); // prettier-ignore
             setIf("PerformanceInsightsKMSKeyId", news.performanceInsightsKMSKeyId, observed.PerformanceInsightsKMSKeyId); // prettier-ignore
             setIf("PerformanceInsightsRetentionPeriod", performanceInsightsRetentionDays, observed.PerformanceInsightsRetentionPeriod); // prettier-ignore
             setIf("MonitoringInterval", monitoringIntervalSeconds, observed.MonitoringInterval); // prettier-ignore
             setIf("MonitoringRoleArn", news.monitoringRoleArn, observed.MonitoringRoleArn); // prettier-ignore
-            setIf("DeletionProtection", news.deletionProtection, observed.DeletionProtection); // prettier-ignore
-            setIf("NetworkType", news.networkType, observed.NetworkType);
-            setIf("DBParameterGroupName", news.dbParameterGroupName, undefined);
-            setIf("PubliclyAccessible", news.publiclyAccessible, observed.PubliclyAccessible); // prettier-ignore
+            setIf("DeletionProtection", configuration.deletionProtection, observed.DeletionProtection); // prettier-ignore
+            setIf(
+              "NetworkType",
+              configuration.networkType,
+              observed.NetworkType,
+            );
+            setIf(
+              "DBParameterGroupName",
+              configuration.dbParameterGroupName,
+              undefined,
+            );
+            setIf("PubliclyAccessible", configuration.publiclyAccessible, observed.PubliclyAccessible); // prettier-ignore
             setIf("PromotionTier", news.promotionTier, observed.PromotionTier);
             setIf("AutoMinorVersionUpgrade", news.autoMinorVersionUpgrade, observed.AutoMinorVersionUpgrade); // prettier-ignore
             setIf("CopyTagsToSnapshot", news.copyTagsToSnapshot, observed.CopyTagsToSnapshot); // prettier-ignore
             // Security groups on Aurora cluster members are managed by the DB
             // cluster (ModifyDBCluster), so only sync them for standalone
             // instances.
-            if (
-              news.vpcSecurityGroupIds !== undefined &&
-              news.dbClusterIdentifier === undefined
-            ) {
-              core.VpcSecurityGroupIds = news.vpcSecurityGroupIds;
+            if (configuration.vpcSecurityGroupIds !== undefined) {
+              core.VpcSecurityGroupIds = configuration.vpcSecurityGroupIds;
               coreDirty = true;
             }
             if (news.allowMajorVersionUpgrade) {
@@ -920,7 +1156,7 @@ export const DBInstanceProvider = () =>
             // never mixes the full-set fields above.
             const logDelta = logExportDelta(
               observed.EnabledCloudwatchLogsExports,
-              news.enableCloudwatchLogsExports,
+              configuration.enableCloudwatchLogsExports,
             );
             if (logDelta) {
               yield* rds.modifyDBInstance({
@@ -950,6 +1186,9 @@ export const DBInstanceProvider = () =>
             });
           }
 
+          if (hasManagedConfiguration(news)) {
+            observed = yield* waitForConfiguration(identifier, news);
+          }
           yield* session.note(dbInstanceArn || identifier);
           return toAttrs({
             instance: observed,

--- a/packages/alchemy/test/AWS/RDS/DBInstance.provider.ts
+++ b/packages/alchemy/test/AWS/RDS/DBInstance.provider.ts
@@ -1,0 +1,180 @@
+import {
+  DBInstance,
+  DBInstanceProvider,
+  type DBInstanceProps,
+} from "@/AWS/RDS/DBInstance.ts";
+import { InstanceId } from "@/InstanceId.ts";
+import * as Provider from "@/Provider.ts";
+import { Stack, type StackSpec } from "@/Stack.ts";
+import { Stage } from "@/Stage.ts";
+import { fromCredentials } from "@distilled.cloud/aws/Credentials";
+import { Region } from "@distilled.cloud/aws/Region";
+import type * as rds from "@distilled.cloud/aws/rds";
+import * as Clock from "effect/Clock";
+import * as Effect from "effect/Effect";
+import * as TestClock from "effect/testing/TestClock";
+import * as Layer from "effect/Layer";
+import * as HttpClient from "effect/unstable/http/HttpClient";
+import * as HttpClientResponse from "effect/unstable/http/HttpClientResponse";
+
+export const instanceId = "0123456789abcdef0123456789abcdef";
+export const props: DBInstanceProps = {
+  dbInstanceIdentifier: "alchemy-rds-instance",
+  dbInstanceClass: "db.t3.micro",
+  engine: "postgres",
+};
+
+const stack: Omit<StackSpec, "output"> = {
+  name: "rds-provider",
+  stage: "test",
+  resources: {},
+  bindings: {},
+  actions: {},
+};
+
+export const instance = (fields: rds.DBInstance = {}): rds.DBInstance => ({
+  DBInstanceIdentifier: props.dbInstanceIdentifier,
+  DBInstanceArn: "arn:aws:rds:us-east-1:123456789012:db:alchemy-rds-instance",
+  DBInstanceStatus: "available",
+  DBInstanceClass: props.dbInstanceClass,
+  Engine: props.engine,
+  TagList: [
+    { Key: "alchemy::stack", Value: stack.name },
+    { Key: "alchemy::stage", Value: stack.stage },
+    { Key: "alchemy::id", Value: "Db" },
+  ],
+  ...fields,
+});
+
+const memberNames: Record<string, string> = {
+  DBParameterGroups: "DBParameterGroup",
+  VpcSecurityGroups: "VpcSecurityGroupMembership",
+  TagList: "Tag",
+};
+
+const xml = (value: unknown): string => {
+  if (value === undefined) return "";
+  if (typeof value === "object" && value !== null) {
+    return Object.entries(value)
+      .filter(([, field]) => field !== undefined)
+      .map(([name, field]) => {
+        const contents = Array.isArray(field)
+          ? field
+              .map(
+                (item) =>
+                  `<${memberNames[name] ?? "member"}>${xml(item)}</${memberNames[name] ?? "member"}>`,
+              )
+              .join("")
+          : xml(field);
+        return `<${name}>${contents}</${name}>`;
+      })
+      .join("");
+  }
+  return String(value)
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
+};
+
+export const response = (action: string, result: string) =>
+  new Response(
+    `<${action}Response xmlns="http://rds.amazonaws.com/doc/2014-10-31/"><${action}Result>${result}</${action}Result></${action}Response>`,
+    {
+      headers: { "content-type": "text/xml" },
+    },
+  );
+
+export const describeInstance = (value: rds.DBInstance | undefined) =>
+  response(
+    "DescribeDBInstances",
+    `<DBInstances>${value === undefined ? "" : `<DBInstance>${xml(value)}</DBInstance>`}</DBInstances>`,
+  );
+
+export const errorResponse = (code: string, status = 400) =>
+  new Response(
+    `<ErrorResponse xmlns="http://rds.amazonaws.com/doc/2014-10-31/"><Error><Type>Sender</Type><Code>${code}</Code><Message>${code}</Message></Error><RequestId>request-id</RequestId></ErrorResponse>`,
+    {
+      status,
+      headers: { "content-type": "text/xml" },
+    },
+  );
+
+export interface Request {
+  action: string;
+  parameters: URLSearchParams;
+  body: string;
+}
+
+/** Run the real provider and distilled request/response codecs without cloud IO. */
+export const withInstance = <A, E, R>(
+  respond: (request: Request) => Response,
+  use: (
+    provider: Provider.ProviderService<DBInstance>,
+    requests: Request[],
+  ) => Effect.Effect<A, E, R>,
+) =>
+  Effect.gen(function* () {
+    const requests: Request[] = [];
+    const clock = yield* Clock.Clock;
+    const http = HttpClient.make((request) =>
+      Effect.sync(() => {
+        if (request.body._tag !== "Uint8Array") {
+          throw new Error(`Unexpected request body: ${request.body._tag}`);
+        }
+        const body = new TextDecoder().decode(request.body.body);
+        const parameters = new URLSearchParams(body);
+        const action =
+          parameters.get("Action") ??
+          request.headers["x-amz-target"]?.split(".").at(-1) ??
+          "";
+        const recorded = { action, parameters, body };
+        requests.push(recorded);
+        return HttpClientResponse.fromWeb(request, respond(recorded));
+      }),
+    );
+    return yield* Effect.gen(function* () {
+      const provider = yield* Provider.Provider<DBInstance>(DBInstance.Type);
+      return yield* use(provider, requests);
+    }).pipe(
+      Effect.provide(DBInstanceProvider()),
+      Effect.provide(
+        Layer.mergeAll(
+          Layer.succeed(HttpClient.HttpClient, http),
+          // Advance virtual time when the provider requests a retry delay.
+          // AWS signing and response parsing use promises, so advancing the
+          // clock before those settle would race the timer's registration.
+          Layer.succeed(Clock.Clock, { ...clock, sleep: TestClock.adjust }),
+          fromCredentials(
+            {
+              accessKeyId: "AKIAIOSFODNN7EXAMPLE",
+              secretAccessKey: "test-secret-key",
+            },
+            "us-east-1",
+          ),
+          Layer.succeed(Region, Effect.succeed("us-east-1")),
+          Layer.succeed(Stack, stack),
+          Layer.succeed(Stage, stack.stage),
+          Layer.succeed(InstanceId, instanceId),
+        ),
+      ),
+    );
+  });
+
+export const reconcile = (
+  provider: Provider.ProviderService<DBInstance>,
+  news: DBInstanceProps,
+) =>
+  provider.reconcile({
+    id: "Db",
+    fqn: "Db",
+    instanceId,
+    news,
+    olds: undefined,
+    output: undefined,
+    bindings: [],
+    session: {
+      emit: () => Effect.void,
+      done: () => Effect.void,
+      note: () => Effect.void,
+    },
+  });

--- a/packages/alchemy/test/AWS/RDS/DBInstance.security.test.ts
+++ b/packages/alchemy/test/AWS/RDS/DBInstance.security.test.ts
@@ -1,0 +1,461 @@
+import { expect, it } from "alchemy-test";
+import * as Effect from "effect/Effect";
+import {
+  describeInstance,
+  errorResponse,
+  instance,
+  instanceId,
+  props,
+  reconcile,
+  response,
+  withInstance,
+} from "./DBInstance.provider.ts";
+
+it.effect(
+  "refreshes legacy outputs before exposing observed associations",
+  () =>
+    withInstance(
+      ({ action }) =>
+        action === "DescribeDBInstances"
+          ? describeInstance(instance())
+          : response(action, ""),
+      (provider, requests) =>
+        Effect.gen(function* () {
+          const output = yield* reconcile(provider, props);
+          // Reproduce an existing state row written before these attributes existed.
+          Reflect.deleteProperty(output, "dbParameterGroups");
+          Reflect.deleteProperty(output, "vpcSecurityGroups");
+          const beforePlanning = requests.length;
+          expect(
+            yield* provider.diff!({
+              id: "Db",
+              fqn: "Db",
+              instanceId,
+              olds: props,
+              news: props,
+              output,
+              oldBindings: [],
+              newBindings: [],
+            }),
+          ).toEqual({ action: "update" });
+          expect(requests).toHaveLength(beforePlanning);
+        }),
+    ),
+);
+
+const auroraInstance = instance({
+  DBClusterIdentifier: "cluster",
+  DBInstanceClass: "db.t3.medium",
+  Engine: "aurora-postgresql",
+  Endpoint: { Port: 5432 },
+  DeletionProtection: false,
+  IAMDatabaseAuthenticationEnabled: false,
+  NetworkType: "IPV4",
+  PubliclyAccessible: false,
+  EnabledCloudwatchLogsExports: [],
+  VpcSecurityGroups: [{ VpcSecurityGroupId: "sg-cluster", Status: "active" }],
+});
+
+const auroraProps = {
+  ...props,
+  engine: "aurora-postgresql",
+  dbInstanceClass: "db.t3.medium",
+  dbClusterIdentifier: "cluster",
+  port: 15432,
+  deletionProtection: true,
+  enableIAMDatabaseAuthentication: true,
+  networkType: "DUAL",
+  enableCloudwatchLogsExports: ["postgresql"],
+  vpcSecurityGroupIds: ["sg-instance"],
+};
+
+const expectNoClusterSettings = (parameters: URLSearchParams) => {
+  for (const field of [
+    "Port",
+    "DBPortNumber",
+    "DeletionProtection",
+    "EnableIAMDatabaseAuthentication",
+    "VpcSecurityGroupIds",
+    "NetworkType",
+    "EnableCloudwatchLogsExports",
+    "CloudwatchLogsExportConfiguration",
+  ]) {
+    expect(
+      [...parameters.keys()].some(
+        (key) => key === field || key.startsWith(`${field}.`),
+      ),
+    ).toBe(false);
+  }
+};
+
+it.effect(
+  "Aurora ignores cluster-owned security settings during reconcile and planning",
+  () =>
+    withInstance(
+      ({ action }) =>
+        action === "DescribeDBInstances"
+          ? describeInstance(auroraInstance)
+          : response(action, ""),
+      (provider, requests) =>
+        Effect.gen(function* () {
+          const output = yield* reconcile(provider, auroraProps);
+          expect(output.endpointPort).toBe(5432);
+          expect(output.deletionProtection).toBe(false);
+          expect(
+            requests.filter(({ action }) => action === "ModifyDBInstance"),
+          ).toEqual([]);
+          const beforePlanning = requests.length;
+          const diff = yield* provider.diff!({
+            id: "Db",
+            fqn: "Db",
+            instanceId,
+            olds: auroraProps,
+            news: auroraProps,
+            output,
+            oldBindings: [],
+            newBindings: [],
+          });
+          expect(diff).toBeUndefined();
+          expect(requests).toHaveLength(beforePlanning);
+        }),
+    ),
+  { timeout: 5000 },
+);
+
+it.effect(
+  "Aurora creation sends only instance-owned security settings",
+  () => {
+    let created = false;
+    const observed = instance({
+      ...auroraInstance,
+      PubliclyAccessible: true,
+      DBParameterGroups: [
+        { DBParameterGroupName: "custom", ParameterApplyStatus: "in-sync" },
+      ],
+    });
+    return withInstance(
+      ({ action }) => {
+        if (action === "DescribeDBInstances")
+          return describeInstance(created ? observed : undefined);
+        if (action === "CreateDBInstance") created = true;
+        return response(action, "");
+      },
+      (provider, requests) =>
+        Effect.gen(function* () {
+          const output = yield* reconcile(provider, {
+            ...auroraProps,
+            publiclyAccessible: true,
+            dbParameterGroupName: "custom",
+          });
+          const creates = requests.filter(
+            ({ action }) => action === "CreateDBInstance",
+          );
+          expect(creates).toHaveLength(1);
+          expectNoClusterSettings(creates[0]!.parameters);
+          expect(creates[0]!.parameters.get("PubliclyAccessible")).toBe("true");
+          expect(creates[0]!.parameters.get("DBParameterGroupName")).toBe(
+            "custom",
+          );
+          expect(
+            requests.filter(({ action }) => action === "ModifyDBInstance"),
+          ).toEqual([]);
+          expect(output.publiclyAccessible).toBe(true);
+          expect(output.dbParameterGroupNames).toEqual(["custom"]);
+          expect(output.endpointPort).toBe(5432);
+          expect(output.deletionProtection).toBe(false);
+        }),
+    );
+  },
+  { timeout: 5000 },
+);
+
+it.effect(
+  "Aurora still reconciles public accessibility and its instance parameter group",
+  () => {
+    let modified = false;
+    return withInstance(
+      ({ action }) => {
+        if (action === "DescribeDBInstances")
+          return describeInstance(
+            instance({
+              ...auroraInstance,
+              PubliclyAccessible: modified,
+              DBParameterGroups: [
+                {
+                  DBParameterGroupName: modified
+                    ? "custom"
+                    : "default.aurora-postgresql16",
+                  ParameterApplyStatus: "in-sync",
+                },
+              ],
+            }),
+          );
+        if (action === "ModifyDBInstance") modified = true;
+        return response(action, "");
+      },
+      (provider, requests) =>
+        Effect.gen(function* () {
+          const output = yield* reconcile(provider, {
+            ...auroraProps,
+            publiclyAccessible: true,
+            dbParameterGroupName: "custom",
+          });
+          const modifies = requests.filter(
+            ({ action }) => action === "ModifyDBInstance",
+          );
+          expect(modifies).toHaveLength(1);
+          expectNoClusterSettings(modifies[0]!.parameters);
+          expect(modifies[0]!.parameters.get("PubliclyAccessible")).toBe(
+            "true",
+          );
+          expect(modifies[0]!.parameters.get("DBParameterGroupName")).toBe(
+            "custom",
+          );
+          expect(output.publiclyAccessible).toBe(true);
+          expect(output.dbParameterGroupNames).toEqual(["custom"]);
+        }),
+    );
+  },
+  { timeout: 5000 },
+);
+
+it.effect(
+  "reports pending-reboot without rebooting or claiming parameters are applied",
+  () =>
+    withInstance(
+      ({ action }) =>
+        action === "DescribeDBInstances"
+          ? describeInstance(
+              instance({
+                DBParameterGroups: [
+                  {
+                    DBParameterGroupName: "custom",
+                    ParameterApplyStatus: "pending-reboot",
+                  },
+                ],
+              }),
+            )
+          : response(action, ""),
+      (provider, requests) =>
+        Effect.gen(function* () {
+          const result = yield* reconcile(provider, {
+            ...props,
+            dbParameterGroupName: "custom",
+          });
+          expect(result.dbParameterGroupNames).toEqual(["custom"]);
+          expect(result.dbParameterGroups).toEqual([
+            { name: "custom", status: "pending-reboot" },
+          ]);
+          expect(
+            requests.some(({ action }) => action === "RebootDBInstance"),
+          ).toBe(false);
+        }),
+    ),
+  { timeout: 5000 },
+);
+
+it.effect(
+  "plans correction of live security drift while keeping stable identifiers",
+  () => {
+    let publicAccess = false;
+    return withInstance(
+      () => describeInstance(instance({ PubliclyAccessible: publicAccess })),
+      (provider) =>
+        Effect.gen(function* () {
+          const news = { ...props, publiclyAccessible: false };
+          const output = yield* provider.read!({
+            id: "Db",
+            fqn: "Db",
+            instanceId,
+            olds: news,
+            output: undefined,
+          });
+          publicAccess = true;
+          const diff = yield* provider.diff!({
+            id: "Db",
+            fqn: "Db",
+            instanceId,
+            olds: news,
+            news,
+            output,
+            oldBindings: [],
+            newBindings: [],
+          });
+          expect(diff).toEqual({ action: "update" });
+          expect(provider.stables).toEqual([
+            "dbInstanceArn",
+            "dbInstanceIdentifier",
+          ]);
+        }),
+    );
+  },
+  { timeout: 5000 },
+);
+
+it.effect(
+  "a missing instance invalidates stable references",
+  () => {
+    let missing = false;
+    return withInstance(
+      () =>
+        describeInstance(
+          missing ? undefined : instance({ PubliclyAccessible: false }),
+        ),
+      (provider) =>
+        Effect.gen(function* () {
+          const news = { ...props, publiclyAccessible: false };
+          const output = yield* provider.read!({
+            id: "Db",
+            fqn: "Db",
+            instanceId,
+            olds: news,
+            output: undefined,
+          });
+          missing = true;
+          const diff = yield* provider.diff!({
+            id: "Db",
+            fqn: "Db",
+            instanceId,
+            olds: news,
+            news,
+            output,
+            oldBindings: [],
+            newBindings: [],
+          });
+          expect(diff).toEqual({ action: "update", stables: [] });
+        }),
+    );
+  },
+  { timeout: 5000 },
+);
+
+it.effect(
+  "waits for security-group application after the instance becomes available",
+  () => {
+    let modified = false;
+    let postModifyReads = 0;
+    return withInstance(
+      ({ action }) => {
+        if (action === "DescribeDBInstances")
+          return describeInstance(
+            instance({
+              VpcSecurityGroups: [
+                {
+                  VpcSecurityGroupId: modified ? "sg-new" : "sg-old",
+                  Status:
+                    modified && ++postModifyReads > 2 ? "active" : "modifying",
+                },
+              ],
+            }),
+          );
+        if (action === "ModifyDBInstance") modified = true;
+        return response(action, "");
+      },
+      (provider, requests) =>
+        Effect.gen(function* () {
+          const result = yield* reconcile(provider, {
+            ...props,
+            vpcSecurityGroupIds: ["sg-new"],
+          });
+          expect(result.vpcSecurityGroups).toEqual([
+            { id: "sg-new", status: "active" },
+          ]);
+          expect(
+            requests.filter(({ action }) => action === "ModifyDBInstance"),
+          ).toHaveLength(1);
+        }),
+    );
+  },
+  { timeout: 5000 },
+);
+
+it.effect(
+  "replaces a conflicting pending IAM-authentication change and verifies it cleared",
+  () => {
+    let modified = false;
+    return withInstance(
+      ({ action }) => {
+        if (action === "DescribeDBInstances")
+          return describeInstance(
+            instance({
+              IAMDatabaseAuthenticationEnabled: true,
+              PendingModifiedValues: modified
+                ? {}
+                : { IAMDatabaseAuthenticationEnabled: false },
+            }),
+          );
+        if (action === "ModifyDBInstance") modified = true;
+        return response(action, "");
+      },
+      (provider, requests) =>
+        Effect.gen(function* () {
+          const result = yield* reconcile(provider, {
+            ...props,
+            enableIAMDatabaseAuthentication: true,
+          });
+          expect(result.iamDatabaseAuthenticationEnabled).toBe(true);
+          expect(
+            result.pendingIamDatabaseAuthenticationEnabled,
+          ).toBeUndefined();
+          const modifies = requests.filter(
+            ({ action }) => action === "ModifyDBInstance",
+          );
+          expect(modifies).toHaveLength(1);
+          expect(
+            modifies[0]!.parameters.get("EnableIAMDatabaseAuthentication"),
+          ).toBe("true");
+          expect(modifies[0]!.parameters.get("ApplyImmediately")).toBe("true");
+        }),
+    );
+  },
+  { timeout: 5000 },
+);
+
+it.effect(
+  "configuration polling is bounded and does not resend modifications",
+  () =>
+    withInstance(
+      ({ action }) =>
+        action === "DescribeDBInstances"
+          ? describeInstance(instance({ PubliclyAccessible: true }))
+          : response(action, ""),
+      (provider, requests) =>
+        Effect.gen(function* () {
+          const error = yield* reconcile(provider, {
+            ...props,
+            publiclyAccessible: false,
+          }).pipe(Effect.flip);
+          expect(error._tag).toBe("DBInstanceConfigurationPending");
+          expect(
+            requests.filter(({ action }) => action === "DescribeDBInstances"),
+          ).toHaveLength(14);
+          expect(
+            requests.filter(({ action }) => action === "ModifyDBInstance"),
+          ).toHaveLength(1);
+        }),
+    ),
+  { timeout: 5000 },
+);
+
+it.effect(
+  "configuration polling propagates authorization failures immediately",
+  () => {
+    let reads = 0;
+    return withInstance(
+      () =>
+        ++reads > 2
+          ? errorResponse("AccessDenied", 403)
+          : describeInstance(instance({ PubliclyAccessible: false })),
+      (provider, requests) =>
+        Effect.gen(function* () {
+          const error = yield* reconcile(provider, {
+            ...props,
+            publiclyAccessible: false,
+          }).pipe(Effect.flip);
+          expect(error._tag).not.toBe("DBInstanceConfigurationPending");
+          expect(requests).toHaveLength(3);
+        }),
+    );
+  },
+  { timeout: 5000 },
+);


### PR DESCRIPTION
Converge RDS instance security settings from desired state, including removal, adoption, and external drift.

Omitted settings mean IAM authentication off, private access, deletion protection off, IPv4 networking, and no log exports. Cluster-owned settings remain on `DBCluster`; Aurora public accessibility remains instance-owned.

Expose observed security-group application states and pending IAM authentication separately from applied values. Wait for applied settings without automatic reboots. Matching queued IAM changes are applied without resending the IAM field; IAM/network updates can apply other queued changes, while public-access, protection, and log updates leave unrelated maintenance changes queued.
