### PR TITLE
refactor: replace fast-glob with tinyglobby

### DIFF
--- a/packages/alchemy/package.json
+++ b/packages/alchemy/package.json
@@ -443,7 +443,6 @@
     "@types/aws-lambda": "catalog:aws",
     "aws4fetch": "catalog:aws",
     "capnweb": "^0.6.1",
-    "fast-glob": "catalog:cloudflare-runtime",
     "fflate": "^0.8.3",
     "libsodium-wrappers": "^0.8.3",
     "pathe": "catalog:tooling",
@@ -451,6 +450,7 @@
     "react": "catalog:frontend",
     "rolldown": "catalog:build",
     "string-width": "^8.2.2",
+    "tinyglobby": "catalog:cloudflare-runtime",
     "undici": "^7.16.0",
     "yaml": "catalog:shared"
   },

--- a/packages/alchemy/src/Cloudflare/Workers/Sources/Prebuilt.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Sources/Prebuilt.ts
@@ -1,6 +1,6 @@
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
-import fg from "fast-glob";
+import { glob } from "tinyglobby";
 import path from "pathe";
 import * as Artifacts from "../../../Artifacts.ts";
 import * as Bundle from "../../../Bundle/Bundle.ts";
@@ -90,11 +90,12 @@ export const readPrebuiltWorkerBundle = Effect.fn(function* (
     Effect.zipWith(
       Effect.tryPromise({
         try: () =>
-          fg.glob(
+          glob(
             (options.rules ?? defaultModuleRules).flatMap((rule) => rule.globs),
             {
               cwd: root,
               onlyFiles: true,
+              expandDirectories: false,
               dot: true,
             },
           ),

--- a/packages/alchemy/src/Cloudflare/Workers/Sources/Python.ts
+++ b/packages/alchemy/src/Cloudflare/Workers/Sources/Python.ts
@@ -2,7 +2,7 @@ import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Stream from "effect/Stream";
 import * as ChildProcess from "effect/unstable/process/ChildProcess";
-import fg from "fast-glob";
+import { glob } from "tinyglobby";
 import path from "pathe";
 import * as Artifacts from "../../../Artifacts.ts";
 import * as Bundle from "../../../Bundle/Bundle.ts";
@@ -280,9 +280,10 @@ const globFiles = (
 ) =>
   Effect.tryPromise({
     try: () =>
-      fg.glob(patterns, {
+      glob(patterns, {
         cwd: options.cwd,
         onlyFiles: true,
+        expandDirectories: false,
         dot: options.dot ?? false,
         ignore: options.ignore,
       }),

--- a/packages/alchemy/src/Command/Memo.ts
+++ b/packages/alchemy/src/Command/Memo.ts
@@ -2,7 +2,7 @@ import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";
 import * as Path from "effect/Path";
 import type { PlatformError } from "effect/PlatformError";
-import fg from "fast-glob";
+import { glob } from "tinyglobby";
 import { gitignoreRulesToGlobs } from "../Util/gitignore-rules-to-globs.ts";
 import { initialCwd } from "../Util/Node.ts";
 import { sha256, sha256Object } from "../Util/sha256.ts";
@@ -109,11 +109,9 @@ const Memo = Effect.gen(function* () {
     const resolvedCwd = path.resolve(initialCwd, cwd ?? ".");
     return {
       cwd: resolvedCwd,
-      // Rewrite absolute include patterns to cwd-relative ones: fast-glob
-      // silently drops an absolute pattern's matches when the same call also
-      // contains relative patterns, and relative patterns keep the matched
-      // keys (and therefore the memo hash) free of machine-specific path
-      // prefixes.
+      // Normalize absolute include patterns to cwd-relative ones so matched
+      // keys (and therefore the memo hash) stay free of machine-specific
+      // path prefixes.
       include: (options.include ?? ["**/*"]).map((pattern) =>
         path.isAbsolute(pattern)
           ? path.relative(resolvedCwd, pattern).replaceAll("\\", "/")
@@ -135,10 +133,11 @@ const Memo = Effect.gen(function* () {
     const [files, lockfile] = yield* Effect.all(
       [
         Effect.promise(() =>
-          fg.glob(options.include, {
+          glob(options.include, {
             cwd: options.cwd,
             ignore: options.exclude,
             onlyFiles: true,
+            expandDirectories: false,
             dot: true,
           }),
         ),

--- a/packages/alchemy/src/Util/gitignore-rules-to-globs.ts
+++ b/packages/alchemy/src/Util/gitignore-rules-to-globs.ts
@@ -1,14 +1,14 @@
 /**
- * Converts gitignore-style rules into glob patterns for tools like fast-glob's {@link https://github.com/mrmlnc/fast-glob#ignore `ignore`} option.
+ * Converts gitignore-style rules into glob patterns for tools like tinyglobby's {@link https://superchupu.dev/tinyglobby/documentation#ignore `ignore`} option.
  *
  * Gitignore and glob differ (ordering, negation, escapes). This maps the common cases:
  *
  * - Rules with no `/` match at any depth → \`**\/name\`, \`**\/name\/\*\/`
- * - A leading `/` anchors to the ignore file's directory (use the same `cwd` in fast-glob) → `name`, `name/**`
+ * - A leading `/` anchors to the ignore file's directory (use the same `cwd` in tinyglobby) → `name`, `name/**`
  * - A `/` in the pattern (not only leading) uses path-aware matching → `a/b`, `a/b/**`
  * - A trailing `/` restricts to directories → adds `/**` as needed
  * - Lines starting with `!` (negation) are returned with a `!` prefix for use in **positive** glob
- *   lists; they are not valid in fast-glob's `ignore` array (filter them out if you only pass `ignore`)
+ *   lists; filter them out when passing only exclusion patterns to an `ignore` array
  *
  * Does not implement full gitignore escaping (e.g. `\\ ` for trailing space) or `**` edge cases
  * identical to git; escape handling can be added later if needed.

--- a/packages/frontend-frameworks/package.json
+++ b/packages/frontend-frameworks/package.json
@@ -53,8 +53,8 @@
     "@distilled.cloud/cloudflare": "workspace:*",
     "@effect/platform-node": "catalog:effect",
     "esbuild": "catalog:cloudflare-runtime",
-    "fast-glob": "catalog:cloudflare-runtime",
-    "rolldown": "catalog:build"
+    "rolldown": "catalog:build",
+    "tinyglobby": "catalog:cloudflare-runtime"
   },
   "devDependencies": {
     "@astrojs/internal-helpers": "catalog:frontend",

--- a/packages/frontend-frameworks/src/astro/source.ts
+++ b/packages/frontend-frameworks/src/astro/source.ts
@@ -305,7 +305,7 @@ const sha256Object = (input: unknown): Effect.Effect<string> =>
 
 // ─────────────────────────────────────────────────────────────────────
 // Glob / gitignore matching (self-contained approximation of the
-// fast-glob + gitignore semantics alchemy's `hashDirectory` uses)
+// glob + gitignore semantics alchemy's `hashDirectory` uses)
 // ─────────────────────────────────────────────────────────────────────
 
 const escapeRegex = (char: string): string =>

--- a/packages/frontend-frameworks/src/nuxt/source.ts
+++ b/packages/frontend-frameworks/src/nuxt/source.ts
@@ -36,7 +36,7 @@ import type * as Path from "effect/Path";
 import type { PlatformError } from "effect/PlatformError";
 import * as Redacted from "effect/Redacted";
 import type * as Scope from "effect/Scope";
-import fg from "fast-glob";
+import { glob } from "tinyglobby";
 import * as NodeCrypto from "node:crypto";
 import * as NodePath from "node:path";
 import { fileURLToPath } from "node:url";
@@ -231,7 +231,7 @@ const sha256Stable = (input: unknown): Effect.Effect<string> =>
   sha256Hex(JSON.stringify(stableValue(input) ?? null));
 
 /**
- * Convert gitignore-style rules into fast-glob `ignore` patterns — a copy of
+ * Convert gitignore-style rules into glob `ignore` patterns — a copy of
  * alchemy's `Util/gitignore-rules-to-globs.ts` (common cases only).
  */
 const gitignoreRulesToGlobs = (rules: ReadonlyArray<string>): Array<string> => {
@@ -326,7 +326,13 @@ const hashDirectory = Effect.fnUntraced(function* (
   const [files, lockfilePath] = yield* Effect.all(
     [
       Effect.promise(() =>
-        fg.glob(include, { cwd, ignore: exclude, onlyFiles: true, dot: true }),
+        glob(include, {
+          cwd,
+          ignore: exclude,
+          onlyFiles: true,
+          expandDirectories: false,
+          dot: true,
+        }),
       ),
       lockfile
         ? Effect.map(
@@ -443,7 +449,7 @@ const readAssetsDirectory = Effect.fnUntraced(function* (
     maybeReadString(fs, NodePath.join(directory, "_redirects")),
   ]);
   const files = yield* Effect.promise(() =>
-    fg.glob(["**/*"], {
+    glob(["**/*"], {
       cwd: directory,
       ignore: [
         ".assetsignore",
@@ -452,6 +458,7 @@ const readAssetsDirectory = Effect.fnUntraced(function* (
         ...gitignoreRulesToGlobs(ignore?.split("\n") ?? []),
       ],
       onlyFiles: true,
+      expandDirectories: false,
       dot: true,
     }),
   );

--- a/packages/frontend-frameworks/src/octane/source.ts
+++ b/packages/frontend-frameworks/src/octane/source.ts
@@ -36,7 +36,7 @@ import * as FileSystem from "effect/FileSystem";
 import type * as Path from "effect/Path";
 import type { PlatformError } from "effect/PlatformError";
 import type * as Scope from "effect/Scope";
-import fg from "fast-glob";
+import { glob } from "tinyglobby";
 import * as NodeCrypto from "node:crypto";
 import * as NodePath from "node:path";
 import { fileURLToPath } from "node:url";
@@ -217,7 +217,7 @@ const sha256Stable = (input: unknown): Effect.Effect<string> =>
   sha256Hex(JSON.stringify(stableValue(input) ?? null));
 
 /**
- * Convert gitignore-style rules into fast-glob `ignore` patterns — a copy of
+ * Convert gitignore-style rules into glob `ignore` patterns — a copy of
  * alchemy's `Util/gitignore-rules-to-globs.ts` (common cases only).
  */
 const gitignoreRulesToGlobs = (rules: ReadonlyArray<string>): Array<string> => {
@@ -312,7 +312,13 @@ const hashDirectory = Effect.fnUntraced(function* (
   const [files, lockfilePath] = yield* Effect.all(
     [
       Effect.promise(() =>
-        fg.glob(include, { cwd, ignore: exclude, onlyFiles: true, dot: true }),
+        glob(include, {
+          cwd,
+          ignore: exclude,
+          onlyFiles: true,
+          expandDirectories: false,
+          dot: true,
+        }),
       ),
       lockfile
         ? Effect.map(
@@ -427,7 +433,7 @@ const readAssetsDirectory = Effect.fnUntraced(function* (
     maybeReadString(fs, NodePath.join(directory, "_redirects")),
   ]);
   const files = yield* Effect.promise(() =>
-    fg.glob(["**/*"], {
+    glob(["**/*"], {
       cwd: directory,
       ignore: [
         ".assetsignore",
@@ -436,6 +442,7 @@ const readAssetsDirectory = Effect.fnUntraced(function* (
         ...gitignoreRulesToGlobs(ignore?.split("\n") ?? []),
       ],
       onlyFiles: true,
+      expandDirectories: false,
       dot: true,
     }),
   );

--- a/packages/frontend-frameworks/src/sveltekit/source.ts
+++ b/packages/frontend-frameworks/src/sveltekit/source.ts
@@ -37,7 +37,7 @@ import type * as Path from "effect/Path";
 import type { PlatformError } from "effect/PlatformError";
 import * as Redacted from "effect/Redacted";
 import type * as Scope from "effect/Scope";
-import fg from "fast-glob";
+import { glob } from "tinyglobby";
 import * as NodeCrypto from "node:crypto";
 import * as NodePath from "node:path";
 import { fileURLToPath } from "node:url";
@@ -236,7 +236,7 @@ const sha256Stable = (input: unknown): Effect.Effect<string> =>
   sha256Hex(JSON.stringify(stableValue(input) ?? null));
 
 /**
- * Convert gitignore-style rules into fast-glob `ignore` patterns — a copy of
+ * Convert gitignore-style rules into glob `ignore` patterns — a copy of
  * alchemy's `Util/gitignore-rules-to-globs.ts` (common cases only).
  */
 const gitignoreRulesToGlobs = (rules: ReadonlyArray<string>): Array<string> => {
@@ -331,7 +331,13 @@ const hashDirectory = Effect.fnUntraced(function* (
   const [files, lockfilePath] = yield* Effect.all(
     [
       Effect.promise(() =>
-        fg.glob(include, { cwd, ignore: exclude, onlyFiles: true, dot: true }),
+        glob(include, {
+          cwd,
+          ignore: exclude,
+          onlyFiles: true,
+          expandDirectories: false,
+          dot: true,
+        }),
       ),
       lockfile
         ? Effect.map(
@@ -448,7 +454,7 @@ const readAssetsDirectory = Effect.fnUntraced(function* (
     maybeReadString(fs, NodePath.join(directory, "_redirects")),
   ]);
   const files = yield* Effect.promise(() =>
-    fg.glob(["**/*"], {
+    glob(["**/*"], {
       cwd: directory,
       ignore: [
         ".assetsignore",
@@ -457,6 +463,7 @@ const readAssetsDirectory = Effect.fnUntraced(function* (
         ...gitignoreRulesToGlobs(ignore?.split("\n") ?? []),
       ],
       onlyFiles: true,
+      expandDirectories: false,
       dot: true,
     }),
   );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,9 +88,6 @@ catalogs:
     esbuild:
       specifier: ^0.28.1
       version: 0.28.2
-    fast-glob:
-      specifier: ^3.3.2
-      version: 3.3.3
     heap-js:
       specifier: ^2.5.0
       version: 2.7.1
@@ -115,6 +112,9 @@ catalogs:
     sharp:
       specifier: ^0.35.3
       version: 0.35.3
+    tinyglobby:
+      specifier: ^0.2.17
+      version: 0.2.17
     toucan-js:
       specifier: 4.0.0
       version: 4.0.0
@@ -4872,9 +4872,6 @@ importers:
       drizzle-orm:
         specifier: 1.0.0-rc.5-ab785fc
         version: 1.0.0-rc.5-ab785fc(@cloudflare/workers-types@5.20260901.1)(@effect/sql-d1@4.0.0-rc.115(effect@4.0.0-rc.115))(@effect/sql-mysql2@4.0.0-rc.115(@types/node@26.2.0)(effect@4.0.0-rc.115))(@effect/sql-pg@4.0.0-rc.115(effect@4.0.0-rc.115))(@effect/sql-sqlite-do@4.0.0-rc.115(effect@4.0.0-rc.115))(@electric-sql/pglite@0.3.15)(@libsql/client@0.17.4)(@neondatabase/serverless@1.1.0)(@types/pg@8.20.0)(arktype@2.2.3)(bun-types@1.3.14)(effect@4.0.0-rc.115)(mysql2@3.24.2(@types/node@26.2.0))(pg@8.23.0)(valibot@1.2.0(typescript@7.0.2))(zod@4.4.3)
-      fast-glob:
-        specifier: catalog:cloudflare-runtime
-        version: 3.3.3
       fflate:
         specifier: ^0.8.3
         version: 0.8.3
@@ -4896,6 +4893,9 @@ importers:
       string-width:
         specifier: ^8.2.2
         version: 8.2.2
+      tinyglobby:
+        specifier: catalog:cloudflare-runtime
+        version: 0.2.17
       undici:
         specifier: ^7.16.0
         version: 7.29.0
@@ -5341,12 +5341,12 @@ importers:
       esbuild:
         specifier: catalog:cloudflare-runtime
         version: 0.28.2
-      fast-glob:
-        specifier: catalog:cloudflare-runtime
-        version: 3.3.3
       rolldown:
         specifier: 1.2.5
         version: 1.2.5
+      tinyglobby:
+        specifier: catalog:cloudflare-runtime
+        version: 0.2.17
     devDependencies:
       '@astrojs/internal-helpers':
         specifier: catalog:frontend

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -60,7 +60,6 @@ catalogs:
     capnp-es: ^0.0.16
     capnweb: ^0.12.0
     esbuild: ^0.28.1
-    fast-glob: ^3.3.2
     heap-js: ^2.5.0
     http-cache-semantics: ^4.2.0
     itty-time: ^2.0.2
@@ -71,6 +70,7 @@ catalogs:
     nuxt: ">=4.5.0"
     postal-mime: ^2.4.3
     sharp: ^0.35.3
+    tinyglobby: ^0.2.17
     toucan-js: 4.0.0
     unenv: ^2.0.0-rc.24
     vite: ^7.0.0 || ^8.0.0


### PR DESCRIPTION
Replaces fast-glob with tinyglobby across build memoization, Worker module discovery, and Nuxt, Octane, and SvelteKit asset collection. All nine calls retain their existing options and disable directory expansion to preserve literal-directory matching behavior. Updates both package dependencies and the shared catalog/lockfile.

Stacked on #1608.

Validation: full workspace `vp exec tsc -b`; 14 build memoization, workspace hashing, and Prebuilt Worker bundle tests; 112 Nuxt, Octane, and SvelteKit tests; formatting and frozen-lockfile install.