### PR TITLE
fix(node-utils): exclude the root's own node_modules from the Bun dev probe

### DIFF
--- a/packages/node-utils/src/watch-import-bun.ts
+++ b/packages/node-utils/src/watch-import-bun.ts
@@ -53,9 +53,14 @@ export class BunImportTracker {
     // Bun reports real paths (`/private/tmp/...` for `/tmp/...` on macOS);
     // match them against the root's real path too.
     const root = realpathSync.native(path.resolve(options.root)) + path.sep;
-    const nodeModules = `${path.sep}node_modules${path.sep}`;
+    const nodeModules = `node_modules${path.sep}`;
+    // `root` already ends in a separator, so the segment right after it has no
+    // leading one: a `.*${sep}node_modules${sep}` lookahead alone would miss
+    // `<root>node_modules/...` and intercept every dependency. Bun cannot
+    // return CommonJS source from `onLoad` (oven-sh/bun#19279), so a CJS
+    // dependency that reaches this probe loses its exports.
     const filter = new RegExp(
-      `^${escapeRegExp(root)}(?!.*${escapeRegExp(nodeModules)}).*\\.[cm]?[jt]sx?$`,
+      `^${escapeRegExp(root)}(?!(?:.*${escapeRegExp(path.sep)})?${escapeRegExp(nodeModules)}).*\\.[cm]?[jt]sx?$`,
     );
     Bun.plugin({
       name: "@alchemy.run/node-utils/watch-import-bun",

--- a/packages/node-utils/test/watch-import-bun.test.ts
+++ b/packages/node-utils/test/watch-import-bun.test.ts
@@ -88,4 +88,48 @@ describe("trackBunImports", () => {
       await tracker.close();
     }
   });
+
+  it("leaves dependencies in the root's own node_modules alone", async () => {
+    const temporaryDirectory = realpathSync(
+      mkdtempSync(path.join(os.tmpdir(), "alchemy-import-bun-nm-")),
+    );
+    temporaryDirectories.push(temporaryDirectory);
+    const packageDirectory = path.join(
+      temporaryDirectory,
+      "node_modules",
+      "cjs-dep",
+    );
+    mkdirSync(packageDirectory, { recursive: true });
+    const dependency = path.join(packageDirectory, "index.js");
+    writeFileSync(
+      path.join(packageDirectory, "package.json"),
+      '{"name":"cjs-dep","version":"1.0.0","main":"index.js"}\n',
+    );
+    // CommonJS: Bun cannot hand this back through `onLoad` without losing its
+    // exports (oven-sh/bun#19279), so intercepting it breaks the import.
+    writeFileSync(
+      dependency,
+      'function hi() { return "hi"; }\nmodule.exports = hi;\n',
+    );
+    const entry = path.join(temporaryDirectory, "entry.ts");
+    writeFileSync(
+      entry,
+      [
+        'import hi from "cjs-dep";',
+        "export const greeting: string = hi();",
+      ].join("\n"),
+    );
+
+    const tracker = trackBunImports({
+      root: temporaryDirectory,
+      debounceMs: 10,
+    });
+    try {
+      const module = (await import(entry)) as { greeting: string };
+      expect(module.greeting).toBe("hi");
+      expect(tracker.dependencies).toEqual(new Set([entry]));
+    } finally {
+      await tracker.close();
+    }
+  });
 });


### PR DESCRIPTION
## Problem

`alchemy dev` under Bun never reaches the dev server on `2.0.0-beta.77`. It fails while importing the stack module:

```
[19:39:11.125] INFO (#29): Importing stack module
alchemy dev: run failed; waiting for the next file change to retry.
SyntaxError: Missing 'default' export in module '/…/node_modules/fast-glob/out/index.js'.
    at Effect.fn (alchemy/src/Alchemist/Session.ts:276:30)
    at openStackSessionUncached (alchemy/src/Alchemist/Session.ts:327:37)
```

`plan`, `deploy`, and `destroy` are unaffected, since only `runBunDevWatcher` registers the probe. Node is unaffected. beta.76 is unaffected because it has no Bun watcher; this arrived with #1461.

## Cause

`BunImportTracker` built its filter like this:

```ts
const root = realpathSync.native(path.resolve(options.root)) + path.sep;
const nodeModules = `${path.sep}node_modules${path.sep}`;
const filter = new RegExp(
  `^${escapeRegExp(root)}(?!.*${escapeRegExp(nodeModules)}).*\\.[cm]?[jt]sx?$`,
);
```

`root` already ends in `path.sep`, so once it is consumed the remaining path starts `node_modules/…` with no leading separator. The lookahead wants `/node_modules/`, so it never matches, and the root's own `node_modules` is not excluded. Only nested `node_modules` is:

```
MATCH   /project/node_modules/fast-glob/out/index.js
MATCH   /project/node_modules/@aws-sdk/credential-providers/dist-cjs/index.js
skip    /project/node_modules/a/node_modules/b/index.js
```

So the probe intercepts every dependency, and Bun cannot return CommonJS source from `onLoad` (oven-sh/bun#19279, open; #21369 closed as a duplicate). The echoed CJS gets linked as ESM and its exports disappear.

This is not only a throwing failure. With the probe active, an intercepted `react-dom` resolves to **0 exports instead of 16**, with no error at all.

## Fix

Reject a `node_modules/` segment immediately after the root as well as anywhere deeper:

```ts
const nodeModules = `node_modules${path.sep}`;
const filter = new RegExp(
  `^${escapeRegExp(root)}(?!(?:.*${escapeRegExp(path.sep)})?${escapeRegExp(nodeModules)}).*\\.[cm]?[jt]sx?$`,
);
```

Verified against the intended behaviour:

```
skip    /project/node_modules/fast-glob/out/index.js
skip    /project/node_modules/a/node_modules/b/index.js
skip    /project/packages/app/node_modules/x/index.js
TRACK   /project/alchemy.run.ts
TRACK   /project/infra/deep/nested/x.tsx
TRACK   /project/node_modules_like/keep.ts
```

With this patch applied, `bun alchemy dev` comes up clean on a `Cloudflare.Website.Astro` stack: `[Website] ready at http://localhost:1337`, no `SyntaxError`, and it stays serving.

## Test

`packages/node-utils/test/watch-import-bun.test.ts` gains a case that puts a CommonJS package in the root's own `node_modules`, statically imports it from the tracked entrypoint, and asserts both that the import works and that the dependency is not tracked. It fails on `main` with the exact production error and passes with the fix:

```
# before
SyntaxError: Missing 'default' export in module '/…/node_modules/cjs-dep/index.js'
(fail) trackBunImports > leaves dependencies in the root's own node_modules alone
 1 pass, 1 fail

# after
 2 pass, 0 fail
```

The import has to be static; a dynamic `import()` of an intercepted CJS file returns an empty namespace instead of throwing, which is why this went unnoticed.

## Note

Since oven-sh/bun#19279 means *any* intercepted CJS file breaks, a defensive bail on `args.path.includes(nodeModules)` inside `onLoad` would be belt and braces against an unusual layout or symlinked install reaching the same wire. I left it out to keep the change to the actual defect; happy to add it if you want it.

## Environment

Bun 1.4.2, Node 24.16.0, macOS arm64. Reproduced on a `Cloudflare.Website.Astro` stack (Astro 7.3.2, React 19.3) with `alchemy@2.0.0-beta.77`.
