### PR TITLE
fix(railway): propagate lifecycle errors and reconcile observed state

### DIFF
--- a/packages/alchemy/src/Drizzle/Postgres.ts
+++ b/packages/alchemy/src/Drizzle/Postgres.ts
@@ -9,7 +9,7 @@ import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import type * as Redacted from "effect/Redacted";
 import { makeExecutionMemo } from "../Runtime/ExecutionMemo.ts";
-import { resolveSsl } from "../SQL/PostgresTls.ts";
+import { resolvePostgresConnection } from "../SQL/PostgresTls.ts";
 import { proxyChain } from "../Util/proxy-chain.ts";
 
 /**
@@ -67,7 +67,7 @@ export const Postgres = <
         );
         const url = yield* connectionString;
         const pgCtx = yield* Layer.build(
-          PgClient.layer({ url, ssl: resolveSsl(url, undefined) }),
+          PgClient.layer(resolvePostgresConnection(url)),
         );
         return yield* PgDrizzle.makeWithDefaults(config).pipe(
           Effect.provideContext(pgCtx),

--- a/packages/alchemy/src/Railway/AuditLog.ts
+++ b/packages/alchemy/src/Railway/AuditLog.ts
@@ -192,7 +192,7 @@ export const AuditLog = Effect.fn(function* (options?: ListAuditLogsOptions) {
       ...(filter !== undefined ? { filter } : {}),
     })
     .pipe(
-      Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
+      Effect.catchTag("NotFound", () =>
         Effect.succeed({
           edges: [] as { node: AuditLogsResponseEdgesItemNode }[],
         }),

--- a/packages/alchemy/src/Railway/Bucket.ts
+++ b/packages/alchemy/src/Railway/Bucket.ts
@@ -402,7 +402,7 @@ const resolveName = (id: string, name: string | undefined, existing?: string) =>
 const listProjectBuckets = (projectId: string) =>
   railway.project({ id: projectId }).pipe(
     Effect.map((project) => project.buckets.edges.map((edge) => edge.node)),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
+    Effect.catchTag("NotFound", () =>
       Effect.succeed([] as ProjectResponseBucketsEdgesItemNode[]),
     ),
   );
@@ -419,11 +419,11 @@ const getEnvironmentConfig = (environmentId: string, projectId: string) =>
   railway.environment({ id: environmentId, projectId }).pipe(
     Effect.map((env) => parseEnvironmentConfig(env.config)),
     Effect.retry({
-      while: (e) => e._tag === "RailwayNotFound" || e._tag === "NotFound",
+      while: (e) => e._tag === "NotFound",
       times: 8,
       schedule: Schedule.spaced("1 second"),
     }),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
+    Effect.catchTag("NotFound", () =>
       Effect.succeed({} as EnvironmentConfigShape),
     ),
   );
@@ -443,7 +443,7 @@ const environmentIdsOf = (project: {
       }
       return Array.from(set);
     }),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
+    Effect.catchTag("NotFound", () =>
       Effect.succeed(
         project.environmentId.length > 0 ? [project.environmentId] : [],
       ),
@@ -491,7 +491,7 @@ const ensureDeployed = Effect.fn(function* (input: {
     },
   }).pipe(
     Effect.retry({
-      while: (e) => e._tag === "RailwayNotFound" || e._tag === "NotFound",
+      while: (e) => e._tag === "NotFound",
       times: 8,
       schedule: Schedule.spaced("1 second"),
     }),
@@ -543,7 +543,7 @@ const fetchCredentials = (input: {
         }
         return Effect.succeed(first);
       }),
-      Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
+      Effect.catchTag("NotFound", () =>
         Effect.fail(new BucketCredentialsPending({ bucketId: input.bucketId })),
       ),
       Effect.retry({
@@ -716,8 +716,7 @@ export const BucketProvider = () =>
           })
           .pipe(
             Effect.retry({
-              while: (e) =>
-                e._tag === "RailwayNotFound" || e._tag === "NotFound",
+              while: (e) => e._tag === "NotFound",
               times: 8,
               schedule: Schedule.spaced("1 second"),
             }),
@@ -776,9 +775,7 @@ export const BucketProvider = () =>
             [bucketId]: { isDeleted: true },
           },
         },
-      }).pipe(
-        Effect.catchTag(["RailwayNotFound", "NotFound"], () => Effect.void),
-      );
+      }).pipe(Effect.catchTag("NotFound", () => Effect.void));
       if (projectId.length > 0) {
         yield* waitUntilGone({ bucketId, projectId, environmentId });
       }

--- a/packages/alchemy/src/Railway/Bucket.ts
+++ b/packages/alchemy/src/Railway/Bucket.ts
@@ -513,11 +513,6 @@ const ensureDeployed = Effect.fn(function* (input: {
       times: 8,
       schedule: Schedule.spaced("1 second"),
     }),
-    Effect.catchTag("Railway.BucketDeployPending", () =>
-      getEnvironmentConfig(input.environmentId, input.projectId).pipe(
-        Effect.map((next) => instanceOf(next, input.bucketId)),
-      ),
-    ),
   );
   return synced;
 });
@@ -551,10 +546,13 @@ const fetchCredentials = (input: {
         times: 8,
         schedule: Schedule.spaced("2 seconds"),
       }),
-      Effect.catchTag("Railway.BucketCredentialsPending", () =>
-        Effect.succeed(undefined),
-      ),
     );
+
+class BucketDeletionPending extends Data.TaggedError(
+  "Railway.BucketDeletionPending",
+)<{
+  bucketId: string;
+}> {}
 
 const waitUntilGone = (input: {
   bucketId: string;
@@ -563,9 +561,14 @@ const waitUntilGone = (input: {
 }) =>
   getEnvironmentConfig(input.environmentId, input.projectId).pipe(
     Effect.map((config) => !isDeployed(config, input.bucketId)),
-    Effect.repeat({
+    Effect.flatMap((gone) =>
+      gone
+        ? Effect.void
+        : Effect.fail(new BucketDeletionPending({ bucketId: input.bucketId })),
+    ),
+    Effect.retry({
       schedule: Schedule.spaced("1 second"),
-      until: (gone) => gone,
+      while: (error) => error._tag === "Railway.BucketDeletionPending",
       times: 8,
     }),
   );
@@ -720,7 +723,7 @@ export const BucketProvider = () =>
               times: 8,
               schedule: Schedule.spaced("1 second"),
             }),
-            Effect.catchTag("RailwayValidationError", () =>
+            Effect.catchTag(["RailwayAlreadyExists", "Conflict"], () =>
               Effect.succeed(undefined),
             ),
           );

--- a/packages/alchemy/src/Railway/CloudAgent.ts
+++ b/packages/alchemy/src/Railway/CloudAgent.ts
@@ -245,12 +245,7 @@ const listAgents = (environmentId: string) =>
     .cloudAgents({ environmentId, mine: true })
     .pipe(
       Effect.catchTag(
-        [
-          "RailwayNotFound",
-          "NotFound",
-          "RailwayForbidden",
-          "RailwayPlanLimitExceeded",
-        ],
+        ["NotFound", "RailwayForbidden", "RailwayPlanLimitExceeded"],
         () => Effect.succeed([] as CloudAgentsResultItem[]),
       ),
     );
@@ -282,7 +277,7 @@ const listEnvironmentIds = (project: {
       }
       return Array.from(set);
     }),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
+    Effect.catchTag("NotFound", () =>
       Effect.succeed(
         project.environmentId.length > 0 ? [project.environmentId] : [],
       ),
@@ -457,9 +452,7 @@ export const CloudAgentProvider = () =>
       if (cloudAgentId.length === 0) return;
       yield* railway
         .deleteCloudAgent({ id: cloudAgentId })
-        .pipe(
-          Effect.catchTag(["RailwayNotFound", "NotFound"], () => Effect.void),
-        );
+        .pipe(Effect.catchTag("NotFound", () => Effect.void));
       if (output.environmentId.length > 0) {
         yield* waitUntilGone(output.environmentId, cloudAgentId);
       }

--- a/packages/alchemy/src/Railway/CloudAgent.ts
+++ b/packages/alchemy/src/Railway/CloudAgent.ts
@@ -244,9 +244,8 @@ const listAgents = (environmentId: string) =>
   railway
     .cloudAgents({ environmentId, mine: true })
     .pipe(
-      Effect.catchTag(
-        ["NotFound", "RailwayForbidden", "RailwayPlanLimitExceeded"],
-        () => Effect.succeed([] as CloudAgentsResultItem[]),
+      Effect.catchTag("NotFound", () =>
+        Effect.succeed([] as CloudAgentsResultItem[]),
       ),
     );
 
@@ -430,7 +429,7 @@ export const CloudAgentProvider = () =>
             },
           })
           .pipe(
-            Effect.catchTag("RailwayValidationError", () =>
+            Effect.catchTag("RailwayAlreadyExists", () =>
               Effect.succeed(undefined),
             ),
           );

--- a/packages/alchemy/src/Railway/CustomDomain.ts
+++ b/packages/alchemy/src/Railway/CustomDomain.ts
@@ -242,9 +242,7 @@ const toAttrs = (
 const getById = (customDomainId: string, projectId: string) =>
   railway.customDomain({ id: customDomainId, projectId }).pipe(
     Effect.map((domain) => (isGone(domain) ? undefined : domain)),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-      Effect.succeed(undefined),
-    ),
+    Effect.catchTag("NotFound", () => Effect.succeed(undefined)),
   );
 
 const listServiceDomains = (
@@ -256,7 +254,7 @@ const listServiceDomains = (
     Effect.map((result) =>
       result.customDomains.filter((domain) => !isGone(domain)),
     ),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
+    Effect.catchTag("NotFound", () =>
       Effect.succeed([] as DomainsResponseCustomDomainsItem[]),
     ),
   );
@@ -334,11 +332,7 @@ export const CustomDomainProvider = () =>
         Effect.gen(function* () {
           const live = yield* railway
             .project({ id: project.projectId })
-            .pipe(
-              Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-                Effect.succeed(undefined),
-              ),
-            );
+            .pipe(Effect.catchTag("NotFound", () => Effect.succeed(undefined)));
           const services = (
             live?.services.edges.map((edge) => edge.node) ?? []
           ).filter(
@@ -517,9 +511,7 @@ export const CustomDomainProvider = () =>
       if (customDomainId.length === 0) return;
       yield* railway
         .deleteCustomDomain({ id: customDomainId })
-        .pipe(
-          Effect.catchTag(["RailwayNotFound", "NotFound"], () => Effect.void),
-        );
+        .pipe(Effect.catchTag("NotFound", () => Effect.void));
       if (projectId.length > 0) {
         yield* waitUntilGone(customDomainId, projectId);
       }

--- a/packages/alchemy/src/Railway/Function.ts
+++ b/packages/alchemy/src/Railway/Function.ts
@@ -661,17 +661,13 @@ const alreadyExists = (message: string) =>
 const getById = (serviceId: string) =>
   railway.service({ id: serviceId }).pipe(
     Effect.map((service) => (isGoneService(service) ? undefined : service)),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-      Effect.succeed(undefined),
-    ),
+    Effect.catchTag("NotFound", () => Effect.succeed(undefined)),
   );
 
 const getInstance = (environmentId: string, serviceId: string) =>
   railway.serviceInstance({ environmentId, serviceId }).pipe(
     Effect.map((instance) => (isGoneInstance(instance) ? undefined : instance)),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-      Effect.succeed(undefined),
-    ),
+    Effect.catchTag("NotFound", () => Effect.succeed(undefined)),
   );
 
 const listProjectServices = (projectId: string) =>
@@ -681,7 +677,7 @@ const listProjectServices = (projectId: string) =>
         .map((edge) => edge.node)
         .filter((node) => !isGoneService(node)),
     ),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
+    Effect.catchTag("NotFound", () =>
       Effect.succeed([] as ProjectResponseServicesEdgesItemNode[]),
     ),
   );
@@ -784,7 +780,7 @@ const listVariableMap = (
     })
     .pipe(
       Effect.map(asVariableMap),
-      Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
+      Effect.catchTag("NotFound", () =>
         Effect.succeed({} as Record<string, string>),
       ),
     );
@@ -1319,12 +1315,7 @@ export const FunctionProvider = () =>
                 ? { environmentId: output.environmentId }
                 : {}),
             })
-            .pipe(
-              Effect.catchTag(
-                ["RailwayNotFound", "NotFound"],
-                () => Effect.void,
-              ),
-            );
+            .pipe(Effect.catchTag(["NotFound"], () => Effect.void));
           yield* getById(serviceId).pipe(
             Effect.map((service) => service === undefined),
             Effect.repeat({

--- a/packages/alchemy/src/Railway/Function.ts
+++ b/packages/alchemy/src/Railway/Function.ts
@@ -13,6 +13,7 @@ import * as Effect from "effect/Effect";
 import type * as Redacted from "effect/Redacted";
 import * as FileSystem from "effect/FileSystem";
 import * as Schedule from "effect/Schedule";
+import * as Stream from "effect/Stream";
 import { Unowned } from "../AdoptPolicy.ts";
 import * as Bundle from "../Bundle/Bundle.ts";
 import { isResolved } from "../Diff.ts";
@@ -655,9 +656,6 @@ const deployReady = (status: string | undefined) =>
 const deployFailed = (status: string | undefined) =>
   status === "FAILED" || status === "CRASHED" || status === "REMOVED";
 
-const alreadyExists = (message: string) =>
-  /already exists|already in use|duplicate/i.test(message);
-
 const getById = (serviceId: string) =>
   railway.service({ id: serviceId }).pipe(
     Effect.map((service) => (isGoneService(service) ? undefined : service)),
@@ -699,29 +697,27 @@ const waitForInstance = (environmentId: string, serviceId: string) =>
     }),
     Effect.retry({
       while: (e) => e._tag === "Railway.FunctionPending",
-      times: 20,
+      times: 10,
       schedule: Schedule.spaced("2 seconds"),
     }),
-    Effect.catchTag("Railway.FunctionPending", () =>
-      getInstance(environmentId, serviceId),
-    ),
   );
 
 const fetchDeployLogs = (deploymentId: string | undefined) =>
   deploymentId === undefined || deploymentId.length === 0
     ? Effect.succeed("")
-    : railway.deploymentLogs({ deploymentId, limit: 80 }).pipe(
-        Effect.map((rows) =>
-          rows
-            .map((row) =>
-              row.severity != null
-                ? `[${row.severity}] ${row.message}`
-                : row.message,
-            )
-            .join("\n"),
-        ),
-        Effect.orElseSucceed(() => ""),
-      );
+    : railway
+        .deploymentLogs({ deploymentId, limit: 80 })
+        .pipe(
+          Effect.map((rows) =>
+            rows
+              .map((row) =>
+                row.severity != null
+                  ? `[${row.severity}] ${row.message}`
+                  : row.message,
+              )
+              .join("\n"),
+          ),
+        );
 
 const waitForDeployment = (environmentId: string, serviceId: string) =>
   Effect.gen(function* () {
@@ -747,8 +743,7 @@ const waitForDeployment = (environmentId: string, serviceId: string) =>
   }).pipe(
     Effect.retry({
       while: (e) => e._tag === "Railway.FunctionDeployPending",
-      // Queued builds under full-suite load can exceed 3 minutes — allow ~8.
-      times: 96,
+      times: 10,
       schedule: Schedule.spaced("5 seconds"),
     }),
   );
@@ -1038,21 +1033,35 @@ export const FunctionProvider = () =>
           const projects = yield* ownedProjects();
           const rows = yield* Effect.forEach(projects, (project) =>
             Effect.gen(function* () {
-              const services = yield* listProjectServices(project.projectId);
               const envIds = yield* projectEnvironmentIds(project);
-              const items = yield* Effect.forEach(
-                services.filter((service) =>
-                  matchesAlchemyPhysicalName(service.name),
-                ),
-                (service) =>
-                  Effect.gen(function* () {
-                    for (const environmentId of envIds) {
+              const items = yield* Effect.forEach(envIds, (environmentId) =>
+                Effect.gen(function* () {
+                  const candidates =
+                    yield* railway.listEnvironmentServiceInstances
+                      .items({ environmentId, first: 50 })
+                      .pipe(
+                        Stream.filter(
+                          (row) =>
+                            row.deletedAt == null &&
+                            isFunctionImage(row.source?.image ?? undefined),
+                        ),
+                        Stream.runCollect,
+                      );
+                  return yield* Effect.forEach(candidates, (candidate) =>
+                    Effect.gen(function* () {
+                      const service = yield* getById(candidate.serviceId);
+                      if (
+                        service === undefined ||
+                        !matchesAlchemyPhysicalName(service.name)
+                      )
+                        return undefined;
                       const instance = yield* getInstance(
                         environmentId,
                         service.id,
                       );
                       const image = instance?.source?.image ?? undefined;
-                      if (!isFunctionImage(image)) continue;
+                      if (instance === undefined || !isFunctionImage(image))
+                        return undefined;
                       return toAttrs({
                         service,
                         instance,
@@ -1064,11 +1073,11 @@ export const FunctionProvider = () =>
                         codeHash: "",
                         rpcToken: "",
                       });
-                    }
-                    return undefined;
-                  }),
+                    }),
+                  );
+                }),
               );
-              return items.filter((item) => item !== undefined);
+              return items.flat().filter((item) => item !== undefined);
             }),
           );
           return rows.flat();
@@ -1180,12 +1189,9 @@ export const FunctionProvider = () =>
                 },
               })
               .pipe(
-                Effect.catchTag("RailwayValidationError", (e) =>
-                  alreadyExists(e.message)
-                    ? Effect.succeed(undefined)
-                    : Effect.fail(e),
+                Effect.catchTag(["RailwayAlreadyExists", "Conflict"], () =>
+                  Effect.succeed(undefined),
                 ),
-                Effect.catchTag("Conflict", () => Effect.succeed(undefined)),
               );
             current = created ?? (yield* findByName(projectId, name));
           }
@@ -1258,14 +1264,10 @@ export const FunctionProvider = () =>
           });
 
           if (needsDeploy || instance?.latestDeployment == null) {
-            yield* railway
-              .serviceInstanceDeployV2({
-                environmentId,
-                serviceId: current.id,
-              })
-              .pipe(
-                Effect.catchTag("RailwayValidationError", () => Effect.void),
-              );
+            yield* railway.serviceInstanceDeployV2({
+              environmentId,
+              serviceId: current.id,
+            });
           }
 
           // Cron-only Functions sleep until the schedule. Waiting for

--- a/packages/alchemy/src/Railway/Group.ts
+++ b/packages/alchemy/src/Railway/Group.ts
@@ -146,13 +146,10 @@ const GroupResource = Resource<Group>("Railway.Group");
  * A Railway.Group organizes services, databases, volumes, and buckets on
  * the project canvas. IaC parity with `group("Backend", [api, worker, db])`.
  *
- * Groups have no dedicated create/delete mutation. Alchemy writes
- * `EnvironmentConfig.groups` (and `services[id].groupId`) via
- * `environmentPatchCommit`, matching Railway's own IaC compiler. Volume
- * membership is observed from `environment.canvasGroupRefs`. When Railway
- * does not persist a first-class Group id, the resource still records
- * member service/volume/bucket ids. `canvasViewMerge` /
- * `canvasViewMergePreview` copy canvas layout between environments.
+ * Alchemy creates groups through `environmentApplyChangeSet`, then updates
+ * membership and deletes groups by ID through `environmentPatchCommit`.
+ * It waits for the commit workflow and verifies persisted state before
+ * returning. Volume membership is observed from `environment.canvasGroupRefs`.
  *
  * @see https://docs.railway.com/infrastructure-as-code/reference
  *
@@ -242,6 +239,13 @@ export const Group: typeof GroupResource = Object.assign(
   ) => GroupResource(id, resolveGroupProps(props)),
   GroupResource,
 );
+
+export class GroupNotCreated extends Data.TaggedError(
+  "Railway.GroupNotCreated",
+)<{
+  groupId: string;
+  environmentId: string;
+}> {}
 
 export class GroupProjectRequired extends Data.TaggedError(
   "Railway.GroupProjectRequired",
@@ -557,22 +561,143 @@ const listEnvironmentIds = (project: {
     ),
   );
 
+export class GroupWorkflowFailed extends Data.TaggedError(
+  "Railway.GroupWorkflowFailed",
+)<{
+  workflowId: string;
+  status: string;
+  error: string | null;
+}> {}
+
+class GroupWorkflowPending extends Data.TaggedError(
+  "Railway.GroupWorkflowPending",
+)<{
+  workflowId: string;
+}> {}
+
+export class GroupApplyFailed extends Data.TaggedError(
+  "Railway.GroupApplyFailed",
+)<{
+  environmentId: string;
+  result: railway.EnvironmentApplyChangeSetResponse;
+}> {}
+
 const commitPatch = (input: {
+  projectId: string;
   environmentId: string;
   commitMessage: string;
-  patch: Record<string, unknown>;
+  patch: EnvironmentConfigShape;
 }) =>
   withEnvironmentConfigLock(
     input.environmentId,
-    railway.environmentPatchCommit({
-      environmentId: input.environmentId,
-      commitMessage: input.commitMessage,
-      patch: input.patch,
+    Effect.gen(function* () {
+      const creates = Object.entries(input.patch.groups ?? {}).flatMap(
+        ([id, group]) => {
+          if (group == null || !group.isCreated) return [];
+          const address = `group.${group.name ?? id}`;
+          const { isCreated, isDeleted, ...resource } = group;
+          return [
+            {
+              kind: "resource.create",
+              address,
+              resource: { type: "group", ...resource },
+              path: `resources.${address}`,
+              summary: input.commitMessage,
+              severity: "safe",
+              deployEffect: "none",
+            },
+          ];
+        },
+      );
+      // Legacy patches create no group; intent-level deletion reports noop.
+      if (creates.length > 0) {
+        const result = yield* railway.environmentApplyChangeSet({
+          environmentId: input.environmentId,
+          commitMessage: input.commitMessage,
+          waitForCompletion: true,
+          input: { version: 1, diagnostics: [], changes: creates },
+        });
+        if (result.status !== "applied") {
+          return yield* new GroupApplyFailed({
+            environmentId: input.environmentId,
+            result,
+          });
+        }
+      }
+      const config = yield* getEnvironmentConfig(
+        input.environmentId,
+        input.projectId,
+      );
+      const resolveGroupId = (id: string | null | undefined) => {
+        if (id == null || config.groups?.[id] != null) return id;
+        return (
+          Object.entries(config.groups ?? {}).find(
+            ([, row]) => row?.name === id,
+          )?.[0] ?? id
+        );
+      };
+      const groups: Record<string, GroupConfig> = {};
+      for (const [id, group] of Object.entries(input.patch.groups ?? {})) {
+        if (group == null) continue;
+        const resolvedId = resolveGroupId(id)!;
+        if (group.isCreated && config.groups?.[resolvedId] == null) {
+          return yield* new GroupNotCreated({
+            groupId: id,
+            environmentId: input.environmentId,
+          });
+        }
+        const { isCreated, ...properties } = group;
+        groups[resolvedId] = properties;
+      }
+      const patch: EnvironmentConfigShape = {
+        ...input.patch,
+        groups,
+        services: Object.fromEntries(
+          Object.entries(input.patch.services ?? {}).map(([id, row]) => [
+            id,
+            row == null
+              ? row
+              : { ...row, groupId: resolveGroupId(row.groupId) },
+          ]),
+        ),
+        buckets: Object.fromEntries(
+          Object.entries(input.patch.buckets ?? {}).map(([id, row]) => [
+            id,
+            row == null
+              ? row
+              : { ...row, groupId: resolveGroupId(row.groupId) },
+          ]),
+        ),
+      };
+      const workflowId = yield* railway.environmentPatchCommit({
+        environmentId: input.environmentId,
+        commitMessage: input.commitMessage,
+        patch,
+      });
+      yield* railway.workflowStatus({ workflowId }).pipe(
+        Effect.flatMap((result) =>
+          result.status === "Running"
+            ? Effect.fail(new GroupWorkflowPending({ workflowId }))
+            : Effect.succeed(result),
+        ),
+        Effect.retry({
+          while: (error) => error._tag === "Railway.GroupWorkflowPending",
+          times: 10,
+          schedule: Schedule.spaced("2 seconds"),
+        }),
+        Effect.flatMap((result) =>
+          result.status === "Complete" && result.error == null
+            ? Effect.void
+            : Effect.fail(
+                new GroupWorkflowFailed({
+                  workflowId,
+                  status: result.status,
+                  error: result.error,
+                }),
+              ),
+        ),
+      );
     }),
-  ).pipe(
-    Effect.catchTag(["RailwayValidationError", "RailwayInternalError"], () =>
-      Effect.succeed(""),
-    ),
   );
 
 const previewCanvas = (environmentId: string) =>
@@ -581,28 +706,16 @@ const previewCanvas = (environmentId: string) =>
       sourceEnvironmentId: environmentId,
       targetEnvironmentId: environmentId,
     })
-    .pipe(
-      Effect.catchTag(
-        ["NotFound", "RailwayValidationError", "RailwayInternalError"],
-        () => Effect.succeed(undefined),
-      ),
-    );
+    .pipe(Effect.catchTag("NotFound", () => Effect.succeed(undefined)));
 
 const mergeCanvas = (
   sourceEnvironmentId: string,
   targetEnvironmentId: string,
 ) =>
-  railway
-    .mergeCanvasView({
-      sourceEnvironmentId,
-      targetEnvironmentId,
-    })
-    .pipe(
-      Effect.catchTag(
-        ["NotFound", "RailwayValidationError", "RailwayInternalError"],
-        () => Effect.succeed(false),
-      ),
-    );
+  railway.mergeCanvasView({
+    sourceEnvironmentId,
+    targetEnvironmentId,
+  });
 
 const projectGroups = (project: ProjectResponse | undefined) =>
   project?.groups.edges.map((edge) => edge.node) ?? [];
@@ -741,18 +854,9 @@ const waitUntilPresent = (input: {
     }),
     Effect.retry({
       while: (e) => e._tag === "Railway.GroupPending",
-      times: 4,
+      times: 10,
       schedule: Schedule.spaced("1 second"),
     }),
-    Effect.catchTag("Railway.GroupPending", () =>
-      observe({
-        projectId: input.projectId,
-        environmentId: input.environmentId,
-        groupId: input.groupId,
-        name: input.name,
-        volumeIds: input.volumeIds,
-      }),
-    ),
   );
 
 const waitUntilGone = (input: {
@@ -767,11 +871,17 @@ const waitUntilGone = (input: {
     groupId: input.groupId,
     name: input.name,
   }).pipe(
-    Effect.map((group) => group === undefined),
-    Effect.repeat({
+    Effect.flatMap((group) =>
+      group === undefined
+        ? Effect.void
+        : Effect.fail(
+            new GroupPending({ groupId: input.groupId, state: "deleting" }),
+          ),
+    ),
+    Effect.retry({
       schedule: Schedule.spaced("1 second"),
-      until: (gone) => gone,
-      times: 4,
+      while: (error) => error._tag === "Railway.GroupPending",
+      times: 10,
     }),
   );
 
@@ -825,8 +935,8 @@ const membershipPatch = (input: {
   remove?: boolean;
   services?: ReadonlyArray<{ serviceId: string; groupId: string | null }>;
   buckets?: ReadonlyArray<{ bucketId: string; groupId: string | null }>;
-}): Record<string, unknown> => {
-  const patch: Record<string, unknown> = {
+}): EnvironmentConfigShape => {
+  const patch: EnvironmentConfigShape = {
     groups: groupPatch(input),
   };
   if (input.services !== undefined && input.services.length > 0) {
@@ -837,26 +947,6 @@ const membershipPatch = (input: {
   }
   return patch;
 };
-
-const fallbackGroup = (input: {
-  groupId: string;
-  name: string;
-  color?: string;
-  icon?: string;
-  collapsed: boolean;
-  serviceIds: readonly string[];
-  volumeIds: readonly string[];
-  bucketIds: readonly string[];
-}): CloudGroup => ({
-  groupId: input.groupId,
-  name: input.name,
-  color: input.color,
-  icon: input.icon,
-  collapsed: input.collapsed,
-  serviceIds: uniqueSorted(input.serviceIds),
-  volumeIds: uniqueSorted(input.volumeIds),
-  bucketIds: uniqueSorted(input.bucketIds),
-});
 
 export const GroupProvider = () =>
   Provider.succeed(Group, {
@@ -910,36 +1000,53 @@ export const GroupProvider = () =>
     list: Effect.fn(function* () {
       const projects = yield* ownedProjects();
       const rows = yield* Effect.forEach(projects, (project) =>
-        railway.project({ id: project.projectId }).pipe(
-          Effect.map((live) =>
-            live.groups.edges.flatMap((edge) => {
-              const group = edge.node;
-              const name = group.name ?? "";
-              if (!matchesAlchemyPhysicalName(name)) return [];
-              return [
-                toAttrs(
-                  {
-                    groupId: group.id,
-                    name,
-                    color: group.color ?? undefined,
-                    icon: group.icon ?? undefined,
-                    collapsed: group.isCollapsed === true,
-                    serviceIds: [] as string[],
-                    volumeIds: [] as string[],
-                    bucketIds: [] as string[],
-                  },
-                  {
-                    projectId: project.projectId,
-                    environmentId: project.environmentId,
-                  },
-                ),
-              ];
-            }),
-          ),
-          Effect.catchTag("NotFound", () =>
-            Effect.succeed([] as Group["Attributes"][]),
-          ),
-        ),
+        Effect.gen(function* () {
+          const environmentIds = yield* listEnvironmentIds(project);
+          const groups = yield* Effect.forEach(
+            environmentIds,
+            (environmentId) =>
+              Effect.gen(function* () {
+                const env = yield* getEnvironment(
+                  environmentId,
+                  project.projectId,
+                );
+                if (env === undefined) return [];
+                const config = parseEnvironmentConfig(env.config);
+                const refs = parseCanvasGroupRefs(env.canvasGroupRefs);
+                const volumeIds = new Set(volumeIdsOf(env));
+                const found: Group["Attributes"][] = [];
+                for (const [groupId, row] of Object.entries(
+                  config.groups ?? {},
+                )) {
+                  if (
+                    row == null ||
+                    row.isDeleted ||
+                    !matchesAlchemyPhysicalName(row.name ?? "")
+                  )
+                    continue;
+                  found.push(
+                    toAttrs(
+                      {
+                        groupId,
+                        name: row.name!,
+                        color: optionalString(row.color),
+                        icon: optionalString(row.icon),
+                        collapsed: row.isCollapsed === true,
+                        serviceIds: servicesForGroup(config, groupId),
+                        bucketIds: bucketsForGroup(config, groupId),
+                        volumeIds: idsForGroup(refs, groupId).filter((id) =>
+                          volumeIds.has(id),
+                        ),
+                      },
+                      { projectId: project.projectId, environmentId },
+                    ),
+                  );
+                }
+                return found;
+              }),
+          );
+          return groups.flat();
+        }),
       );
       const seen = new Set<string>();
       const unique: Group["Attributes"][] = [];
@@ -989,6 +1096,7 @@ export const GroupProvider = () =>
 
       if (current === undefined) {
         yield* commitPatch({
+          projectId,
           environmentId,
           commitMessage: `Alchemy: create group ${name}`,
           patch: membershipPatch({
@@ -1006,6 +1114,7 @@ export const GroupProvider = () =>
         });
         if (desired.bucketIds.length > 0) {
           yield* commitPatch({
+            projectId,
             environmentId,
             commitMessage: `Alchemy: assign buckets to group ${name}`,
             patch: {
@@ -1078,6 +1187,7 @@ export const GroupProvider = () =>
               })),
           ];
           yield* commitPatch({
+            projectId,
             environmentId,
             commitMessage: `Alchemy: update group ${name}`,
             patch: membershipPatch({
@@ -1115,29 +1225,10 @@ export const GroupProvider = () =>
         volumeIds: desired.volumeIds,
       });
 
-      const resolved = observed ?? current;
-      return toAttrs(
-        fallbackGroup({
-          groupId: resolved?.groupId ?? groupId,
-          name: resolved?.name || name,
-          color: props.color ?? resolved?.color,
-          icon: props.icon ?? resolved?.icon,
-          collapsed: resolved?.collapsed ?? collapsed,
-          serviceIds:
-            resolved !== undefined && resolved.serviceIds.length > 0
-              ? resolved.serviceIds
-              : desired.serviceIds,
-          volumeIds: uniqueSorted([
-            ...(resolved?.volumeIds ?? []),
-            ...desired.volumeIds,
-          ]),
-          bucketIds: uniqueSorted([
-            ...(resolved?.bucketIds ?? []),
-            ...desired.bucketIds,
-          ]),
-        }),
-        { projectId, environmentId },
-      );
+      if (observed === undefined) {
+        return yield* new GroupNotCreated({ groupId, environmentId });
+      }
+      return toAttrs(observed, { projectId, environmentId });
     }),
 
     delete: Effect.fn(function* ({ output }) {
@@ -1154,6 +1245,7 @@ export const GroupProvider = () =>
       });
       if (current === undefined) return;
       yield* commitPatch({
+        projectId,
         environmentId,
         commitMessage: `Alchemy: delete group ${output.name}`,
         patch: membershipPatch({

--- a/packages/alchemy/src/Railway/Group.ts
+++ b/packages/alchemy/src/Railway/Group.ts
@@ -516,7 +516,7 @@ const resolveName = (id: string, name: string | undefined, existing?: string) =>
 const getProject = (projectId: string) =>
   railway.project({ id: projectId }).pipe(
     Effect.map((project) => (project.deletedAt != null ? undefined : project)),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
+    Effect.catchTag("NotFound", () =>
       Effect.succeed(undefined as ProjectResponse | undefined),
     ),
   );
@@ -524,11 +524,7 @@ const getProject = (projectId: string) =>
 const getEnvironment = (environmentId: string, projectId: string) =>
   railway
     .environment({ id: environmentId, projectId })
-    .pipe(
-      Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-        Effect.succeed(undefined),
-      ),
-    );
+    .pipe(Effect.catchTag("NotFound", () => Effect.succeed(undefined)));
 
 const getEnvironmentConfig = (environmentId: string, projectId: string) =>
   getEnvironment(environmentId, projectId).pipe(
@@ -554,7 +550,7 @@ const listEnvironmentIds = (project: {
       }
       return Array.from(set);
     }),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
+    Effect.catchTag("NotFound", () =>
       Effect.succeed(
         project.environmentId.length > 0 ? [project.environmentId] : [],
       ),
@@ -587,12 +583,7 @@ const previewCanvas = (environmentId: string) =>
     })
     .pipe(
       Effect.catchTag(
-        [
-          "RailwayNotFound",
-          "NotFound",
-          "RailwayValidationError",
-          "RailwayInternalError",
-        ],
+        ["NotFound", "RailwayValidationError", "RailwayInternalError"],
         () => Effect.succeed(undefined),
       ),
     );
@@ -608,12 +599,7 @@ const mergeCanvas = (
     })
     .pipe(
       Effect.catchTag(
-        [
-          "RailwayNotFound",
-          "NotFound",
-          "RailwayValidationError",
-          "RailwayInternalError",
-        ],
+        ["NotFound", "RailwayValidationError", "RailwayInternalError"],
         () => Effect.succeed(false),
       ),
     );
@@ -950,7 +936,7 @@ export const GroupProvider = () =>
               ];
             }),
           ),
-          Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
+          Effect.catchTag("NotFound", () =>
             Effect.succeed([] as Group["Attributes"][]),
           ),
         ),
@@ -1185,11 +1171,7 @@ export const GroupProvider = () =>
             groupId: null,
           })),
         }),
-      }).pipe(
-        Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-          Effect.succeed(""),
-        ),
-      );
+      }).pipe(Effect.catchTag("NotFound", () => Effect.succeed("")));
       if (projectId.length > 0) {
         yield* waitUntilGone({
           projectId,

--- a/packages/alchemy/src/Railway/LoginSession.ts
+++ b/packages/alchemy/src/Railway/LoginSession.ts
@@ -78,7 +78,7 @@ const LOGIN_POLL_TIMES = 300;
  * Exhaustion returns `undefined` (not a failure) so the AuthProvider can
  * surface a timeout rather than a poll error.
  */
