### PR TITLE
fix(cloudflare/r2): forward put options on the stream path

### DIFF
--- a/packages/alchemy/src/Cloudflare/R2/WriteBucketBinding.ts
+++ b/packages/alchemy/src/Cloudflare/R2/WriteBucketBinding.ts
@@ -82,18 +82,21 @@ export const makeWrite = ({
     ) =>
       use((raw) => {
         if (Stream.isStream(value)) {
+          // `contentLength` is ours; everything else (checksums, metadata,
+          // conditions) is R2's and must reach it on every path.
+          const { contentLength, ...r2Options } = options ?? {};
           const rawStream = getRawStream(value);
           if (rawStream) {
-            return raw.put(key, rawStream as any, options);
-          } else if (!options?.contentLength) {
+            return raw.put(key, rawStream as any, r2Options);
+          } else if (!contentLength) {
             throw new Error("Content length is required");
           }
-          // content length myst be known, so we pipe through fixed length stream
-          // TODO(sam): is it more efficient to just assign the contentLength as a property?
+          // R2 needs a known length, so the stream is piped through a fixed
+          // length stream.
           const readable = Stream.toReadableStream(value).pipeThrough(
-            new FixedLengthStream(options.contentLength),
+            new FixedLengthStream(contentLength),
           );
-          return raw.put(key, readable as any);
+          return raw.put(key, readable as any, r2Options);
         }
         return raw.put(key, value as any, options);
       }).pipe(Effect.map(wrapR2ObjectOrBody)) as any,

--- a/packages/alchemy/test/Cloudflare/R2/Binding.test.ts
+++ b/packages/alchemy/test/Cloudflare/R2/Binding.test.ts
@@ -8,6 +8,7 @@ import * as Schedule from "effect/Schedule";
 import * as HttpClient from "effect/unstable/http/HttpClient";
 import * as HttpClientRequest from "effect/unstable/http/HttpClientRequest";
 import type * as HttpClientResponse from "effect/unstable/http/HttpClientResponse";
+import { createHash } from "node:crypto";
 import Stack from "./fixtures/stack.ts";
 
 const { test, beforeAll, afterAll, deploy, destroy } = Test.make({
@@ -125,6 +126,14 @@ const put = (base: string, key: string, value: string) =>
         HttpClientRequest.bodyText(value),
       ),
     ),
+  );
+
+/** PUT `/put-stream?key=&sha256=`: the body is streamed into R2 under a declared hash. */
+const putStream = (base: string, key: string, body: string, sha256: string) =>
+  HttpClient.execute(
+    HttpClientRequest.put(
+      `${base}/put-stream?key=${encodeURIComponent(key)}&sha256=${sha256}`,
+    ).pipe(HttpClientRequest.bodyText(body)),
   );
 
 const del = (base: string, key: string) =>
@@ -266,6 +275,45 @@ test(
       out.readWriteBinding,
       out.readWriteBinding,
       true,
+    );
+  }).pipe(logLevel),
+  { timeout: TEST_TIMEOUT },
+);
+
+// A `put` given an Effect `Stream` goes through a `FixedLengthStream`, and
+// the options passed alongside it must still reach R2. Without them R2 has
+// nothing to verify and stores whatever bytes arrive under the declared
+// hash, which lets a caller plant content under a hash it does not have.
+test(
+  "native binding: a streamed put is verified against its declared sha256",
+  Effect.gen(function* () {
+    const out = yield* stack;
+    const value = "stream-value";
+    const sha256 = yield* Effect.sync(() =>
+      createHash("sha256").update(value).digest("hex"),
+    );
+
+    // Matching hash: stored and readable.
+    const ok = yield* untilOk(
+      putStream(out.writeBinding, "stream/ok", value, sha256),
+    );
+    expect(((yield* ok.json) as { stored: boolean }).stored).toBe(true);
+    expect(yield* expectValue(out.readBinding, "stream/ok", value)).toBe(value);
+
+    // Mismatched hash: R2 rejects the body and nothing is stored. The key is
+    // cleared first so a previous run cannot satisfy the final check.
+    yield* del(out.writeBinding, "stream/bad");
+    yield* expectMissing(out.readBinding, "stream/bad");
+    const bad = yield* putStream(
+      out.writeBinding,
+      "stream/bad",
+      value,
+      "0".repeat(64),
+    );
+    expect(bad.status).toBe(400);
+    expect(((yield* bad.json) as { stored: boolean }).stored).toBe(false);
+    expect((yield* headObject(out.readBinding, "stream/bad")).exists).toBe(
+      false,
     );
   }).pipe(logLevel),
   { timeout: TEST_TIMEOUT },

--- a/packages/alchemy/test/Cloudflare/R2/fixtures/write-binding.ts
+++ b/packages/alchemy/test/Cloudflare/R2/fixtures/write-binding.ts
@@ -16,6 +16,31 @@ export default class R2WriteBindingWorker extends Cloudflare.Worker<R2WriteBindi
       fetch: Effect.gen(function* () {
         const request = yield* HttpServerRequest;
         const url = new URL(request.url, "http://x");
+        // `PUT /put-stream?key=&sha256=` — `put(key, stream, { contentLength,
+        // sha256 })`: the body reaches R2 as an Effect `Stream`, and R2 must
+        // verify it against the declared hash. Only the native binding can
+        // stream, so this route is not part of the shared write routes.
+        if (request.method === "PUT" && url.pathname === "/put-stream") {
+          const key = url.searchParams.get("key") ?? "";
+          const sha256 = url.searchParams.get("sha256") ?? "";
+          const contentLength = Number(request.headers["content-length"] ?? 0);
+          return yield* r2
+            .put(key, request.stream, { contentLength, sha256 })
+            .pipe(
+              Effect.flatMap((object) =>
+                HttpServerResponse.json({
+                  stored: true,
+                  size: object?.size ?? null,
+                }),
+              ),
+              Effect.catchTag("R2Error", (e) =>
+                HttpServerResponse.json(
+                  { stored: false, error: e.message },
+                  { status: 400 },
+                ),
+              ),
+            );
+        }
         const handled = yield* writeRoutes(r2, request, url);
         return handled ?? HttpServerResponse.text("Not Found", { status: 404 });
       }),


### PR DESCRIPTION
`WriteBucketBinding.put` dropped every option when the value was an Effect `Stream`: the `FixedLengthStream` branch called `raw.put(key, readable)` with nothing else, so `sha256`, `md5`, `httpMetadata`, `customMetadata`, and `onlyIf` never reached R2. A caller declaring a hash got no verification, and R2 stored whatever bytes arrived under that key.

```diff
-          return raw.put(key, readable as any);
+          return raw.put(key, readable as any, r2Options);
```

`contentLength` is the only option that is ours, so it is split off and the rest is forwarded on both stream paths.

The binding fixture gains `PUT /put-stream?key=&sha256=`, which streams the request body with a declared hash, and `Binding.test.ts` uploads once with the right hash and once with a wrong one. Without the fix the wrong one answered 200 and the object existed; with it R2 rejects the body and nothing is stored.