-const missingSession = ["RailwayNotFound", "NotFound"] as const;
+const missingSession = ["NotFound"] as const;
 
 export const pollLoginSessionToken = (
   code: string,

--- a/packages/alchemy/src/Railway/Mongo.ts
+++ b/packages/alchemy/src/Railway/Mongo.ts
@@ -536,17 +536,13 @@ const toAttrs = (input: {
 const getById = (serviceId: string) =>
   railway.service({ id: serviceId }).pipe(
     Effect.map((service) => (isGoneService(service) ? undefined : service)),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-      Effect.succeed(undefined),
-    ),
+    Effect.catchTag("NotFound", () => Effect.succeed(undefined)),
   );
 
 const getInstance = (environmentId: string, serviceId: string) =>
   railway.serviceInstance({ environmentId, serviceId }).pipe(
     Effect.map((instance) => (isGoneInstance(instance) ? undefined : instance)),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-      Effect.succeed(undefined),
-    ),
+    Effect.catchTag("NotFound", () => Effect.succeed(undefined)),
   );
 
 const listProjectServices = (projectId: string) =>
@@ -556,7 +552,7 @@ const listProjectServices = (projectId: string) =>
         .map((edge) => edge.node)
         .filter((node) => !isGoneService(node)),
     ),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
+    Effect.catchTag("NotFound", () =>
       Effect.succeed([] as ProjectResponseServicesEdgesItemNode[]),
     ),
   );
@@ -569,9 +565,7 @@ const findByName = (projectId: string, name: string) =>
 const getVolumeByInstanceId = (volumeInstanceId: string) =>
   railway.volumeInstance({ id: volumeInstanceId }).pipe(
     Effect.map((instance) => (isGoneVolume(instance) ? undefined : instance)),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-      Effect.succeed(undefined),
-    ),
+    Effect.catchTag("NotFound", () => Effect.succeed(undefined)),
   );
 
 const listVolumeInstances = (environmentId: string, projectId: string) =>
@@ -583,7 +577,7 @@ const listVolumeInstances = (environmentId: string, projectId: string) =>
             .map((edge) => edge.node)
             .filter((node) => !isGoneVolume(node)),
     ),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
+    Effect.catchTag("NotFound", () =>
       Effect.succeed([] as EnvironmentResponseVolumeInstancesEdgesItemNode[]),
     ),
   );
@@ -600,7 +594,7 @@ const findVolume = (
 const listProxies = (environmentId: string, serviceId: string) =>
   railway.tcpProxies({ environmentId, serviceId }).pipe(
     Effect.map((items) => items.filter((proxy) => !isGoneProxy(proxy))),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
+    Effect.catchTag("NotFound", () =>
       Effect.succeed([] as TcpProxiesResultItem[]),
     ),
   );
@@ -630,7 +624,7 @@ const deleteProxy = (id: string) =>
       schedule: Schedule.spaced("3 seconds"),
       times: 20,
     }),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () => Effect.void),
+    Effect.catchTag("NotFound", () => Effect.void),
     Effect.asVoid,
   );
 
@@ -661,7 +655,7 @@ const listVariableMap = (
     })
     .pipe(
       Effect.map(asVariableMap),
-      Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
+      Effect.catchTag("NotFound", () =>
         Effect.succeed({} as Record<string, string>),
       ),
     );
@@ -927,9 +921,7 @@ export const MongoProvider = () =>
               Stream.filter((env) => env.deletedAt == null),
               Stream.runCollect,
               Effect.map((chunk) => Array.from(chunk)),
-              Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-                Effect.succeed([]),
-              ),
+              Effect.catchTag("NotFound", () => Effect.succeed([])),
             );
           const volumes = envRows.flatMap((env) =>
             env.volumeInstances.edges.map((edge) => edge.node),
@@ -1279,9 +1271,7 @@ export const MongoProvider = () =>
             id: serviceId,
             ...(environmentId.length > 0 ? { environmentId } : {}),
           })
-          .pipe(
-            Effect.catchTag(["RailwayNotFound", "NotFound"], () => Effect.void),
-          );
+          .pipe(Effect.catchTag("NotFound", () => Effect.void));
         yield* getById(serviceId).pipe(
           Effect.map((service) => service === undefined),
           Effect.repeat({
@@ -1314,9 +1304,7 @@ export const MongoProvider = () =>
       if (output.volumeId.length > 0) {
         yield* railway
           .deleteVolume({ volumeId: output.volumeId })
-          .pipe(
-            Effect.catchTag(["RailwayNotFound", "NotFound"], () => Effect.void),
-          );
+          .pipe(Effect.catchTag("NotFound", () => Effect.void));
         const check =
           output.volumeInstanceId.length > 0
             ? getVolumeByInstanceId(output.volumeInstanceId).pipe(

--- a/packages/alchemy/src/Railway/Mongo.ts
+++ b/packages/alchemy/src/Railway/Mongo.ts
@@ -408,9 +408,6 @@ const isGoneProxy = (proxy: CloudProxy | undefined) =>
 
 const normalizeDomain = (domain: string) => domain.replace(/\.+$/, "");
 
-const alreadyExists = (message: string) =>
-  /already exists|already in use|duplicate/i.test(message);
-
 const sameImage = (observed: string | null | undefined, desired: string) => {
   if (observed == null || observed.length === 0) return false;
   if (observed === desired) return true;
@@ -622,7 +619,7 @@ const deleteProxy = (id: string) =>
         e._tag === "RailwayInternalError" &&
         e.message.includes("operation is already in progress"),
       schedule: Schedule.spaced("3 seconds"),
-      times: 20,
+      times: 10,
     }),
     Effect.catchTag("NotFound", () => Effect.void),
     Effect.asVoid,
@@ -715,40 +712,34 @@ const waitForInstance = (environmentId: string, serviceId: string) =>
     }),
     Effect.retry({
       while: (e) => e._tag === "Railway.MongoPending",
-      // serviceCreate fans the instance out to each environment
-      // asynchronously; under full-suite load the fan-out can take minutes.
-      times: 60,
+      times: 10,
       schedule: Schedule.spaced("2 seconds"),
     }),
-    Effect.catchTag("Railway.MongoPending", () =>
-      getInstance(environmentId, serviceId),
-    ),
   );
 
 const waitForDeployment = (environmentId: string, serviceId: string) =>
-  getInstance(environmentId, serviceId).pipe(
-    Effect.flatMap((instance) => {
-      const latest = instance?.latestDeployment;
-      const status = latest?.status;
-      if (instance !== undefined && deployReady(status)) {
-        return Effect.succeed(instance);
-      }
-      return Effect.fail(
-        new MongoDeployPending({
-          serviceId,
-          status: status ?? "pending",
-        }),
-      );
-    }),
+  Effect.gen(function* () {
+    const instance = yield* getInstance(environmentId, serviceId);
+    const latest = instance?.latestDeployment;
+    const status = latest?.status;
+    if (instance !== undefined && deployReady(status)) return instance;
+    if (status !== undefined && deployFailed(status)) {
+      return yield* new MongoDeployFailed({
+        serviceId,
+        status,
+        deploymentId: latest?.id,
+      });
+    }
+    return yield* new MongoDeployPending({
+      serviceId,
+      status: status ?? "pending",
+    });
+  }).pipe(
     Effect.retry({
       while: (e) => e._tag === "Railway.MongoDeployPending",
-      // Queued builds under full-suite load can exceed 3 minutes — allow ~8.
-      times: 96,
+      times: 10,
       schedule: Schedule.spaced("5 seconds"),
     }),
-    Effect.catchTag("Railway.MongoDeployPending", () =>
-      getInstance(environmentId, serviceId),
-    ),
   );
 
 const waitForVolume = (
@@ -782,7 +773,6 @@ const waitForVolume = (
       times: 10,
       schedule: Schedule.spaced("3 seconds"),
     }),
-    Effect.catchTag("Railway.MongoVolumePending", () => observe),
   );
 };
 
@@ -799,22 +789,38 @@ const stampVolumeName = (volumeId: string, name: string) =>
 export const pingMongo = (
   url: string,
 ): Effect.Effect<{ ok: number }, MongoCommandError> =>
-  Effect.tryPromise({
-    try: async () => {
-      const { MongoClient } = await import("mongodb");
-      const client = new MongoClient(url, {
-        directConnection: true,
-        serverSelectionTimeoutMS: 8000,
-      });
-      try {
-        await client.connect();
-        const result = await client.db("admin").command({ ping: 1 });
-        return { ok: Number(result.ok) };
-      } finally {
-        await client.close().catch(() => {});
-      }
-    },
-    catch: (cause) => new MongoCommandError({ cause }),
+  Effect.gen(function* () {
+    const { MongoClient } = yield* Effect.tryPromise({
+      try: () => import("mongodb"),
+      catch: (cause) => new MongoCommandError({ cause }),
+    });
+    return yield* Effect.acquireUseRelease(
+      Effect.try({
+        try: () =>
+          new MongoClient(url, {
+            directConnection: true,
+            serverSelectionTimeoutMS: 8000,
+          }),
+        catch: (cause) => new MongoCommandError({ cause }),
+      }),
+      (client) =>
+        Effect.gen(function* () {
+          yield* Effect.tryPromise({
+            try: () => client.connect(),
+            catch: (cause) => new MongoCommandError({ cause }),
+          });
+          const result = yield* Effect.tryPromise({
+            try: () => client.db("admin").command({ ping: 1 }),
+            catch: (cause) => new MongoCommandError({ cause }),
+          });
+          return { ok: Number(result.ok) };
+        }),
+      (client) =>
+        Effect.tryPromise({
+          try: () => client.close(),
+          catch: (cause) => new MongoCommandError({ cause }),
+        }),
+    );
   });
 
 export const MongoProvider = () =>
@@ -914,7 +920,6 @@ export const MongoProvider = () =>
       const projects = yield* ownedProjects();
       const rows = yield* Effect.forEach(projects, (project) =>
         Effect.gen(function* () {
-          const services = yield* listProjectServices(project.projectId);
           const envRows = yield* railway.environments
             .items({ projectId: project.projectId, first: 50 })
             .pipe(
@@ -926,44 +931,33 @@ export const MongoProvider = () =>
           const volumes = envRows.flatMap((env) =>
             env.volumeInstances.edges.map((edge) => edge.node),
           );
-          const items = yield* Effect.forEach(
-            services.filter((service) =>
-              matchesAlchemyPhysicalName(service.name),
-            ),
-            (service) =>
-              Effect.gen(function* () {
-                const volume = volumes.find(
-                  (row) => (row.serviceId ?? undefined) === service.id,
-                );
-                const envIds =
-                  volume !== undefined
-                    ? [volume.environmentId]
-                    : envRows.map((env) => env.id);
-                let instance: ServiceInstanceResponse | undefined;
-                let environmentId = project.environmentId;
-                for (const id of envIds) {
-                  const candidate = yield* getInstance(id, service.id);
-                  if (isMongoImage(candidate?.source?.image)) {
-                    instance = candidate;
-                    environmentId = id;
-                    break;
-                  }
-                }
-                if (!isMongoImage(instance?.source?.image)) {
-                  return undefined;
-                }
-                return toAttrs({
-                  service,
-                  instance,
-                  volume,
-                  proxy: undefined,
-                  projectId: project.projectId,
-                  environmentId,
-                  user: DEFAULT_MONGO_USER,
-                  password: "",
-                  database: DEFAULT_MONGO_DATABASE,
-                });
-              }),
+          const items = yield* Effect.forEach(volumes, (volume) =>
+            Effect.gen(function* () {
+              if (volume.serviceId == null) return undefined;
+              const environmentId = volume.environmentId;
+              const instance = yield* getInstance(
+                environmentId,
+                volume.serviceId,
+              );
+              if (!isMongoImage(instance?.source?.image)) return undefined;
+              const service = yield* getById(volume.serviceId);
+              if (
+                service === undefined ||
+                !matchesAlchemyPhysicalName(service.name)
+              )
+                return undefined;
+              return toAttrs({
+                service,
+                instance,
+                volume,
+                proxy: undefined,
+                projectId: project.projectId,
+                environmentId,
+                user: DEFAULT_MONGO_USER,
+                password: "",
+                database: DEFAULT_MONGO_DATABASE,
+              });
+            }),
           );
           return items.filter((item) => item !== undefined);
         }),
@@ -1034,12 +1028,9 @@ export const MongoProvider = () =>
             },
           })
           .pipe(
-            Effect.catchTag("RailwayValidationError", (e) =>
-              alreadyExists(e.message)
-                ? Effect.succeed(undefined)
-                : Effect.fail(e),
+            Effect.catchTag(["RailwayAlreadyExists", "Conflict"], () =>
+              Effect.succeed(undefined),
             ),
-            Effect.catchTag("Conflict", () => Effect.succeed(undefined)),
           );
         current = created ?? (yield* findByName(projectId, name));
       }
@@ -1171,19 +1162,13 @@ export const MongoProvider = () =>
 
       let proxy = yield* findProxy(environmentId, current.id, MONGO_PORT);
       if (wantPublic && proxy === undefined) {
-        const created = yield* railway
-          .createTcpProxy({
-            input: {
-              applicationPort: MONGO_PORT,
-              environmentId,
-              serviceId: current.id,
-            },
-          })
-          .pipe(
-            Effect.catchTag("RailwayValidationError", () =>
-              Effect.succeed(undefined),
-            ),
-          );
+        const created = yield* railway.createTcpProxy({
+          input: {
+            applicationPort: MONGO_PORT,
+            environmentId,
+            serviceId: current.id,
+          },
+        });
         proxy =
           created !== undefined && !isGoneProxy(created)
             ? created
@@ -1195,40 +1180,13 @@ export const MongoProvider = () =>
       }
 
       if (needsDeploy || instance?.latestDeployment == null) {
-        yield* railway
-          .serviceInstanceDeployV2({
-            environmentId,
-            serviceId: current.id,
-          })
-          .pipe(Effect.catchTag("RailwayValidationError", () => Effect.void));
-      }
-
-      instance =
-        (yield* waitForDeployment(environmentId, current.id)) ?? instance;
-      let finalStatus = instance?.latestDeployment?.status;
-      // A deployment can wedge in DEPLOYING and never reach SUCCESS — the
-      // container may serve, but Railway keeps its per-environment operation
-      // lock and the TCP proxy's routing is not committed. Converge: cancel
-      // the wedged deployment, redeploy once, and insist on SUCCESS.
-      if (!deployFailed(finalStatus) && !deployReady(finalStatus)) {
-        const wedged = instance?.latestDeployment?.id;
-        if (wedged != null && wedged.length > 0) {
-          yield* railway.cancelDeployment({ id: wedged }).pipe(Effect.ignore);
-        }
-        yield* railway
-          .serviceInstanceDeployV2({ environmentId, serviceId: current.id })
-          .pipe(Effect.catchTag("RailwayValidationError", () => Effect.void));
-        instance =
-          (yield* waitForDeployment(environmentId, current.id)) ?? instance;
-        finalStatus = instance?.latestDeployment?.status;
-      }
-      if (deployFailed(finalStatus) || !deployReady(finalStatus)) {
-        return yield* new MongoDeployFailed({
+        yield* railway.serviceInstanceDeployV2({
+          environmentId,
           serviceId: current.id,
-          status: finalStatus ?? "failed",
-          deploymentId: instance?.latestDeployment?.id,
         });
       }
+
+      instance = yield* waitForDeployment(environmentId, current.id);
 
       return toAttrs({
         service: current,
@@ -1261,7 +1219,7 @@ export const MongoProvider = () =>
         ) {
           yield* railway
             .cancelDeployment({ id: latest.id })
-            .pipe(Effect.ignore);
+            .pipe(Effect.catchTag("NotFound", () => Effect.void));
         }
       }
       // Delete the SERVICE next — its teardown cascades onto the proxies.
@@ -1289,7 +1247,7 @@ export const MongoProvider = () =>
           Effect.repeat({
             schedule: Schedule.spaced("3 seconds"),
             until: (rows) => rows.length === 0,
-            times: 20,
+            times: 10,
           }),
         );
         yield* Effect.forEach(leftover, (proxy) => deleteProxy(proxy.id), {

--- a/packages/alchemy/src/Railway/MySQL.ts
+++ b/packages/alchemy/src/Railway/MySQL.ts
@@ -536,17 +536,13 @@ const toAttrs = (input: {
 const getById = (serviceId: string) =>
   railway.service({ id: serviceId }).pipe(
     Effect.map((service) => (isGoneService(service) ? undefined : service)),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-      Effect.succeed(undefined),
-    ),
+    Effect.catchTag("NotFound", () => Effect.succeed(undefined)),
   );
 
 const getInstance = (environmentId: string, serviceId: string) =>
   railway.serviceInstance({ environmentId, serviceId }).pipe(
     Effect.map((instance) => (isGoneInstance(instance) ? undefined : instance)),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-      Effect.succeed(undefined),
-    ),
+    Effect.catchTag("NotFound", () => Effect.succeed(undefined)),
   );
 
 const listProjectServices = (projectId: string) =>
@@ -556,7 +552,7 @@ const listProjectServices = (projectId: string) =>
         .map((edge) => edge.node)
         .filter((node) => !isGoneService(node)),
     ),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
+    Effect.catchTag("NotFound", () =>
       Effect.succeed([] as ProjectResponseServicesEdgesItemNode[]),
     ),
   );
@@ -569,9 +565,7 @@ const findByName = (projectId: string, name: string) =>
 const getVolumeByInstanceId = (volumeInstanceId: string) =>
   railway.volumeInstance({ id: volumeInstanceId }).pipe(
     Effect.map((instance) => (isGoneVolume(instance) ? undefined : instance)),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-      Effect.succeed(undefined),
-    ),
+    Effect.catchTag("NotFound", () => Effect.succeed(undefined)),
   );
 
 const listVolumeInstances = (environmentId: string, projectId: string) =>
@@ -583,7 +577,7 @@ const listVolumeInstances = (environmentId: string, projectId: string) =>
             .map((edge) => edge.node)
             .filter((node) => !isGoneVolume(node)),
     ),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
+    Effect.catchTag("NotFound", () =>
       Effect.succeed([] as EnvironmentResponseVolumeInstancesEdgesItemNode[]),
     ),
   );
@@ -600,7 +594,7 @@ const findVolume = (
 const listProxies = (environmentId: string, serviceId: string) =>
   railway.tcpProxies({ environmentId, serviceId }).pipe(
     Effect.map((items) => items.filter((proxy) => !isGoneProxy(proxy))),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
+    Effect.catchTag("NotFound", () =>
       Effect.succeed([] as TcpProxiesResultItem[]),
     ),
   );
@@ -630,7 +624,7 @@ const deleteProxy = (id: string) =>
       schedule: Schedule.spaced("3 seconds"),
       times: 20,
     }),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () => Effect.void),
+    Effect.catchTag("NotFound", () => Effect.void),
     Effect.asVoid,
   );
 
@@ -661,7 +655,7 @@ const listVariableMap = (
     })
     .pipe(
       Effect.map(asVariableMap),
-      Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
+      Effect.catchTag("NotFound", () =>
         Effect.succeed({} as Record<string, string>),
       ),
     );
@@ -925,9 +919,7 @@ export const MySQLProvider = () =>
               Stream.filter((env) => env.deletedAt == null),
               Stream.runCollect,
               Effect.map((chunk) => Array.from(chunk)),
-              Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-                Effect.succeed([]),
-              ),
+              Effect.catchTag("NotFound", () => Effect.succeed([])),
             );
           const volumes = envRows.flatMap((env) =>
             env.volumeInstances.edges.map((edge) => edge.node),
@@ -1280,9 +1272,7 @@ export const MySQLProvider = () =>
             id: serviceId,
             ...(environmentId.length > 0 ? { environmentId } : {}),
           })
-          .pipe(
-            Effect.catchTag(["RailwayNotFound", "NotFound"], () => Effect.void),
-          );
+          .pipe(Effect.catchTag("NotFound", () => Effect.void));
         yield* getById(serviceId).pipe(
           Effect.map((service) => service === undefined),
           Effect.repeat({
@@ -1315,9 +1305,7 @@ export const MySQLProvider = () =>
       if (output.volumeId.length > 0) {
         yield* railway
           .deleteVolume({ volumeId: output.volumeId })
-          .pipe(
-            Effect.catchTag(["RailwayNotFound", "NotFound"], () => Effect.void),
-          );
+          .pipe(Effect.catchTag("NotFound", () => Effect.void));
         const check =
           output.volumeInstanceId.length > 0
             ? getVolumeByInstanceId(output.volumeInstanceId).pipe(

--- a/packages/alchemy/src/Railway/MySQL.ts
+++ b/packages/alchemy/src/Railway/MySQL.ts
@@ -398,9 +398,6 @@ const isGoneProxy = (proxy: CloudProxy | undefined) =>
 
 const normalizeDomain = (domain: string) => domain.replace(/\.+$/, "");
 
-const alreadyExists = (message: string) =>
-  /already exists|already in use|duplicate/i.test(message);
-
 const sameImage = (observed: string | null | undefined, desired: string) => {
   if (observed == null || observed.length === 0) return false;
   if (observed === desired) return true;
@@ -622,7 +619,7 @@ const deleteProxy = (id: string) =>
         e._tag === "RailwayInternalError" &&
         e.message.includes("operation is already in progress"),
       schedule: Schedule.spaced("3 seconds"),
-      times: 20,
+      times: 10,
     }),
     Effect.catchTag("NotFound", () => Effect.void),
     Effect.asVoid,
@@ -715,40 +712,34 @@ const waitForInstance = (environmentId: string, serviceId: string) =>
     }),
     Effect.retry({
       while: (e) => e._tag === "Railway.MySQLPending",
-      // serviceCreate fans the instance out to each environment
-      // asynchronously; under full-suite load the fan-out can take minutes.
-      times: 60,
+      times: 10,
       schedule: Schedule.spaced("2 seconds"),
     }),
-    Effect.catchTag("Railway.MySQLPending", () =>
-      getInstance(environmentId, serviceId),
-    ),
   );
 
 const waitForDeployment = (environmentId: string, serviceId: string) =>
-  getInstance(environmentId, serviceId).pipe(
-    Effect.flatMap((instance) => {
-      const latest = instance?.latestDeployment;
-      const status = latest?.status;
-      if (instance !== undefined && deployReady(status)) {
-        return Effect.succeed(instance);
-      }
-      return Effect.fail(
-        new MySQLDeployPending({
-          serviceId,
-          status: status ?? "pending",
-        }),
-      );
-    }),
+  Effect.gen(function* () {
+    const instance = yield* getInstance(environmentId, serviceId);
+    const latest = instance?.latestDeployment;
+    const status = latest?.status;
+    if (instance !== undefined && deployReady(status)) return instance;
+    if (status !== undefined && deployFailed(status)) {
+      return yield* new MySQLDeployFailed({
+        serviceId,
+        status,
+        deploymentId: latest?.id,
+      });
+    }
+    return yield* new MySQLDeployPending({
+      serviceId,
+      status: status ?? "pending",
+    });
+  }).pipe(
     Effect.retry({
       while: (e) => e._tag === "Railway.MySQLDeployPending",
-      // Queued builds under full-suite load can exceed 3 minutes — allow ~8.
-      times: 96,
+      times: 10,
       schedule: Schedule.spaced("5 seconds"),
     }),
-    Effect.catchTag("Railway.MySQLDeployPending", () =>
-      getInstance(environmentId, serviceId),
-    ),
   );
 
 const waitForVolume = (
@@ -782,7 +773,6 @@ const waitForVolume = (
       times: 10,
       schedule: Schedule.spaced("3 seconds"),
     }),
-    Effect.catchTag("Railway.MySQLVolumePending", () => observe),
   );
 };
 
@@ -912,7 +902,6 @@ export const MySQLProvider = () =>
       const projects = yield* ownedProjects();
       const rows = yield* Effect.forEach(projects, (project) =>
         Effect.gen(function* () {
-          const services = yield* listProjectServices(project.projectId);
           const envRows = yield* railway.environments
             .items({ projectId: project.projectId, first: 50 })
             .pipe(
@@ -924,44 +913,33 @@ export const MySQLProvider = () =>
           const volumes = envRows.flatMap((env) =>
             env.volumeInstances.edges.map((edge) => edge.node),
           );
-          const items = yield* Effect.forEach(
-            services.filter((service) =>
-              matchesAlchemyPhysicalName(service.name),
-            ),
-            (service) =>
-              Effect.gen(function* () {
-                const volume = volumes.find(
-                  (row) => (row.serviceId ?? undefined) === service.id,
-                );
-                const envIds =
-                  volume !== undefined
-                    ? [volume.environmentId]
-                    : envRows.map((env) => env.id);
-                let instance: ServiceInstanceResponse | undefined;
-                let environmentId = project.environmentId;
-                for (const id of envIds) {
-                  const candidate = yield* getInstance(id, service.id);
-                  if (isMysqlImage(candidate?.source?.image)) {
-                    instance = candidate;
-                    environmentId = id;
-                    break;
-                  }
-                }
-                if (!isMysqlImage(instance?.source?.image)) {
-                  return undefined;
-                }
-                return toAttrs({
-                  service,
-                  instance,
-                  volume,
-                  proxy: undefined,
-                  projectId: project.projectId,
-                  environmentId,
-                  user: DEFAULT_MYSQL_USER,
-                  password: "",
-                  database: DEFAULT_MYSQL_DATABASE,
-                });
-              }),
+          const items = yield* Effect.forEach(volumes, (volume) =>
+            Effect.gen(function* () {
+              if (volume.serviceId == null) return undefined;
+              const environmentId = volume.environmentId;
+              const instance = yield* getInstance(
+                environmentId,
+                volume.serviceId,
+              );
+              if (!isMysqlImage(instance?.source?.image)) return undefined;
+              const service = yield* getById(volume.serviceId);
+              if (
+                service === undefined ||
+                !matchesAlchemyPhysicalName(service.name)
+              )
+                return undefined;
+              return toAttrs({
+                service,
+                instance,
+                volume,
+                proxy: undefined,
+                projectId: project.projectId,
+                environmentId,
+                user: DEFAULT_MYSQL_USER,
+                password: "",
+                database: DEFAULT_MYSQL_DATABASE,
+              });
+            }),
           );
           return items.filter((item) => item !== undefined);
         }),
@@ -1035,12 +1013,9 @@ export const MySQLProvider = () =>
             },
           })
           .pipe(
-            Effect.catchTag("RailwayValidationError", (e) =>
-              alreadyExists(e.message)
-                ? Effect.succeed(undefined)
-                : Effect.fail(e),
+            Effect.catchTag(["RailwayAlreadyExists", "Conflict"], () =>
+              Effect.succeed(undefined),
             ),
-            Effect.catchTag("Conflict", () => Effect.succeed(undefined)),
           );
         current = created ?? (yield* findByName(projectId, name));
       }
@@ -1172,19 +1147,13 @@ export const MySQLProvider = () =>
 
       let proxy = yield* findProxy(environmentId, current.id, MYSQL_PORT);
       if (wantPublic && proxy === undefined) {
-        const created = yield* railway
-          .createTcpProxy({
-            input: {
-              applicationPort: MYSQL_PORT,
-              environmentId,
-              serviceId: current.id,
-            },
-          })
-          .pipe(
-            Effect.catchTag("RailwayValidationError", () =>
-              Effect.succeed(undefined),
-            ),
-          );
+        const created = yield* railway.createTcpProxy({
+          input: {
+            applicationPort: MYSQL_PORT,
+            environmentId,
+            serviceId: current.id,
+          },
+        });
         proxy =
           created !== undefined && !isGoneProxy(created)
             ? created
@@ -1196,40 +1165,13 @@ export const MySQLProvider = () =>
       }
 
       if (needsDeploy || instance?.latestDeployment == null) {
-        yield* railway
-          .serviceInstanceDeployV2({
-            environmentId,
-            serviceId: current.id,
-          })
-          .pipe(Effect.catchTag("RailwayValidationError", () => Effect.void));
-      }
-
-      instance =
-        (yield* waitForDeployment(environmentId, current.id)) ?? instance;
-      let finalStatus = instance?.latestDeployment?.status;
-      // A deployment can wedge in DEPLOYING and never reach SUCCESS — the
-      // container may serve, but Railway keeps its per-environment operation
-      // lock and the TCP proxy's routing is not committed. Converge: cancel
-      // the wedged deployment, redeploy once, and insist on SUCCESS.
-      if (!deployFailed(finalStatus) && !deployReady(finalStatus)) {
-        const wedged = instance?.latestDeployment?.id;
-        if (wedged != null && wedged.length > 0) {
-          yield* railway.cancelDeployment({ id: wedged }).pipe(Effect.ignore);
-        }
-        yield* railway
-          .serviceInstanceDeployV2({ environmentId, serviceId: current.id })
-          .pipe(Effect.catchTag("RailwayValidationError", () => Effect.void));
-        instance =
-          (yield* waitForDeployment(environmentId, current.id)) ?? instance;
-        finalStatus = instance?.latestDeployment?.status;
-      }
-      if (deployFailed(finalStatus) || !deployReady(finalStatus)) {
-        return yield* new MySQLDeployFailed({
+        yield* railway.serviceInstanceDeployV2({
+          environmentId,
           serviceId: current.id,
-          status: finalStatus ?? "failed",
-          deploymentId: instance?.latestDeployment?.id,
         });
       }
+
+      instance = yield* waitForDeployment(environmentId, current.id);
 
       return toAttrs({
         service: current,
@@ -1262,7 +1204,7 @@ export const MySQLProvider = () =>
         ) {
           yield* railway
             .cancelDeployment({ id: latest.id })
-            .pipe(Effect.ignore);
+            .pipe(Effect.catchTag("NotFound", () => Effect.void));
         }
       }
       // Delete the SERVICE next — its teardown cascades onto the proxies.
@@ -1290,7 +1232,7 @@ export const MySQLProvider = () =>
           Effect.repeat({
             schedule: Schedule.spaced("3 seconds"),
             until: (rows) => rows.length === 0,
-            times: 20,
+            times: 10,
           }),
         );
         yield* Effect.forEach(leftover, (proxy) => deleteProxy(proxy.id), {

--- a/packages/alchemy/src/Railway/Postgres.ts
+++ b/packages/alchemy/src/Railway/Postgres.ts
@@ -395,9 +395,6 @@ const isGoneProxy = (proxy: CloudProxy | undefined) =>
 
 const normalizeDomain = (domain: string) => domain.replace(/\.+$/, "");
 
-const alreadyExists = (message: string) =>
-  /already exists|already in use|duplicate/i.test(message);
-
 const sameImage = (observed: string | null | undefined, desired: string) => {
   if (observed == null || observed.length === 0) return false;
   if (observed === desired) return true;
@@ -608,7 +605,7 @@ const deleteProxy = (id: string) =>
         e._tag === "RailwayInternalError" &&
         e.message.includes("operation is already in progress"),
       schedule: Schedule.spaced("3 seconds"),
-      times: 20,
+      times: 10,
     }),
     Effect.catchTag("NotFound", () => Effect.void),
     Effect.asVoid,
@@ -703,40 +700,34 @@ const waitForInstance = (environmentId: string, serviceId: string) =>
     }),
     Effect.retry({
       while: (e) => e._tag === "Railway.PostgresPending",
-      // serviceCreate fans the instance out to each environment
-      // asynchronously; under full-suite load the fan-out can take minutes.
-      times: 60,
+      times: 10,
       schedule: Schedule.spaced("2 seconds"),
     }),
-    Effect.catchTag("Railway.PostgresPending", () =>
-      getInstance(environmentId, serviceId),
-    ),
   );
 
 const waitForDeployment = (environmentId: string, serviceId: string) =>
-  getInstance(environmentId, serviceId).pipe(
-    Effect.flatMap((instance) => {
-      const latest = instance?.latestDeployment;
-      const status = latest?.status;
-      if (instance !== undefined && deployReady(status)) {
-        return Effect.succeed(instance);
-      }
-      return Effect.fail(
-        new PostgresDeployPending({
-          serviceId,
-          status: status ?? "pending",
-        }),
-      );
-    }),
+  Effect.gen(function* () {
+    const instance = yield* getInstance(environmentId, serviceId);
+    const latest = instance?.latestDeployment;
+    const status = latest?.status;
+    if (instance !== undefined && deployReady(status)) return instance;
+    if (status !== undefined && deployFailed(status)) {
+      return yield* new PostgresDeployFailed({
+        serviceId,
+        status,
+        deploymentId: latest?.id,
+      });
+    }
+    return yield* new PostgresDeployPending({
+      serviceId,
+      status: status ?? "pending",
+    });
+  }).pipe(
     Effect.retry({
       while: (e) => e._tag === "Railway.PostgresDeployPending",
-      // Queued builds under full-suite load can exceed 3 minutes — allow ~8.
-      times: 96,
+      times: 10,
       schedule: Schedule.spaced("5 seconds"),
     }),
-    Effect.catchTag("Railway.PostgresDeployPending", () =>
-      getInstance(environmentId, serviceId),
-    ),
   );
 
 const waitForVolume = (
@@ -770,7 +761,6 @@ const waitForVolume = (
       times: 10,
       schedule: Schedule.spaced("3 seconds"),
     }),
-    Effect.catchTag("Railway.PostgresVolumePending", () => observe),
   );
 };
 
@@ -874,7 +864,6 @@ export const PostgresProvider = () =>
       const projects = yield* ownedProjects();
       const rows = yield* Effect.forEach(projects, (project) =>
         Effect.gen(function* () {
-          const services = yield* listProjectServices(project.projectId);
           const envRows = yield* railway.environments
             .items({ projectId: project.projectId, first: 50 })
             .pipe(
@@ -886,44 +875,33 @@ export const PostgresProvider = () =>
           const volumes = envRows.flatMap((env) =>
             env.volumeInstances.edges.map((edge) => edge.node),
           );
-          const items = yield* Effect.forEach(
-            services.filter((service) =>
-              matchesAlchemyPhysicalName(service.name),
-            ),
-            (service) =>
-              Effect.gen(function* () {
-                const volume = volumes.find(
-                  (row) => (row.serviceId ?? undefined) === service.id,
-                );
-                const envIds =
-                  volume !== undefined
-                    ? [volume.environmentId]
-                    : envRows.map((env) => env.id);
-                let instance: ServiceInstanceResponse | undefined;
-                let environmentId = project.environmentId;
-                for (const id of envIds) {
-                  const candidate = yield* getInstance(id, service.id);
-                  if (isPostgresImage(candidate?.source?.image)) {
-                    instance = candidate;
-                    environmentId = id;
-                    break;
-                  }
-                }
-                if (!isPostgresImage(instance?.source?.image)) {
-                  return undefined;
-                }
-                return toAttrs({
-                  service,
-                  instance,
-                  volume,
-                  proxy: undefined,
-                  projectId: project.projectId,
-                  environmentId,
-                  user: DEFAULT_POSTGRES_USER,
-                  password: "",
-                  database: DEFAULT_POSTGRES_DATABASE,
-                });
-              }),
+          const items = yield* Effect.forEach(volumes, (volume) =>
+            Effect.gen(function* () {
+              if (volume.serviceId == null) return undefined;
+              const environmentId = volume.environmentId;
+              const instance = yield* getInstance(
+                environmentId,
+                volume.serviceId,
+              );
+              if (!isPostgresImage(instance?.source?.image)) return undefined;
+              const service = yield* getById(volume.serviceId);
+              if (
+                service === undefined ||
+                !matchesAlchemyPhysicalName(service.name)
+              )
+                return undefined;
+              return toAttrs({
+                service,
+                instance,
+                volume,
+                proxy: undefined,
+                projectId: project.projectId,
+                environmentId,
+                user: DEFAULT_POSTGRES_USER,
+                password: "",
+                database: DEFAULT_POSTGRES_DATABASE,
+              });
+            }),
           );
           return items.filter((item) => item !== undefined);
         }),
@@ -990,12 +968,9 @@ export const PostgresProvider = () =>
             },
           })
           .pipe(
-            Effect.catchTag("RailwayValidationError", (e) =>
-              alreadyExists(e.message)
-                ? Effect.succeed(undefined)
-                : Effect.fail(e),
+            Effect.catchTag(["RailwayAlreadyExists", "Conflict"], () =>
+              Effect.succeed(undefined),
             ),
-            Effect.catchTag("Conflict", () => Effect.succeed(undefined)),
           );
         current = created ?? (yield* findByName(projectId, name));
       }
@@ -1123,19 +1098,13 @@ export const PostgresProvider = () =>
 
       let proxy = yield* findProxy(environmentId, current.id, POSTGRES_PORT);
       if (wantPublic && proxy === undefined) {
-        const created = yield* railway
-          .createTcpProxy({
-            input: {
-              applicationPort: POSTGRES_PORT,
-              environmentId,
-              serviceId: current.id,
-            },
-          })
-          .pipe(
-            Effect.catchTag("RailwayValidationError", () =>
-              Effect.succeed(undefined),
-            ),
-          );
+        const created = yield* railway.createTcpProxy({
+          input: {
+            applicationPort: POSTGRES_PORT,
+            environmentId,
+            serviceId: current.id,
+          },
+        });
         proxy =
           created !== undefined && !isGoneProxy(created)
             ? created
@@ -1147,40 +1116,13 @@ export const PostgresProvider = () =>
       }
 
       if (needsDeploy || instance?.latestDeployment == null) {
-        yield* railway
-          .serviceInstanceDeployV2({
-            environmentId,
-            serviceId: current.id,
-          })
-          .pipe(Effect.catchTag("RailwayValidationError", () => Effect.void));
-      }
-
-      instance =
-        (yield* waitForDeployment(environmentId, current.id)) ?? instance;
-      let finalStatus = instance?.latestDeployment?.status;
-      // A deployment can wedge in DEPLOYING and never reach SUCCESS — the
-      // container may serve, but Railway keeps its per-environment operation
-      // lock and the TCP proxy's routing is not committed. Converge: cancel
-      // the wedged deployment, redeploy once, and insist on SUCCESS.
-      if (!deployFailed(finalStatus) && !deployReady(finalStatus)) {
-        const wedged = instance?.latestDeployment?.id;
-        if (wedged != null && wedged.length > 0) {
-          yield* railway.cancelDeployment({ id: wedged }).pipe(Effect.ignore);
-        }
-        yield* railway
-          .serviceInstanceDeployV2({ environmentId, serviceId: current.id })
-          .pipe(Effect.catchTag("RailwayValidationError", () => Effect.void));
-        instance =
-          (yield* waitForDeployment(environmentId, current.id)) ?? instance;
-        finalStatus = instance?.latestDeployment?.status;
-      }
-      if (deployFailed(finalStatus) || !deployReady(finalStatus)) {
-        return yield* new PostgresDeployFailed({
+        yield* railway.serviceInstanceDeployV2({
+          environmentId,
           serviceId: current.id,
-          status: finalStatus ?? "failed",
-          deploymentId: instance?.latestDeployment?.id,
         });
       }
+
+      instance = yield* waitForDeployment(environmentId, current.id);
 
       return toAttrs({
         service: current,
@@ -1213,7 +1155,7 @@ export const PostgresProvider = () =>
         ) {
           yield* railway
             .cancelDeployment({ id: latest.id })
-            .pipe(Effect.ignore);
+            .pipe(Effect.catchTag("NotFound", () => Effect.void));
         }
       }
       // Delete the SERVICE next — its teardown cascades onto the proxies.
@@ -1241,7 +1183,7 @@ export const PostgresProvider = () =>
           Effect.repeat({
             schedule: Schedule.spaced("3 seconds"),
             until: (rows) => rows.length === 0,
-            times: 20,
+            times: 10,
           }),
         );
         yield* Effect.forEach(leftover, (proxy) => deleteProxy(proxy.id), {

--- a/packages/alchemy/src/Railway/Postgres.ts
+++ b/packages/alchemy/src/Railway/Postgres.ts
@@ -522,17 +522,13 @@ const toAttrs = (input: {
 const getById = (serviceId: string) =>
   railway.service({ id: serviceId }).pipe(
     Effect.map((service) => (isGoneService(service) ? undefined : service)),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-      Effect.succeed(undefined),
-    ),
+    Effect.catchTag("NotFound", () => Effect.succeed(undefined)),
   );
 
 const getInstance = (environmentId: string, serviceId: string) =>
   railway.serviceInstance({ environmentId, serviceId }).pipe(
     Effect.map((instance) => (isGoneInstance(instance) ? undefined : instance)),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-      Effect.succeed(undefined),
-    ),
+    Effect.catchTag("NotFound", () => Effect.succeed(undefined)),
   );
 
 const listProjectServices = (projectId: string) =>
@@ -542,7 +538,7 @@ const listProjectServices = (projectId: string) =>
         .map((edge) => edge.node)
         .filter((node) => !isGoneService(node)),
     ),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
+    Effect.catchTag("NotFound", () =>
       Effect.succeed([] as ProjectResponseServicesEdgesItemNode[]),
     ),
   );
@@ -555,9 +551,7 @@ const findByName = (projectId: string, name: string) =>
 const getVolumeByInstanceId = (volumeInstanceId: string) =>
   railway.volumeInstance({ id: volumeInstanceId }).pipe(
     Effect.map((instance) => (isGoneVolume(instance) ? undefined : instance)),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-      Effect.succeed(undefined),
-    ),
+    Effect.catchTag("NotFound", () => Effect.succeed(undefined)),
   );
 
 const listVolumeInstances = (environmentId: string, projectId: string) =>
@@ -569,7 +563,7 @@ const listVolumeInstances = (environmentId: string, projectId: string) =>
             .map((edge) => edge.node)
             .filter((node) => !isGoneVolume(node)),
     ),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
+    Effect.catchTag("NotFound", () =>
       Effect.succeed([] as EnvironmentResponseVolumeInstancesEdgesItemNode[]),
     ),
   );
@@ -586,7 +580,7 @@ const findVolume = (
 const listProxies = (environmentId: string, serviceId: string) =>
   railway.tcpProxies({ environmentId, serviceId }).pipe(
     Effect.map((items) => items.filter((proxy) => !isGoneProxy(proxy))),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
+    Effect.catchTag("NotFound", () =>
       Effect.succeed([] as TcpProxiesResultItem[]),
     ),
   );
@@ -616,7 +610,7 @@ const deleteProxy = (id: string) =>
       schedule: Schedule.spaced("3 seconds"),
       times: 20,
     }),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () => Effect.void),
+    Effect.catchTag("NotFound", () => Effect.void),
     Effect.asVoid,
   );
 
@@ -647,7 +641,7 @@ const listVariableMap = (
     })
     .pipe(
       Effect.map(asVariableMap),
-      Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
+      Effect.catchTag("NotFound", () =>
         Effect.succeed({} as Record<string, string>),
       ),
     );
@@ -887,9 +881,7 @@ export const PostgresProvider = () =>
               Stream.filter((env) => env.deletedAt == null),
               Stream.runCollect,
               Effect.map((chunk) => Array.from(chunk)),
-              Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-                Effect.succeed([]),
-              ),
+              Effect.catchTag("NotFound", () => Effect.succeed([])),
             );
           const volumes = envRows.flatMap((env) =>
             env.volumeInstances.edges.map((edge) => edge.node),
@@ -1231,9 +1223,7 @@ export const PostgresProvider = () =>
             id: serviceId,
             ...(environmentId.length > 0 ? { environmentId } : {}),
           })
-          .pipe(
-            Effect.catchTag(["RailwayNotFound", "NotFound"], () => Effect.void),
-          );
+          .pipe(Effect.catchTag("NotFound", () => Effect.void));
         yield* getById(serviceId).pipe(
           Effect.map((service) => service === undefined),
           Effect.repeat({
@@ -1266,9 +1256,7 @@ export const PostgresProvider = () =>
       if (output.volumeId.length > 0) {
         yield* railway
           .deleteVolume({ volumeId: output.volumeId })
-          .pipe(
-            Effect.catchTag(["RailwayNotFound", "NotFound"], () => Effect.void),
-          );
+          .pipe(Effect.catchTag("NotFound", () => Effect.void));
         const check =
           output.volumeInstanceId.length > 0
             ? getVolumeByInstanceId(output.volumeInstanceId).pipe(

--- a/packages/alchemy/src/Railway/PrivateNetwork.ts
+++ b/packages/alchemy/src/Railway/PrivateNetwork.ts
@@ -261,7 +261,7 @@ const resolveNetworkName = (
 const listNetworks = (environmentId: string) =>
   railway.privateNetworks({ environmentId }).pipe(
     Effect.map((items) => items.filter((network) => !isGoneNetwork(network))),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
+    Effect.catchTag("NotFound", () =>
       Effect.succeed([] as PrivateNetworksResultItem[]),
     ),
   );
@@ -289,7 +289,7 @@ const listEnvironmentIds = (project: {
       }
       return Array.from(set);
     }),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
+    Effect.catchTag("NotFound", () =>
       Effect.succeed(
         project.environmentId.length > 0 ? [project.environmentId] : [],
       ),
@@ -689,9 +689,7 @@ const getEndpoint = (input: {
     Effect.map((endpoint) =>
       endpoint == null || isGoneEndpoint(endpoint) ? undefined : endpoint,
     ),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-      Effect.succeed(undefined),
-    ),
+    Effect.catchTag("NotFound", () => Effect.succeed(undefined)),
   );
 
 const resolveServiceName = (serviceId: string, hint?: string) =>
@@ -699,7 +697,7 @@ const resolveServiceName = (serviceId: string, hint?: string) =>
     ? Effect.succeed(hint)
     : railway.service({ id: serviceId }).pipe(
         Effect.map((service) => service.name),
-        Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
+        Effect.catchTag("NotFound", () =>
           Effect.succeed(sanitizeRailwayName(serviceId)),
         ),
       );
@@ -711,7 +709,7 @@ const listProjectServices = (projectId: string) =>
         .map((edge) => edge.node)
         .filter((node) => node.deletedAt == null),
     ),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
+    Effect.catchTag("NotFound", () =>
       Effect.succeed([] as ProjectResponseServicesEdgesItemNode[]),
     ),
   );
@@ -829,11 +827,7 @@ export const PrivateNetworkEndpointProvider = () =>
           );
           const live = yield* railway
             .project({ id: project.projectId })
-            .pipe(
-              Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-                Effect.succeed(undefined),
-              ),
-            );
+            .pipe(Effect.catchTag("NotFound", () => Effect.succeed(undefined)));
           const services = (
             live?.services.edges.map((edge) => edge.node) ?? []
           ).filter((service) => service.deletedAt == null);
@@ -971,9 +965,7 @@ export const PrivateNetworkEndpointProvider = () =>
       if (id.length === 0) return;
       yield* railway
         .deletePrivateNetworkEndpoint({ id })
-        .pipe(
-          Effect.catchTag(["RailwayNotFound", "NotFound"], () => Effect.void),
-        );
+        .pipe(Effect.catchTag("NotFound", () => Effect.void));
       if (
         output.environmentId.length > 0 &&
         output.privateNetworkId.length > 0 &&

--- a/packages/alchemy/src/Railway/PrivateNetwork.ts
+++ b/packages/alchemy/src/Railway/PrivateNetwork.ts
@@ -719,14 +719,53 @@ const waitUntilEndpointGone = (input: {
   privateNetworkId: string;
   serviceId: string;
 }) =>
-  getEndpoint(input).pipe(
-    Effect.map((endpoint) => endpoint === undefined),
-    Effect.repeat({
+  railway.privateNetworkEndpoint(input).pipe(
+    Effect.map(
+      (endpoint) =>
+        endpoint == null ||
+        endpoint.deletedAt != null ||
+        endpoint.syncStatus === "DELETED",
+    ),
+    Effect.catchTag("NotFound", () => Effect.succeed(true)),
+    Effect.flatMap((gone) =>
+      gone
+        ? Effect.void
+        : Effect.fail(
+            new PrivateNetworkEndpointPending({ serviceId: input.serviceId }),
+          ),
+    ),
+    Effect.retry({
       schedule: Schedule.spaced("1 second"),
-      until: (gone) => gone,
+      while: (error) => error._tag === "Railway.PrivateNetworkEndpointPending",
       times: 8,
     }),
   );
+
+class PrivateNetworkEndpointPending extends Data.TaggedError(
+  "Railway.PrivateNetworkEndpointPending",
+)<{
+  serviceId: string;
+}> {}
+
+export class PrivateNetworkEndpointNameUnavailable extends Data.TaggedError(
+  "Railway.PrivateNetworkEndpointNameUnavailable",
+)<{
+  privateNetworkId: string;
+  prefix: string;
+}> {}
+
+class PrivateNetworkEndpointNamePending extends Data.TaggedError(
+  "Railway.PrivateNetworkEndpointNamePending",
+)<{
+  prefix: string;
+  dnsName: string | undefined;
+  newDnsName: string | null | undefined;
+  syncStatus: string | undefined;
+}> {
+  get message() {
+    return `Expected DNS prefix ${this.prefix}, observed ${this.dnsName} (pending ${this.newDnsName}, status ${this.syncStatus})`;
+  }
+}
 
 const waitUntilEndpointNamed = (input: {
   environmentId: string;
@@ -738,22 +777,21 @@ const waitUntilEndpointNamed = (input: {
     Effect.flatMap((endpoint) => {
       if (endpoint == null || dnsPrefix(endpoint.dnsName) !== input.prefix) {
         return Effect.fail(
-          new PrivateNetworkEndpointNotCreated({
-            privateNetworkId: input.privateNetworkId,
-            serviceId: input.serviceId,
+          new PrivateNetworkEndpointNamePending({
+            prefix: input.prefix,
+            dnsName: endpoint?.dnsName,
+            newDnsName: endpoint?.newDnsName,
+            syncStatus: endpoint?.syncStatus,
           }),
         );
       }
       return Effect.succeed(endpoint);
     }),
     Effect.retry({
-      while: (e) => e._tag === "Railway.PrivateNetworkEndpointNotCreated",
+      while: (e) => e._tag === "Railway.PrivateNetworkEndpointNamePending",
       times: 8,
       schedule: Schedule.spaced("1 second"),
     }),
-    Effect.catchTag("Railway.PrivateNetworkEndpointNotCreated", () =>
-      getEndpoint(input),
-    ),
   );
 
 export const PrivateNetworkEndpointProvider = () =>
@@ -936,20 +974,23 @@ export const PrivateNetworkEndpointProvider = () =>
           privateNetworkId,
           prefix: desiredPrefix,
         });
-        if (available) {
-          yield* railway.renamePrivateNetworkEndpoint({
-            dnsName: desiredPrefix,
-            id: current.publicId,
+        if (!available) {
+          return yield* new PrivateNetworkEndpointNameUnavailable({
             privateNetworkId,
+            prefix: desiredPrefix,
           });
-          current =
-            (yield* waitUntilEndpointNamed({
-              environmentId,
-              privateNetworkId,
-              serviceId,
-              prefix: desiredPrefix,
-            })) ?? current;
         }
+        yield* railway.renamePrivateNetworkEndpoint({
+          dnsName: desiredPrefix,
+          id: current.publicId,
+          privateNetworkId,
+        });
+        current = yield* waitUntilEndpointNamed({
+          environmentId,
+          privateNetworkId,
+          serviceId,
+          prefix: desiredPrefix,
+        });
       }
 
       return toEndpointAttrs(current, {

--- a/packages/alchemy/src/Railway/Project.ts
+++ b/packages/alchemy/src/Railway/Project.ts
@@ -208,9 +208,7 @@ const fillEnvironmentId = (attrs: Project["Attributes"]) => {
           ? { ...attrs, environmentId: option.value.id }
           : attrs,
       ),
-      Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-        Effect.succeed(attrs),
-      ),
+      Effect.catchTag("NotFound", () => Effect.succeed(attrs)),
     );
 };
 
@@ -227,9 +225,7 @@ const isGone = (project: CloudProject | undefined) =>
 const getById = (projectId: string) =>
   railway.project({ id: projectId }).pipe(
     Effect.map((project) => (isGone(project) ? undefined : project)),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-      Effect.succeed(undefined),
-    ),
+    Effect.catchTag("NotFound", () => Effect.succeed(undefined)),
   );
 
 const currentWorkspaceId = Effect.fn(function* () {
@@ -307,7 +303,7 @@ export const projectEnvironmentIds = (project: {
       }
       return Array.from(set);
     }),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
+    Effect.catchTag("NotFound", () =>
       Effect.succeed(
         project.environmentId.length > 0 ? [project.environmentId] : [],
       ),
@@ -421,9 +417,7 @@ export const ProjectProvider = () =>
       if (projectId.length === 0) return;
       yield* railway
         .deleteProject({ id: projectId })
-        .pipe(
-          Effect.catchTag(["RailwayNotFound", "NotFound"], () => Effect.void),
-        );
+        .pipe(Effect.catchTag("NotFound", () => Effect.void));
       yield* getById(projectId).pipe(
         Effect.map((project) => project === undefined),
         Effect.repeat({

--- a/packages/alchemy/src/Railway/Project.ts
+++ b/packages/alchemy/src/Railway/Project.ts
@@ -377,7 +377,7 @@ export const ProjectProvider = () =>
             ? { defaultEnvironmentName: props.defaultEnvironmentName }
             : {}),
         }).pipe(
-          Effect.catchTag("RailwayValidationError", () =>
+          Effect.catchTag("RailwayAlreadyExists", () =>
             Effect.succeed(undefined),
           ),
         );

--- a/packages/alchemy/src/Railway/ProjectEnvironment.ts
+++ b/packages/alchemy/src/Railway/ProjectEnvironment.ts
@@ -214,9 +214,7 @@ const getById = (environmentId: string, projectId?: string) =>
     })
     .pipe(
       Effect.map((env) => (isGone(env) ? undefined : env)),
-      Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-        Effect.succeed(undefined),
-      ),
+      Effect.catchTag("NotFound", () => Effect.succeed(undefined)),
     );
 
 const findByName = (projectId: string, name: string) =>
@@ -225,16 +223,14 @@ const findByName = (projectId: string, name: string) =>
     Stream.take(1),
     Stream.runHead,
     Effect.map((option) => (option._tag === "Some" ? option.value : undefined)),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-      Effect.succeed(undefined),
-    ),
+    Effect.catchTag("NotFound", () => Effect.succeed(undefined)),
   );
 
 const listProjectEnvironments = (projectId: string) =>
   railway.environments.items({ projectId, first: 50 }).pipe(
     Stream.runCollect,
     Effect.map((envs) => Array.from(envs)),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
+    Effect.catchTag("NotFound", () =>
       Effect.succeed([] as EnvironmentsResponseEdgesItemNode[]),
     ),
   );
@@ -295,7 +291,7 @@ export const EnvironmentProvider = () =>
                 };
               }),
             ),
-            Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
+            Effect.catchTag("NotFound", () =>
               Effect.succeed([] as Environment["Attributes"][]),
             ),
           ),
@@ -359,9 +355,7 @@ export const EnvironmentProvider = () =>
       if (environmentId.length === 0) return;
       yield* railway
         .deleteEnvironment({ id: environmentId })
-        .pipe(
-          Effect.catchTag(["RailwayNotFound", "NotFound"], () => Effect.void),
-        );
+        .pipe(Effect.catchTag("NotFound", () => Effect.void));
       yield* getById(environmentId, output.projectId).pipe(
         Effect.map((env) => env === undefined),
         Effect.repeat({

--- a/packages/alchemy/src/Railway/ProjectEnvironment.ts
+++ b/packages/alchemy/src/Railway/ProjectEnvironment.ts
@@ -329,7 +329,7 @@ export const EnvironmentProvider = () =>
             },
           }),
         ).pipe(
-          Effect.catchTag("RailwayValidationError", () =>
+          Effect.catchTag("RailwayAlreadyExists", () =>
             Effect.succeed(undefined),
           ),
         );

--- a/packages/alchemy/src/Railway/Redis.ts
+++ b/packages/alchemy/src/Railway/Redis.ts
@@ -11,6 +11,7 @@ import * as Data from "effect/Data";
 import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import * as Schedule from "effect/Schedule";
+import * as Stream from "effect/Stream";
 import { Unowned } from "../AdoptPolicy.ts";
 import { isResolved } from "../Diff.ts";
 import * as Provider from "../Provider.ts";
@@ -360,9 +361,6 @@ const deployReady = (status: string | undefined) =>
 const deployFailed = (status: string | undefined) =>
   status === "FAILED" || status === "CRASHED" || status === "REMOVED";
 
-const alreadyExists = (message: string) =>
-  /already exists|already in use|duplicate/i.test(message);
-
 const getById = (serviceId: string) =>
   railway.service({ id: serviceId }).pipe(
     Effect.map((service) => (isGoneService(service) ? undefined : service)),
@@ -402,14 +400,9 @@ const waitForInstance = (environmentId: string, serviceId: string) =>
     }),
     Effect.retry({
       while: (e) => e._tag === "Railway.RedisPending",
-      // serviceCreate fans the instance out to each environment
-      // asynchronously; under full-suite load the fan-out can take minutes.
-      times: 60,
+      times: 10,
       schedule: Schedule.spaced("2 seconds"),
     }),
-    Effect.catchTag("Railway.RedisPending", () =>
-      getInstance(environmentId, serviceId),
-    ),
   );
 
 const waitForDeployment = (environmentId: string, serviceId: string) =>
@@ -434,13 +427,9 @@ const waitForDeployment = (environmentId: string, serviceId: string) =>
   }).pipe(
     Effect.retry({
       while: (e) => e._tag === "Railway.RedisDeployPending",
-      // Queued builds under full-suite load can exceed 3 minutes — allow ~8.
-      times: 96,
+      times: 10,
       schedule: Schedule.spaced("5 seconds"),
     }),
-    Effect.catchTag("Railway.RedisDeployPending", () =>
-      getInstance(environmentId, serviceId),
-    ),
   );
 
 const asVariableMap = (value: unknown): Record<string, string> => {
@@ -621,33 +610,47 @@ export const RedisProvider = () =>
       const projects = yield* ownedProjects();
       const rows = yield* Effect.forEach(projects, (project) =>
         Effect.gen(function* () {
-          const services = yield* listProjectServices(project.projectId);
           const envIds = yield* projectEnvironmentIds(project);
-          const items = yield* Effect.forEach(
-            services.filter((service) =>
-              matchesAlchemyPhysicalName(service.name),
-            ),
-            (service) =>
-              Effect.gen(function* () {
-                for (const environmentId of envIds) {
+          const items = yield* Effect.forEach(envIds, (environmentId) =>
+            Effect.gen(function* () {
+              const candidates = yield* railway.listEnvironmentServiceInstances
+                .items({ environmentId, first: 50 })
+                .pipe(
+                  Stream.filter(
+                    (row) =>
+                      row.deletedAt == null && isRedisImage(row.source?.image),
+                  ),
+                  Stream.runCollect,
+                );
+              return yield* Effect.forEach(candidates, (candidate) =>
+                Effect.gen(function* () {
+                  const service = yield* getById(candidate.serviceId);
+                  if (
+                    service === undefined ||
+                    !matchesAlchemyPhysicalName(service.name)
+                  )
+                    return undefined;
                   const instance = yield* getInstance(
                     environmentId,
                     service.id,
                   );
-                  const image = instance?.source?.image ?? undefined;
-                  if (!isRedisImage(image)) continue;
+                  if (
+                    instance === undefined ||
+                    !isRedisImage(instance.source?.image)
+                  )
+                    return undefined;
                   return toAttrs({
                     service,
                     instance,
                     projectId: project.projectId,
                     environmentId,
-                    image: image ?? DEFAULT_REDIS_IMAGE,
+                    image: instance.source?.image ?? DEFAULT_REDIS_IMAGE,
                   });
-                }
-                return undefined;
-              }),
+                }),
+              );
+            }),
           );
-          return items.filter((item) => item !== undefined);
+          return items.flat().filter((item) => item !== undefined);
         }),
       );
       return rows.flat();
@@ -709,12 +712,9 @@ export const RedisProvider = () =>
             },
           })
           .pipe(
-            Effect.catchTag("RailwayValidationError", (e) =>
-              alreadyExists(e.message)
-                ? Effect.succeed(undefined)
-                : Effect.fail(e),
+            Effect.catchTag(["RailwayAlreadyExists", "Conflict"], () =>
+              Effect.succeed(undefined),
             ),
-            Effect.catchTag("Conflict", () => Effect.succeed(undefined)),
           );
         current = created ?? (yield* findByName(projectId, name));
       }
@@ -763,16 +763,13 @@ export const RedisProvider = () =>
       if (envChanged) needsDeploy = true;
 
       if (needsDeploy || instance?.latestDeployment == null) {
-        yield* railway
-          .serviceInstanceDeployV2({
-            environmentId,
-            serviceId: current.id,
-          })
-          .pipe(Effect.catchTag("RailwayValidationError", () => Effect.void));
+        yield* railway.serviceInstanceDeployV2({
+          environmentId,
+          serviceId: current.id,
+        });
       }
 
-      instance =
-        (yield* waitForDeployment(environmentId, current.id)) ?? instance;
+      instance = yield* waitForDeployment(environmentId, current.id);
 
       return toAttrs({
         service: current,

--- a/packages/alchemy/src/Railway/Redis.ts
+++ b/packages/alchemy/src/Railway/Redis.ts
@@ -366,17 +366,13 @@ const alreadyExists = (message: string) =>
 const getById = (serviceId: string) =>
   railway.service({ id: serviceId }).pipe(
     Effect.map((service) => (isGoneService(service) ? undefined : service)),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-      Effect.succeed(undefined),
-    ),
+    Effect.catchTag("NotFound", () => Effect.succeed(undefined)),
   );
 
 const getInstance = (environmentId: string, serviceId: string) =>
   railway.serviceInstance({ environmentId, serviceId }).pipe(
     Effect.map((instance) => (isGoneInstance(instance) ? undefined : instance)),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-      Effect.succeed(undefined),
-    ),
+    Effect.catchTag("NotFound", () => Effect.succeed(undefined)),
   );
 
 const listProjectServices = (projectId: string) =>
@@ -386,7 +382,7 @@ const listProjectServices = (projectId: string) =>
         .map((edge) => edge.node)
         .filter((node) => !isGoneService(node)),
     ),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
+    Effect.catchTag("NotFound", () =>
       Effect.succeed([] as ProjectResponseServicesEdgesItemNode[]),
     ),
   );
@@ -474,7 +470,7 @@ const listVariableMap = (
     })
     .pipe(
       Effect.map(asVariableMap),
-      Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
+      Effect.catchTag("NotFound", () =>
         Effect.succeed({} as Record<string, string>),
       ),
     );
@@ -797,9 +793,7 @@ export const RedisProvider = () =>
             ? { environmentId: output.environmentId }
             : {}),
         })
-        .pipe(
-          Effect.catchTag(["RailwayNotFound", "NotFound"], () => Effect.void),
-        );
+        .pipe(Effect.catchTag("NotFound", () => Effect.void));
       yield* getById(serviceId).pipe(
         Effect.map((service) => service === undefined),
         Effect.repeat({

--- a/packages/alchemy/src/Railway/RetryPolicy.ts
+++ b/packages/alchemy/src/Railway/RetryPolicy.ts
@@ -12,18 +12,8 @@ const isThrottled = (error: unknown): boolean =>
 /**
  * Railway-wide retry policy for every SDK call made by the providers.
  *
- * Railway's GraphQL gateway rate-limits aggressively under concurrency
- * (many resources reconciling at once) and usually omits `Retry-After`,
- * so the SDK's default policy — 8 attempts, ~20s of patience — gives up
- * while the throttling window is still open and a bare `TooManyRequests`
- * escapes the provider. Keep the default transient classification (which
- * includes throttling, server, network, and locked errors) but:
- *
- * - throttling errors poll SLOWLY (25s floor) so the rate window refills
- *   instead of being re-drained by the retries themselves, with ~30
- *   attempts (~12 minutes of patience for a suite-wide window);
- * - every other transient error keeps fast exponential backoff capped at
- *   15s per delay.
+ * Preserve the SDK's transient classification and leave time for the
+ * throttling window to refill, with a bounded retry budget.
  */
 export const factory: railway.Retry.Factory = (lastError) => {
   const base = railway.Retry.makeDefault(lastError);
@@ -43,8 +33,8 @@ export const factory: railway.Retry.Factory = (lastError) => {
         ),
         railway.Retry.jittered,
       ),
-      Schedule.recurs(30),
-    ]),
+      Schedule.recurs(8),
+    ]).pipe(Schedule.upTo({ duration: "45 seconds" })),
   };
 };
 

--- a/packages/alchemy/src/Railway/Sandbox.ts
+++ b/packages/alchemy/src/Railway/Sandbox.ts
@@ -369,9 +369,8 @@ const listSandboxes = (environmentId: string) =>
     Stream.filter((sandbox) => !isGone(sandbox)),
     Stream.runCollect,
     Effect.map((chunk) => Array.from(chunk)),
-    Effect.catchTag(
-      ["NotFound", "RailwayForbidden", "Forbidden", "RailwayPlanLimitExceeded"],
-      () => Effect.succeed([] as SandboxesResponseEdgesItemNode[]),
+    Effect.catchTag("NotFound", () =>
+      Effect.succeed([] as SandboxesResponseEdgesItemNode[]),
     ),
   );
 
@@ -422,19 +421,22 @@ const waitUntilRunning = (environmentId: string, sandboxId: string) =>
       times: 10,
       schedule: Schedule.spaced("3 seconds"),
     }),
-    Effect.catchTag("Railway.SandboxPending", () =>
-      getById(environmentId, sandboxId),
-    ),
   );
 
 const waitUntilGone = (environmentId: string, sandboxId: string) =>
-  getById(environmentId, sandboxId).pipe(
-    Effect.map((sandbox) => sandbox === undefined),
+  railway.sandbox({ environmentId, id: sandboxId }).pipe(
+    Effect.map((sandbox) => sandbox.status === "DESTROYED"),
+    Effect.catchTag("NotFound", () => Effect.succeed(true)),
     Effect.repeat({
       schedule: Schedule.spaced("1 second"),
       until: (gone) => gone,
       times: 10,
     }),
+    Effect.flatMap((gone) =>
+      gone
+        ? Effect.void
+        : Effect.fail(new SandboxPending({ sandboxId, status: "destroying" })),
+    ),
   );
 
 /**

--- a/packages/alchemy/src/Railway/Sandbox.ts
+++ b/packages/alchemy/src/Railway/Sandbox.ts
@@ -361,9 +361,7 @@ const templateKey = (template: SandboxTemplate | undefined) => {
 const getById = (environmentId: string, sandboxId: string) =>
   railway.sandbox({ environmentId, id: sandboxId }).pipe(
     Effect.map((sandbox) => (isGone(sandbox) ? undefined : sandbox)),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-      Effect.succeed(undefined),
-    ),
+    Effect.catchTag("NotFound", () => Effect.succeed(undefined)),
   );
 
 const listSandboxes = (environmentId: string) =>
@@ -372,13 +370,7 @@ const listSandboxes = (environmentId: string) =>
     Stream.runCollect,
     Effect.map((chunk) => Array.from(chunk)),
     Effect.catchTag(
-      [
-        "RailwayNotFound",
-        "NotFound",
-        "RailwayForbidden",
-        "Forbidden",
-        "RailwayPlanLimitExceeded",
-      ],
+      ["NotFound", "RailwayForbidden", "Forbidden", "RailwayPlanLimitExceeded"],
       () => Effect.succeed([] as SandboxesResponseEdgesItemNode[]),
     ),
   );
@@ -398,7 +390,7 @@ const listEnvironmentIds = (project: {
       }
       return Array.from(set);
     }),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
+    Effect.catchTag("NotFound", () =>
       Effect.succeed(
         project.environmentId.length > 0 ? [project.environmentId] : [],
       ),
@@ -551,7 +543,7 @@ export const deleteSandboxCheckpoint = Effect.fn(function* (input: {
       environmentId: input.environmentId,
       id: found.id,
     })
-    .pipe(Effect.catchTag(["RailwayNotFound", "NotFound"], () => Effect.void));
+    .pipe(Effect.catchTag("NotFound", () => Effect.void));
 });
 
 export type ExecRequest = {
@@ -764,9 +756,7 @@ export const SandboxProvider = () =>
       if (sandboxId.length === 0 || environmentId.length === 0) return;
       yield* railway
         .sandboxDestroy({ environmentId, id: sandboxId })
-        .pipe(
-          Effect.catchTag(["RailwayNotFound", "NotFound"], () => Effect.void),
-        );
+        .pipe(Effect.catchTag("NotFound", () => Effect.void));
       yield* waitUntilGone(environmentId, sandboxId);
     }),
   });

--- a/packages/alchemy/src/Railway/ServiceDomain.ts
+++ b/packages/alchemy/src/Railway/ServiceDomain.ts
@@ -61,7 +61,7 @@ export const listServiceDomains = (
     Effect.map((result) =>
       result.serviceDomains.filter((domain) => !isGone(domain)),
     ),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
+    Effect.catchTag("NotFound", () =>
       Effect.succeed([] as DomainsResponseServiceDomainsItem[]),
     ),
   );
@@ -84,9 +84,7 @@ const findCloudDomainById = (input: {
           (candidate) => candidate.id === input.domainId,
         ),
       ),
-      Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-        Effect.succeed(undefined),
-      ),
+      Effect.catchTag("NotFound", () => Effect.succeed(undefined)),
     );
 
 export const findServiceDomainById = Effect.fn(function* (input: {
@@ -164,7 +162,7 @@ export const deleteOwnedServiceDomain = Effect.fn(function* (input: {
       input.environmentId,
       railway.deleteServiceDomain({ id: row.id }),
     ).pipe(
-      Effect.catchTag(["RailwayNotFound", "NotFound"], () => Effect.void),
+      Effect.catchTag("NotFound", () => Effect.void),
       Effect.asVoid,
     );
   }
@@ -369,7 +367,7 @@ const createViaMutation = (input: {
       Effect.catchTag("RailwayServiceDomainCreateFailed", (error) =>
         listedOrFail(error),
       ),
-      Effect.catchTag("RailwayNotFound", (error) =>
+      Effect.catchTag("NotFound", (error) =>
         input.domainId !== undefined &&
         error.message.includes("ServiceInstance not found")
           ? listedOrFail(error)
@@ -388,7 +386,7 @@ const createViaMutation = (input: {
       while: (error) =>
         (input.domainId === undefined &&
           error._tag === "RailwayServiceDomainCreateFailed") ||
-        (error._tag === "RailwayNotFound" &&
+        (error._tag === "NotFound" &&
           error.message.includes("ServiceInstance not found")),
       times: 12,
       schedule: Schedule.spaced("5 seconds"),

--- a/packages/alchemy/src/Railway/ServiceDomain.ts
+++ b/packages/alchemy/src/Railway/ServiceDomain.ts
@@ -154,7 +154,7 @@ export const deleteOwnedServiceDomain = Effect.fn(function* (input: {
         },
       },
     }),
-  ).pipe(Effect.ignore);
+  );
 
   for (const row of owned) {
     if (row.syncStatus === "DELETING") continue;
@@ -247,7 +247,7 @@ const createViaEnvironmentPatch = (input: {
           },
         },
       }),
-    ).pipe(Effect.ignore);
+    );
     return domainKey;
   });
 
@@ -446,7 +446,7 @@ const syncDomain = (input: {
         ...(retarget ? { targetPort: input.targetPort } : {}),
       },
     }),
-  ).pipe(Effect.ignore);
+  );
 };
 
 /**

--- a/packages/alchemy/src/Railway/ServiceProvider.ts
+++ b/packages/alchemy/src/Railway/ServiceProvider.ts
@@ -142,17 +142,13 @@ const resolveName = (id: string, name: string | undefined, existing?: string) =>
 const getById = (serviceId: string) =>
   railway.service({ id: serviceId }).pipe(
     Effect.map((service) => (isGoneService(service) ? undefined : service)),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-      Effect.succeed(undefined),
-    ),
+    Effect.catchTag("NotFound", () => Effect.succeed(undefined)),
   );
 
 const getInstance = (environmentId: string, serviceId: string) =>
   railway.serviceInstance({ environmentId, serviceId }).pipe(
     Effect.map((instance) => (isGoneInstance(instance) ? undefined : instance)),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-      Effect.succeed(undefined),
-    ),
+    Effect.catchTag("NotFound", () => Effect.succeed(undefined)),
   );
 
 const listProjectServices = (projectId: string) =>
@@ -162,7 +158,7 @@ const listProjectServices = (projectId: string) =>
         .map((edge) => edge.node)
         .filter((node) => !isGoneService(node)),
     ),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
+    Effect.catchTag("NotFound", () =>
       Effect.succeed([] as ProjectResponseServicesEdgesItemNode[]),
     ),
   );
@@ -412,7 +408,7 @@ const listDeploymentTriggers = (
     .pipe(
       Stream.runCollect,
       Effect.map((triggers) => Array.from(triggers)),
-      Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
+      Effect.catchTag("NotFound", () =>
         Effect.succeed([] as DeploymentTriggersResponseEdgesItemNode[]),
       ),
     );
@@ -487,11 +483,7 @@ const syncAutoUpdates = Effect.fn(function* (input: {
       projectId: input.projectId,
       serviceId: input.serviceId,
     })
-    .pipe(
-      Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-        Effect.succeed(undefined),
-      ),
-    );
+    .pipe(Effect.catchTag("NotFound", () => Effect.succeed(undefined)));
   if (status?.enabled === input.enabled) return;
   yield* railway.serviceInstanceAutoDeployUpdate({
     input: {
@@ -624,9 +616,7 @@ const listUploadedDeployment = (input: {
       }),
       // The deployment record lags the upload; absence means "not visible
       // yet" and the caller treats it as pending. Anything else bubbles.
-      Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-        Effect.succeed(undefined),
-      ),
+      Effect.catchTag("NotFound", () => Effect.succeed(undefined)),
     );
 
 const waitForDeploymentById = (input: {
@@ -747,7 +737,7 @@ const listVariableMap = (
     })
     .pipe(
       Effect.map(asVariableMap),
-      Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
+      Effect.catchTag("NotFound", () =>
         Effect.succeed({} as Record<string, string>),
       ),
     );
@@ -1417,12 +1407,7 @@ export const ServiceProvider = () =>
                 ? { environmentId: output.environmentId }
                 : {}),
             })
-            .pipe(
-              Effect.catchTag(
-                ["RailwayNotFound", "NotFound"],
-                () => Effect.void,
-              ),
-            );
+            .pipe(Effect.catchTag(["NotFound"], () => Effect.void));
           yield* getById(serviceId).pipe(
             Effect.map((service) => service === undefined),
             Effect.repeat({

--- a/packages/alchemy/src/Railway/ServiceProvider.ts
+++ b/packages/alchemy/src/Railway/ServiceProvider.ts
@@ -507,20 +507,20 @@ const waitForInstance = (environmentId: string, serviceId: string) =>
     }),
     Effect.retry({
       while: (e) => e._tag === "Railway.ServicePending",
-      // serviceCreate fans the instance out to each environment
-      // asynchronously; under full-suite load the fan-out can take minutes.
-      times: 60,
+      times: 10,
       schedule: Schedule.spaced("2 seconds"),
     }),
-    Effect.catchTag("Railway.ServicePending", () =>
-      getInstance(environmentId, serviceId),
-    ),
   );
 
 const fetchDeployLogs = (deploymentId: string | undefined) =>
   deploymentId === undefined || deploymentId.length === 0
     ? Effect.succeed("")
     : railway.deploymentLogs({ deploymentId, limit: 80 }).pipe(
+        Effect.flatMap((rows) =>
+          rows.length > 0
+            ? Effect.succeed(rows)
+            : railway.buildLogs({ deploymentId, limit: 80 }),
+        ),
         Effect.map((rows) =>
           rows
             .map((row) =>
@@ -530,7 +530,6 @@ const fetchDeployLogs = (deploymentId: string | undefined) =>
             )
             .join("\n"),
         ),
-        Effect.orElseSucceed(() => ""),
       );
 
 const waitForDeployment = (environmentId: string, serviceId: string) =>
@@ -557,8 +556,7 @@ const waitForDeployment = (environmentId: string, serviceId: string) =>
   }).pipe(
     Effect.retry({
       while: (e) => e._tag === "Railway.ServiceDeployPending",
-      // Queued builds under full-suite load can exceed 3 minutes — allow ~8.
-      times: 96,
+      times: 10,
       schedule: Schedule.spaced("5 seconds"),
     }),
   );
@@ -661,7 +659,7 @@ const waitForDeploymentById = (input: {
   }).pipe(
     Effect.retry({
       while: (e) => e._tag === "Railway.ServiceDeployPending",
-      times: 90,
+      times: 10,
       schedule: Schedule.spaced("5 seconds"),
     }),
     Effect.catchTag("Railway.ServiceDeployPending", (pending) =>

--- a/packages/alchemy/src/Railway/ServiceProvider.ts
+++ b/packages/alchemy/src/Railway/ServiceProvider.ts
@@ -172,9 +172,6 @@ const findByName = (projectId: string, name: string) =>
     Effect.map((services) => services.find((service) => service.name === name)),
   );
 
-const alreadyExists = (message: string) =>
-  /already exists|already in use|duplicate/i.test(message);
-
 const sameImage = (observed: string | null | undefined, desired: string) => {
   if (observed == null || observed.length === 0) return false;
   if (observed === desired) return true;
@@ -617,13 +614,18 @@ const listUploadedDeployment = (input: {
       Stream.take(1),
       Stream.runCollect,
       Effect.map((chunk) => Array.from(chunk)[0]),
-      Effect.timeoutOrElse({
-        duration: "8 seconds",
-        orElse: () => Effect.succeed(undefined),
+      // Bounded pacing for the surrounding poll loop; a persistent timeout
+      // bubbles as TimeoutError instead of masquerading as "pending".
+      Effect.timeout("8 seconds"),
+      Effect.retry({
+        while: (e) => e._tag === "TimeoutError",
+        times: 2,
+        schedule: Schedule.spaced("1 second"),
       }),
-      Effect.catchTag(
-        ["NotFound", "UnknownRailwayError", "RailwayParseError"],
-        () => Effect.succeed(undefined),
+      // The deployment record lags the upload; absence means "not visible
+      // yet" and the caller treats it as pending. Anything else bubbles.
+      Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
+        Effect.succeed(undefined),
       ),
     );
 
@@ -1141,12 +1143,13 @@ export const ServiceProvider = () =>
                 },
               })
               .pipe(
-                Effect.catchTag("RailwayValidationError", (e) =>
-                  alreadyExists(e.message)
-                    ? Effect.succeed(undefined)
-                    : Effect.fail(e),
+                // Create race: another reconcile won; re-read by name below.
+                // Railway reports name collisions as INTERNAL_SERVER_ERROR
+                // with `already exists` — typed as RailwayAlreadyExists in
+                // distilled (observed 2026-09-11).
+                Effect.catchTag(["RailwayAlreadyExists", "Conflict"], () =>
+                  Effect.succeed(undefined),
                 ),
-                Effect.catchTag("Conflict", () => Effect.succeed(undefined)),
               );
             current = created ?? (yield* findByName(projectId, name));
           }
@@ -1374,28 +1377,20 @@ export const ServiceProvider = () =>
             !uploadSource &&
             (needsDeploy || instance?.latestDeployment == null)
           ) {
-            yield* railway
-              .serviceInstanceDeployV2({
-                environmentId,
-                serviceId: current.id,
-              })
-              .pipe(
-                Effect.catchTag("RailwayValidationError", () => Effect.void),
-              );
+            yield* railway.serviceInstanceDeployV2({
+              environmentId,
+              serviceId: current.id,
+            });
             instance =
               sourceRepo !== undefined
                 ? ((yield* getInstance(environmentId, current.id)) ?? instance)
                 : ((yield* waitForDeployment(environmentId, current.id)) ??
                   instance);
           } else if (uploadSource && needsDeploy) {
-            yield* railway
-              .serviceInstanceDeployV2({
-                environmentId,
-                serviceId: current.id,
-              })
-              .pipe(
-                Effect.catchTag("RailwayValidationError", () => Effect.void),
-              );
+            yield* railway.serviceInstanceDeployV2({
+              environmentId,
+              serviceId: current.id,
+            });
             instance =
               (yield* waitForDeployment(environmentId, current.id)) ?? instance;
           }

--- a/packages/alchemy/src/Railway/TcpProxy.ts
+++ b/packages/alchemy/src/Railway/TcpProxy.ts
@@ -231,7 +231,7 @@ const targetOf = (
 const listProxies = (environmentId: string, serviceId: string) =>
   railway.tcpProxies({ environmentId, serviceId }).pipe(
     Effect.map((items) => items.filter((proxy) => !isGone(proxy))),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
+    Effect.catchTag("NotFound", () =>
       Effect.succeed([] as TcpProxiesResultItem[]),
     ),
   );
@@ -297,11 +297,7 @@ export const TcpProxyProvider = () =>
         Effect.gen(function* () {
           const live = yield* railway
             .project({ id: project.projectId })
-            .pipe(
-              Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-                Effect.succeed(undefined),
-              ),
-            );
+            .pipe(Effect.catchTag("NotFound", () => Effect.succeed(undefined)));
           const services = (
             live?.services.edges.map((edge) => edge.node) ?? []
           ).filter(
@@ -433,7 +429,7 @@ export const TcpProxyProvider = () =>
           schedule: Schedule.spaced("3 seconds"),
           times: 20,
         }),
-        Effect.catchTag(["RailwayNotFound", "NotFound"], () => Effect.void),
+        Effect.catchTag("NotFound", () => Effect.void),
       );
       if (output.environmentId.length > 0 && output.serviceId.length > 0) {
         yield* waitUntilGone(output.environmentId, output.serviceId, id);

--- a/packages/alchemy/src/Railway/Template.ts
+++ b/packages/alchemy/src/Railway/Template.ts
@@ -354,28 +354,18 @@ const toAttrs = (input: {
 const getProject = (projectId: string) =>
   railway.project({ id: projectId }).pipe(
     Effect.map((project) => (isGoneProject(project) ? undefined : project)),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-      Effect.succeed(undefined),
-    ),
+    Effect.catchTag("NotFound", () => Effect.succeed(undefined)),
   );
 
 const getTemplateById = (id: string) =>
   railway
     .template({ id })
-    .pipe(
-      Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-        Effect.succeed(undefined),
-      ),
-    );
+    .pipe(Effect.catchTag("NotFound", () => Effect.succeed(undefined)));
 
 const getTemplateByCode = (code: string) =>
   railway
     .template({ code })
-    .pipe(
-      Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-        Effect.succeed(undefined),
-      ),
-    );
+    .pipe(Effect.catchTag("NotFound", () => Effect.succeed(undefined)));
 
 const findPublished = (needle: string) =>
   railway.templates.items({ first: 50 }).pipe(
@@ -385,9 +375,7 @@ const findPublished = (needle: string) =>
     Stream.take(1),
     Stream.runHead,
     Effect.map((option) => (option._tag === "Some" ? option.value : undefined)),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-      Effect.succeed(undefined),
-    ),
+    Effect.catchTag("NotFound", () => Effect.succeed(undefined)),
   );
 
 const resolveMarketplaceTemplate = (templateId: string) =>
@@ -407,7 +395,7 @@ const sourceForProject = (projectId: string) =>
   railway
     .templateSourceForProject({ projectId })
     .pipe(
-      Effect.catchTag(["RailwayNotFound", "NotFound", "RailwayForbidden"], () =>
+      Effect.catchTag(["NotFound", "RailwayForbidden"], () =>
         Effect.succeed(undefined),
       ),
     );
@@ -419,7 +407,7 @@ const listProjectServices = (projectId: string) =>
         .map((edge) => edge.node)
         .filter((node) => !isGoneService(node)),
     ),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
+    Effect.catchTag("NotFound", () =>
       Effect.succeed([] as ProjectResponseServicesEdgesItemNode[]),
     ),
   );
@@ -427,9 +415,7 @@ const listProjectServices = (projectId: string) =>
 const hydrateService = (serviceId: string) =>
   railway.service({ id: serviceId }).pipe(
     Effect.map((service) => (isGoneService(service) ? undefined : service)),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-      Effect.succeed(undefined),
-    ),
+    Effect.catchTag("NotFound", () => Effect.succeed(undefined)),
   );
 
 const hydrateServices = (services: readonly CloudService[]) =>
@@ -505,7 +491,7 @@ const normalizeConfig = (config: unknown): unknown => {
 const waitForWorkflow = (workflowId: string, projectId: string) =>
   Effect.gen(function* () {
     const result = yield* railway.workflowStatus({ workflowId }).pipe(
-      Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
+      Effect.catchTag("NotFound", () =>
         Effect.succeed({
           status: "NotFound",
           error: null,
@@ -694,11 +680,7 @@ export const TemplateProvider = () =>
         Effect.gen(function* () {
           const live = yield* railway
             .project({ id: project.projectId })
-            .pipe(
-              Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-                Effect.succeed(undefined),
-              ),
-            );
+            .pipe(Effect.catchTag("NotFound", () => Effect.succeed(undefined)));
           if (live === undefined || live.deletedAt != null) {
             return [] as Template["Attributes"][];
           }
@@ -874,9 +856,7 @@ export const TemplateProvider = () =>
               ? { environmentId: output.environmentId }
               : {}),
           })
-          .pipe(
-            Effect.catchTag(["RailwayNotFound", "NotFound"], () => Effect.void),
-          );
+          .pipe(Effect.catchTag("NotFound", () => Effect.void));
         yield* waitUntilServiceGone(serviceId);
       }
       if (!output.ownsProject) return;
@@ -884,9 +864,7 @@ export const TemplateProvider = () =>
       if (projectId.length === 0) return;
       yield* railway
         .deleteProject({ id: projectId })
-        .pipe(
-          Effect.catchTag(["RailwayNotFound", "NotFound"], () => Effect.void),
-        );
+        .pipe(Effect.catchTag("NotFound", () => Effect.void));
       yield* waitUntilProjectGone(projectId);
     }),
   });

--- a/packages/alchemy/src/Railway/Usage.ts
+++ b/packages/alchemy/src/Railway/Usage.ts
@@ -382,11 +382,7 @@ const currentWorkspaceId = Effect.fn(function* () {
 const getWorkspace = (workspaceId: string) =>
   railway
     .workspace({ workspaceId })
-    .pipe(
-      Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-        Effect.succeed(undefined),
-      ),
-    );
+    .pipe(Effect.catchTag("NotFound", () => Effect.succeed(undefined)));
 
 const toAttrs = (
   limit: CloudLimit,
@@ -559,9 +555,7 @@ export const UsageLimitProvider = () =>
       if (customerId.length === 0) return;
       yield* railway
         .removeUsageLimit({ input: { customerId } })
-        .pipe(
-          Effect.catchTag(["RailwayNotFound", "NotFound"], () => Effect.void),
-        );
+        .pipe(Effect.catchTag("NotFound", () => Effect.void));
       if (workspaceId.length > 0 && output.usageLimitId.length > 0) {
         yield* waitUntilGone(workspaceId, output.usageLimitId);
       }

--- a/packages/alchemy/src/Railway/Variable.ts
+++ b/packages/alchemy/src/Railway/Variable.ts
@@ -381,7 +381,7 @@ const listVariableMap = (
     })
     .pipe(
       Effect.map(asVariableMap),
-      Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
+      Effect.catchTag("NotFound", () =>
         Effect.succeed({} as Record<string, string>),
       ),
     );
@@ -429,7 +429,7 @@ const listEnvironmentIds = (project: {
       }
       return Array.from(set);
     }),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
+    Effect.catchTag("NotFound", () =>
       Effect.succeed(
         project.environmentId.length > 0 ? [project.environmentId] : [],
       ),
@@ -645,9 +645,7 @@ export const VariableProvider = () =>
               : {}),
           },
         })
-        .pipe(
-          Effect.catchTag(["RailwayNotFound", "NotFound"], () => Effect.void),
-        );
+        .pipe(Effect.catchTag("NotFound", () => Effect.void));
       yield* getValue(
         output.projectId,
         output.environmentId,

--- a/packages/alchemy/src/Railway/Volume.ts
+++ b/packages/alchemy/src/Railway/Volume.ts
@@ -529,9 +529,6 @@ const waitUntilSynced = (
       times: 10,
       schedule: Schedule.spaced("3 seconds"),
     }),
-    Effect.catchTag("Railway.VolumePending", () =>
-      getByInstanceId(volumeInstanceId),
-    ),
   );
 
 const waitForInstance = (
@@ -560,13 +557,6 @@ const waitForInstance = (
       times: 10,
       schedule: Schedule.spaced("3 seconds"),
     }),
-    Effect.catchTag("Railway.VolumePending", () =>
-      findInEnvironment(
-        environmentId,
-        projectId,
-        (instance) => instance.volumeId === volumeId,
-      ),
-    ),
   );
 
 /**
@@ -603,7 +593,13 @@ export const attachVolumeToService = Effect.fn(function* (input: {
           mountPath: input.mountPath,
         },
       })
-      .pipe(Effect.catchTag("NotFound", () => Effect.void));
+      .pipe(
+        Effect.retry({
+          while: (error) => error._tag === "NotFound",
+          times: 8,
+          schedule: Schedule.spaced("2 seconds"),
+        }),
+      );
   }
   const instance =
     observed ??
@@ -625,20 +621,41 @@ const waitUntilGone = (input: {
   environmentId: string;
   projectId: string;
 }) => {
+  // Railway retains deleted volumes for 48 hours; deletedAt confirms scheduling.
   const check =
     input.volumeInstanceId !== undefined && input.volumeInstanceId.length > 0
-      ? getByInstanceId(input.volumeInstanceId).pipe(
-          Effect.map((instance) => instance === undefined),
+      ? railway.volumeInstance({ id: input.volumeInstanceId }).pipe(
+          Effect.map(
+            (instance) =>
+              instance.deletedAt != null || instance.state === "DELETED",
+          ),
+          Effect.catchTag("NotFound", () => Effect.succeed(true)),
         )
-      : findInEnvironment(
-          input.environmentId,
-          input.projectId,
-          (instance) => instance.volumeId === input.volumeId,
-        ).pipe(Effect.map((instance) => instance === undefined));
+      : railway
+          .environment({ id: input.environmentId, projectId: input.projectId })
+          .pipe(
+            Effect.map(
+              (env) =>
+                !env.volumeInstances.edges.some(
+                  ({ node }) =>
+                    node.volumeId === input.volumeId &&
+                    node.deletedAt == null &&
+                    node.state !== "DELETED",
+                ),
+            ),
+            Effect.catchTag("NotFound", () => Effect.succeed(true)),
+          );
   return check.pipe(
-    Effect.repeat({
+    Effect.flatMap((gone) =>
+      gone
+        ? Effect.void
+        : Effect.fail(
+            new VolumePending({ volumeId: input.volumeId, state: "deleting" }),
+          ),
+    ),
+    Effect.retry({
       schedule: Schedule.spaced("1 second"),
-      until: (gone) => gone,
+      while: (error) => error._tag === "Railway.VolumePending",
       times: 8,
     }),
   );

--- a/packages/alchemy/src/Railway/Volume.ts
+++ b/packages/alchemy/src/Railway/Volume.ts
@@ -395,9 +395,7 @@ const resolveName = (id: string, existing?: string) =>
 const getByInstanceId = (volumeInstanceId: string) =>
   railway.volumeInstance({ id: volumeInstanceId }).pipe(
     Effect.map((instance) => (isGone(instance) ? undefined : instance)),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-      Effect.succeed(undefined),
-    ),
+    Effect.catchTag("NotFound", () => Effect.succeed(undefined)),
   );
 
 const listVolumeInstances = (environmentId: string, projectId: string) =>
@@ -409,7 +407,7 @@ const listVolumeInstances = (environmentId: string, projectId: string) =>
             .map((edge) => edge.node)
             .filter((node) => !isGone(node)),
     ),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
+    Effect.catchTag("NotFound", () =>
       Effect.succeed([] as EnvironmentResponseVolumeInstancesEdgesItemNode[]),
     ),
   );
@@ -491,7 +489,7 @@ const listEnvironmentIds = (project: {
       }
       return Array.from(set);
     }),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
+    Effect.catchTag("NotFound", () =>
       Effect.succeed(
         project.environmentId.length > 0 ? [project.environmentId] : [],
       ),
@@ -605,9 +603,7 @@ export const attachVolumeToService = Effect.fn(function* (input: {
           mountPath: input.mountPath,
         },
       })
-      .pipe(
-        Effect.catchTag(["RailwayNotFound", "NotFound"], () => Effect.void),
-      );
+      .pipe(Effect.catchTag("NotFound", () => Effect.void));
   }
   const instance =
     observed ??
@@ -742,7 +738,7 @@ export const VolumeProvider = () =>
                   .map((instance) => toAttrs(instance)),
               ),
             ),
-            Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
+            Effect.catchTag("NotFound", () =>
               Effect.succeed([] as Volume["Attributes"][]),
             ),
           ),
@@ -913,9 +909,7 @@ export const VolumeProvider = () =>
       if (volumeId.length === 0) return;
       yield* railway
         .deleteVolume({ volumeId })
-        .pipe(
-          Effect.catchTag(["RailwayNotFound", "NotFound"], () => Effect.void),
-        );
+        .pipe(Effect.catchTag("NotFound", () => Effect.void));
       yield* waitUntilGone({
         volumeInstanceId: output.volumeInstanceId,
         volumeId,

--- a/packages/alchemy/src/Railway/VolumeBackup.ts
+++ b/packages/alchemy/src/Railway/VolumeBackup.ts
@@ -495,14 +495,12 @@ const waitForWorkflow = (
       schedule: Schedule.spaced("2 seconds"),
     }),
     Effect.catchTag("Railway.VolumeBackupPending", () =>
-      mode === "delete"
-        ? Effect.void
-        : Effect.fail(
-            new VolumeBackupWorkflowFailed({
-              workflowId,
-              error: "timed out waiting for backup workflow",
-            }),
-          ),
+      Effect.fail(
+        new VolumeBackupWorkflowFailed({
+          workflowId,
+          error: `timed out waiting for backup ${mode} workflow`,
+        }),
+      ),
     ),
   );
 
@@ -530,9 +528,6 @@ const waitUntilReady = (volumeInstanceId: string) =>
       times: 10,
       schedule: Schedule.spaced("2 seconds"),
     }),
-    Effect.catchTag("Railway.VolumeBackupPending", () =>
-      getByInstanceId(volumeInstanceId),
-    ),
   );
 
 const waitForBackup = (input: {
@@ -561,15 +556,6 @@ const waitForBackup = (input: {
       times: 10,
       schedule: Schedule.spaced("2 seconds"),
     }),
-    Effect.catchTag("Railway.VolumeBackupPending", () =>
-      listBackups(input.volumeInstanceId).pipe(
-        Effect.map(
-          (backups) =>
-            findBackup(backups, { id: input.id, name: input.name }) ??
-            backups.find((backup) => !input.previousIds.has(backup.id)),
-        ),
-      ),
-    ),
   );
 
 const waitUntilGone = (
@@ -581,9 +567,16 @@ const waitUntilGone = (
       (backups) =>
         !backups.some((backup) => backup.id === volumeInstanceBackupId),
     ),
-    Effect.repeat({
+    Effect.flatMap((gone) =>
+      gone
+        ? Effect.void
+        : Effect.fail(
+            new VolumeBackupPending({ volumeInstanceId, state: "deleting" }),
+          ),
+    ),
+    Effect.retry({
       schedule: Schedule.spaced("1 second"),
-      until: (gone) => gone,
+      while: (error) => error._tag === "Railway.VolumeBackupPending",
       times: 8,
     }),
   );

--- a/packages/alchemy/src/Railway/VolumeBackup.ts
+++ b/packages/alchemy/src/Railway/VolumeBackup.ts
@@ -368,7 +368,7 @@ const listBackups = (volumeInstanceId: string) =>
   railway
     .listVolumeInstanceBackup({ volumeInstanceId })
     .pipe(
-      Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
+      Effect.catchTag("NotFound", () =>
         Effect.succeed([] as ListVolumeInstanceBackupResultItem[]),
       ),
     );
@@ -376,7 +376,7 @@ const listBackups = (volumeInstanceId: string) =>
 const listSchedules = (volumeInstanceId: string) =>
   railway.listVolumeInstanceBackupSchedule({ volumeInstanceId }).pipe(
     Effect.map((items) => uniqueKinds(items.map((item) => item.kind))),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
+    Effect.catchTag("NotFound", () =>
       Effect.succeed([] as VolumeBackupScheduleKind[]),
     ),
   );
@@ -424,9 +424,7 @@ const findBackup = (
 const getByInstanceId = (volumeInstanceId: string) =>
   railway.volumeInstance({ id: volumeInstanceId }).pipe(
     Effect.map((instance) => (isGoneInstance(instance) ? undefined : instance)),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-      Effect.succeed(undefined),
-    ),
+    Effect.catchTag("NotFound", () => Effect.succeed(undefined)),
   );
 
 const listVolumeInstances = (environmentId: string, projectId: string) =>
@@ -438,7 +436,7 @@ const listVolumeInstances = (environmentId: string, projectId: string) =>
             .map((edge) => edge.node)
             .filter((node) => !isGoneInstance(node)),
     ),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
+    Effect.catchTag("NotFound", () =>
       Effect.succeed([] as EnvironmentResponseVolumeInstancesEdgesItemNode[]),
     ),
   );
@@ -458,7 +456,7 @@ const listEnvironmentIds = (project: {
       }
       return Array.from(set);
     }),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
+    Effect.catchTag("NotFound", () =>
       Effect.succeed(
         project.environmentId.length > 0 ? [project.environmentId] : [],
       ),
@@ -472,7 +470,7 @@ const waitForWorkflow = (
 ) =>
   Effect.gen(function* () {
     const result = yield* railway.workflowStatus({ workflowId }).pipe(
-      Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
+      Effect.catchTag("NotFound", () =>
         Effect.succeed({
           status: "NotFound",
           error: null,
@@ -750,9 +748,7 @@ export const VolumeBackupProvider = () =>
               Stream.filter((env) => env.deletedAt == null),
               Stream.runCollect,
               Effect.map((chunk) => Array.from(chunk)),
-              Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-                Effect.succeed([]),
-              ),
+              Effect.catchTag("NotFound", () => Effect.succeed([])),
             );
           const instances = envRows.flatMap((env) =>
             env.volumeInstances.edges
@@ -913,7 +909,7 @@ export const VolumeBackupProvider = () =>
           volumeInstanceId,
         })
         .pipe(
-          Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
+          Effect.catchTag("NotFound", () =>
             Effect.succeed({ workflowId: null as string | null }),
           ),
         );

--- a/packages/alchemy/src/Railway/Website/Cdn.ts
+++ b/packages/alchemy/src/Railway/Website/Cdn.ts
@@ -133,14 +133,11 @@ export const CdnProvider = () =>
         });
       }
       const config = { caching: cachingInput(news) };
-      const retryTransient = {
-        while: (e: { _tag: string }) =>
-          e._tag === "RailwayInternalError" ||
-          e._tag === "TimeoutError" ||
-          isRailwayTransient(e),
-        times: 2 as const,
-        schedule: Schedule.spaced("1 second"),
-      };
+      // enableServiceCdn is an upsert of the edge config. Transient
+      // failures (`Problem processing request` is typed retryable and
+      // absorbed by the SDK retry policy) get a bounded outer retry;
+      // anything persistent bubbles typed instead of faking success
+      // with stale output.
       const enabled = yield* railway
         .enableServiceCdn({
           input: {
@@ -150,25 +147,15 @@ export const CdnProvider = () =>
           },
         })
         .pipe(
-          Effect.timeout("5 seconds"),
-          Effect.retry(retryTransient),
-          Effect.catchTag("UnknownRailwayError", () =>
-            railway
-              .updateServiceEdgeConfig({
-                input: {
-                  serviceId,
-                  environmentId,
-                  config,
-                },
-              })
-              .pipe(Effect.timeout("5 seconds"), Effect.retry(retryTransient)),
-          ),
-          Effect.catchTag(["TimeoutError", "RailwayInternalError"], () =>
-            Effect.succeed({
-              id: output?.edgeConfigId ?? "",
-              enabled: output?.enabled ?? false,
-            }),
-          ),
+          Effect.timeout("30 seconds"),
+          Effect.retry({
+            while: (e) =>
+              e._tag === "RailwayInternalError" ||
+              e._tag === "TimeoutError" ||
+              isRailwayTransient(e),
+            times: 2,
+            schedule: Schedule.spaced("1 second"),
+          }),
         );
       return {
         serviceId,
@@ -181,6 +168,8 @@ export const CdnProvider = () =>
     delete: Effect.fn(function* ({ output }) {
       if (output === undefined) return;
       if (output.edgeConfigId.length === 0) return;
+      // disableServiceCdn is idempotent (verified live); only a missing
+      // service maps to "already gone".
       yield* railway
         .disableServiceCdn({
           input: {
@@ -188,11 +177,6 @@ export const CdnProvider = () =>
             serviceId: output.serviceId,
           },
         })
-        .pipe(
-          Effect.catchTag(
-            ["UnknownRailwayError", "RailwayValidationError"],
-            () => Effect.void,
-          ),
-        );
+        .pipe(Effect.catchTag("NotFound", () => Effect.void));
     }),
   });

--- a/packages/alchemy/src/Railway/transient.ts
+++ b/packages/alchemy/src/Railway/transient.ts
@@ -40,24 +40,18 @@ const retryCreateRateLimit = <A, E, R>(
   effect: Effect.Effect<A, E, R>,
 ): Effect.Effect<A, E, R> =>
   effect.pipe(
-    Effect.catch((error) =>
-      error instanceof railway.RailwayRateLimited
-        ? Effect.sleep(
-            Duration.sum(
-              error.retryAfter ?? createRateLimitWait,
-              jitterUpTo(Duration.seconds(30)),
-            ),
-          ).pipe(Effect.andThen(retryCreateRateLimit(effect)))
-        : Effect.fail(error),
-    ),
+    railway.Retry.none,
+    Effect.retry({
+      while: (error) => error instanceof railway.RailwayRateLimited,
+      schedule: Schedule.spaced(createRateLimitWait),
+      times: 1,
+    }),
   );
 
 /**
  * Railway meters project and environment creates at 1 per 30s per user.
- * Distilled tags those as `RailwayRateLimited`. Sleep the hinted delay
- * (or 31s) plus 0–30s jitter and retry until the cap opens. Unbounded.
- * The gate is held across the sleep so the next waiter does not fire
- * another create into a closed window.
+ * Retry once after that window, with nested SDK retries disabled.
+ * Hold the gate across the sleep so another create cannot race the retry.
  */
 export const waitOutCreateRateLimit = <A, E, R>(
   effect: Effect.Effect<A, E, R>,

--- a/packages/alchemy/src/SQL/Postgres.ts
+++ b/packages/alchemy/src/SQL/Postgres.ts
@@ -6,7 +6,7 @@ import type * as Redacted from "effect/Redacted";
 import * as Sql from "effect/unstable/sql/SqlClient";
 import { makeExecutionMemo } from "../Runtime/ExecutionMemo.ts";
 import { proxyChain } from "../Util/proxy-chain.ts";
-import { resolveSsl } from "./PostgresTls.ts";
+import { resolvePostgresConnection } from "./PostgresTls.ts";
 
 /**
  * Options for {@link Postgres}: `@effect/sql-pg`'s pool configuration, with
@@ -58,8 +58,7 @@ export const Postgres = <E = never, R = never>(config: PostgresConfig<E, R>) =>
         const pgCtx = yield* Layer.build(
           PgClient.layer({
             ...pool,
-            url: resolved,
-            ssl: resolveSsl(resolved, pool.ssl),
+            ...resolvePostgresConnection(resolved, pool.ssl),
           }),
         );
         return Context.get(pgCtx, PgClient.PgClient);

--- a/packages/alchemy/src/SQL/PostgresTls.ts
+++ b/packages/alchemy/src/SQL/PostgresTls.ts
@@ -3,6 +3,24 @@ import * as Redacted from "effect/Redacted";
 
 type PgSsl = PgClient.PgPoolConfig["ssl"];
 
+/** Translate node-postgres's `no-verify` URL mode into explicit TLS options. */
+export const resolvePostgresConnection = (
+  url: Redacted.Redacted<string>,
+  ssl?: PgSsl,
+) => {
+  const resolvedSsl = resolveSsl(url, ssl);
+  try {
+    const parsed = new URL(Redacted.value(url));
+    if (parsed.searchParams.get("sslmode") === "no-verify") {
+      parsed.searchParams.delete("sslmode");
+      return { url: Redacted.make(parsed.toString()), ssl: resolvedSsl };
+    }
+  } catch {
+    // Let the driver report invalid connection URLs.
+  }
+  return { url, ssl: resolvedSsl };
+};
+
 /**
  * `sslmode` values that `@effect/sql-pg`'s URL parser reads as "use TLS"
  * on its own.
@@ -69,6 +87,9 @@ export const resolveSsl = (
   }
 
   const sslmode = parsed.searchParams.get("sslmode");
+  if (sslmode === "no-verify" && ssl === undefined) {
+    ssl = { rejectUnauthorized: false };
+  }
   const tlsRequested =
     ssl === true ||
     typeof ssl === "object" ||

--- a/packages/alchemy/src/State/PostgresState.ts
+++ b/packages/alchemy/src/State/PostgresState.ts
@@ -7,7 +7,7 @@ import * as Scope from "effect/Scope";
 import * as Semaphore from "effect/Semaphore";
 import type * as SqlClient from "effect/unstable/sql/SqlClient";
 import type * as SqlError from "effect/unstable/sql/SqlError";
-import { resolveSsl } from "../SQL/PostgresTls.ts";
+import { resolvePostgresConnection } from "../SQL/PostgresTls.ts";
 import { recordStateStoreInit } from "../Telemetry/Metrics.ts";
 import { STATE_STORE_VERSION } from "./HttpStateApi.ts";
 import type { ReplacedResourceState } from "./ResourceState.ts";
@@ -275,10 +275,7 @@ export const makePostgresState = <E = never, R = never>(
           ? yield* Effect.provideContext(url, context).pipe(stateError)
           : url;
         const built = yield* Layer.build(
-          PgClient.layer({
-            url: resolved,
-            ssl: resolveSsl(resolved, undefined),
-          }),
+          PgClient.layer(resolvePostgresConnection(resolved)),
         ).pipe(Scope.provide(scope), stateError);
         return Context.get(built, PgClient.PgClient);
       });

--- a/packages/alchemy/test/Railway/AuditLog.test.ts
+++ b/packages/alchemy/test/Railway/AuditLog.test.ts
@@ -66,5 +66,5 @@ test.provider(
 
       yield* stack.destroy();
     }).pipe(logLevel),
-  { timeout: 3_600_000 },
+  { timeout: 120_000 },
 );

--- a/packages/alchemy/test/Railway/Bindings.test.ts
+++ b/packages/alchemy/test/Railway/Bindings.test.ts
@@ -172,9 +172,9 @@ const Stack = Alchemy.Stack(
   }),
 );
 
-const stack = beforeAll(deploy(Stack), { timeout: 3_600_000 });
+const stack = beforeAll(deploy(Stack), { timeout: 120_000 });
 afterAll.skipIf(!!process.env.NO_DESTROY)(destroy(Stack), {
-  timeout: 3_600_000,
+  timeout: 120_000,
 });
 
 const retryTransient = {
@@ -267,7 +267,7 @@ describe("Railway Bindings", () => {
         expect(bucketBody.length).toBeGreaterThan(0);
       }
     }).pipe(logLevel),
-    { timeout: 3_600_000 },
+    { timeout: 120_000 },
   );
 
   describe("ReadWriteRedis", () => {
@@ -318,7 +318,7 @@ describe("Railway Bindings", () => {
         const got = yield* Railway.runRedisCommand(url, "GET", ["marker"]);
         expect(got).toEqual(REDIS_VALUE);
       }).pipe(logLevel),
-      { timeout: 3_600_000 },
+      { timeout: 120_000 },
     );
   });
 
@@ -383,7 +383,7 @@ describe("Railway Bindings", () => {
             : yield* Stream.mkString(Stream.decodeText(got.Body));
         expect(text).toEqual(OBJECT_BODY);
       }).pipe(logLevel),
-      { timeout: 3_600_000 },
+      { timeout: 120_000 },
     );
   });
 });

--- a/packages/alchemy/test/Railway/Bindings.test.ts
+++ b/packages/alchemy/test/Railway/Bindings.test.ts
@@ -84,7 +84,7 @@ const readServiceVariables = (
     })
     .pipe(
       Effect.map(asVariableMap),
-      Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
+      Effect.catchTag("NotFound", () =>
         Effect.succeed({} as Record<string, string>),
       ),
     );

--- a/packages/alchemy/test/Railway/Bucket.test.ts
+++ b/packages/alchemy/test/Railway/Bucket.test.ts
@@ -263,5 +263,5 @@ test.provider(
       );
       expect(gone).toEqual("gone");
     }).pipe(logLevel),
-  { timeout: 3_600_000 },
+  { timeout: 120_000 },
 );

--- a/packages/alchemy/test/Railway/Bucket.test.ts
+++ b/packages/alchemy/test/Railway/Bucket.test.ts
@@ -27,7 +27,7 @@ const OBJECT_BODY = "hello-from-railway";
 const listProjectBuckets = (projectId: string) =>
   railway.project({ id: projectId }).pipe(
     Effect.map((project) => project.buckets.edges.map((edge) => edge.node)),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () => Effect.succeed([])),
+    Effect.catchTag("NotFound", () => Effect.succeed([])),
   );
 
 const findBucket = (projectId: string, bucketId: string, name: string) =>
@@ -85,9 +85,7 @@ const waitUntilBucketGone = (
         ? ("gone" as const)
         : ("found" as const);
     }),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-      Effect.succeed("gone" as const),
-    ),
+    Effect.catchTag("NotFound", () => Effect.succeed("gone" as const)),
     Effect.repeat({
       schedule: Schedule.spaced("2 seconds"),
       until: (status) => status === "gone",

--- a/packages/alchemy/test/Railway/CloudAgent.test.ts
+++ b/packages/alchemy/test/Railway/CloudAgent.test.ts
@@ -69,6 +69,7 @@ test.provider(
         }),
       );
       if (Result.isFailure(probe)) {
+        yield* Effect.logInfo(probe.failure);
         expect(
           ["RailwayForbidden", "RailwayPlanLimitExceeded"].includes(
             probe.failure._tag,
@@ -143,5 +144,5 @@ test.provider(
       );
       expect(agentGone).toEqual("gone");
     }).pipe(logLevel),
-  { timeout: 3_600_000 },
+  { timeout: 120_000 },
 );

--- a/packages/alchemy/test/Railway/CloudAgent.test.ts
+++ b/packages/alchemy/test/Railway/CloudAgent.test.ts
@@ -24,11 +24,7 @@ const logLevel = Effect.provideService(
 const listLive = (environmentId: string) =>
   railway
     .cloudAgents({ environmentId, mine: true })
-    .pipe(
-      Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-        Effect.succeed([]),
-      ),
-    );
+    .pipe(Effect.catchTag("NotFound", () => Effect.succeed([])));
 
 const waitUntilAgentGone = (environmentId: string, cloudAgentId: string) =>
   listLive(environmentId).pipe(
@@ -49,7 +45,7 @@ const waitUntilAgentGone = (environmentId: string, cloudAgentId: string) =>
 const deleteAgent = (id: string) =>
   railway
     .deleteCloudAgent({ id })
-    .pipe(Effect.catchTag(["RailwayNotFound", "NotFound"], () => Effect.void));
+    .pipe(Effect.catchTag("NotFound", () => Effect.void));
 
 test.provider(
   "create, list, and delete a cloud agent",

--- a/packages/alchemy/test/Railway/CustomDomain.test.ts
+++ b/packages/alchemy/test/Railway/CustomDomain.test.ts
@@ -167,7 +167,7 @@ test.provider(
       );
       expect(domainGone).toEqual("gone");
     }).pipe(logLevel),
-  { timeout: 3_600_000 },
+  { timeout: 120_000 },
 );
 
 test.provider.skipIf(!TEST_DOMAIN)(
@@ -217,5 +217,5 @@ test.provider.skipIf(!TEST_DOMAIN)(
       );
       expect(domainGone).toEqual("gone");
     }).pipe(logLevel),
-  { timeout: 3_600_000 },
+  { timeout: 120_000 },
 );

--- a/packages/alchemy/test/Railway/CustomDomain.test.ts
+++ b/packages/alchemy/test/Railway/CustomDomain.test.ts
@@ -28,7 +28,7 @@ const listLive = (
         (domain) => domain.deletedAt == null && domain.syncStatus !== "DELETED",
       ),
     ),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () => Effect.succeed([])),
+    Effect.catchTag("NotFound", () => Effect.succeed([])),
   );
 
 const waitUntilDomainGone = (customDomainId: string, projectId: string) =>
@@ -38,9 +38,7 @@ const waitUntilDomainGone = (customDomainId: string, projectId: string) =>
         ? ("gone" as const)
         : ("found" as const),
     ),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-      Effect.succeed("gone" as const),
-    ),
+    Effect.catchTag("NotFound", () => Effect.succeed("gone" as const)),
     Effect.repeat({
       schedule: Schedule.spaced("1 second"),
       until: (status) => status === "gone",

--- a/packages/alchemy/test/Railway/Environment.test.ts
+++ b/packages/alchemy/test/Railway/Environment.test.ts
@@ -130,5 +130,5 @@ test.provider(
       );
       expect(envGone).toEqual("gone");
     }).pipe(logLevel),
-  { timeout: 3_600_000 },
+  { timeout: 120_000 },
 );

--- a/packages/alchemy/test/Railway/Environment.test.ts
+++ b/packages/alchemy/test/Railway/Environment.test.ts
@@ -20,9 +20,7 @@ const waitUntilEnvGone = (environmentId: string) =>
     Effect.map((env) =>
       env.deletedAt != null ? ("gone" as const) : ("found" as const),
     ),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-      Effect.succeed("gone" as const),
-    ),
+    Effect.catchTag("NotFound", () => Effect.succeed("gone" as const)),
     Effect.repeat({
       schedule: Schedule.spaced("1 second"),
       until: (status) => status === "gone",

--- a/packages/alchemy/test/Railway/Function.test.ts
+++ b/packages/alchemy/test/Railway/Function.test.ts
@@ -33,9 +33,7 @@ const waitUntilGone = (serviceId: string) =>
     Effect.map((service) =>
       service.deletedAt != null ? ("gone" as const) : ("found" as const),
     ),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-      Effect.succeed("gone" as const),
-    ),
+    Effect.catchTag("NotFound", () => Effect.succeed("gone" as const)),
     Effect.repeat({
       schedule: Schedule.spaced("1 second"),
       until: (status) => status === "gone",

--- a/packages/alchemy/test/Railway/Function.test.ts
+++ b/packages/alchemy/test/Railway/Function.test.ts
@@ -152,7 +152,7 @@ test.provider(
       const gone = yield* waitUntilGone(created.ping.serviceId);
       expect(gone).toEqual("gone");
     }).pipe(logLevel),
-  { timeout: 3_600_000 },
+  { timeout: 120_000 },
 );
 
 test.provider(
@@ -215,7 +215,7 @@ test.provider(
       const gone = yield* waitUntilGone(created.ping.serviceId);
       expect(gone).toEqual("gone");
     }).pipe(logLevel),
-  { timeout: 3_600_000 },
+  { timeout: 120_000 },
 );
 
 test.provider.skip(
@@ -277,5 +277,5 @@ test.provider.skip(
       const gone = yield* waitUntilGone(created.ping.serviceId);
       expect(gone).toEqual("gone");
     }).pipe(logLevel),
-  { timeout: 3_600_000 },
+  { timeout: 120_000 },
 );

--- a/packages/alchemy/test/Railway/Group.test.ts
+++ b/packages/alchemy/test/Railway/Group.test.ts
@@ -136,7 +136,8 @@ test.provider(
         fromConfig !== undefined ||
         fromProject !== undefined ||
         apiLive?.groupId === created.backend.groupId;
-      expect(persisted || created.backend.serviceIds.length === 1).toBe(true);
+      expect(persisted).toBe(true);
+      expect(apiLive?.groupId).toBe(created.backend.groupId);
       if (fromConfig !== undefined) {
         expect(fromConfig.name).toEqual(created.backend.name);
       }
@@ -151,10 +152,8 @@ test.provider(
           group.groupId === created.backend.groupId &&
           group.environmentId === created.backend.environmentId,
       );
-      if (fromConfig !== undefined || fromProject !== undefined) {
-        expect(found).toBeDefined();
-        expect(found?.name).toEqual(created.backend.name);
-      }
+      expect(found).toBeDefined();
+      expect(found?.name).toEqual(created.backend.name);
 
       const updated = yield* stack.deploy(
         Effect.gen(function* () {
@@ -184,6 +183,36 @@ test.provider(
         created.backend.serviceIds.sort(),
       );
 
+      const changed = yield* stack.deploy(
+        Effect.gen(function* () {
+          const { project, environment } = yield* suitePartition;
+          const api = yield* Railway.Service("Api", {
+            project,
+            environment,
+            image: "hashicorp/http-echo",
+            port: 5678,
+          });
+          const backend = yield* Railway.Group("Backend", {
+            project,
+            environment,
+            resources: [],
+            collapsed: true,
+            color: "#00ff00",
+          });
+          return { project, environment, api, backend };
+        }),
+      );
+      expect(changed.backend.groupId).toEqual(created.backend.groupId);
+      expect(changed.backend.collapsed).toBe(true);
+      expect(changed.backend.color).toBe("#00ff00");
+      expect(changed.backend.serviceIds).toEqual([]);
+      expect((yield* readService(created.api.serviceId))?.groupId).toBeNull();
+      const changedGroups = yield* readProjectGroups(changed.backend.projectId);
+      expect(
+        changedGroups.find((group) => group.id === changed.backend.groupId)
+          ?.isCollapsed,
+      ).toBe(true);
+
       yield* stack.destroy();
 
       const groupGone = yield* waitUntilGroupGone(
@@ -194,5 +223,5 @@ test.provider(
       );
       expect(groupGone).toEqual("gone");
     }).pipe(logLevel),
-  { timeout: 3_600_000 },
+  { timeout: 120_000 },
 );

--- a/packages/alchemy/test/Railway/Group.test.ts
+++ b/packages/alchemy/test/Railway/Group.test.ts
@@ -38,7 +38,7 @@ const asGroupMap = (value: unknown): Record<string, { name?: string }> => {
 const readConfigGroups = (environmentId: string, projectId: string) =>
   railway.environment({ id: environmentId, projectId }).pipe(
     Effect.map((env) => asGroupMap(env.config)),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
+    Effect.catchTag("NotFound", () =>
       Effect.succeed({} as Record<string, { name?: string }>),
     ),
   );
@@ -50,17 +50,13 @@ const readProjectGroups = (projectId: string) =>
         .map((edge) => edge.node)
         .filter((group) => group.name != null && group.name.length > 0),
     ),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () => Effect.succeed([])),
+    Effect.catchTag("NotFound", () => Effect.succeed([])),
   );
 
 const readService = (serviceId: string) =>
   railway
     .service({ id: serviceId })
-    .pipe(
-      Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-        Effect.succeed(undefined),
-      ),
-    );
+    .pipe(Effect.catchTag("NotFound", () => Effect.succeed(undefined)));
 
 const waitUntilGroupGone = (
   projectId: string,

--- a/packages/alchemy/test/Railway/LoginSession.test.ts
+++ b/packages/alchemy/test/Railway/LoginSession.test.ts
@@ -80,5 +80,5 @@ test.provider(
 
       yield* stack.destroy();
     }).pipe(logLevel),
-  { timeout: 3_600_000 },
+  { timeout: 120_000 },
 );

--- a/packages/alchemy/test/Railway/LoginSession.test.ts
+++ b/packages/alchemy/test/Railway/LoginSession.test.ts
@@ -12,7 +12,7 @@ const logLevel = Effect.provideService(
   process.env.DEBUG ? "Debug" : "Info",
 );
 
-const missingSession = ["RailwayNotFound", "NotFound"] as const;
+const missingSession = ["NotFound"] as const;
 
 test.provider(
   "create, verify, and cancel a login session",

--- a/packages/alchemy/test/Railway/Mongo.test.ts
+++ b/packages/alchemy/test/Railway/Mongo.test.ts
@@ -72,7 +72,7 @@ const readServiceVariables = (
     })
     .pipe(
       Effect.map(asVariableMap),
-      Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
+      Effect.catchTag("NotFound", () =>
         Effect.succeed({} as Record<string, string>),
       ),
     );
@@ -82,9 +82,7 @@ const waitUntilServiceGone = (serviceId: string) =>
     Effect.map((service) =>
       service.deletedAt != null ? ("gone" as const) : ("found" as const),
     ),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-      Effect.succeed("gone" as const),
-    ),
+    Effect.catchTag("NotFound", () => Effect.succeed("gone" as const)),
     Effect.repeat({
       schedule: Schedule.spaced("1 second"),
       until: (status) => status === "gone",

--- a/packages/alchemy/test/Railway/Mongo.test.ts
+++ b/packages/alchemy/test/Railway/Mongo.test.ts
@@ -39,10 +39,8 @@ const distilled = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
 
 const ping = (url: string) =>
   Railway.pingMongo(url).pipe(
-    // A fresh Mongo behind a freshly created TCP proxy can take minutes to
-    // accept connections under full-suite load (cold volume init + proxy
-    // port propagation). Keep retrying, bounded to ~4 minutes.
-    Effect.retry({ schedule: Schedule.spaced("5 seconds"), times: 48 }),
+    Effect.retry({ schedule: Schedule.spaced("3 seconds"), times: 10 }),
+    Effect.timeout("45 seconds"),
   );
 
 const asVariableMap = (value: unknown): Record<string, string> => {
@@ -123,10 +121,10 @@ const FixtureStack = Alchemy.Stack(
 );
 
 const fixture = beforeAll(deploy(FixtureStack), {
-  timeout: 3_600_000,
+  timeout: 120_000,
 });
 afterAll.skipIf(!!process.env.NO_DESTROY)(destroy(FixtureStack), {
-  timeout: 3_600_000,
+  timeout: 120_000,
 });
 
 test.provider(
@@ -272,7 +270,7 @@ test.provider(
       );
       expect(volumeGone).toEqual("gone");
     }).pipe(logLevel),
-  { timeout: 3_600_000 },
+  { timeout: 120_000 },
 );
 
 test(
@@ -362,5 +360,5 @@ test(
     const pong = yield* ping(out.publicConnectionUri);
     expect(pong.ok).toEqual(1);
   }).pipe(logLevel),
-  { timeout: 3_600_000 },
+  { timeout: 120_000 },
 );

--- a/packages/alchemy/test/Railway/MySQL.test.ts
+++ b/packages/alchemy/test/Railway/MySQL.test.ts
@@ -93,7 +93,7 @@ const readServiceVariables = (
     })
     .pipe(
       Effect.map(asVariableMap),
-      Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
+      Effect.catchTag("NotFound", () =>
         Effect.succeed({} as Record<string, string>),
       ),
     );
@@ -103,9 +103,7 @@ const waitUntilServiceGone = (serviceId: string) =>
     Effect.map((service) =>
       service.deletedAt != null ? ("gone" as const) : ("found" as const),
     ),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-      Effect.succeed("gone" as const),
-    ),
+    Effect.catchTag("NotFound", () => Effect.succeed("gone" as const)),
     Effect.repeat({
       schedule: Schedule.spaced("1 second"),
       until: (status) => status === "gone",

--- a/packages/alchemy/test/Railway/MySQL.test.ts
+++ b/packages/alchemy/test/Railway/MySQL.test.ts
@@ -59,12 +59,10 @@ const selectOne = (url: string) =>
       }
     },
     catch: (cause) => new Error(String(cause)),
-    // A fresh MySQL behind a freshly created TCP proxy can take minutes to
-    // accept connections under full-suite load (cold volume init + proxy
-    // port propagation) — the proxy accepts and immediately closes until
-    // the upstream is ready ("Connection lost: The server closed the
-    // connection"). Keep retrying, bounded to ~4 minutes.
-  }).pipe(Effect.retry({ schedule: Schedule.spaced("5 seconds"), times: 48 }));
+  }).pipe(
+    Effect.retry({ schedule: Schedule.spaced("3 seconds"), times: 10 }),
+    Effect.timeout("45 seconds"),
+  );
 
 const asVariableMap = (value: unknown): Record<string, string> => {
   if (value === null || typeof value !== "object" || Array.isArray(value)) {
@@ -143,31 +141,10 @@ const FixtureStack = Alchemy.Stack(
   }),
 );
 
-/**
- * HTTP fixture gated: full-suite `beforeAll` died with
- * `RailwayServiceDomainCreateFailed` ("Failed to create service domain,
- * please try again") and took the CRUD test with it. Flip to `true` to
- * retry the ConnectMySQL HTTP path. See `src/Railway/TODO.md`.
- */
-const MYSQL_HTTP_FIXTURE = false;
-
-const fixture = MYSQL_HTTP_FIXTURE
-  ? beforeAll(deploy(FixtureStack), {
-      timeout: 3_600_000,
-    })
-  : Effect.succeed({
-      projectId: "",
-      environmentId: "",
-      serviceId: "",
-      url: undefined as string | undefined,
-      publicConnectionUri: "",
-      mode: "effect" as const,
-    });
-if (MYSQL_HTTP_FIXTURE) {
-  afterAll.skipIf(!!process.env.NO_DESTROY)(destroy(FixtureStack), {
-    timeout: 3_600_000,
-  });
-}
+const fixture = beforeAll(deploy(FixtureStack), { timeout: 120_000 });
+afterAll.skipIf(!!process.env.NO_DESTROY)(destroy(FixtureStack), {
+  timeout: 120_000,
+});
 
 test.provider(
   "create, select 1, update, list, and delete mysql",
@@ -312,10 +289,10 @@ test.provider(
       );
       expect(volumeGone).toEqual("gone");
     }).pipe(logLevel),
-  { timeout: 3_600_000 },
+  { timeout: 120_000 },
 );
 
-test.skipIf(!MYSQL_HTTP_FIXTURE)(
+test(
   "a Service connects and SELECTs through ConnectMySQL",
   Effect.gen(function* () {
     const out = yield* fixture;
@@ -402,5 +379,5 @@ test.skipIf(!MYSQL_HTTP_FIXTURE)(
     const rows = yield* selectOne(out.publicConnectionUri);
     expect(firstOk(rows)).toEqual(1);
   }).pipe(logLevel),
-  { timeout: 3_600_000 },
+  { timeout: 120_000 },
 );

--- a/packages/alchemy/test/Railway/Postgres.test.ts
+++ b/packages/alchemy/test/Railway/Postgres.test.ts
@@ -66,12 +66,10 @@ const selectOne = (url: string) =>
       }
     },
     catch: (cause) => new Error(String(cause)),
-    // A fresh Postgres behind a freshly created TCP proxy can take minutes
-    // to accept connections under full-suite load (cold volume init + proxy
-    // port propagation) — the proxy accepts and immediately closes until
-    // the upstream is ready ("Connection terminated unexpectedly"). Keep
-    // retrying, bounded to ~4 minutes.
-  }).pipe(Effect.retry({ schedule: Schedule.spaced("5 seconds"), times: 48 }));
+  }).pipe(
+    Effect.retry({ schedule: Schedule.spaced("3 seconds"), times: 10 }),
+    Effect.timeout("45 seconds"),
+  );
 
 const asVariableMap = (value: unknown): Record<string, string> => {
   if (value === null || typeof value !== "object" || Array.isArray(value)) {
@@ -154,10 +152,10 @@ const FixtureStack = Alchemy.Stack(
 );
 
 const fixture = beforeAll(deploy(FixtureStack), {
-  timeout: 3_600_000,
+  timeout: 120_000,
 });
 afterAll.skipIf(!!process.env.NO_DESTROY)(destroy(FixtureStack), {
-  timeout: 3_600_000,
+  timeout: 120_000,
 });
 
 test.provider(
@@ -287,7 +285,7 @@ test.provider(
       );
       expect(volumeGone).toEqual("gone");
     }).pipe(logLevel),
-  { timeout: 3_600_000 },
+  { timeout: 120_000 },
 );
 
 test(
@@ -381,7 +379,7 @@ test(
     const rows = yield* selectOne(out.publicConnectionUri);
     expect(firstOk(rows)).toEqual(1);
   }).pipe(logLevel),
-  { timeout: 3_600_000 },
+  { timeout: 120_000 },
 );
 
 test(
@@ -433,5 +431,5 @@ test(
     const health = (yield* get("/")) as { rows?: unknown };
     expect(firstOk(health.rows)).toEqual(1);
   }).pipe(logLevel),
-  { timeout: 3_600_000 },
+  { timeout: 120_000 },
 );

--- a/packages/alchemy/test/Railway/Postgres.test.ts
+++ b/packages/alchemy/test/Railway/Postgres.test.ts
@@ -100,7 +100,7 @@ const readServiceVariables = (
     })
     .pipe(
       Effect.map(asVariableMap),
-      Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
+      Effect.catchTag("NotFound", () =>
         Effect.succeed({} as Record<string, string>),
       ),
     );
@@ -110,9 +110,7 @@ const waitUntilServiceGone = (serviceId: string) =>
     Effect.map((service) =>
       service.deletedAt != null ? ("gone" as const) : ("found" as const),
     ),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-      Effect.succeed("gone" as const),
-    ),
+    Effect.catchTag("NotFound", () => Effect.succeed("gone" as const)),
     Effect.repeat({
       schedule: Schedule.spaced("1 second"),
       until: (status) => status === "gone",

--- a/packages/alchemy/test/Railway/PrivateNetwork.test.ts
+++ b/packages/alchemy/test/Railway/PrivateNetwork.test.ts
@@ -1,216 +1,117 @@
 import * as railway from "@distilled.cloud/railway";
 import * as Provider from "@/Provider";
 import * as Railway from "@/Railway";
-import { suitePartition } from "./suiteProject.ts";
 import * as Test from "@/Test/Alchemy";
 import { expect } from "alchemy-test";
 import * as Effect from "effect/Effect";
-import { MinimumLogLevel } from "effect/References";
 import * as Schedule from "effect/Schedule";
+import { suitePartition } from "./suiteProject.ts";
 
 const { test } = Test.make({ providers: Railway.providers() });
 
-const logLevel = Effect.provideService(
-  MinimumLogLevel,
-  process.env.DEBUG ? "Debug" : "Info",
-);
+const resources = Effect.gen(function* () {
+  const { project, environment } = yield* suitePartition;
+  const api = yield* Railway.Service("Api", {
+    project,
+    environment,
+    image: "hashicorp/http-echo",
+    port: 5678,
+  });
+  const network = yield* Railway.PrivateNetwork("Mesh", { environment });
+  return { project, environment, api, network };
+});
 
-const listLive = (environmentId: string) =>
-  railway.privateNetworks({ environmentId }).pipe(
-    Effect.map((items) => items.filter((network) => network.deletedAt == null)),
-    Effect.catchTag("NotFound", () => Effect.succeed([])),
-  );
+const withEndpoint = (name: string) =>
+  Effect.gen(function* () {
+    const base = yield* resources;
+    const endpoint = yield* Railway.PrivateNetworkEndpoint("ApiDns", {
+      network: base.network,
+      service: base.api,
+      name,
+    });
+    return { ...base, endpoint };
+  });
 
-const waitUntilEndpointGone = (input: {
-  environmentId: string;
-  privateNetworkId: string;
-  serviceId: string;
-}) =>
-  railway.privateNetworkEndpoint(input).pipe(
-    Effect.map((endpoint) =>
-      endpoint == null ||
-      endpoint.deletedAt != null ||
-      endpoint.syncStatus === "DELETED" ||
-      endpoint.syncStatus === "DELETING"
-        ? ("gone" as const)
-        : ("found" as const),
-    ),
-    Effect.catchTag("NotFound", () => Effect.succeed("gone" as const)),
-    Effect.repeat({
-      schedule: Schedule.spaced("1 second"),
-      until: (status) => status === "gone",
-      times: 10,
-    }),
-  );
-
-test.provider.skip(
-  "create-or-get a private network is idempotent (dnsName was delightful-purpose, expected to contain api)",
+test.provider(
+  "create, rename, and delete a private network endpoint",
   (stack) =>
     Effect.gen(function* () {
       yield* stack.destroy();
-
-      const created = yield* stack.deploy(
-        Effect.gen(function* () {
-          const { project, environment } = yield* suitePartition;
-          const network = yield* Railway.PrivateNetwork("Mesh", {
-            environment,
-          });
-          return { project, environment, network };
-        }),
-      );
-
-      expect(created.network.publicId).toEqual(expect.any(String));
-      expect(created.network.publicId.length).toBeGreaterThan(0);
-      expect(typeof created.network.networkId).toEqual("string");
-      expect(created.network.networkId.length).toBeGreaterThan(0);
+      const created = yield* stack.deploy(withEndpoint("api"));
       expect(created.network.networkId).toMatch(/^\d+$/);
       expect(created.network.projectId).toEqual(created.project.projectId);
       expect(created.network.environmentId).toEqual(
         created.environment.environmentId,
       );
-      expect(created.network.name).toEqual(expect.any(String));
-      expect(created.network.name.length).toBeGreaterThan(0);
-      expect(created.network.name.length).toBeLessThanOrEqual(32);
-      expect(created.network.name).toMatch(/^[a-z][a-z0-9-]*$/);
-      expect(created.network.dnsName).toEqual(expect.any(String));
-      expect(created.network.dnsName.length).toBeGreaterThan(0);
-      expect(created.network.tags).toEqual(expect.any(Array));
-
-      const listed = yield* listLive(created.network.environmentId);
-      const fetched = listed.find(
-        (network) => network.publicId === created.network.publicId,
+      expect(created.endpoint.serviceId).toEqual(created.api.serviceId);
+      expect(created.endpoint.privateNetworkId).toEqual(
+        created.network.publicId,
       );
-      expect(fetched).toBeDefined();
-      expect(fetched?.name).toEqual(created.network.name);
-      expect(fetched?.dnsName).toEqual(created.network.dnsName);
-      expect(fetched?.projectId).toEqual(created.network.projectId);
-      expect(fetched?.environmentId).toEqual(created.network.environmentId);
+      expect(created.endpoint.dnsName.split(".")[0]).toBe("api");
 
       const again = yield* railway.privateNetworkCreateOrGet({
         input: {
           environmentId: created.network.environmentId,
-          projectId: created.network.projectId,
+          projectId: created.project.projectId,
           name: created.network.name,
           tags: ["alchemy"],
         },
       });
       expect(again.publicId).toEqual(created.network.publicId);
-      expect(again.name).toEqual(created.network.name);
-      expect(again.dnsName).toEqual(created.network.dnsName);
-      expect(String(again.networkId)).toEqual(created.network.networkId);
-
-      const provider = yield* Provider.findProvider(Railway.PrivateNetwork);
-      const owned = yield* provider.list();
-      const found = owned.find(
-        (network) => network.publicId === created.network.publicId,
-      );
-      expect(found).toBeDefined();
-      expect(found?.name).toEqual(created.network.name);
-      expect(found?.dnsName).toEqual(created.network.dnsName);
-
-      const updated = yield* stack.deploy(
-        Effect.gen(function* () {
-          const { project, environment } = yield* suitePartition;
-          const network = yield* Railway.PrivateNetwork("Mesh", {
-            environment,
-          });
-          return { project, environment, network };
-        }),
-      );
-
-      expect(updated.network.publicId).toEqual(created.network.publicId);
-      expect(updated.network.name).toEqual(created.network.name);
-      expect(updated.network.dnsName).toEqual(created.network.dnsName);
-      expect(updated.project.projectId).toEqual(created.project.projectId);
-
-      const service = yield* railway.createService({
-        input: {
-          projectId: created.project.projectId,
-          environmentId: created.environment.environmentId,
-          source: { image: "hashicorp/http-echo" },
-        },
-      });
-
-      const withEndpoint = yield* stack.deploy(
-        Effect.gen(function* () {
-          const { project, environment } = yield* suitePartition;
-          const network = yield* Railway.PrivateNetwork("Mesh", {
-            environment,
-          });
-          const endpoint = yield* Railway.PrivateNetworkEndpoint("ApiDns", {
-            network,
-            service: { serviceId: service.id, name: service.name },
-            name: "api",
-          });
-          return { project, environment, network, endpoint };
-        }),
-      );
-
-      expect(withEndpoint.network.publicId).toEqual(created.network.publicId);
-      expect(withEndpoint.endpoint.publicId).toEqual(expect.any(String));
-      expect(withEndpoint.endpoint.publicId.length).toBeGreaterThan(0);
-      expect(withEndpoint.endpoint.serviceId).toEqual(service.id);
-      expect(withEndpoint.endpoint.privateNetworkId).toEqual(
-        created.network.publicId,
-      );
-      expect(withEndpoint.endpoint.environmentId).toEqual(
-        created.environment.environmentId,
-      );
-      expect(withEndpoint.endpoint.dnsName).toEqual(expect.any(String));
-      expect(withEndpoint.endpoint.dnsName.length).toBeGreaterThan(0);
-      expect(withEndpoint.endpoint.dnsName.toLowerCase()).toContain("api");
-
-      const liveEndpoint = yield* railway.privateNetworkEndpoint({
-        environmentId: created.environment.environmentId,
-        privateNetworkId: created.network.publicId,
-        serviceId: service.id,
-      });
-      expect(liveEndpoint).not.toBeNull();
-      expect(liveEndpoint?.publicId).toEqual(withEndpoint.endpoint.publicId);
-      expect(liveEndpoint?.dnsName).toEqual(withEndpoint.endpoint.dnsName);
-
       const endpointAgain = yield* railway.privateNetworkEndpointCreateOrGet({
         input: {
           environmentId: created.environment.environmentId,
           privateNetworkId: created.network.publicId,
-          serviceId: service.id,
+          serviceId: created.api.serviceId,
           serviceName: "api",
           tags: ["alchemy"],
         },
       });
-      expect(endpointAgain.publicId).toEqual(withEndpoint.endpoint.publicId);
+      expect(endpointAgain.publicId).toEqual(created.endpoint.publicId);
 
-      const renamed = yield* stack.deploy(
-        Effect.gen(function* () {
-          const { project, environment } = yield* suitePartition;
-          const network = yield* Railway.PrivateNetwork("Mesh", {
-            environment,
-          });
-          const endpoint = yield* Railway.PrivateNetworkEndpoint("ApiDns", {
-            network,
-            service: { serviceId: service.id, name: service.name },
-            name: "gateway",
-          });
-          return { project, environment, network, endpoint };
-        }),
-      );
+      const provider = yield* Provider.findProvider(Railway.PrivateNetwork);
+      const listed = yield* provider.list();
+      expect(
+        listed.find((row) => row.publicId === created.network.publicId),
+      ).toBeDefined();
 
-      expect(renamed.endpoint.publicId).toEqual(withEndpoint.endpoint.publicId);
-      expect(renamed.endpoint.dnsName.toLowerCase()).toContain("gateway");
+      const noop = yield* stack.deploy(withEndpoint("api"));
+      expect(noop.endpoint.publicId).toEqual(created.endpoint.publicId);
+      expect(noop.endpoint.dnsName).toEqual(created.endpoint.dnsName);
 
-      yield* stack.destroy();
-
-      const endpointGone = yield* waitUntilEndpointGone({
+      const renamed = yield* stack.deploy(withEndpoint("gateway"));
+      expect(renamed.endpoint.publicId).toEqual(created.endpoint.publicId);
+      expect(renamed.endpoint.dnsName.split(".")[0]).toBe("gateway");
+      const live = yield* railway.privateNetworkEndpoint({
         environmentId: created.environment.environmentId,
         privateNetworkId: created.network.publicId,
-        serviceId: service.id,
+        serviceId: created.api.serviceId,
       });
-      expect(endpointGone).toEqual("gone");
-      // Named networks have no delete API — tearing them down would
-      // also drop the environment's default mesh. They leave with the
-      // parent Project / Environment.
-      const networks = yield* listLive(created.environment.environmentId);
-      expect(networks.length).toBeGreaterThan(0);
-    }).pipe(logLevel),
-  { timeout: 3_600_000 },
+      expect(live?.dnsName).toEqual(renamed.endpoint.dnsName);
+
+      yield* stack.destroy();
+      const gone = yield* railway
+        .privateNetworkEndpoint({
+          environmentId: created.environment.environmentId,
+          privateNetworkId: created.network.publicId,
+          serviceId: created.api.serviceId,
+        })
+        .pipe(
+          Effect.map((row) => row == null || row.syncStatus === "DELETED"),
+          Effect.catchTag("NotFound", () => Effect.succeed(true)),
+          Effect.repeat({
+            schedule: Schedule.spaced("1 second"),
+            times: 10,
+            until: (gone) => gone,
+          }),
+        );
+      expect(gone).toBe(true);
+      const networks = yield* railway
+        .privateNetworks({ environmentId: created.environment.environmentId })
+        .pipe(Effect.catchTag("NotFound", () => Effect.succeed([])));
+      expect(networks.filter((network) => network.deletedAt == null)).toEqual(
+        [],
+      );
+    }),
+  { timeout: 120_000 },
 );

--- a/packages/alchemy/test/Railway/PrivateNetwork.test.ts
+++ b/packages/alchemy/test/Railway/PrivateNetwork.test.ts
@@ -18,7 +18,7 @@ const logLevel = Effect.provideService(
 const listLive = (environmentId: string) =>
   railway.privateNetworks({ environmentId }).pipe(
     Effect.map((items) => items.filter((network) => network.deletedAt == null)),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () => Effect.succeed([])),
+    Effect.catchTag("NotFound", () => Effect.succeed([])),
   );
 
 const waitUntilEndpointGone = (input: {
@@ -35,9 +35,7 @@ const waitUntilEndpointGone = (input: {
         ? ("gone" as const)
         : ("found" as const),
     ),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-      Effect.succeed("gone" as const),
-    ),
+    Effect.catchTag("NotFound", () => Effect.succeed("gone" as const)),
     Effect.repeat({
       schedule: Schedule.spaced("1 second"),
       until: (status) => status === "gone",

--- a/packages/alchemy/test/Railway/Project.test.ts
+++ b/packages/alchemy/test/Railway/Project.test.ts
@@ -19,9 +19,7 @@ const waitUntilGone = (projectId: string) =>
     Effect.map((project) =>
       project.deletedAt != null ? ("gone" as const) : ("found" as const),
     ),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-      Effect.succeed("gone" as const),
-    ),
+    Effect.catchTag("NotFound", () => Effect.succeed("gone" as const)),
     Effect.repeat({
       schedule: Schedule.spaced("1 second"),
       until: (status) => status === "gone",

--- a/packages/alchemy/test/Railway/Project.test.ts
+++ b/packages/alchemy/test/Railway/Project.test.ts
@@ -99,5 +99,5 @@ test.provider(
       const gone = yield* waitUntilGone(created.projectId);
       expect(gone).toEqual("gone");
     }).pipe(logLevel),
-  { timeout: 3_600_000 },
+  { timeout: 120_000 },
 );

--- a/packages/alchemy/test/Railway/Redis.test.ts
+++ b/packages/alchemy/test/Railway/Redis.test.ts
@@ -44,7 +44,7 @@ const readServiceVariables = (
     })
     .pipe(
       Effect.map(asVariableMap),
-      Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
+      Effect.catchTag("NotFound", () =>
         Effect.succeed({} as Record<string, string>),
       ),
     );
@@ -54,9 +54,7 @@ const waitUntilGone = (serviceId: string) =>
     Effect.map((service) =>
       service.deletedAt != null ? ("gone" as const) : ("found" as const),
     ),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-      Effect.succeed("gone" as const),
-    ),
+    Effect.catchTag("NotFound", () => Effect.succeed("gone" as const)),
     Effect.repeat({
       schedule: Schedule.spaced("1 second"),
       until: (status) => status === "gone",
@@ -80,9 +78,7 @@ const waitUntilProxyGone = (
         ? ("found" as const)
         : ("gone" as const),
     ),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-      Effect.succeed("gone" as const),
-    ),
+    Effect.catchTag("NotFound", () => Effect.succeed("gone" as const)),
     Effect.repeat({
       schedule: Schedule.spaced("1 second"),
       until: (status) => status === "gone",

--- a/packages/alchemy/test/Railway/Redis.test.ts
+++ b/packages/alchemy/test/Railway/Redis.test.ts
@@ -216,5 +216,5 @@ test.provider(
       const gone = yield* waitUntilGone(created.cache.serviceId);
       expect(gone).toEqual("gone");
     }).pipe(logLevel),
-  { timeout: 3_600_000 },
+  { timeout: 120_000 },
 );

--- a/packages/alchemy/test/Railway/RetryPolicy.test.ts
+++ b/packages/alchemy/test/Railway/RetryPolicy.test.ts
@@ -1,0 +1,46 @@
+import { waitOutCreateRateLimit } from "@/Railway/transient.ts";
+import * as railway from "@distilled.cloud/railway";
+import { expect, it } from "alchemy-test";
+import * as Effect from "effect/Effect";
+import * as Fiber from "effect/Fiber";
+import * as TestClock from "effect/testing/TestClock";
+
+it.effect(
+  "create throttling retries once and releases the gate after exhaustion",
+  () =>
+    Effect.gen(function* () {
+      let attempts = 0;
+      const error = new railway.RailwayRateLimited({
+        message: "creating environments too quickly",
+      });
+      const fiber = yield* waitOutCreateRateLimit(
+        Effect.suspend(() => {
+          attempts++;
+          return Effect.fail(error);
+        }),
+      ).pipe(Effect.flip, Effect.forkChild({ startImmediately: true }));
+      yield* TestClock.adjust("60 seconds");
+      expect(yield* Fiber.join(fiber)).toBe(error);
+      expect(attempts).toBe(2);
+      expect(yield* waitOutCreateRateLimit(Effect.succeed("released"))).toBe(
+        "released",
+      );
+    }).pipe(Effect.provide(TestClock.layer())),
+);
+
+it.effect("create validation failures propagate without retrying", () =>
+  Effect.gen(function* () {
+    let attempts = 0;
+    const error = new railway.RailwayValidationError({
+      message: "invalid input",
+    });
+    const failure = yield* waitOutCreateRateLimit(
+      Effect.suspend(() => {
+        attempts++;
+        return Effect.fail(error);
+      }),
+    ).pipe(Effect.flip);
+    expect(failure).toBe(error);
+    expect(attempts).toBe(1);
+  }),
+);

--- a/packages/alchemy/test/Railway/Rpc.test.ts
+++ b/packages/alchemy/test/Railway/Rpc.test.ts
@@ -101,7 +101,7 @@ test.provider.skip(
 
       yield* stack.destroy();
     }).pipe(logLevel),
-  { timeout: 3_600_000 },
+  { timeout: 120_000 },
 );
 
 test.provider.skip(
@@ -163,5 +163,5 @@ test.provider.skip(
 
       yield* stack.destroy();
     }).pipe(logLevel),
-  { timeout: 3_600_000 },
+  { timeout: 120_000 },
 );

--- a/packages/alchemy/test/Railway/Sandbox.test.ts
+++ b/packages/alchemy/test/Railway/Sandbox.test.ts
@@ -24,9 +24,7 @@ const waitUntilGone = (environmentId: string, sandboxId: string) =>
     Effect.map((sandbox) =>
       isGoneStatus(sandbox.status) ? ("gone" as const) : ("found" as const),
     ),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-      Effect.succeed("gone" as const),
-    ),
+    Effect.catchTag("NotFound", () => Effect.succeed("gone" as const)),
     Effect.repeat({
       schedule: Schedule.spaced("1 second"),
       until: (status) => status === "gone",
@@ -36,7 +34,7 @@ const waitUntilGone = (environmentId: string, sandboxId: string) =>
 
 const destroyLive = (environmentId: string, sandboxId: string) =>
   railway.sandboxDestroy({ environmentId, id: sandboxId }).pipe(
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () => Effect.void),
+    Effect.catchTag("NotFound", () => Effect.void),
     Effect.flatMap(() => waitUntilGone(environmentId, sandboxId)),
   );
 

--- a/packages/alchemy/test/Railway/Sandbox.test.ts
+++ b/packages/alchemy/test/Railway/Sandbox.test.ts
@@ -16,8 +16,7 @@ const logLevel = Effect.provideService(
   process.env.DEBUG ? "Debug" : "Info",
 );
 
-const isGoneStatus = (status: string | undefined) =>
-  status === "DESTROYED" || status === "DESTROYING";
+const isGoneStatus = (status: string | undefined) => status === "DESTROYED";
 
 const waitUntilGone = (environmentId: string, sandboxId: string) =>
   railway.sandbox({ environmentId, id: sandboxId }).pipe(
@@ -73,7 +72,7 @@ test.provider(
 
       yield* stack.destroy();
     }).pipe(logLevel),
-  { timeout: 3_600_000 },
+  { timeout: 120_000 },
 );
 
 test.provider(
@@ -141,5 +140,5 @@ test.provider(
       );
       expect(gone).toEqual("gone");
     }).pipe(logLevel),
-  { timeout: 3_600_000 },
+  { timeout: 120_000 },
 );

--- a/packages/alchemy/test/Railway/Service.test.ts
+++ b/packages/alchemy/test/Railway/Service.test.ts
@@ -381,7 +381,7 @@ test.provider(
       const gone = yield* waitUntilGone(created.api.serviceId);
       expect(gone).toEqual("gone");
     }).pipe(logLevel),
-  { timeout: 3_600_000 },
+  { timeout: 120_000 },
 );
 
 test.provider(
@@ -443,7 +443,7 @@ test.provider(
       yield* stack.destroy();
       expect(yield* waitUntilGone(created.worker.serviceId)).toEqual("gone");
     }).pipe(logLevel),
-  { timeout: 3_600_000 },
+  { timeout: 120_000 },
 );
 
 const localContextDir = `${import.meta.dirname}/fixtures/local-context`;
@@ -533,7 +533,7 @@ test.provider(
       yield* stack.destroy();
       expect(yield* waitUntilGone(created.api.serviceId)).toEqual("gone");
     }).pipe(logLevel),
-  { timeout: 3_600_000 },
+  { timeout: 120_000 },
 );
 
 // GitHub repo source requires a GitHub App connection on the Railway
@@ -562,7 +562,7 @@ test.provider(
 
       yield* stack.destroy();
     }).pipe(logLevel),
-  { timeout: 3_600_000 },
+  { timeout: 120_000 },
 );
 
 test.provider.skipIf(!githubEntitled)(
@@ -603,5 +603,5 @@ test.provider.skipIf(!githubEntitled)(
       const gone = yield* waitUntilGone(created.api.serviceId);
       expect(gone).toEqual("gone");
     }).pipe(logLevel),
-  { timeout: 3_600_000 },
+  { timeout: 120_000 },
 );

--- a/packages/alchemy/test/Railway/Service.test.ts
+++ b/packages/alchemy/test/Railway/Service.test.ts
@@ -23,9 +23,7 @@ const waitUntilGone = (serviceId: string) =>
     Effect.map((service) =>
       service.deletedAt != null ? ("gone" as const) : ("found" as const),
     ),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-      Effect.succeed("gone" as const),
-    ),
+    Effect.catchTag("NotFound", () => Effect.succeed("gone" as const)),
     Effect.repeat({
       schedule: Schedule.spaced("1 second"),
       until: (status) => status === "gone",

--- a/packages/alchemy/test/Railway/TcpProxy.test.ts
+++ b/packages/alchemy/test/Railway/TcpProxy.test.ts
@@ -125,7 +125,7 @@ test.provider(
       );
       expect(proxyGone).toEqual("gone");
     }).pipe(logLevel),
-  { timeout: 3_600_000 },
+  { timeout: 120_000 },
 );
 
 test.provider(
@@ -187,5 +187,5 @@ test.provider(
       );
       expect(proxyGone).toEqual("gone");
     }).pipe(logLevel),
-  { timeout: 3_600_000 },
+  { timeout: 120_000 },
 );

--- a/packages/alchemy/test/Railway/TcpProxy.test.ts
+++ b/packages/alchemy/test/Railway/TcpProxy.test.ts
@@ -26,7 +26,7 @@ const listLive = (environmentId: string, serviceId: string) =>
           domain: proxy.domain.replace(/\.+$/, ""),
         })),
     ),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () => Effect.succeed([])),
+    Effect.catchTag("NotFound", () => Effect.succeed([])),
   );
 
 const waitUntilProxyGone = (

--- a/packages/alchemy/test/Railway/Template.test.ts
+++ b/packages/alchemy/test/Railway/Template.test.ts
@@ -22,9 +22,7 @@ const waitUntilServiceGone = (serviceId: string) =>
     Effect.map((service) =>
       service.deletedAt != null ? ("gone" as const) : ("found" as const),
     ),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-      Effect.succeed("gone" as const),
-    ),
+    Effect.catchTag("NotFound", () => Effect.succeed("gone" as const)),
     Effect.repeat({
       schedule: Schedule.spaced("1 second"),
       until: (status) => status === "gone",
@@ -97,9 +95,8 @@ test.provider.skip(
           projectId: created.project.projectId,
         })
         .pipe(
-          Effect.catchTag(
-            ["RailwayNotFound", "NotFound", "RailwayForbidden"],
-            () => Effect.succeed(undefined),
+          Effect.catchTag(["NotFound", "RailwayForbidden"], () =>
+            Effect.succeed(undefined),
           ),
         );
       if (source !== undefined) {

--- a/packages/alchemy/test/Railway/Template.test.ts
+++ b/packages/alchemy/test/Railway/Template.test.ts
@@ -45,7 +45,7 @@ test.provider(
 
       yield* stack.destroy();
     }).pipe(logLevel),
-  { timeout: 3_600_000 },
+  { timeout: 120_000 },
 );
 
 test.provider.skip(
@@ -128,5 +128,5 @@ test.provider.skip(
         expect(gone).toEqual("gone");
       }
     }).pipe(logLevel),
-  { timeout: 3_600_000 },
+  { timeout: 120_000 },
 );

--- a/packages/alchemy/test/Railway/Usage.test.ts
+++ b/packages/alchemy/test/Railway/Usage.test.ts
@@ -25,9 +25,7 @@ const waitUntilLimitGone = (workspaceId: string, usageLimitId: string) =>
       if (limit == null) return "gone" as const;
       return limit.id === usageLimitId ? ("found" as const) : ("gone" as const);
     }),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-      Effect.succeed("gone" as const),
-    ),
+    Effect.catchTag("NotFound", () => Effect.succeed("gone" as const)),
     Effect.repeat({
       schedule: Schedule.spaced("1 second"),
       until: (status) => status === "gone",
@@ -95,9 +93,7 @@ test.provider(
 
       yield* railway
         .removeUsageLimit({ input: { customerId } })
-        .pipe(
-          Effect.catchTag(["RailwayNotFound", "NotFound"], () => Effect.void),
-        );
+        .pipe(Effect.catchTag("NotFound", () => Effect.void));
 
       const created = yield* stack.deploy(
         Effect.gen(function* () {

--- a/packages/alchemy/test/Railway/Usage.test.ts
+++ b/packages/alchemy/test/Railway/Usage.test.ts
@@ -59,7 +59,7 @@ test.provider(
 
       yield* stack.destroy();
     }).pipe(logLevel),
-  { timeout: 3_600_000 },
+  { timeout: 120_000 },
 );
 
 test.provider(
@@ -153,5 +153,5 @@ test.provider(
       );
       expect(gone).toEqual("gone");
     }).pipe(logLevel),
-  { timeout: 3_600_000 },
+  { timeout: 120_000 },
 );

--- a/packages/alchemy/test/Railway/Variable.test.ts
+++ b/packages/alchemy/test/Railway/Variable.test.ts
@@ -162,5 +162,5 @@ test.provider(
       );
       expect(variableGone).toEqual("gone");
     }).pipe(logLevel),
-  { timeout: 3_600_000 },
+  { timeout: 120_000 },
 );

--- a/packages/alchemy/test/Railway/Variable.test.ts
+++ b/packages/alchemy/test/Railway/Variable.test.ts
@@ -46,7 +46,7 @@ const readVariables = (
     })
     .pipe(
       Effect.map(asVariableMap),
-      Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
+      Effect.catchTag("NotFound", () =>
         Effect.succeed({} as Record<string, string>),
       ),
     );

--- a/packages/alchemy/test/Railway/VariableRef.test.ts
+++ b/packages/alchemy/test/Railway/VariableRef.test.ts
@@ -156,5 +156,5 @@ test.provider(
       );
       expect(variableGone).toEqual("gone");
     }).pipe(logLevel),
-  { timeout: 3_600_000 },
+  { timeout: 120_000 },
 );

--- a/packages/alchemy/test/Railway/VariableRef.test.ts
+++ b/packages/alchemy/test/Railway/VariableRef.test.ts
@@ -41,7 +41,7 @@ const readVariables = (
     })
     .pipe(
       Effect.map(asVariableMap),
-      Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
+      Effect.catchTag("NotFound", () =>
         Effect.succeed({} as Record<string, string>),
       ),
     );

--- a/packages/alchemy/test/Railway/Volume.test.ts
+++ b/packages/alchemy/test/Railway/Volume.test.ts
@@ -116,7 +116,7 @@ test.provider(
       const gone = yield* waitUntilVolumeGone(created.volume.volumeInstanceId);
       expect(gone).toEqual("gone");
     }).pipe(logLevel),
-  { timeout: 3_600_000 },
+  { timeout: 120_000 },
 );
 
 test.provider(
@@ -179,7 +179,7 @@ test.provider(
 
       yield* stack.destroy();
     }).pipe(logLevel),
-  { timeout: 3_600_000 },
+  { timeout: 120_000 },
 );
 
 test.provider(
@@ -241,5 +241,5 @@ test.provider(
       const gone = yield* waitUntilVolumeGone(created.data.volumeInstanceId);
       expect(gone).toEqual("gone");
     }).pipe(logLevel),
-  { timeout: 3_600_000 },
+  { timeout: 120_000 },
 );

--- a/packages/alchemy/test/Railway/VolumeBackup.test.ts
+++ b/packages/alchemy/test/Railway/VolumeBackup.test.ts
@@ -16,11 +16,10 @@ const logLevel = Effect.provideService(
   process.env.DEBUG ? "Debug" : "Info",
 );
 
-// Volume backups are Pro-plan gated. Railway rejects Hobby/unentitled
-// workspaces with GraphQL `Not Authorized`, already typed as
-// RailwayForbidden. The probe always runs and pins that tag. The
-// create+list+delete lifecycle is opt-in via RAILWAY_TEST_VOLUME_BACKUP=1.
-const backupEntitled = !!process.env.RAILWAY_TEST_VOLUME_BACKUP;
+// This workspace accepts backup creation but workflowStatus returns
+// RailwayForbidden: Not Authorized. Full lifecycle requires
+// RAILWAY_TEST_VOLUME_BACKUP=1 and a token with backup workflow access.
+const backupEntitled = process.env.RAILWAY_TEST_VOLUME_BACKUP === "1";
 
 const VolumeStack = Effect.gen(function* () {
   const { project, environment } = yield* suitePartition;
@@ -41,11 +40,7 @@ const VolumeStack = Effect.gen(function* () {
 const listLive = (volumeInstanceId: string) =>
   railway
     .listVolumeInstanceBackup({ volumeInstanceId })
-    .pipe(
-      Effect.catchTag(["NotFound", "RailwayForbidden"], () =>
-        Effect.succeed([]),
-      ),
-    );
+    .pipe(Effect.catchTag("NotFound", () => Effect.succeed([])));
 
 const waitUntilReady = (volumeInstanceId: string) =>
   railway.volumeInstance({ id: volumeInstanceId }).pipe(
@@ -87,7 +82,7 @@ const waitUntilBackupGone = (
   );
 
 test.provider(
-  "volume backup create surfaces a typed entitlement error",
+  "backup creation and workflow access surface typed authorization errors",
   (stack) =>
     Effect.gen(function* () {
       yield* stack.destroy();
@@ -102,31 +97,48 @@ test.provider(
       );
       if (Result.isSuccess(result)) {
         yield* Effect.logInfo(
-          "volume backups are entitled on this token; probe is a no-op",
+          "backup creation was accepted; checking workflow and backup access",
         );
         if (
           result.success.workflowId != null &&
           result.success.workflowId.length > 0
         ) {
-          yield* railway
-            .workflowStatus({
-              workflowId: result.success.workflowId,
-            })
-            .pipe(Effect.catchTag(["RailwayForbidden"], () => Effect.void));
+          const workflow = yield* railway
+            .workflowStatus({ workflowId: result.success.workflowId })
+            .pipe(
+              Effect.repeat({
+                schedule: Schedule.spaced("2 seconds"),
+                times: 10,
+                until: (row) => row.status !== "Running",
+              }),
+              Effect.result,
+            );
+          if (Result.isFailure(workflow)) {
+            expect(workflow.failure._tag).toBe("RailwayForbidden");
+            expect(workflow.failure.message).toBe("Not Authorized");
+            yield* Effect.logInfo(
+              "workflowStatus rejects backup access: RailwayForbidden: Not Authorized",
+            );
+            yield* stack.destroy();
+            return;
+          }
+          expect(workflow.success.status).toBe("Complete");
+          expect(workflow.success.error).toBeNull();
         }
-        const extras = yield* listLive(created.volume.volumeInstanceId);
+        const extras = yield* listLive(created.volume.volumeInstanceId).pipe(
+          Effect.tapError((error) =>
+            Effect.logError(
+              `listVolumeInstanceBackup: ${error._tag}: ${error.message}`,
+            ),
+          ),
+        );
         for (const extra of extras) {
           yield* railway
             .deleteVolumeInstanceBackup({
               volumeInstanceBackupId: extra.id,
               volumeInstanceId: created.volume.volumeInstanceId,
             })
-            .pipe(
-              Effect.catchTag(
-                ["NotFound", "RailwayForbidden"],
-                () => Effect.void,
-              ),
-            );
+            .pipe(Effect.catchTag("NotFound", () => Effect.void));
         }
         yield* stack.destroy();
         return;
@@ -136,7 +148,7 @@ test.provider(
 
       yield* stack.destroy();
     }).pipe(logLevel),
-  { timeout: 3_600_000 },
+  { timeout: 120_000 },
 );
 
 test.provider.skipIf(!backupEntitled)(
@@ -211,5 +223,5 @@ test.provider.skipIf(!backupEntitled)(
       );
       expect(backupGone).toEqual("gone");
     }).pipe(logLevel),
-  { timeout: 3_600_000 },
+  { timeout: 120_000 },
 );

--- a/packages/alchemy/test/Railway/VolumeBackup.test.ts
+++ b/packages/alchemy/test/Railway/VolumeBackup.test.ts
@@ -42,7 +42,7 @@ const listLive = (volumeInstanceId: string) =>
   railway
     .listVolumeInstanceBackup({ volumeInstanceId })
     .pipe(
-      Effect.catchTag(["RailwayNotFound", "NotFound", "RailwayForbidden"], () =>
+      Effect.catchTag(["NotFound", "RailwayForbidden"], () =>
         Effect.succeed([]),
       ),
     );
@@ -61,9 +61,7 @@ const waitUntilReady = (volumeInstanceId: string) =>
         ? ("ready" as const)
         : ("pending" as const),
     ),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-      Effect.succeed("pending" as const),
-    ),
+    Effect.catchTag("NotFound", () => Effect.succeed("pending" as const)),
     Effect.repeat({
       schedule: Schedule.spaced("2 seconds"),
       until: (status) => status === "ready",
@@ -125,7 +123,7 @@ test.provider(
             })
             .pipe(
               Effect.catchTag(
-                ["RailwayNotFound", "NotFound", "RailwayForbidden"],
+                ["NotFound", "RailwayForbidden"],
                 () => Effect.void,
               ),
             );

--- a/packages/alchemy/test/Railway/Website/Astro.test.ts
+++ b/packages/alchemy/test/Railway/Website/Astro.test.ts
@@ -113,5 +113,5 @@ test.provider(
       const gone = yield* waitUntilGone(serviceId);
       expect(gone).toEqual("gone");
     }).pipe(logLevel),
-  { timeout: 3_600_000 },
+  { timeout: 120_000 },
 );

--- a/packages/alchemy/test/Railway/Website/Astro.test.ts
+++ b/packages/alchemy/test/Railway/Website/Astro.test.ts
@@ -36,9 +36,7 @@ const waitUntilGone = (serviceId: string) =>
     Effect.map((service) =>
       service.deletedAt != null ? ("gone" as const) : ("found" as const),
     ),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-      Effect.succeed("gone" as const),
-    ),
+    Effect.catchTag("NotFound", () => Effect.succeed("gone" as const)),
     Effect.repeat({
       schedule: Schedule.spaced("1 second"),
       until: (status) => status === "gone",

--- a/packages/alchemy/test/Railway/Website/Foldkit.test.ts
+++ b/packages/alchemy/test/Railway/Website/Foldkit.test.ts
@@ -89,5 +89,5 @@ test.provider(
       const gone = yield* waitUntilGone(serviceId);
       expect(gone).toEqual("gone");
     }).pipe(logLevel),
-  { timeout: 3_600_000 },
+  { timeout: 120_000 },
 );

--- a/packages/alchemy/test/Railway/Website/Foldkit.test.ts
+++ b/packages/alchemy/test/Railway/Website/Foldkit.test.ts
@@ -29,9 +29,7 @@ const waitUntilGone = (serviceId: string) =>
     Effect.map((service) =>
       service.deletedAt != null ? ("gone" as const) : ("found" as const),
     ),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-      Effect.succeed("gone" as const),
-    ),
+    Effect.catchTag("NotFound", () => Effect.succeed("gone" as const)),
     Effect.repeat({
       schedule: Schedule.spaced("1 second"),
       until: (status) => status === "gone",

--- a/packages/alchemy/test/Railway/Website/Nextjs.test.ts
+++ b/packages/alchemy/test/Railway/Website/Nextjs.test.ts
@@ -36,9 +36,7 @@ const waitUntilGone = (serviceId: string) =>
     Effect.map((service) =>
       service.deletedAt != null ? ("gone" as const) : ("found" as const),
     ),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-      Effect.succeed("gone" as const),
-    ),
+    Effect.catchTag("NotFound", () => Effect.succeed("gone" as const)),
     Effect.repeat({
       schedule: Schedule.spaced("1 second"),
       until: (status) => status === "gone",

--- a/packages/alchemy/test/Railway/Website/Nextjs.test.ts
+++ b/packages/alchemy/test/Railway/Website/Nextjs.test.ts
@@ -108,5 +108,5 @@ test.provider(
       const gone = yield* waitUntilGone(serviceId);
       expect(gone).toEqual("gone");
     }).pipe(logLevel),
-  { timeout: 3_600_000 },
+  { timeout: 120_000 },
 );

--- a/packages/alchemy/test/Railway/Website/Nuxt.test.ts
+++ b/packages/alchemy/test/Railway/Website/Nuxt.test.ts
@@ -109,5 +109,5 @@ test.provider(
       const gone = yield* waitUntilGone(serviceId);
       expect(gone).toEqual("gone");
     }).pipe(logLevel),
-  { timeout: 3_600_000 },
+  { timeout: 120_000 },
 );

--- a/packages/alchemy/test/Railway/Website/Nuxt.test.ts
+++ b/packages/alchemy/test/Railway/Website/Nuxt.test.ts
@@ -36,9 +36,7 @@ const waitUntilGone = (serviceId: string) =>
     Effect.map((service) =>
       service.deletedAt != null ? ("gone" as const) : ("found" as const),
     ),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-      Effect.succeed("gone" as const),
-    ),
+    Effect.catchTag("NotFound", () => Effect.succeed("gone" as const)),
     Effect.repeat({
       schedule: Schedule.spaced("1 second"),
       until: (status) => status === "gone",

--- a/packages/alchemy/test/Railway/Website/Octane.test.ts
+++ b/packages/alchemy/test/Railway/Website/Octane.test.ts
@@ -39,9 +39,7 @@ const waitUntilGone = (serviceId: string) =>
     Effect.map((service) =>
       service.deletedAt != null ? ("gone" as const) : ("found" as const),
     ),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-      Effect.succeed("gone" as const),
-    ),
+    Effect.catchTag("NotFound", () => Effect.succeed("gone" as const)),
     Effect.repeat({
       schedule: Schedule.spaced("1 second"),
       until: (status) => status === "gone",

--- a/packages/alchemy/test/Railway/Website/Octane.test.ts
+++ b/packages/alchemy/test/Railway/Website/Octane.test.ts
@@ -120,5 +120,5 @@ test.provider(
       const gone = yield* waitUntilGone(serviceId);
       expect(gone).toEqual("gone");
     }).pipe(logLevel),
-  { timeout: 3_600_000 },
+  { timeout: 120_000 },
 );

--- a/packages/alchemy/test/Railway/Website/ReactRouter.test.ts
+++ b/packages/alchemy/test/Railway/Website/ReactRouter.test.ts
@@ -36,9 +36,7 @@ const waitUntilGone = (serviceId: string) =>
     Effect.map((service) =>
       service.deletedAt != null ? ("gone" as const) : ("found" as const),
     ),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-      Effect.succeed("gone" as const),
-    ),
+    Effect.catchTag("NotFound", () => Effect.succeed("gone" as const)),
     Effect.repeat({
       schedule: Schedule.spaced("1 second"),
       until: (status) => status === "gone",

--- a/packages/alchemy/test/Railway/Website/ReactRouter.test.ts
+++ b/packages/alchemy/test/Railway/Website/ReactRouter.test.ts
@@ -101,5 +101,5 @@ test.provider(
       const gone = yield* waitUntilGone(serviceId);
       expect(gone).toEqual("gone");
     }).pipe(logLevel),
-  { timeout: 3_600_000 },
+  { timeout: 120_000 },
 );

--- a/packages/alchemy/test/Railway/Website/SolidStart.test.ts
+++ b/packages/alchemy/test/Railway/Website/SolidStart.test.ts
@@ -103,5 +103,5 @@ test.provider(
       const gone = yield* waitUntilGone(serviceId);
       expect(gone).toEqual("gone");
     }).pipe(logLevel),
-  { timeout: 3_600_000 },
+  { timeout: 120_000 },
 );

--- a/packages/alchemy/test/Railway/Website/SolidStart.test.ts
+++ b/packages/alchemy/test/Railway/Website/SolidStart.test.ts
@@ -35,9 +35,7 @@ const waitUntilGone = (serviceId: string) =>
     Effect.map((service) =>
       service.deletedAt != null ? ("gone" as const) : ("found" as const),
     ),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-      Effect.succeed("gone" as const),
-    ),
+    Effect.catchTag("NotFound", () => Effect.succeed("gone" as const)),
     Effect.repeat({
       schedule: Schedule.spaced("1 second"),
       until: (status) => status === "gone",

--- a/packages/alchemy/test/Railway/Website/StaticSite.test.ts
+++ b/packages/alchemy/test/Railway/Website/StaticSite.test.ts
@@ -93,5 +93,5 @@ test.provider(
       const gone = yield* waitUntilGone(serviceId);
       expect(gone).toEqual("gone");
     }).pipe(logLevel),
-  { timeout: 3_600_000 },
+  { timeout: 120_000 },
 );

--- a/packages/alchemy/test/Railway/Website/StaticSite.test.ts
+++ b/packages/alchemy/test/Railway/Website/StaticSite.test.ts
@@ -29,9 +29,7 @@ const waitUntilGone = (serviceId: string) =>
     Effect.map((service) =>
       service.deletedAt != null ? ("gone" as const) : ("found" as const),
     ),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-      Effect.succeed("gone" as const),
-    ),
+    Effect.catchTag("NotFound", () => Effect.succeed("gone" as const)),
     Effect.repeat({
       schedule: Schedule.spaced("1 second"),
       until: (status) => status === "gone",

--- a/packages/alchemy/test/Railway/Website/SvelteKit.test.ts
+++ b/packages/alchemy/test/Railway/Website/SvelteKit.test.ts
@@ -29,9 +29,7 @@ const waitUntilGone = (serviceId: string) =>
     Effect.map((service) =>
       service.deletedAt != null ? ("gone" as const) : ("found" as const),
     ),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-      Effect.succeed("gone" as const),
-    ),
+    Effect.catchTag("NotFound", () => Effect.succeed("gone" as const)),
     Effect.repeat({
       schedule: Schedule.spaced("1 second"),
       until: (status) => status === "gone",

--- a/packages/alchemy/test/Railway/Website/SvelteKit.test.ts
+++ b/packages/alchemy/test/Railway/Website/SvelteKit.test.ts
@@ -88,5 +88,5 @@ test.provider(
       const gone = yield* waitUntilGone(serviceId);
       expect(gone).toEqual("gone");
     }).pipe(logLevel),
-  { timeout: 3_600_000 },
+  { timeout: 120_000 },
 );

--- a/packages/alchemy/test/Railway/Website/TanStackStart.test.ts
+++ b/packages/alchemy/test/Railway/Website/TanStackStart.test.ts
@@ -35,9 +35,7 @@ const waitUntilGone = (serviceId: string) =>
     Effect.map((service) =>
       service.deletedAt != null ? ("gone" as const) : ("found" as const),
     ),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-      Effect.succeed("gone" as const),
-    ),
+    Effect.catchTag("NotFound", () => Effect.succeed("gone" as const)),
     Effect.repeat({
       schedule: Schedule.spaced("1 second"),
       until: (status) => status === "gone",

--- a/packages/alchemy/test/Railway/Website/TanStackStart.test.ts
+++ b/packages/alchemy/test/Railway/Website/TanStackStart.test.ts
@@ -99,5 +99,5 @@ test.provider(
       const gone = yield* waitUntilGone(serviceId);
       expect(gone).toEqual("gone");
     }).pipe(logLevel),
-  { timeout: 3_600_000 },
+  { timeout: 120_000 },
 );

--- a/packages/alchemy/test/Railway/Website/Vite.test.ts
+++ b/packages/alchemy/test/Railway/Website/Vite.test.ts
@@ -30,9 +30,7 @@ const waitUntilGone = (serviceId: string) =>
     Effect.map((service) =>
       service.deletedAt != null ? ("gone" as const) : ("found" as const),
     ),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-      Effect.succeed("gone" as const),
-    ),
+    Effect.catchTag("NotFound", () => Effect.succeed("gone" as const)),
     Effect.repeat({
       schedule: Schedule.spaced("1 second"),
       until: (status) => status === "gone",

--- a/packages/alchemy/test/Railway/Website/Vite.test.ts
+++ b/packages/alchemy/test/Railway/Website/Vite.test.ts
@@ -104,5 +104,5 @@ test.provider(
       const gone = yield* waitUntilGone(serviceId);
       expect(gone).toEqual("gone");
     }).pipe(logLevel),
-  { timeout: 3_600_000 },
+  { timeout: 120_000 },
 );

--- a/packages/alchemy/test/Railway/Website/Vocs.test.ts
+++ b/packages/alchemy/test/Railway/Website/Vocs.test.ts
@@ -92,5 +92,5 @@ test.provider(
       const gone = yield* waitUntilGone(serviceId);
       expect(gone).toEqual("gone");
     }).pipe(logLevel),
-  { timeout: 3_600_000 },
+  { timeout: 120_000 },
 );

--- a/packages/alchemy/test/Railway/Website/Vocs.test.ts
+++ b/packages/alchemy/test/Railway/Website/Vocs.test.ts
@@ -35,9 +35,7 @@ const waitUntilGone = (serviceId: string) =>
     Effect.map((service) =>
       service.deletedAt != null ? ("gone" as const) : ("found" as const),
     ),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-      Effect.succeed("gone" as const),
-    ),
+    Effect.catchTag("NotFound", () => Effect.succeed("gone" as const)),
     Effect.repeat({
       schedule: Schedule.spaced("1 second"),
       until: (status) => status === "gone",

--- a/packages/alchemy/test/Railway/Website/Waku.test.ts
+++ b/packages/alchemy/test/Railway/Website/Waku.test.ts
@@ -35,9 +35,7 @@ const waitUntilGone = (serviceId: string) =>
     Effect.map((service) =>
       service.deletedAt != null ? ("gone" as const) : ("found" as const),
     ),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-      Effect.succeed("gone" as const),
-    ),
+    Effect.catchTag("NotFound", () => Effect.succeed("gone" as const)),
     Effect.repeat({
       schedule: Schedule.spaced("1 second"),
       until: (status) => status === "gone",

--- a/packages/alchemy/test/Railway/Website/Waku.test.ts
+++ b/packages/alchemy/test/Railway/Website/Waku.test.ts
@@ -98,5 +98,5 @@ test.provider(
       const gone = yield* waitUntilGone(serviceId);
       expect(gone).toEqual("gone");
     }).pipe(logLevel),
-  { timeout: 3_600_000 },
+  { timeout: 120_000 },
 );

--- a/packages/alchemy/test/Railway/fixtures/mongo-api.ts
+++ b/packages/alchemy/test/Railway/fixtures/mongo-api.ts
@@ -1,4 +1,5 @@
 import * as Railway from "@/Railway";
+import * as Cause from "effect/Cause";
 import * as Effect from "effect/Effect";
 import * as Redacted from "effect/Redacted";
 import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
@@ -25,6 +26,7 @@ export default class MongoApi extends Railway.Service<MongoApi>()(
     environment: Partition,
     main: import.meta.url,
     port: MONGO_HTTP_PORT,
+    healthcheckTimeout: 30,
     build: { install: ["mongodb"] },
   },
   Effect.gen(function* () {
@@ -44,6 +46,9 @@ export default class MongoApi extends Railway.Service<MongoApi>()(
         }
         return yield* HttpServerResponse.json(ping, { status: 404 });
       }).pipe(
+        Effect.tapError((error) =>
+          Effect.logError(Cause.pretty(Cause.fail(error))),
+        ),
         Effect.catch((error) =>
           HttpServerResponse.json(
             { ok: false, error: String(error) },

--- a/packages/alchemy/test/Railway/fixtures/mysql-api.ts
+++ b/packages/alchemy/test/Railway/fixtures/mysql-api.ts
@@ -1,5 +1,6 @@
 import * as Drizzle from "@/Drizzle/MySQL.ts";
 import * as Railway from "@/Railway";
+import * as Cause from "effect/Cause";
 import * as Effect from "effect/Effect";
 import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
@@ -25,7 +26,8 @@ export default class MySQLApi extends Railway.Service<MySQLApi>()(
     environment: Partition,
     main: import.meta.url,
     port: MYSQL_API_PORT,
-    build: { install: ["mysql2"] },
+    healthcheckTimeout: 30,
+    build: { install: { mysql2: "3.24.2" } },
   },
   Effect.gen(function* () {
     const conn = yield* Railway.ConnectMySQL(Db);
@@ -44,6 +46,9 @@ export default class MySQLApi extends Railway.Service<MySQLApi>()(
         }
         return yield* HttpServerResponse.json({ rows }, { status: 404 });
       }).pipe(
+        Effect.tapError((error) =>
+          Effect.logError(Cause.pretty(Cause.fail(error))),
+        ),
         Effect.catch((error) =>
           HttpServerResponse.json(
             { ok: false, error: String(error) },

--- a/packages/alchemy/test/Railway/fixtures/postgres-api.ts
+++ b/packages/alchemy/test/Railway/fixtures/postgres-api.ts
@@ -1,5 +1,6 @@
 import * as Drizzle from "@/Drizzle/Postgres.ts";
 import * as Railway from "@/Railway";
+import * as Cause from "effect/Cause";
 import * as Effect from "effect/Effect";
 import { HttpServerRequest } from "effect/unstable/http/HttpServerRequest";
 import * as HttpServerResponse from "effect/unstable/http/HttpServerResponse";
@@ -21,6 +22,7 @@ export default class PostgresApi extends Railway.Service<PostgresApi>()(
     environment: Partition,
     main: import.meta.url,
     port: POSTGRES_PORT,
+    healthcheckTimeout: 30,
     build: { install: ["pg"] },
   },
   Effect.gen(function* () {
@@ -40,6 +42,9 @@ export default class PostgresApi extends Railway.Service<PostgresApi>()(
         }
         return yield* HttpServerResponse.json({ rows }, { status: 404 });
       }).pipe(
+        Effect.tapError((error) =>
+          Effect.logError(Cause.pretty(Cause.fail(error))),
+        ),
         Effect.catch((error) =>
           HttpServerResponse.json(
             { ok: false, error: String(error) },

--- a/packages/alchemy/test/Railway/waitUntilVolumeGone.ts
+++ b/packages/alchemy/test/Railway/waitUntilVolumeGone.ts
@@ -18,9 +18,7 @@ export const waitUntilVolumeGone = (volumeInstanceId: string) =>
     Effect.map((instance) =>
       isGoneInstance(instance) ? ("gone" as const) : ("found" as const),
     ),
-    Effect.catchTag(["RailwayNotFound", "NotFound"], () =>
-      Effect.succeed("gone" as const),
-    ),
+    Effect.catchTag("NotFound", () => Effect.succeed("gone" as const)),
     Effect.repeat({
       schedule: Schedule.spaced("1 second"),
       until: (status) => status === "gone",

--- a/packages/alchemy/test/Railway/waitUntilVolumeGone.ts
+++ b/packages/alchemy/test/Railway/waitUntilVolumeGone.ts
@@ -6,11 +6,7 @@ const isGoneInstance = (instance: {
   deletedAt: string | null;
   isPendingDeletion: boolean;
   state: string | null;
-}) =>
-  instance.deletedAt != null ||
-  instance.isPendingDeletion ||
-  instance.state === "DELETED" ||
-  instance.state === "DELETING";
+}) => instance.deletedAt != null || instance.state === "DELETED";
 
 /** Poll `volumeInstance({id})` until Railway reports the instance gone. */
 export const waitUntilVolumeGone = (volumeInstanceId: string) =>

--- a/packages/alchemy/test/SQL/PostgresTls.test.ts
+++ b/packages/alchemy/test/SQL/PostgresTls.test.ts
@@ -1,10 +1,46 @@
-import { resolveSsl } from "@/SQL/PostgresTls.ts";
+import { resolvePostgresConnection, resolveSsl } from "@/SQL/PostgresTls.ts";
 import { describe, expect, it } from "alchemy-test";
 import * as Redacted from "effect/Redacted";
 
 const url = (s: string) => Redacted.make(s);
 
 describe("SQL/PostgresTls resolveSsl", () => {
+  it("translates no-verify without changing credentials or other URL options", () => {
+    const input = url(
+      "postgresql://u:p%40ss@db.railway.internal:5432/railway?sslmode=no-verify&application_name=test",
+    );
+    const config = resolvePostgresConnection(input);
+    expect(Redacted.value(config.url)).toBe(
+      "postgresql://u:p%40ss@db.railway.internal:5432/railway?application_name=test",
+    );
+    expect(config.ssl).toEqual({
+      rejectUnauthorized: false,
+      servername: "db.railway.internal",
+    });
+    expect(Redacted.value(input)).toContain("sslmode=no-verify");
+  });
+
+  it("honors explicit TLS settings over no-verify", () => {
+    const input = url("postgres://u@db.example.com/x?sslmode=no-verify");
+    expect(resolvePostgresConnection(input, false).ssl).toBe(false);
+    expect(resolvePostgresConnection(input, true).ssl).toEqual({
+      servername: "db.example.com",
+    });
+    expect(
+      resolvePostgresConnection(input, { rejectUnauthorized: true }).ssl,
+    ).toEqual({ rejectUnauthorized: true, servername: "db.example.com" });
+  });
+
+  it("keeps supported and invalid URLs unchanged", () => {
+    for (const text of [
+      "postgres://u@db.example.com/x?sslmode=require",
+      "not a url",
+    ]) {
+      const input = url(text);
+      expect(resolvePostgresConnection(input).url).toBe(input);
+    }
+  });
+
   it("adds servername when the URL requests TLS via sslmode", () => {
     expect(
       resolveSsl(


### PR DESCRIPTION
Propagate Railway lifecycle failures instead of treating validation errors, exhausted waits, and failed API calls as successful reconciliation.

- Handle create races with typed `RailwayAlreadyExists` / `Conflict` errors and use the shared `NotFound` tag for absence.
- Bound retries and retain deployment diagnostics.
- Discover database and Function instances without probing every service/environment pair.
- Normalize PostgreSQL `sslmode=no-verify` for the Effect SQL driver.
- Create canvas groups with Railway's intent API, apply updates/deletes by ID, and wait for commit completion.
- Tighten sandbox, volume, and backup lifecycle checks.

```ts
Effect.catchTag(["RailwayAlreadyExists", "Conflict"], () =>
  Effect.succeed(undefined),
)
```

Includes the companion SDK changes from https://github.com/alchemy-run/distilled/pull/579.
